### PR TITLE
AST Generation for Structured Language

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This reuses parts of the [Petr4](https://github.com/verified-network-toolchain/p
   ```shell
   $ opam switch create 5.1.0
   $ eval $(opam env)
-  $ opam install dune bignum menhir core core_unix bisect_ppx
+  $ opam install dune bignum menhir core core_unix bisect_ppx yojson ppx_deriving_yojson
   ```
 
 ### Building the Project

--- a/p4spec/bin/main.ml
+++ b/p4spec/bin/main.ml
@@ -360,7 +360,6 @@ let json_ast_command =
              let spec_il = Elaborate.Elab.elab_spec spec in
              let spec_sl = Structure.Struct.struct_spec spec_il in
              let sl_ast_json = Sl.Ast.spec_to_yojson spec_sl in
-             (* Yojson.Safe.pp Format.std_formatter sl_ast_json; *)
              Yojson.Safe.pretty_print Format.std_formatter sl_ast_json;
              ()
            with

--- a/p4spec/bin/main.ml
+++ b/p4spec/bin/main.ml
@@ -345,11 +345,23 @@ let emit_ast_command =
          let spec_il = Elaborate.Elab.elab_spec spec in
          let spec_sl = Structure.Struct.struct_spec spec_il in
          let sl_ast_json = Sl.Ast.spec_to_yojson spec_sl in
+         (* Yojson.Safe.pp Format.std_formatter sl_ast_json; *)
          Yojson.Safe.pretty_print Format.std_formatter sl_ast_json;
          ()
        with
        | ParseError (at, msg) -> Format.printf "%s\n" (string_of_error at msg)
        | ElabError (at, msg) -> Format.printf "%s\n" (string_of_error at msg))
+
+let parse_ast_command =
+  Core.Command.basic ~summary:"Parse JSON AST to Structured Language"
+    (let open Core.Command.Let_syntax in
+     let open Core.Command.Param in
+     let%map filename = anon ("filename" %: string) in
+     fun () ->
+       let parsed = Yojson.Safe.from_file filename |> Sl.Ast.spec_of_yojson in
+       match parsed with
+       | Ok spec -> Format.printf "%s\n" (Sl.Print.string_of_spec spec)
+       | _ -> failwith "foo")
 
 let command =
   Core.Command.group
@@ -364,6 +376,7 @@ let command =
       ("testgen-dbg", run_testgen_debug_command);
       ("interesting", interesting_command);
       ("emit-ast", emit_ast_command);
+      ("parse-ast", parse_ast_command);
     ]
 
 let () = Command_unix.run ~version command

--- a/p4spec/lib/el/ast.ml
+++ b/p4spec/lib/el/ast.ml
@@ -6,19 +6,24 @@ open Util.Source
 (* Numbers *)
 
 type num = Num.t
+[@@deriving yojson]
 
 (* Texts *)
 
 type text = string
+[@@deriving yojson]
 
 (* Identifiers *)
 
 type id = id' phrase
+[@@deriving yojson]
 and id' = string
+[@@deriving yojson]
 
 (* Atoms *)
 
 type atom = Atom.t phrase
+[@@deriving yojson]
 
 (* Iterators *)
 
@@ -103,6 +108,7 @@ and exp' =
   | FuseE of exp * exp                                (* exp `#` exp *)
   | UnparenE of exp                                   (* `##` exp *)
   | LatexE of string                                  (* `latex` `(` `"..."`* `)` *)
+[@@deriving yojson]
 
 (* Paths *)
 

--- a/p4spec/lib/el/dune
+++ b/p4spec/lib/el/dune
@@ -2,4 +2,5 @@
  (name el)
  (libraries bignum util xl domain yojson)
  (modules ast print free)
- (preprocess (pps ppx_deriving_yojson)))
+ (preprocess
+  (pps ppx_deriving_yojson)))

--- a/p4spec/lib/el/dune
+++ b/p4spec/lib/el/dune
@@ -1,4 +1,5 @@
 (library
  (name el)
- (libraries bignum util xl domain)
- (modules ast print free))
+ (libraries bignum util xl domain yojson ppx_deriving_yojson.runtime)
+ (modules ast print free)
+ (preprocess (pps ppx_deriving_yojson)))

--- a/p4spec/lib/el/dune
+++ b/p4spec/lib/el/dune
@@ -1,5 +1,5 @@
 (library
  (name el)
- (libraries bignum util xl domain yojson ppx_deriving_yojson.runtime)
+ (libraries bignum util xl domain yojson)
  (modules ast print free)
  (preprocess (pps ppx_deriving_yojson)))

--- a/p4spec/lib/il/ast.ml
+++ b/p4spec/lib/il/ast.ml
@@ -66,7 +66,7 @@ and typcase = nottyp
 (* Values *)
 
 and vid = int
-and vnote = { vid : vid; typ : typ' }
+and vnote = { vid : vid; typ : typ' } [@@deriving yojson]
 
 and value = (value', vnote) note
 and value' =
@@ -79,9 +79,12 @@ and value' =
   | OptV of value option
   | ListV of value list
   | FuncV of id
+[@@deriving yojson]
 
 and valuefield = atom * value
+[@@deriving yojson]
 and valuecase = mixop * value list
+[@@deriving yojson]
 
 (* Operators *)
 

--- a/p4spec/lib/il/ast.ml
+++ b/p4spec/lib/il/ast.ml
@@ -6,24 +6,25 @@ open Util.Source
 (* Numbers *)
 
 type num = Num.t
+[@@deriving yojson]
 
 (* Texts *)
 
-type text = string
+type text = string [@@deriving yojson]
 
 (* Identifiers *)
 
-type id = id' phrase
-and id' = string
+type id = id' phrase [@@deriving yojson]
+and id' = string [@@deriving yojson]
 
 (* Atoms *)
 
-type atom = atom' phrase
-and atom' = Atom.t
+type atom = atom' phrase [@@deriving yojson]
+and atom' = Atom.t [@@deriving yojson]
 
 (* Mixfix operators *)
 
-type mixop = Mixop.t
+type mixop = Mixop.t [@@deriving yojson]
 
 (* Iterators *)
 
@@ -47,9 +48,12 @@ and typ' =
   | TupleT of typ list      (* `(` list(typ, `,`) `)` *)
   | IterT of typ * iter     (* typ iter *)
   | FuncT                   (* `func` *)
+[@@deriving yojson]
 
 and nottyp = nottyp' phrase
+[@@deriving yojson]
 and nottyp' = mixop * typ list
+[@@deriving yojson]
 
 and deftyp = deftyp' phrase
 and deftyp' =
@@ -82,7 +86,7 @@ and valuecase = mixop * value list
 
 (* Operators *)
 
-and numop = [ `DecOp | `HexOp ]
+and numop = [ `DecOp | `HexOp ] [@@deriving yojson]
 and unop = [ Bool.unop | Num.unop ]
 and binop = [ Bool.binop | Num.binop ]
 and cmpop = [ Bool.cmpop | Num.cmpop ]
@@ -162,8 +166,8 @@ and arg' =
 
 (* Type arguments *)
 
-and targ = targ' phrase
-and targ' = typ'
+and targ = targ' phrase [@@deriving yojson]
+and targ' = typ' [@@deriving yojson]
 
 (* Rules *)
 

--- a/p4spec/lib/il/ast.ml
+++ b/p4spec/lib/il/ast.ml
@@ -5,8 +5,7 @@ open Util.Source
 
 (* Numbers *)
 
-type num = Num.t
-[@@deriving yojson]
+type num = Num.t [@@deriving yojson]
 
 (* Texts *)
 

--- a/p4spec/lib/il/ast.ml
+++ b/p4spec/lib/il/ast.ml
@@ -30,6 +30,7 @@ type mixop = Mixop.t
 type iter =
   | Opt       (* `?` *)
   | List      (* `*` *)
+[@@deriving yojson]
 
 (* Variables *)
 

--- a/p4spec/lib/il/dune
+++ b/p4spec/lib/il/dune
@@ -2,4 +2,5 @@
  (name il)
  (libraries bignum util xl el yojson)
  (modules ast eq print free)
- (preprocess (pps ppx_deriving_yojson)))
+ (preprocess
+  (pps ppx_deriving_yojson)))

--- a/p4spec/lib/il/dune
+++ b/p4spec/lib/il/dune
@@ -1,4 +1,5 @@
 (library
  (name il)
- (libraries bignum util xl el)
- (modules ast eq print free))
+ (libraries bignum util xl el yojson ppx_deriving_yojson.runtime)
+ (modules ast eq print free)
+ (preprocess (pps ppx_deriving_yojson)))

--- a/p4spec/lib/il/dune
+++ b/p4spec/lib/il/dune
@@ -1,5 +1,5 @@
 (library
  (name il)
- (libraries bignum util xl el yojson ppx_deriving_yojson.runtime)
+ (libraries bignum util xl el yojson)
  (modules ast eq print free)
  (preprocess (pps ppx_deriving_yojson)))

--- a/p4spec/lib/sl/ast.ml
+++ b/p4spec/lib/sl/ast.ml
@@ -4,11 +4,11 @@ open Util.Source
 
 (* Numbers *)
 
-type num = Il.Ast.num
+type num = Il.Ast.num [@@deriving yojson]
 
 (* Texts *)
 
-type text = Il.Ast.text
+type text = Il.Ast.text [@@deriving yojson]
 
 (* Identifiers *)
 
@@ -17,7 +17,7 @@ type id' = Il.Ast.id'
 
 (* Atoms *)
 
-type atom = Il.Ast.atom
+type atom = Il.Ast.atom [@@deriving yojson]
 type atom' = Il.Ast.atom'
 
 (* Mixfix operators *)
@@ -26,42 +26,42 @@ type mixop = Il.Ast.mixop [@@deriving yojson]
 
 (* Iterators *)
 
-type iter = Il.Ast.iter
+type iter = Il.Ast.iter [@@deriving yojson]
 
 (* Variables *)
 
-type var = Il.Ast.var
+type var = Il.Ast.var [@@deriving yojson]
 
 (* Types *)
 
 type typ = Il.Ast.typ [@@deriving yojson]
 type typ' = Il.Ast.typ'
 
-type nottyp = Il.Ast.nottyp
+type nottyp = Il.Ast.nottyp [@@deriving yojson]
 type nottyp' = Il.Ast.nottyp'
 
 type deftyp = Il.Ast.deftyp [@@deriving yojson]
 type deftyp' = Il.Ast.deftyp'
 
-type typfield = Il.Ast.typfield
-type typcase = Il.Ast.typcase
+type typfield = Il.Ast.typfield [@@deriving yojson]
+type typcase = Il.Ast.typcase [@@deriving yojson]
 
 (* Values *)
 
 type vid = Il.Ast.vid
 type vnote = Il.Ast.vnote
 
-type value = Il.Ast.value
+type value = Il.Ast.value [@@deriving yojson]
 type value' = Il.Ast.value'
 
-type valuefield = atom * value
-type valuecase = mixop * value list
+type valuefield = atom * value [@@deriving yojson]
+type valuecase = mixop * value list [@@deriving yojson]
 
 (* Operators *)
 
-type numop = Il.Ast.numop
-type unop = Il.Ast.unop
-type binop = Il.Ast.binop
+type numop = Il.Ast.numop [@@deriving yojson]
+type unop = Il.Ast.unop [@@deriving yojson]
+type binop = Il.Ast.binop [@@deriving yojson]
 type cmpop = Il.Ast.cmpop [@@deriving yojson]
 type optyp = Il.Ast.optyp [@@deriving yojson]
 
@@ -71,8 +71,7 @@ type exp = Il.Ast.exp [@@deriving yojson]
 type exp' = Il.Ast.exp'
 
 type notexp = Il.Ast.notexp [@@deriving yojson]
-type iterexp = Il.Ast.iterexp
-[@@deriving yojson]
+type iterexp = Il.Ast.iterexp [@@deriving yojson]
 
 (* Patterns *)
 
@@ -81,12 +80,12 @@ type pattern = Il.Ast.pattern
 
 (* Path *)
 
-type path = Il.Ast.path
+type path = Il.Ast.path [@@deriving yojson]
 type path' = Il.Ast.path'
 
 (* Parameters *)
 
-type param = Il.Ast.param
+type param = Il.Ast.param [@@deriving yojson]
 type param' = Il.Ast.param'
 
 (* Type parameters *)
@@ -109,15 +108,18 @@ type targ' = Il.Ast.targ'
 and pid = int
 
 and phantom = pid * pathcond list
+[@@deriving yojson]
 
 and pathcond =
   | ForallC of exp * iterexp list
   | ExistsC of exp * iterexp list
   | PlainC of exp
+[@@deriving yojson]
 
 (* Case analysis *)
 
 and case = guard * instr list
+[@@deriving yojson]
 
 and guard =
   | BoolG of bool
@@ -125,6 +127,7 @@ and guard =
   | SubG of typ
   | MatchG of pattern
   | MemG of exp
+[@@deriving yojson]
 
 (* Instructions *)
 
@@ -142,6 +145,7 @@ and instr' =
 (* Hints *)
 
 type hint = { hintid : id; hintexp : El.Ast.exp }
+[@@deriving yojson]
 
 (* Definitions *)
 

--- a/p4spec/lib/sl/ast.ml
+++ b/p4spec/lib/sl/ast.ml
@@ -12,7 +12,7 @@ type text = Il.Ast.text
 
 (* Identifiers *)
 
-type id = Il.Ast.id
+type id = Il.Ast.id [@@deriving yojson]
 type id' = Il.Ast.id'
 
 (* Atoms *)
@@ -22,7 +22,7 @@ type atom' = Il.Ast.atom'
 
 (* Mixfix operators *)
 
-type mixop = Il.Ast.mixop
+type mixop = Il.Ast.mixop [@@deriving yojson]
 
 (* Iterators *)
 
@@ -34,13 +34,13 @@ type var = Il.Ast.var
 
 (* Types *)
 
-type typ = Il.Ast.typ
+type typ = Il.Ast.typ [@@deriving yojson]
 type typ' = Il.Ast.typ'
 
 type nottyp = Il.Ast.nottyp
 type nottyp' = Il.Ast.nottyp'
 
-type deftyp = Il.Ast.deftyp
+type deftyp = Il.Ast.deftyp [@@deriving yojson]
 type deftyp' = Il.Ast.deftyp'
 
 type typfield = Il.Ast.typfield
@@ -62,20 +62,22 @@ type valuecase = mixop * value list
 type numop = Il.Ast.numop
 type unop = Il.Ast.unop
 type binop = Il.Ast.binop
-type cmpop = Il.Ast.cmpop
-type optyp = Il.Ast.optyp
+type cmpop = Il.Ast.cmpop [@@deriving yojson]
+type optyp = Il.Ast.optyp [@@deriving yojson]
 
 (* Expressions *)
 
-type exp = Il.Ast.exp
+type exp = Il.Ast.exp [@@deriving yojson]
 type exp' = Il.Ast.exp'
 
-type notexp = Il.Ast.notexp
+type notexp = Il.Ast.notexp [@@deriving yojson]
 type iterexp = Il.Ast.iterexp
+[@@deriving yojson]
 
 (* Patterns *)
 
 type pattern = Il.Ast.pattern
+[@@deriving yojson]
 
 (* Path *)
 
@@ -89,17 +91,17 @@ type param' = Il.Ast.param'
 
 (* Type parameters *)
 
-type tparam = Il.Ast.tparam
+type tparam = Il.Ast.tparam [@@deriving yojson]
 type tparam' = Il.Ast.tparam'
 
 (* Arguments *)
 
-type arg = Il.Ast.arg
+type arg = Il.Ast.arg [@@deriving yojson]
 type arg' = Il.Ast.arg'
 
 (* Type arguments *)
 
-type targ = Il.Ast.targ
+type targ = Il.Ast.targ [@@deriving yojson]
 type targ' = Il.Ast.targ'
 
 (* Path conditions *)
@@ -126,7 +128,7 @@ and guard =
 
 (* Instructions *)
 
-and instr = instr' phrase
+and instr = instr' phrase [@@deriving yojson]
 and instr' =
   | IfI of exp * iterexp list * instr list * phantom option
   | CaseI of exp * case list * phantom option 
@@ -135,6 +137,7 @@ and instr' =
   | RuleI of id * notexp * iterexp list
   | ResultI of exp list
   | ReturnI of exp
+[@@deriving yojson]
 
 (* Hints *)
 
@@ -150,7 +153,8 @@ and def' =
   | RelD of id * (mixop * int list) * exp list * instr list
   (* `dec` id `<` list(tparam, `,`) `>` list(param, `,`) `:` typ instr* *)
   | DecD of id * tparam list * arg list * instr list
+[@@deriving yojson]
 
 (* Spec *)
 
-type spec = def list
+type spec = def list [@@deriving yojson]

--- a/p4spec/lib/sl/dune
+++ b/p4spec/lib/sl/dune
@@ -2,4 +2,5 @@
  (name sl)
  (libraries bignum util xl el il yojson)
  (modules ast eq print)
- (preprocess (pps ppx_deriving_yojson)))
+ (preprocess
+  (pps ppx_deriving_yojson)))

--- a/p4spec/lib/sl/dune
+++ b/p4spec/lib/sl/dune
@@ -1,4 +1,5 @@
 (library
  (name sl)
- (libraries bignum util xl el il)
- (modules ast eq print))
+ (libraries bignum util xl el il yojson ppx_deriving_yojson.runtime)
+ (modules ast eq print)
+ (preprocess (pps ppx_deriving_yojson)))

--- a/p4spec/lib/sl/dune
+++ b/p4spec/lib/sl/dune
@@ -1,5 +1,5 @@
 (library
  (name sl)
- (libraries bignum util xl el il yojson ppx_deriving_yojson.runtime)
+ (libraries bignum util xl el il yojson)
  (modules ast eq print)
  (preprocess (pps ppx_deriving_yojson)))

--- a/p4spec/lib/util/bigint_json.ml
+++ b/p4spec/lib/util/bigint_json.ml
@@ -1,0 +1,9 @@
+let to_yojson (num : Bigint.t) : Yojson.Safe.t = `String (Bigint.to_string num)
+
+let of_yojson : Yojson.Safe.t -> (Bigint.t, string) result = function
+  | `String n -> (
+      try Ok (Bigint.of_string n)
+      with _ -> Error (Format.sprintf "Error while converting %s to Bigint" n))
+  | `Int n -> Ok (Bigint.of_int n)
+  | json ->
+      Error (Format.sprintf "Invalid Bigint: %s" (Yojson.Safe.to_string json))

--- a/p4spec/lib/util/bigint_json.ml
+++ b/p4spec/lib/util/bigint_json.ml
@@ -1,3 +1,5 @@
+(* json conversion helpers for bignum librarie's bigint *)
+
 let to_yojson (num : Bigint.t) : Yojson.Safe.t = `String (Bigint.to_string num)
 
 let of_yojson : Yojson.Safe.t -> (Bigint.t, string) result = function

--- a/p4spec/lib/util/dune
+++ b/p4spec/lib/util/dune
@@ -2,4 +2,5 @@
  (name util)
  (libraries bignum yojson)
  (modules print source error attempt bigint_json)
- (preprocess (pps ppx_deriving_yojson)))
+ (preprocess
+  (pps ppx_deriving_yojson)))

--- a/p4spec/lib/util/dune
+++ b/p4spec/lib/util/dune
@@ -1,5 +1,5 @@
 (library
  (name util)
+ (libraries bignum yojson)
  (modules print source error attempt bigint_json)
- (libraries bignum yojson ppx_deriving_yojson.runtime)
  (preprocess (pps ppx_deriving_yojson)))

--- a/p4spec/lib/util/dune
+++ b/p4spec/lib/util/dune
@@ -1,3 +1,4 @@
 (library
  (name util)
- (modules print source error attempt))
+ (modules print source error attempt bigint_json)
+ (libraries bignum yojson))

--- a/p4spec/lib/util/dune
+++ b/p4spec/lib/util/dune
@@ -1,4 +1,5 @@
 (library
  (name util)
  (modules print source error attempt bigint_json)
- (libraries bignum yojson))
+ (libraries bignum yojson ppx_deriving_yojson.runtime)
+ (preprocess (pps ppx_deriving_yojson)))

--- a/p4spec/lib/util/source.ml
+++ b/p4spec/lib/util/source.ml
@@ -1,7 +1,7 @@
 (* Positions and regions *)
 
-type pos = { file : string; line : int; column : int }
-type region = { left : pos; right : pos }
+type pos = { file : string; line : int; column : int } [@@deriving yojson]
+type region = { left : pos; right : pos } [@@deriving yojson]
 
 let no_pos = { file = ""; line = 0; column = 0 }
 let no_region = { left = no_pos; right = no_pos }
@@ -34,10 +34,10 @@ let string_of_region region =
 
 (* Phrases *)
 
-type ('a, 'b, 'c) info = { it : 'a; note : 'b; at : 'c }
-type ('a, 'b) note_phrase = ('a, 'b, region) info
-type ('a, 'b) note = ('a, 'b, unit) info
-type 'a phrase = ('a, unit, region) info
+type ('a, 'b, 'c) info = { it : 'a; note : 'b; at : 'c } [@@deriving yojson]
+type ('a, 'b) note_phrase = ('a, 'b, region) info [@@deriving yojson]
+type ('a, 'b) note = ('a, 'b, unit) info [@@deriving yojson]
+type 'a phrase = ('a, unit, region) info [@@deriving yojson]
 
 let ( $ ) it at = { it; at; note = () }
 let ( $$ ) it (at, note) = { it; at; note }

--- a/p4spec/lib/util/source.ml
+++ b/p4spec/lib/util/source.ml
@@ -35,11 +35,6 @@ let string_of_region region =
 (* Phrases *)
 
 type ('a, 'b, 'c) info = { it : 'a; note : 'b; at : 'c } [@@deriving yojson]
-
-let info_to_yojson (fa : 'a -> Yojson.Safe.t) (_fb : 'b -> Yojson.Safe.t)
-    (_fc : 'c -> Yojson.Safe.t) (value : ('a, 'b, 'c) info) =
-  fa value.it
-
 type ('a, 'b) note_phrase = ('a, 'b, region) info [@@deriving yojson]
 type ('a, 'b) note = ('a, 'b, unit) info [@@deriving yojson]
 type 'a phrase = ('a, unit, region) info [@@deriving yojson]

--- a/p4spec/lib/util/source.ml
+++ b/p4spec/lib/util/source.ml
@@ -35,6 +35,11 @@ let string_of_region region =
 (* Phrases *)
 
 type ('a, 'b, 'c) info = { it : 'a; note : 'b; at : 'c } [@@deriving yojson]
+
+let info_to_yojson (fa : 'a -> Yojson.Safe.t) (_fb : 'b -> Yojson.Safe.t)
+    (_fc : 'c -> Yojson.Safe.t) (value : ('a, 'b, 'c) info) =
+  fa value.it
+
 type ('a, 'b) note_phrase = ('a, 'b, region) info [@@deriving yojson]
 type ('a, 'b) note = ('a, 'b, unit) info [@@deriving yojson]
 type 'a phrase = ('a, unit, region) info [@@deriving yojson]

--- a/p4spec/lib/xl/atom.ml
+++ b/p4spec/lib/xl/atom.ml
@@ -50,6 +50,7 @@ type t =
   | RBrack          (* ``[` `]` *)
   | LBrace
   | RBrace          (* ``{` `}` *)
+[@@deriving yojson]
 [@@@ocamlformat "enable"]
 
 let compare atom_a atom_b = compare atom_a atom_b

--- a/p4spec/lib/xl/bool.ml
+++ b/p4spec/lib/xl/bool.ml
@@ -1,13 +1,13 @@
 (* Boolens *)
 
-type t = [ `BoolT ]
-type typ = [ `BoolT ]
+type t = [ `BoolT ] [@@deriving yojson]
+type typ = [ `BoolT ] [@@deriving yojson]
 
 (* Operations *)
 
-type unop = [ `NotOp ]
-type binop = [ `AndOp | `OrOp | `ImplOp | `EquivOp ]
-type cmpop = [ `EqOp | `NeOp ]
+type unop = [ `NotOp ] [@@deriving yojson]
+type binop = [ `AndOp | `OrOp | `ImplOp | `EquivOp ] [@@deriving yojson]
+type cmpop = [ `EqOp | `NeOp ] [@@deriving yojson]
 
 (* Stringifiers *)
 

--- a/p4spec/lib/xl/dune
+++ b/p4spec/lib/xl/dune
@@ -2,4 +2,5 @@
  (name xl)
  (libraries util bignum yojson)
  (modules atom bool num utf8 mixop var)
- (preprocess (pps ppx_deriving_yojson)))
+ (preprocess
+  (pps ppx_deriving_yojson)))

--- a/p4spec/lib/xl/dune
+++ b/p4spec/lib/xl/dune
@@ -1,4 +1,5 @@
 (library
  (name xl)
- (libraries util bignum)
- (modules atom bool num utf8 mixop var))
+ (libraries util bignum yojson ppx_deriving_yojson.runtime)
+ (modules atom bool num utf8 mixop var)
+ (preprocess (pps ppx_deriving_yojson)))

--- a/p4spec/lib/xl/dune
+++ b/p4spec/lib/xl/dune
@@ -1,5 +1,5 @@
 (library
  (name xl)
- (libraries util bignum yojson ppx_deriving_yojson.runtime)
+ (libraries util bignum yojson)
  (modules atom bool num utf8 mixop var)
  (preprocess (pps ppx_deriving_yojson)))

--- a/p4spec/lib/xl/mixop.ml
+++ b/p4spec/lib/xl/mixop.ml
@@ -2,7 +2,7 @@ open Util.Source
 
 (* Mixop is a generalized case constructor *)
 
-type t = Atom.t phrase list list
+type t = Atom.t phrase list list [@@deriving yojson]
 
 let compare mixop_a mixop_b =
   let mixop_a = List.map (List.map it) mixop_a in

--- a/p4spec/lib/xl/num.ml
+++ b/p4spec/lib/xl/num.ml
@@ -1,16 +1,29 @@
 (* Numbers: natural numbers and integers *)
 
-type t = [ `Nat of Bigint.t | `Int of Bigint.t ]
-type typ = [ `NatT | `IntT ]
+type t =
+  [ `Nat of
+    (Bigint.t
+    [@to_yojson Util.Bigint_json.to_yojson]
+    [@of_yojson Util.Bigint_json.of_yojson])
+  | `Int of
+    (Bigint.t
+    [@to_yojson Util.Bigint_json.to_yojson]
+    [@of_yojson Util.Bigint_json.of_yojson]) ]
+[@@deriving yojson]
+
+type typ = [ `NatT | `IntT ] [@@deriving yojson]
 
 let to_typ = function `Nat _ -> `NatT | `Int _ -> `IntT
 let to_int = function `Nat i | `Int i -> i
 
 (* Operations *)
 
-type unop = [ `PlusOp | `MinusOp ]
+type unop = [ `PlusOp | `MinusOp ] [@@deriving yojson]
+
 type binop = [ `AddOp | `SubOp | `MulOp | `DivOp | `ModOp | `PowOp ]
-type cmpop = [ `LtOp | `GtOp | `LeOp | `GeOp ]
+[@@deriving yojson]
+
+type cmpop = [ `LtOp | `GtOp | `LeOp | `GeOp ] [@@deriving yojson]
 
 (* Comparison *)
 


### PR DESCRIPTION
This PR adds the `json-ast` command to `p4spectec`, which has two options: `-emit` and `-parse`.

The `-emit` option accepts one or more SpecTec files and prints out the JSON AST to stdout:
```bash
$ ./p4spectec json-ast -emit spec/*.watsup
```

The `-parse` option accepts a single JSON file, parses it and prints out its Structured Language to stdout:
```bash
$ ./p4spectec json-ast -parse <ast.json>
```

One can perform a round trip test as follows:
```bash
$ ./p4spectec struct spec/*.watsup > original-sl.log
$ ./p4spectec json-ast -emit spec/*.watsup > ast.json
$ ./p4spectec json-ast -parse ast.json > round-trip-sl.log
$ diff original-sl.log round-trip-sl.log # no output means identical contents
```

Which could also be written as:
```bash
$ diff <(./p4spectec struct spec/*.watsup) <(./p4spectec json-ast -parse <(./p4spectec json-ast -emit spec/*.watsup))
```