### PR TITLE
use head of list as fold_left start value in min and forbid empty lists as arguments to min and max

### DIFF
--- a/p4spec/lib/interp-il/builtin/nats.ml
+++ b/p4spec/lib/interp-il/builtin/nats.ml
@@ -2,6 +2,7 @@ open Xl
 open Il.Ast
 module Value = Runtime_dynamic.Value
 open Util.Source
+open Error
 
 (* Conversion between meta-numerics and OCaml numerics *)
 
@@ -33,7 +34,10 @@ let max (at : region) (targs : targ list) (values_input : value list) : value =
   let values =
     Extract.one at values_input |> Value.get_list |> List.map bigint_of_value
   in
-  let max = List.fold_left Bigint.max Bigint.zero values in
+  let max = match values with
+    | [] -> error at "max of empty list"
+    | hd :: tl -> List.fold_left Bigint.max hd tl
+  in
   value_of_bigint max
 
 (* dec $min(nat* ) : nat *)
@@ -43,5 +47,8 @@ let min (at : region) (targs : targ list) (values_input : value list) : value =
   let values =
     Extract.one at values_input |> Value.get_list |> List.map bigint_of_value
   in
-  let min = List.fold_left Bigint.min Bigint.zero values in
+  let min = match values with
+    | [] -> error at "min of empty list"
+    | hd :: tl -> List.fold_left Bigint.min hd tl
+  in
   value_of_bigint min

--- a/p4spec/lib/interp-sl/builtin/nats.ml
+++ b/p4spec/lib/interp-sl/builtin/nats.ml
@@ -3,6 +3,7 @@ open Il.Ast
 module Value = Runtime_dynamic.Value
 module Dep = Runtime_testgen.Dep
 open Util.Source
+open Error
 
 (* Conversion between meta-numerics and OCaml numerics *)
 
@@ -37,7 +38,10 @@ let max (ctx : Ctx.t) (at : region) (targs : targ list)
   let values =
     Extract.one at values_input |> Value.get_list |> List.map bigint_of_value
   in
-  let max = List.fold_left Bigint.max Bigint.zero values in
+  let max = match values with
+    | [] -> error at "max of empty list"
+    | hd :: tl -> List.fold_left Bigint.max hd tl
+  in
   value_of_bigint ctx max
 
 (* dec $min(nat* ) : nat *)
@@ -48,5 +52,8 @@ let min (ctx : Ctx.t) (at : region) (targs : targ list)
   let values =
     Extract.one at values_input |> Value.get_list |> List.map bigint_of_value
   in
-  let min = List.fold_left Bigint.min Bigint.zero values in
+  let min = match values with
+    | [] -> error at "min of empty list"
+    | hd :: tl -> List.fold_left Bigint.min hd tl
+  in
   value_of_bigint ctx min

--- a/p4spec/lib/structure/optimize.ml
+++ b/p4spec/lib/structure/optimize.ml
@@ -1080,7 +1080,7 @@ let rec remove_singleton_match (tdenv : TDEnv.t) (instrs : instr list) :
   | [] -> []
   | instr_h :: instrs_t -> (
       match instr_h.it with
-      | IfI (exp_cond, iterexps, instrs) when is_singleton_match tdenv exp_cond
+      | IfI (exp_cond, _iterexps, instrs) when is_singleton_match tdenv exp_cond
         ->
           instrs @ instrs_t |> remove_singleton_match tdenv
       | IfI (exp_cond, iterexps, instrs) ->

--- a/p4spec/test/elab.expected
+++ b/p4spec/test/elab.expected
@@ -4878,19 +4878,19 @@ def $bitacc_op(value, value, value) : value =
 ;; ../../../../spec/3-numerics.watsup:752.1-752.32
 def $sizeof(typeIR, id) : value =
 
-   ;; ../../../../spec/3-numerics.watsup:792.1-793.34
+   ;; ../../../../spec/3-numerics.watsup:796.1-797.34
    clause 0(typeIR, text) = $sizeof_minSizeInBits(typeIR)
       -- if (text = "minSizeInBits")
 
-   ;; ../../../../spec/3-numerics.watsup:800.1-801.35
+   ;; ../../../../spec/3-numerics.watsup:804.1-805.35
    clause 1(typeIR, text) = $sizeof_minSizeInBytes(typeIR)
       -- if (text = "minSizeInBytes")
 
-   ;; ../../../../spec/3-numerics.watsup:829.1-830.34
+   ;; ../../../../spec/3-numerics.watsup:837.1-838.34
    clause 2(typeIR, text) = $sizeof_maxSizeInBits(typeIR)
       -- if (text = "maxSizeInBits")
 
-   ;; ../../../../spec/3-numerics.watsup:837.1-838.35
+   ;; ../../../../spec/3-numerics.watsup:845.1-846.35
    clause 3(typeIR, text) = $sizeof_maxSizeInBytes(typeIR)
       -- if (text = "maxSizeInBytes")
 
@@ -4970,103 +4970,117 @@ def $sizeof_minSizeInBits''(typeIR) : nat =
       -- if typeIR' <: headerTypeIR
       -- let `HeaderT%%`_headerTypeIR(_tid, `%%`_fieldTypeIR(typeIR, _id)*{_id <- _id*, typeIR <- typeIR*}) = typeIR' as headerTypeIR
 
-   ;; ../../../../spec/3-numerics.watsup:789.1-790.42
-   clause 10(typeIR') = $min($sizeof_minSizeInBits'(typeIR)*{typeIR <- typeIR*})
+   ;; ../../../../spec/3-numerics.watsup:789.1-791.22
+   clause 10(typeIR') = 0
       -- if typeIR' <: headerUnionTypeIR
       -- let `HeaderUnionT%%`_headerUnionTypeIR(_tid, `%%`_fieldTypeIR(typeIR, _id)*{_id <- _id*, typeIR <- typeIR*}) = typeIR' as headerUnionTypeIR
+      -- if (|typeIR*{typeIR <- typeIR*}| = 0)
+
+   ;; ../../../../spec/3-numerics.watsup:792.1-794.24
+   clause 11(typeIR') = $min($sizeof_minSizeInBits'(typeIR)*{typeIR <- typeIR*})
+      -- if typeIR' <: headerUnionTypeIR
+      -- let `HeaderUnionT%%`_headerUnionTypeIR(_tid, `%%`_fieldTypeIR(typeIR, _id)*{_id <- _id*, typeIR <- typeIR*}) = typeIR' as headerUnionTypeIR
+      -- if (|typeIR*{typeIR <- typeIR*}| =/= 0)
 
 ;; ../../../../spec/3-numerics.watsup:758.1-758.43
 def $sizeof_minSizeInBytes(typeIR) : value =
 
-   ;; ../../../../spec/3-numerics.watsup:797.1-798.48
+   ;; ../../../../spec/3-numerics.watsup:801.1-802.48
    clause 0(typeIR) = `IntV%`_numberValue((n_size / 8) as int) as value
       -- let n_size = $sizeof_minSizeInBits'(typeIR)
 
 ;; ../../../../spec/3-numerics.watsup:760.1-760.42
 def $sizeof_maxSizeInBits(typeIR) : value =
 
-   ;; ../../../../spec/3-numerics.watsup:805.1-806.40
+   ;; ../../../../spec/3-numerics.watsup:809.1-810.40
    clause 0(typeIR) = `IntV%`_numberValue($sizeof_maxSizeInBits'(typeIR) as int) as value
 
 ;; ../../../../spec/3-numerics.watsup:761.1-761.41
 def $sizeof_maxSizeInBits'(typeIR) : nat =
 
-   ;; ../../../../spec/3-numerics.watsup:807.1-808.44
+   ;; ../../../../spec/3-numerics.watsup:811.1-812.44
    clause 0(typeIR) = $sizeof_maxSizeInBits''($canon(typeIR))
 
 ;; ../../../../spec/3-numerics.watsup:762.1-762.42
 def $sizeof_maxSizeInBits''(typeIR) : nat =
 
-   ;; ../../../../spec/3-numerics.watsup:810.1-810.39
+   ;; ../../../../spec/3-numerics.watsup:814.1-814.39
    clause 0(typeIR) = 1
       -- if typeIR <: primitiveTypeIR
       -- let primitiveTypeIR = typeIR as primitiveTypeIR
       -- if primitiveTypeIR matches `BoolT`
 
-   ;; ../../../../spec/3-numerics.watsup:811.1-811.41
+   ;; ../../../../spec/3-numerics.watsup:815.1-815.41
    clause 1(typeIR) = w
       -- if typeIR <: numberTypeIR
       -- let numberTypeIR = typeIR as numberTypeIR
       -- if numberTypeIR matches `FBitT%`
       -- let `FBitT%`_numberTypeIR(w) = numberTypeIR
 
-   ;; ../../../../spec/3-numerics.watsup:812.1-812.41
+   ;; ../../../../spec/3-numerics.watsup:816.1-816.41
    clause 2(typeIR) = w
       -- if typeIR <: numberTypeIR
       -- let numberTypeIR = typeIR as numberTypeIR
       -- if numberTypeIR matches `FIntT%`
       -- let `FIntT%`_numberTypeIR(w) = numberTypeIR
 
-   ;; ../../../../spec/3-numerics.watsup:813.1-813.41
+   ;; ../../../../spec/3-numerics.watsup:817.1-817.41
    clause 3(typeIR) = w
       -- if typeIR <: numberTypeIR
       -- let numberTypeIR = typeIR as numberTypeIR
       -- if numberTypeIR matches `VBitT%`
       -- let `VBitT%`_numberTypeIR(w) = numberTypeIR
 
-   ;; ../../../../spec/3-numerics.watsup:814.1-815.35
+   ;; ../../../../spec/3-numerics.watsup:818.1-819.35
    clause 4(typeIR') = $sizeof_maxSizeInBits'(typeIR)
       -- if typeIR' <: aliasTypeIR
       -- let aliasTypeIR = typeIR' as aliasTypeIR
       -- if aliasTypeIR matches `NewT%%`
       -- let `NewT%%`_aliasTypeIR(_tid, typeIR) = aliasTypeIR
 
-   ;; ../../../../spec/3-numerics.watsup:816.1-817.35
+   ;; ../../../../spec/3-numerics.watsup:820.1-821.35
    clause 5(typeIR') = $sizeof_maxSizeInBits'(typeIR)
       -- if typeIR' <: enumTypeIR
       -- let enumTypeIR = typeIR' as enumTypeIR
       -- if enumTypeIR matches `SEnumT%%%`
       -- let `SEnumT%%%`_enumTypeIR(_tid, typeIR, _valueFieldIR*{_valueFieldIR <- _valueFieldIR*}) = enumTypeIR
 
-   ;; ../../../../spec/3-numerics.watsup:818.1-819.42
+   ;; ../../../../spec/3-numerics.watsup:822.1-823.42
    clause 6(typeIR') = $sum($sizeof_maxSizeInBits'(typeIR)*{typeIR <- typeIR*})
       -- if typeIR' <: tupleTypeIR
       -- let `TupleT%`_tupleTypeIR(typeIR*{typeIR <- typeIR*}) = typeIR' as tupleTypeIR
 
-   ;; ../../../../spec/3-numerics.watsup:820.1-821.47
+   ;; ../../../../spec/3-numerics.watsup:824.1-825.47
    clause 7(typeIR') = ($sizeof_maxSizeInBits'(typeIR) * n_size)
       -- if typeIR' <: headerStackTypeIR
       -- let `HeaderStackT%%`_headerStackTypeIR(typeIR, n_size) = typeIR' as headerStackTypeIR
 
-   ;; ../../../../spec/3-numerics.watsup:822.1-823.42
+   ;; ../../../../spec/3-numerics.watsup:826.1-827.42
    clause 8(typeIR') = $sum($sizeof_maxSizeInBits'(typeIR)*{typeIR <- typeIR*})
       -- if typeIR' <: structTypeIR
       -- let `StructT%%`_structTypeIR(_tid, `%%`_fieldTypeIR(typeIR, _id)*{_id <- _id*, typeIR <- typeIR*}) = typeIR' as structTypeIR
 
-   ;; ../../../../spec/3-numerics.watsup:824.1-825.42
+   ;; ../../../../spec/3-numerics.watsup:828.1-829.42
    clause 9(typeIR') = $sum($sizeof_maxSizeInBits'(typeIR)*{typeIR <- typeIR*})
       -- if typeIR' <: headerTypeIR
       -- let `HeaderT%%`_headerTypeIR(_tid, `%%`_fieldTypeIR(typeIR, _id)*{_id <- _id*, typeIR <- typeIR*}) = typeIR' as headerTypeIR
 
-   ;; ../../../../spec/3-numerics.watsup:826.1-827.42
-   clause 10(typeIR') = $max($sizeof_maxSizeInBits'(typeIR)*{typeIR <- typeIR*})
+   ;; ../../../../spec/3-numerics.watsup:830.1-832.22
+   clause 10(typeIR') = 0
       -- if typeIR' <: headerUnionTypeIR
       -- let `HeaderUnionT%%`_headerUnionTypeIR(_tid, `%%`_fieldTypeIR(typeIR, _id)*{_id <- _id*, typeIR <- typeIR*}) = typeIR' as headerUnionTypeIR
+      -- if (|typeIR*{typeIR <- typeIR*}| = 0)
+
+   ;; ../../../../spec/3-numerics.watsup:833.1-835.24
+   clause 11(typeIR') = $max($sizeof_maxSizeInBits'(typeIR)*{typeIR <- typeIR*})
+      -- if typeIR' <: headerUnionTypeIR
+      -- let `HeaderUnionT%%`_headerUnionTypeIR(_tid, `%%`_fieldTypeIR(typeIR, _id)*{_id <- _id*, typeIR <- typeIR*}) = typeIR' as headerUnionTypeIR
+      -- if (|typeIR*{typeIR <- typeIR*}| =/= 0)
 
 ;; ../../../../spec/3-numerics.watsup:764.1-764.43
 def $sizeof_maxSizeInBytes(typeIR) : value =
 
-   ;; ../../../../spec/3-numerics.watsup:834.1-835.48
+   ;; ../../../../spec/3-numerics.watsup:842.1-843.48
    clause 0(typeIR) = `IntV%`_numberValue((n_size / 8) as int) as value
       -- let n_size = $sizeof_maxSizeInBits'(typeIR)
 

--- a/p4spec/test/struct.expected
+++ b/p4spec/test/struct.expected
@@ -6885,7 +6885,15 @@ def $sizeof_minSizeInBits''(typeIR'')
 
     1. (Let (HeaderUnionT _tid (typeIR _id)*{_id <- _id*, typeIR <- typeIR*}) be (typeIR'' as headerUnionTypeIR))
 
-    2. Return $min($sizeof_minSizeInBits'(typeIR)*{typeIR <- typeIR*})
+    2. Case analysis on |typeIR*{typeIR <- typeIR*}|
+
+      1. Case (% = 0)
+
+        1. Return 0
+
+      2. Case (% =/= 0)
+
+        1. Return $min($sizeof_minSizeInBits'(typeIR)*{typeIR <- typeIR*})
 
 1. Else Phantom#385
 
@@ -6999,7 +7007,15 @@ def $sizeof_maxSizeInBits''(typeIR'')
 
     1. (Let (HeaderUnionT _tid (typeIR _id)*{_id <- _id*, typeIR <- typeIR*}) be (typeIR'' as headerUnionTypeIR))
 
-    2. Return $max($sizeof_maxSizeInBits'(typeIR)*{typeIR <- typeIR*})
+    2. Case analysis on |typeIR*{typeIR <- typeIR*}|
+
+      1. Case (% = 0)
+
+        1. Return 0
+
+      2. Case (% =/= 0)
+
+        1. Return $max($sizeof_maxSizeInBits'(typeIR)*{typeIR <- typeIR*})
 
 1. Else Phantom#390
 

--- a/spec/3-numerics.watsup
+++ b/spec/3-numerics.watsup
@@ -787,7 +787,11 @@ def $sizeof_minSizeInBits''(StructT _ (typeIR _)*)
 def $sizeof_minSizeInBits''(HeaderT _ (typeIR _)*)
   = $sum($sizeof_minSizeInBits'(typeIR)*)
 def $sizeof_minSizeInBits''(HeaderUnionT _ (typeIR _)*)
+  = 0
+  -- if |typeIR*| = 0
+def $sizeof_minSizeInBits''(HeaderUnionT _ (typeIR _)*)
   = $min($sizeof_minSizeInBits'(typeIR)*)
+  -- if |typeIR*| =/= 0
 
 def $sizeof(typeIR, "minSizeInBits")
   = $sizeof_minSizeInBits(typeIR)
@@ -824,7 +828,11 @@ def $sizeof_maxSizeInBits''(StructT _ (typeIR _)*)
 def $sizeof_maxSizeInBits''(HeaderT _ (typeIR _)*)
   = $sum($sizeof_maxSizeInBits'(typeIR)*)
 def $sizeof_maxSizeInBits''(HeaderUnionT _ (typeIR _)*)
+  = 0
+  -- if |typeIR*| = 0
+def $sizeof_maxSizeInBits''(HeaderUnionT _ (typeIR _)*)
   = $max($sizeof_maxSizeInBits'(typeIR)*)
+  -- if |typeIR*| =/= 0
 
 def $sizeof(typeIR, "maxSizeInBits")
   = $sizeof_maxSizeInBits(typeIR)


### PR DESCRIPTION
fixes #10. it's a re-do of #11, which had unrelated changes.