### PR TITLE
fix: make use p4program VarT, like the spec defines

### DIFF
--- a/p4spec/lib/interface/parser.mly
+++ b/p4spec/lib/interface/parser.mly
@@ -1564,4 +1564,4 @@ declarationList_:
   | dl = declarationList_ { dl |> wrap_list_v "declaration" }
 
 p4program:
-	| dl = declarationList END { dl #@@ "program" }
+	| dl = declarationList END { dl #@@ "p4program" }


### PR DESCRIPTION
I'm a little bit unsure about this PR, but ran into the following issue today: the 'new' spec uses the type `p4program` for the P4 program values:

https://github.com/kaist-plrg/p4-spectec/blob/48fcc27d3f305c2789179c5aed3959cf1b967eba/spec/1-syntax.watsup#L690

the old spec used `program`:

https://github.com/kaist-plrg/p4-spectec/blob/48fcc27d3f305c2789179c5aed3959cf1b967eba/spec-old/1a-syntax-el.watsup#L325

This PR makes the parser produce a `p4program` `VarT`.