### PR TITLE
Coercion for serializable enums

### DIFF
--- a/excludes/exclude-bug/coerce-serializable-enum.exclude
+++ b/excludes/exclude-bug/coerce-serializable-enum.exclude
@@ -1,3 +1,0 @@
-p4c/testdata/p4_16_samples/enumCast.p4
-p4c/testdata/p4_16_samples/issue3333.p4
-p4c/testdata/p4_16_samples/table-entries-ser-enum-bmv2.p4

--- a/excludes/exclude-p4c-discussion/tuple-lvalue.exclude
+++ b/excludes/exclude-p4c-discussion/tuple-lvalue.exclude
@@ -1,1 +1,0 @@
-p4c/testdata/p4_16_samples/issue4057.p4

--- a/excludes/exclude-target-specific/switch-within-action.exclude
+++ b/excludes/exclude-target-specific/switch-within-action.exclude
@@ -1,1 +1,0 @@
-p4c/testdata/p4_16_errors/issue3299.p4

--- a/p4spec/test/elab.expected
+++ b/p4spec/test/elab.expected
@@ -3303,17 +3303,25 @@ def $write_value_from_bits'(value, nat, bool*) : (value, bool*) =
   -- let b_t*{b_t <- b_t*} = b*{b <- b*}[n_var : n_t]
   -- let i = $int_to_bitstr(n_var as int, $bits_to_int_signed(b_h*{b_h <- b_h*}))
 
-  ;; ../../../../spec-concrete/2.1.2-value-aux.watsup:187.1-191.63
+  ;; ../../../../spec-concrete/2.1.2-value-aux.watsup:185.1-189.63
   clause 5 : (value, n_var, b*{b <- b*}) = (struct tid { fieldValue_updated*{fieldValue_updated <- fieldValue_updated*} } as value, b_rest*{b_rest <- b_rest*})
   -- if value <: structValue
   -- let struct tid { fieldValue*{fieldValue <- fieldValue*} } = value as structValue
   -- let (fieldValue_updated*{fieldValue_updated <- fieldValue_updated*}, b_rest*{b_rest <- b_rest*}) = $write_value_fields_from_bits'(fieldValue*{fieldValue <- fieldValue*}, n_var, b*{b <- b*})
 
-  ;; ../../../../spec-concrete/2.1.2-value-aux.watsup:192.1-196.63
+  ;; ../../../../spec-concrete/2.1.2-value-aux.watsup:190.1-194.63
   clause 6 : (value, n_var, b*{b <- b*}) = (header tid { true ; fieldValue_updated*{fieldValue_updated <- fieldValue_updated*} } as value, b_rest*{b_rest <- b_rest*})
   -- if value <: headerValue
   -- let header tid { _bool ; fieldValue*{fieldValue <- fieldValue*} } = value as headerValue
   -- let (fieldValue_updated*{fieldValue_updated <- fieldValue_updated*}, b_rest*{b_rest <- b_rest*}) = $write_value_fields_from_bits'(fieldValue*{fieldValue <- fieldValue*}, n_var, b*{b <- b*})
+
+  ;; ../../../../spec-concrete/2.1.2-value-aux.watsup:196.1-199.77
+  clause 7 : (value', n_var, b*{b <- b*}) = (tid . "__UNSPECIFIED" . value_updated as value, b_rest*{b_rest <- b_rest*})
+  -- if value' <: enumValue
+  -- let enumValue = value' as enumValue
+  -- if enumValue matches `%.%.%`
+  -- let tid . id . value = enumValue
+  -- let (value_updated, b_rest*{b_rest <- b_rest*}) = $write_value_from_bits'(value, n_var, b*{b <- b*})
 
 ;; ../../../../spec-concrete/2.1.2-value-aux.watsup:142.1-142.83
 def $write_value_fields_from_bits'(fieldValue*, nat, bool*) : (fieldValue*, bool*) =
@@ -3322,7 +3330,7 @@ def $write_value_fields_from_bits'(fieldValue*, nat, bool*) : (fieldValue*, bool
   clause 0 : (fieldValue*{fieldValue <- fieldValue*}, n_var, b*{b <- b*}) = ([], b*{b <- b*})
   -- if fieldValue*{fieldValue <- fieldValue*} matches []
 
-  ;; ../../../../spec-concrete/2.1.2-value-aux.watsup:171.1-178.67
+  ;; ../../../../spec-concrete/2.1.2-value-aux.watsup:171.1-177.67
   clause 1 : (fieldValue*{fieldValue <- fieldValue*}, n_var, b*{b <- b*}) = (fieldValue_h_updated :: fieldValue_t_updated*{fieldValue_t_updated <- fieldValue_t_updated*}, b_rest*{b_rest <- b_rest*})
   -- if fieldValue*{fieldValue <- fieldValue*} matches _ :: _
   -- let fieldValue_h :: fieldValue_t*{fieldValue_t <- fieldValue_t*} = fieldValue*{fieldValue <- fieldValue*}
@@ -3332,65 +3340,72 @@ def $write_value_fields_from_bits'(fieldValue*, nat, bool*) : (fieldValue*, bool
 ;; ../../../../spec-concrete/2.1.2-value-aux.watsup:143.1-143.80
 def $write_value_field_from_bits'(fieldValue, nat, bool*) : (fieldValue, bool*) =
 
-  ;; ../../../../spec-concrete/2.1.2-value-aux.watsup:180.1-185.50
+  ;; ../../../../spec-concrete/2.1.2-value-aux.watsup:179.1-183.50
   clause 0 : (value id ;, n_var, b*{b <- b*}) = (value_updated id ;, b_rest*{b_rest <- b_rest*})
   -- let (value_updated, b_rest*{b_rest <- b_rest*}) = $write_value_from_bits'(value, n_var, b*{b <- b*})
 
-;; ../../../../spec-concrete/2.1.2-value-aux.watsup:202.1-202.42
+;; ../../../../spec-concrete/2.1.2-value-aux.watsup:205.1-205.42
 def $write_bits_from_value(value) : bool* =
 
-  ;; ../../../../spec-concrete/2.1.2-value-aux.watsup:204.1-204.40
+  ;; ../../../../spec-concrete/2.1.2-value-aux.watsup:207.1-207.40
   clause 0 : (value) = [b]
   -- if value <: boolValue
   -- let b b = value as boolValue
 
-  ;; ../../../../spec-concrete/2.1.2-value-aux.watsup:205.1-206.30
+  ;; ../../../../spec-concrete/2.1.2-value-aux.watsup:208.1-209.30
   clause 1 : (value) = $int_to_bits_signed(w, i)
   -- if value <: integerLiteral
   -- let integerLiteral = value as integerLiteral
   -- if integerLiteral matches `%S%`
   -- let w s i = integerLiteral
 
-  ;; ../../../../spec-concrete/2.1.2-value-aux.watsup:207.1-208.32
+  ;; ../../../../spec-concrete/2.1.2-value-aux.watsup:210.1-211.32
   clause 2 : (value) = $int_to_bits_unsigned(w, i)
   -- if value <: integerLiteral
   -- let integerLiteral = value as integerLiteral
   -- if integerLiteral matches `%W%`
   -- let w w i = integerLiteral
 
-  ;; ../../../../spec-concrete/2.1.2-value-aux.watsup:209.1-210.32
+  ;; ../../../../spec-concrete/2.1.2-value-aux.watsup:212.1-213.32
   clause 3 : (value) = $int_to_bits_unsigned(w, i)
   -- if value <: integerValue
   -- let integerValue = value as integerValue
   -- if integerValue matches `%.%V%`
   -- let _nat . w v i = integerValue
 
-  ;; ../../../../spec-concrete/2.1.2-value-aux.watsup:212.1-215.59
+  ;; ../../../../spec-concrete/2.1.2-value-aux.watsup:215.1-217.59
   clause 4 : (value) = $concat_<bool>($write_bits_from_value(value_element)*{value_element <- value_element*})
   -- if value <: headerStackValue
   -- let header_stack[ value_element*{value_element <- value_element*} ( _nat ; _nat' )] = value as headerStackValue
 
-  ;; ../../../../spec-concrete/2.1.2-value-aux.watsup:216.1-219.57
+  ;; ../../../../spec-concrete/2.1.2-value-aux.watsup:219.1-221.57
   clause 5 : (value) = $concat_<bool>($write_bits_from_value(value_field)*{value_field <- value_field*})
   -- if value <: structValue
   -- let struct _tid { value_field id_field ;*{id_field <- id_field*, value_field <- value_field*} } = value as structValue
 
-  ;; ../../../../spec-concrete/2.1.2-value-aux.watsup:220.1-223.57
+  ;; ../../../../spec-concrete/2.1.2-value-aux.watsup:222.1-224.57
   clause 6 : (value) = $concat_<bool>($write_bits_from_value(value_field)*{value_field <- value_field*})
   -- if value <: headerValue
   -- let header _tid { bool ; value_field id_field ;*{id_field <- id_field*, value_field <- value_field*} } = value as headerValue
   -- if (bool = true)
 
-  ;; ../../../../spec-concrete/2.1.2-value-aux.watsup:224.1-224.59
+  ;; ../../../../spec-concrete/2.1.2-value-aux.watsup:225.1-225.59
   clause 7 : (value) = []
   -- if value <: headerValue
   -- let header _tid { bool ; _fieldValue*{_fieldValue <- _fieldValue*} } = value as headerValue
   -- if (bool = false)
 
-  ;; ../../../../spec-concrete/2.1.2-value-aux.watsup:225.1-228.51
+  ;; ../../../../spec-concrete/2.1.2-value-aux.watsup:226.1-228.51
   clause 8 : (value') = $concat_<bool>($write_bits_from_value(value)*{value <- value*})
   -- if value' <: headerUnionValue
   -- let header_union _tid { value id ;*{id <- id*, value <- value*} } = value' as headerUnionValue
+
+  ;; ../../../../spec-concrete/2.1.2-value-aux.watsup:230.1-231.34
+  clause 9 : (value') = $write_bits_from_value(value)
+  -- if value' <: enumValue
+  -- let enumValue = value' as enumValue
+  -- if enumValue matches `%.%.%`
+  -- let tid . id . value = enumValue
 
 ;; ../../../../spec-concrete/2.2.1-type.watsup:9.21-9.25
 syntax voidTypeIR = 
@@ -6425,27 +6440,27 @@ def $bin_op(binop, value, value) : value =
   clause 12 : (binop, value_l, value_r) = b $bin_gt(value_l, value_r) as value
   -- if binop matches `>`
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:422.1-422.65
+  ;; ../../../../spec-concrete/3-numerics.watsup:421.1-421.65
   clause 13 : (binop, value_l, value_r) = b $bin_eq(value_l, value_r) as value
   -- if binop matches `==`
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:431.1-431.65
+  ;; ../../../../spec-concrete/3-numerics.watsup:430.1-430.65
   clause 14 : (binop, value_l, value_r) = b $bin_ne(value_l, value_r) as value
   -- if binop matches `!=`
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:445.1-445.64
+  ;; ../../../../spec-concrete/3-numerics.watsup:444.1-444.64
   clause 15 : (binop, value_l, value_r) = $bin_band(value_l, value_r)
   -- if binop matches `&`
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:459.1-459.64
+  ;; ../../../../spec-concrete/3-numerics.watsup:458.1-458.64
   clause 16 : (binop, value_l, value_r) = $bin_bxor(value_l, value_r)
   -- if binop matches `^`
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:473.1-473.63
+  ;; ../../../../spec-concrete/3-numerics.watsup:472.1-472.63
   clause 17 : (binop, value_l, value_r) = $bin_bor(value_l, value_r)
   -- if binop matches `|`
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:504.1-504.67
+  ;; ../../../../spec-concrete/3-numerics.watsup:503.1-503.67
   clause 18 : (binop, value_l, value_r) = $bin_concat(value_l, value_r)
   -- if binop matches `++`
 
@@ -7300,8 +7315,8 @@ def $bin_eq(value, value) : bool =
   -- if enumValue' matches `%.%`
   -- let tid_b . id_field_b = enumValue'
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:398.1-403.45
-  clause 15 : (value, value') = (((tid_a = tid_b) /\ (id_field_a = id_field_b)) /\ $bin_eq(value_field_a, value_field_b))
+  ;; ../../../../spec-concrete/3-numerics.watsup:398.1-402.61
+  clause 15 : (value, value') = ((tid_a = tid_b) /\ $bin_eq(value_field_a, value_field_b))
   -- if value <: enumValue
   -- let enumValue = value as enumValue
   -- if enumValue matches `%.%.%`
@@ -7311,7 +7326,7 @@ def $bin_eq(value, value) : bool =
   -- if enumValue' matches `%.%.%`
   -- let tid_b . id_field_b . value_field_b = enumValue'
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:405.1-405.31
+  ;; ../../../../spec-concrete/3-numerics.watsup:404.1-404.31
   clause 16 : (value, value') = true
   -- if value <: invalidHeaderValue
   -- let invalidHeaderValue = value as invalidHeaderValue
@@ -7323,24 +7338,24 @@ def $bin_eq(value, value) : bool =
 ;; ../../../../spec-concrete/3-numerics.watsup:344.1-345.23
 def $bin_eqs(value*, value*) : bool =
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:407.1-407.30
+  ;; ../../../../spec-concrete/3-numerics.watsup:406.1-406.30
   clause 0 : (value*{value <- value*}, value'*{value' <- value'*}) = true
   -- if value*{value <- value*} matches []
   -- if value'*{value' <- value'*} matches []
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:408.1-408.34
+  ;; ../../../../spec-concrete/3-numerics.watsup:407.1-407.34
   clause 1 : (value*{value <- value*}, value'*{value' <- value'*}) = false
   -- if value*{value <- value*} matches []
   -- if value'*{value' <- value'*} matches _ :: _
   -- let _value :: _value'*{_value' <- _value'*} = value'*{value' <- value'*}
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:409.1-409.34
+  ;; ../../../../spec-concrete/3-numerics.watsup:408.1-408.34
   clause 2 : (value*{value <- value*}, value'*{value' <- value'*}) = false
   -- if value*{value <- value*} matches _ :: _
   -- let _value :: _value'*{_value' <- _value'*} = value*{value <- value*}
   -- if value'*{value' <- value'*} matches []
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:410.1-411.70
+  ;; ../../../../spec-concrete/3-numerics.watsup:409.1-410.70
   clause 3 : (value*{value <- value*}, value'*{value' <- value'*}) = ($bin_eq(value_a_h, value_b_h) /\ $bin_eqs(value_a_t*{value_a_t <- value_a_t*}, value_b_t*{value_b_t <- value_b_t*}))
   -- if value*{value <- value*} matches _ :: _
   -- let value_a_h :: value_a_t*{value_a_t <- value_a_t*} = value*{value <- value*}
@@ -7350,40 +7365,40 @@ def $bin_eqs(value*, value*) : bool =
 ;; ../../../../spec-concrete/3-numerics.watsup:346.1-347.23
 def $bin_eqs_fields((value, id)*, (value, id)*) : bool =
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:413.1-413.37
+  ;; ../../../../spec-concrete/3-numerics.watsup:412.1-412.37
   clause 0 : ((value, id)*{(value, id) <- (value, id)*}, (value, id)'*{(value, id)' <- (value, id)'*}) = true
   -- if (value, id)*{(value, id) <- (value, id)*} matches []
   -- if (value, id)'*{(value, id)' <- (value, id)'*} matches []
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:414.1-414.41
+  ;; ../../../../spec-concrete/3-numerics.watsup:413.1-413.41
   clause 1 : ((value, id)*{(value, id) <- (value, id)*}, (value, id)'*{(value, id)' <- (value, id)'*}) = false
   -- if (value, id)*{(value, id) <- (value, id)*} matches []
   -- if (value, id)'*{(value, id)' <- (value, id)'*} matches _ :: _
   -- let _(value, id) :: _(value, id)'*{_(value, id)' <- _(value, id)'*} = (value, id)'*{(value, id)' <- (value, id)'*}
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:415.1-415.41
+  ;; ../../../../spec-concrete/3-numerics.watsup:414.1-414.41
   clause 2 : ((value, id)*{(value, id) <- (value, id)*}, (value, id)'*{(value, id)' <- (value, id)'*}) = false
   -- if (value, id)*{(value, id) <- (value, id)*} matches _ :: _
   -- let _(value, id) :: _(value, id)'*{_(value, id)' <- _(value, id)'*} = (value, id)*{(value, id) <- (value, id)*}
   -- if (value, id)'*{(value, id)' <- (value, id)'*} matches []
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:416.1-420.67
+  ;; ../../../../spec-concrete/3-numerics.watsup:415.1-419.67
   clause 3 : ((value, id)*{(value, id) <- (value, id)*}, (value, id)'*{(value, id)' <- (value, id)'*}) = (((id_a_h = id_b_h) /\ $bin_eq(value_a_h, value_b_h)) /\ $bin_eqs_fields((value_a_t, id_a_t)*{id_a_t <- id_a_t*, value_a_t <- value_a_t*}, (value_b_t, id_b_t)*{id_b_t <- id_b_t*, value_b_t <- value_b_t*}))
   -- if (value, id)*{(value, id) <- (value, id)*} matches _ :: _
   -- let (value_a_h, id_a_h) :: (value_a_t, id_a_t)*{id_a_t <- id_a_t*, value_a_t <- value_a_t*} = (value, id)*{(value, id) <- (value, id)*}
   -- if (value, id)'*{(value, id)' <- (value, id)'*} matches _ :: _
   -- let (value_b_h, id_b_h) :: (value_b_t, id_b_t)*{id_b_t <- id_b_t*, value_b_t <- value_b_t*} = (value, id)'*{(value, id)' <- (value, id)'*}
 
-;; ../../../../spec-concrete/3-numerics.watsup:426.1-427.23
+;; ../../../../spec-concrete/3-numerics.watsup:425.1-426.23
 def $bin_ne(value, value) : bool =
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:429.1-429.59
+  ;; ../../../../spec-concrete/3-numerics.watsup:428.1-428.59
   clause 0 : (value_l, value_r) = ~$bin_eq(value_l, value_r)
 
-;; ../../../../spec-concrete/3-numerics.watsup:435.1-436.23
+;; ../../../../spec-concrete/3-numerics.watsup:434.1-435.23
 def $bin_band(value, value) : value =
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:438.1-439.48
+  ;; ../../../../spec-concrete/3-numerics.watsup:437.1-438.48
   clause 0 : (value, value') = w w i' as value
   -- if value <: integerLiteral
   -- let integerLiteral = value as integerLiteral
@@ -7396,7 +7411,7 @@ def $bin_band(value, value) : value =
   -- if (w = w')
   -- let i' = $int_to_bitstr(w as int, $band(i_l, i_r))
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:440.1-443.50
+  ;; ../../../../spec-concrete/3-numerics.watsup:439.1-442.50
   clause 1 : (value, value') = w s i' as value
   -- if value <: integerLiteral
   -- let integerLiteral = value as integerLiteral
@@ -7411,10 +7426,10 @@ def $bin_band(value, value) : value =
   -- let i_r' = $bitstr_to_int(w as int, i_r)
   -- let i' = $int_to_bitstr(w as int, $band(i_l', i_r'))
 
-;; ../../../../spec-concrete/3-numerics.watsup:449.1-450.23
+;; ../../../../spec-concrete/3-numerics.watsup:448.1-449.23
 def $bin_bxor(value, value) : value =
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:452.1-453.48
+  ;; ../../../../spec-concrete/3-numerics.watsup:451.1-452.48
   clause 0 : (value, value') = w w i' as value
   -- if value <: integerLiteral
   -- let integerLiteral = value as integerLiteral
@@ -7427,7 +7442,7 @@ def $bin_bxor(value, value) : value =
   -- if (w = w')
   -- let i' = $int_to_bitstr(w as int, $bxor(i_l, i_r))
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:454.1-457.50
+  ;; ../../../../spec-concrete/3-numerics.watsup:453.1-456.50
   clause 1 : (value, value') = w s i' as value
   -- if value <: integerLiteral
   -- let integerLiteral = value as integerLiteral
@@ -7442,10 +7457,10 @@ def $bin_bxor(value, value) : value =
   -- let i_r' = $bitstr_to_int(w as int, i_r)
   -- let i' = $int_to_bitstr(w as int, $bxor(i_l', i_r'))
 
-;; ../../../../spec-concrete/3-numerics.watsup:463.1-464.23
+;; ../../../../spec-concrete/3-numerics.watsup:462.1-463.23
 def $bin_bor(value, value) : value =
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:466.1-467.47
+  ;; ../../../../spec-concrete/3-numerics.watsup:465.1-466.47
   clause 0 : (value, value') = w w i' as value
   -- if value <: integerLiteral
   -- let integerLiteral = value as integerLiteral
@@ -7458,7 +7473,7 @@ def $bin_bor(value, value) : value =
   -- if (w = w')
   -- let i' = $int_to_bitstr(w as int, $bor(i_l, i_r))
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:468.1-471.49
+  ;; ../../../../spec-concrete/3-numerics.watsup:467.1-470.49
   clause 1 : (value, value') = w s i' as value
   -- if value <: integerLiteral
   -- let integerLiteral = value as integerLiteral
@@ -7473,17 +7488,17 @@ def $bin_bor(value, value) : value =
   -- let i_r' = $bitstr_to_int(w as int, i_r)
   -- let i' = $int_to_bitstr(w as int, $bor(i_l', i_r'))
 
-;; ../../../../spec-concrete/3-numerics.watsup:477.1-478.23
+;; ../../../../spec-concrete/3-numerics.watsup:476.1-477.23
 def $bin_concat(value, value) : value =
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:480.1-480.59
+  ;; ../../../../spec-concrete/3-numerics.watsup:479.1-479.59
   clause 0 : (value, value') = " t_l ++ t_r " as value
   -- if value <: stringLiteral
   -- let " t_l " = value as stringLiteral
   -- if value' <: stringLiteral
   -- let " t_r " = value' as stringLiteral
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:481.1-485.39
+  ;; ../../../../spec-concrete/3-numerics.watsup:480.1-484.39
   clause 1 : (value, value') = w w i'' as value
   -- if value <: integerLiteral
   -- let integerLiteral = value as integerLiteral
@@ -7498,7 +7513,7 @@ def $bin_concat(value, value) : value =
   -- let w = (w_l + w_r)
   -- let i'' = $int_to_bitstr(w as int, i_l'')
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:486.1-490.39
+  ;; ../../../../spec-concrete/3-numerics.watsup:485.1-489.39
   clause 2 : (value, value') = w w i'' as value
   -- if value <: integerLiteral
   -- let integerLiteral = value as integerLiteral
@@ -7513,7 +7528,7 @@ def $bin_concat(value, value) : value =
   -- let w = (w_l + w_r)
   -- let i'' = $int_to_bitstr(w as int, i_l'')
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:491.1-496.41
+  ;; ../../../../spec-concrete/3-numerics.watsup:490.1-495.41
   clause 3 : (value, value') = w s i''' as value
   -- if value <: integerLiteral
   -- let integerLiteral = value as integerLiteral
@@ -7529,7 +7544,7 @@ def $bin_concat(value, value) : value =
   -- let w = (w_l + w_r)
   -- let i''' = $int_to_bitstr(w as int, i_l''')
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:497.1-502.41
+  ;; ../../../../spec-concrete/3-numerics.watsup:496.1-501.41
   clause 4 : (value, value') = w s i''' as value
   -- if value <: integerLiteral
   -- let integerLiteral = value as integerLiteral
@@ -7545,208 +7560,208 @@ def $bin_concat(value, value) : value =
   -- let w = (w_l + w_r)
   -- let i''' = $int_to_bitstr(w as int, i_l''')
 
-;; ../../../../spec-concrete/3-numerics.watsup:508.1-509.23
+;; ../../../../spec-concrete/3-numerics.watsup:507.1-508.23
 def $bin_land(value, value) : value =
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:511.1-511.45
+  ;; ../../../../spec-concrete/3-numerics.watsup:510.1-510.45
   clause 0 : (value, value') = b (b_l /\ b_r) as value
   -- if value <: boolValue
   -- let b b_l = value as boolValue
   -- if value' <: boolValue
   -- let b b_r = value' as boolValue
 
-;; ../../../../spec-concrete/3-numerics.watsup:515.1-516.23
+;; ../../../../spec-concrete/3-numerics.watsup:514.1-515.23
 def $bin_lor(value, value) : value =
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:518.1-518.44
+  ;; ../../../../spec-concrete/3-numerics.watsup:517.1-517.44
   clause 0 : (value, value') = b (b_l \/ b_r) as value
   -- if value <: boolValue
   -- let b b_l = value as boolValue
   -- if value' <: boolValue
   -- let b b_r = value' as boolValue
 
-;; ../../../../spec-concrete/3-numerics.watsup:524.1-526.40
+;; ../../../../spec-concrete/3-numerics.watsup:523.1-525.40
 def $cast_op(typeIR, value) : value =
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:547.1-547.50
+  ;; ../../../../spec-concrete/3-numerics.watsup:546.1-546.50
   clause 0 : (typeIR, value) = $cast_bool(typeIR, b)
   -- if value <: boolValue
   -- let b b = value as boolValue
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:565.1-565.52
+  ;; ../../../../spec-concrete/3-numerics.watsup:564.1-564.52
   clause 1 : (typeIR, value) = $cast_arbint(typeIR, i)
   -- if value <: integerLiteral
   -- let integerLiteral = value as integerLiteral
   -- if integerLiteral matches `D%`
   -- let d i = integerLiteral
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:585.1-585.57
+  ;; ../../../../spec-concrete/3-numerics.watsup:584.1-584.57
   clause 2 : (typeIR, value) = $cast_fixbit(typeIR, w, i)
   -- if value <: integerLiteral
   -- let integerLiteral = value as integerLiteral
   -- if integerLiteral matches `%W%`
   -- let w w i = integerLiteral
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:604.1-604.57
+  ;; ../../../../spec-concrete/3-numerics.watsup:603.1-603.57
   clause 3 : (typeIR, value) = $cast_fixint(typeIR, w, i)
   -- if value <: integerLiteral
   -- let integerLiteral = value as integerLiteral
   -- if integerLiteral matches `%S%`
   -- let w s i = integerLiteral
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:617.1-617.73
+  ;; ../../../../spec-concrete/3-numerics.watsup:616.1-616.73
   clause 4 : (typeIR, value) = $cast_varbit(typeIR, w_max, w, i)
   -- if value <: integerValue
   -- let integerValue = value as integerValue
   -- if integerValue matches `%.%V%`
   -- let w_max . w v i = integerValue
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:632.1-633.56
+  ;; ../../../../spec-concrete/3-numerics.watsup:631.1-632.56
   clause 5 : (typeIR, value) = $cast_struct(typeIR, tid, (value_field, id_field)*{id_field <- id_field*, value_field <- value_field*})
   -- if value <: structValue
   -- let struct tid { value_field id_field ;*{id_field <- id_field*, value_field <- value_field*} } = value as structValue
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:648.1-649.59
+  ;; ../../../../spec-concrete/3-numerics.watsup:647.1-648.59
   clause 6 : (typeIR, value) = $cast_header(typeIR, tid, b, (value_field, id_field)*{id_field <- id_field*, value_field <- value_field*})
   -- if value <: headerValue
   -- let header tid { b ; value_field id_field ;*{id_field <- id_field*, value_field <- value_field*} } = value as headerValue
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:653.1-653.64
+  ;; ../../../../spec-concrete/3-numerics.watsup:652.1-652.64
   clause 7 : (typeIR, value') = $cast_op(typeIR, value)
   -- if value' <: enumValue
   -- let enumValue = value' as enumValue
   -- if enumValue matches `%.%.%`
   -- let _tid . _id . value = enumValue
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:684.1-684.71
+  ;; ../../../../spec-concrete/3-numerics.watsup:683.1-683.71
   clause 8 : (typeIR, value') = $cast_sequence(typeIR, value*{value <- value*})
   -- if value' <: sequenceValue
   -- let sequenceValue = value' as sequenceValue
   -- if sequenceValue matches `SEQ(%)`
   -- let seq( value*{value <- value*} ) = sequenceValue
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:716.1-717.39
+  ;; ../../../../spec-concrete/3-numerics.watsup:715.1-716.39
   clause 9 : (typeIR, value') = $cast_record(typeIR, (value, id)*{id <- id*, value <- value*})
   -- if value' <: recordValue
   -- let recordValue = value' as recordValue
   -- if recordValue matches `RECORD{%}`
   -- let record{ value id ;*{id <- id*, value <- value*} } = recordValue
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:723.1-723.49
+  ;; ../../../../spec-concrete/3-numerics.watsup:722.1-722.49
   clause 10 : (typeIR, value) = $default(typeIR)
   -- if value <: defaultValue
   -- let defaultValue = value as defaultValue
   -- if (defaultValue = default)
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:738.1-738.51
+  ;; ../../../../spec-concrete/3-numerics.watsup:737.1-737.51
   clause 11 : (typeIR, value) = $cast_invalid(typeIR)
   -- if value <: invalidHeaderValue
   -- let invalidHeaderValue = value as invalidHeaderValue
   -- if (invalidHeaderValue = {#})
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:779.1-780.39
+  ;; ../../../../spec-concrete/3-numerics.watsup:778.1-779.39
   clause 12 : (typeIR, value') = $cast_set_singleton(typeIR, value)
   -- if value' <: setValue
   -- let setValue = value' as setValue
   -- if setValue matches `SET{%}`
   -- let set{ value } = setValue
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:781.1-782.45
+  ;; ../../../../spec-concrete/3-numerics.watsup:780.1-781.45
   clause 13 : (typeIR, value) = $cast_set_mask(typeIR, value_b, value_m)
   -- if value <: setValue
   -- let setValue = value as setValue
   -- if setValue matches `SET{%&&&%}`
   -- let set{ value_b &&& value_m } = setValue
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:783.1-784.46
+  ;; ../../../../spec-concrete/3-numerics.watsup:782.1-783.46
   clause 14 : (typeIR, value) = $cast_set_range(typeIR, value_l, value_u)
   -- if value <: setValue
   -- let setValue = value as setValue
   -- if setValue matches `SET{%..%}`
   -- let set{ value_l .. value_u } = setValue
 
-;; ../../../../spec-concrete/3-numerics.watsup:528.1-529.49
+;; ../../../../spec-concrete/3-numerics.watsup:527.1-528.49
 def $default(typeIR) : value =
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:791.1-791.56
+  ;; ../../../../spec-concrete/3-numerics.watsup:790.1-790.56
   clause 0 : (typeIR) = $default'($canon_typeIR(typeIR))
 
-;; ../../../../spec-concrete/3-numerics.watsup:530.1-531.49
+;; ../../../../spec-concrete/3-numerics.watsup:529.1-530.49
 def $default'(typeIR) : value =
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:793.1-793.30
+  ;; ../../../../spec-concrete/3-numerics.watsup:792.1-792.30
   clause 0 : (typeIR) = b false as value
   -- if typeIR <: boolTypeIR
   -- let boolTypeIR = typeIR as boolTypeIR
   -- if (boolTypeIR = bool)
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:794.1-794.42
+  ;; ../../../../spec-concrete/3-numerics.watsup:793.1-793.42
   clause 1 : (typeIR) = error. "NoError" as value
   -- if typeIR <: errorTypeIR
   -- let errorTypeIR = typeIR as errorTypeIR
   -- if (errorTypeIR = error)
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:795.1-796.24
+  ;; ../../../../spec-concrete/3-numerics.watsup:794.1-795.24
   clause 2 : (typeIR) = " text_empty " as value
   -- if typeIR <: stringTypeIR
   -- let stringTypeIR = typeIR as stringTypeIR
   -- if (stringTypeIR = string)
   -- let text_empty = ""
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:798.1-798.25
+  ;; ../../../../spec-concrete/3-numerics.watsup:797.1-797.25
   clause 3 : (typeIR) = d 0 as int as value
   -- if typeIR <: integerTypeIR
   -- let integerTypeIR = typeIR as integerTypeIR
   -- if integerTypeIR matches `INT`
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:799.1-799.34
+  ;; ../../../../spec-concrete/3-numerics.watsup:798.1-798.34
   clause 4 : (typeIR) = w w 0 as int as value
   -- if typeIR <: integerTypeIR
   -- let integerTypeIR = typeIR as integerTypeIR
   -- if integerTypeIR matches `BIT<%>`
   -- let bit< w > = integerTypeIR
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:800.1-800.34
+  ;; ../../../../spec-concrete/3-numerics.watsup:799.1-799.34
   clause 5 : (typeIR) = w s 0 as int as value
   -- if typeIR <: integerTypeIR
   -- let integerTypeIR = typeIR as integerTypeIR
   -- if integerTypeIR matches `INT<%>`
   -- let int< w > = integerTypeIR
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:801.1-801.42
+  ;; ../../../../spec-concrete/3-numerics.watsup:800.1-800.42
   clause 6 : (typeIR) = w . 0 v 0 as int as value
   -- if typeIR <: integerTypeIR
   -- let integerTypeIR = typeIR as integerTypeIR
   -- if integerTypeIR matches `VARBIT<%>`
   -- let varbit< w > = integerTypeIR
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:803.1-803.65
+  ;; ../../../../spec-concrete/3-numerics.watsup:802.1-802.65
   clause 7 : (typeIR') = tuple( $default(typeIR)*{typeIR <- typeIR*} ) as value
   -- if typeIR' <: tupleTypeIR
   -- let tuple< typeIR*{typeIR <- typeIR*} > = typeIR' as tupleTypeIR
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:805.1-806.56
+  ;; ../../../../spec-concrete/3-numerics.watsup:804.1-805.56
   clause 8 : (typeIR') = header_stack[ value*{value <- value*} ( 0 ; n_s )] as value
   -- if typeIR' <: headerStackTypeIR
   -- let typeIR [ n_s ] = typeIR' as headerStackTypeIR
   -- let value*{value <- value*} = $repeat_<value>($default(typeIR), n_s)
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:808.1-809.50
+  ;; ../../../../spec-concrete/3-numerics.watsup:807.1-808.50
   clause 9 : (typeIR) = struct tid { $default(typeIR_f) id_f ;*{id_f <- id_f*, typeIR_f <- typeIR_f*} } as value
   -- if typeIR <: structTypeIR
   -- let struct tid { typeIR_f id_f ;*{id_f <- id_f*, typeIR_f <- typeIR_f*} } = typeIR as structTypeIR
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:811.1-812.59
+  ;; ../../../../spec-concrete/3-numerics.watsup:810.1-811.59
   clause 10 : (typeIR) = header tid { false ; $default(typeIR_f) id_f ;*{id_f <- id_f*, typeIR_f <- typeIR_f*} } as value
   -- if typeIR <: headerTypeIR
   -- let header tid { typeIR_f id_f ;*{id_f <- id_f*, typeIR_f <- typeIR_f*} } = typeIR as headerTypeIR
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:814.1-815.56
+  ;; ../../../../spec-concrete/3-numerics.watsup:813.1-814.56
   clause 11 : (typeIR) = header_union tid { $default(typeIR_f) id_f ;*{id_f <- id_f*, typeIR_f <- typeIR_f*} } as value
   -- if typeIR <: headerUnionTypeIR
   -- let header_union tid { typeIR_f id_f ;*{id_f <- id_f*, typeIR_f <- typeIR_f*} } = typeIR as headerUnionTypeIR
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:817.1-817.57
+  ;; ../../../../spec-concrete/3-numerics.watsup:816.1-816.57
   clause 12 : (typeIR) = tid . id_f_h as value
   -- if typeIR <: enumTypeIR
   -- let enumTypeIR = typeIR as enumTypeIR
@@ -7755,7 +7770,7 @@ def $default'(typeIR) : value =
   -- if id*{id <- id*} matches _ :: _
   -- let id_f_h :: _id*{_id <- _id*} = id*{id <- id*}
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:819.1-822.75
+  ;; ../../../../spec-concrete/3-numerics.watsup:818.1-821.75
   clause 13 : (typeIR') = tid . id_zero . value_zero as value
   -- if typeIR' <: enumTypeIR
   -- let enumTypeIR = typeIR' as enumTypeIR
@@ -7766,7 +7781,7 @@ def $default'(typeIR) : value =
   -- if id?{id <- id?} matches (_)
   -- let ?(id_zero) = id?{id <- id?}
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:824.1-828.34
+  ;; ../../../../spec-concrete/3-numerics.watsup:823.1-827.34
   clause 14 : (typeIR') = tid . id_zero . value_zero as value
   -- if typeIR' <: enumTypeIR
   -- let enumTypeIR = typeIR' as enumTypeIR
@@ -7776,22 +7791,22 @@ def $default'(typeIR) : value =
   -- if (?() = $assoc_<value, id>(value_zero, (value_field, id_field)*{id_field <- id_field*, value_field <- value_field*}))
   -- let id_zero = "__UNSPECIFIED"
 
-;; ../../../../spec-concrete/3-numerics.watsup:535.1-536.23
+;; ../../../../spec-concrete/3-numerics.watsup:534.1-535.23
 def $cast_bool(typeIR, bool) : value =
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:540.1-540.66
+  ;; ../../../../spec-concrete/3-numerics.watsup:539.1-539.66
   clause 0 : (typeIR, b) = $cast_bool'($canon_typeIR(typeIR), b)
 
-;; ../../../../spec-concrete/3-numerics.watsup:537.1-538.23
+;; ../../../../spec-concrete/3-numerics.watsup:536.1-537.23
 def $cast_bool'(typeIR, bool) : value =
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:542.1-542.31
+  ;; ../../../../spec-concrete/3-numerics.watsup:541.1-541.31
   clause 0 : (typeIR, b) = b b as value
   -- if typeIR <: boolTypeIR
   -- let boolTypeIR = typeIR as boolTypeIR
   -- if (boolTypeIR = bool)
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:543.1-543.42
+  ;; ../../../../spec-concrete/3-numerics.watsup:542.1-542.42
   clause 1 : (typeIR, bool) = w w 1 as int as value
   -- if typeIR <: integerTypeIR
   -- let integerTypeIR = typeIR as integerTypeIR
@@ -7799,7 +7814,7 @@ def $cast_bool'(typeIR, bool) : value =
   -- let bit< w > = integerTypeIR
   -- if (bool = true)
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:544.1-544.43
+  ;; ../../../../spec-concrete/3-numerics.watsup:543.1-543.43
   clause 2 : (typeIR, bool) = w w 0 as int as value
   -- if typeIR <: integerTypeIR
   -- let integerTypeIR = typeIR as integerTypeIR
@@ -7807,80 +7822,80 @@ def $cast_bool'(typeIR, bool) : value =
   -- let bit< w > = integerTypeIR
   -- if (bool = false)
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:545.1-545.58
+  ;; ../../../../spec-concrete/3-numerics.watsup:544.1-544.58
   clause 3 : (typeIR', b) = $cast_bool(typeIR, b)
   -- if typeIR' <: newTypeIR
   -- let type _tid typeIR = typeIR' as newTypeIR
 
-;; ../../../../spec-concrete/3-numerics.watsup:551.1-552.23
+;; ../../../../spec-concrete/3-numerics.watsup:550.1-551.23
 def $cast_arbint(typeIR, int) : value =
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:556.1-556.70
+  ;; ../../../../spec-concrete/3-numerics.watsup:555.1-555.70
   clause 0 : (typeIR, i) = $cast_arbint'($canon_typeIR(typeIR), i)
 
-;; ../../../../spec-concrete/3-numerics.watsup:553.1-554.23
+;; ../../../../spec-concrete/3-numerics.watsup:552.1-553.23
 def $cast_arbint'(typeIR, int) : value =
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:558.1-558.41
+  ;; ../../../../spec-concrete/3-numerics.watsup:557.1-557.41
   clause 0 : (typeIR, i) = b (i =/= 0 as int) as value
   -- if typeIR <: boolTypeIR
   -- let boolTypeIR = typeIR as boolTypeIR
   -- if (boolTypeIR = bool)
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:559.1-559.32
+  ;; ../../../../spec-concrete/3-numerics.watsup:558.1-558.32
   clause 1 : (typeIR, i) = d i as value
   -- if typeIR <: integerTypeIR
   -- let integerTypeIR = typeIR as integerTypeIR
   -- if integerTypeIR matches `INT`
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:560.1-560.62
+  ;; ../../../../spec-concrete/3-numerics.watsup:559.1-559.62
   clause 2 : (typeIR, i) = w w $int_to_bitstr(w as int, i) as value
   -- if typeIR <: integerTypeIR
   -- let integerTypeIR = typeIR as integerTypeIR
   -- if integerTypeIR matches `BIT<%>`
   -- let bit< w > = integerTypeIR
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:561.1-561.62
+  ;; ../../../../spec-concrete/3-numerics.watsup:560.1-560.62
   clause 3 : (typeIR, i) = w s $int_to_bitstr(w as int, i) as value
   -- if typeIR <: integerTypeIR
   -- let integerTypeIR = typeIR as integerTypeIR
   -- if integerTypeIR matches `INT<%>`
   -- let int< w > = integerTypeIR
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:562.1-562.62
+  ;; ../../../../spec-concrete/3-numerics.watsup:561.1-561.62
   clause 4 : (typeIR', i) = $cast_arbint(typeIR, i)
   -- if typeIR' <: newTypeIR
   -- let type _tid typeIR = typeIR' as newTypeIR
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:563.1-563.73
+  ;; ../../../../spec-concrete/3-numerics.watsup:562.1-562.73
   clause 5 : (typeIR'', i) = set{ $cast_arbint(typeIR, i) } as value
   -- if typeIR'' <: setTypeIR
   -- let set< typeIR'*{typeIR' <- typeIR'*} > = typeIR'' as setTypeIR
   -- if typeIR'*{typeIR' <- typeIR'*} matches [ _/1 ]
   -- let [typeIR] = typeIR'*{typeIR' <- typeIR'*}
 
-;; ../../../../spec-concrete/3-numerics.watsup:569.1-570.23
+;; ../../../../spec-concrete/3-numerics.watsup:568.1-569.23
 def $cast_fixbit(typeIR, nat, int) : value =
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:574.1-574.76
+  ;; ../../../../spec-concrete/3-numerics.watsup:573.1-573.76
   clause 0 : (typeIR, w, i) = $cast_fixbit'($canon_typeIR(typeIR), w, i)
 
-;; ../../../../spec-concrete/3-numerics.watsup:571.1-572.23
+;; ../../../../spec-concrete/3-numerics.watsup:570.1-571.23
 def $cast_fixbit'(typeIR, nat, int) : value =
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:576.1-576.44
+  ;; ../../../../spec-concrete/3-numerics.watsup:575.1-575.44
   clause 0 : (typeIR, w, i) = b (i =/= 0 as int) as value
   -- if typeIR <: boolTypeIR
   -- let boolTypeIR = typeIR as boolTypeIR
   -- if (boolTypeIR = bool)
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:577.1-577.35
+  ;; ../../../../spec-concrete/3-numerics.watsup:576.1-576.35
   clause 1 : (typeIR, _nat, i) = d i as value
   -- if typeIR <: integerTypeIR
   -- let integerTypeIR = typeIR as integerTypeIR
   -- if integerTypeIR matches `INT`
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:578.1-579.37
+  ;; ../../../../spec-concrete/3-numerics.watsup:577.1-578.37
   clause 2 : (typeIR, _nat, i) = w_to w i' as value
   -- if typeIR <: integerTypeIR
   -- let integerTypeIR = typeIR as integerTypeIR
@@ -7888,7 +7903,7 @@ def $cast_fixbit'(typeIR, nat, int) : value =
   -- let bit< w_to > = integerTypeIR
   -- let i' = $int_to_bitstr(w_to as int, i)
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:580.1-581.37
+  ;; ../../../../spec-concrete/3-numerics.watsup:579.1-580.37
   clause 3 : (typeIR, _nat, i) = w_to s i' as value
   -- if typeIR <: integerTypeIR
   -- let integerTypeIR = typeIR as integerTypeIR
@@ -7896,34 +7911,34 @@ def $cast_fixbit'(typeIR, nat, int) : value =
   -- let int< w_to > = integerTypeIR
   -- let i' = $int_to_bitstr(w_to as int, i)
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:582.1-582.68
+  ;; ../../../../spec-concrete/3-numerics.watsup:581.1-581.68
   clause 4 : (typeIR', w, i) = $cast_fixbit(typeIR, w, i)
   -- if typeIR' <: newTypeIR
   -- let type _tid typeIR = typeIR' as newTypeIR
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:583.1-583.79
+  ;; ../../../../spec-concrete/3-numerics.watsup:582.1-582.79
   clause 5 : (typeIR'', w, i) = set{ $cast_fixbit(typeIR, w, i) } as value
   -- if typeIR'' <: setTypeIR
   -- let set< typeIR'*{typeIR' <- typeIR'*} > = typeIR'' as setTypeIR
   -- if typeIR'*{typeIR' <- typeIR'*} matches [ _/1 ]
   -- let [typeIR] = typeIR'*{typeIR' <- typeIR'*}
 
-;; ../../../../spec-concrete/3-numerics.watsup:589.1-590.23
+;; ../../../../spec-concrete/3-numerics.watsup:588.1-589.23
 def $cast_fixint(typeIR, nat, int) : value =
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:594.1-594.76
+  ;; ../../../../spec-concrete/3-numerics.watsup:593.1-593.76
   clause 0 : (typeIR, w, i) = $cast_fixint'($canon_typeIR(typeIR), w, i)
 
-;; ../../../../spec-concrete/3-numerics.watsup:591.1-592.23
+;; ../../../../spec-concrete/3-numerics.watsup:590.1-591.23
 def $cast_fixint'(typeIR, nat, int) : value =
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:596.1-596.54
+  ;; ../../../../spec-concrete/3-numerics.watsup:595.1-595.54
   clause 0 : (typeIR, w, i) = d $bitstr_to_int(w as int, i) as value
   -- if typeIR <: integerTypeIR
   -- let integerTypeIR = typeIR as integerTypeIR
   -- if integerTypeIR matches `INT`
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:597.1-598.61
+  ;; ../../../../spec-concrete/3-numerics.watsup:596.1-597.61
   clause 1 : (typeIR, w_from, i) = w_to w i' as value
   -- if typeIR <: integerTypeIR
   -- let integerTypeIR = typeIR as integerTypeIR
@@ -7931,7 +7946,7 @@ def $cast_fixint'(typeIR, nat, int) : value =
   -- let bit< w_to > = integerTypeIR
   -- let i' = $int_to_bitstr(w_to as int, $bitstr_to_int(w_from as int, i))
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:599.1-600.61
+  ;; ../../../../spec-concrete/3-numerics.watsup:598.1-599.61
   clause 2 : (typeIR, w_from, i) = w_to s i' as value
   -- if typeIR <: integerTypeIR
   -- let integerTypeIR = typeIR as integerTypeIR
@@ -7939,28 +7954,28 @@ def $cast_fixint'(typeIR, nat, int) : value =
   -- let int< w_to > = integerTypeIR
   -- let i' = $int_to_bitstr(w_to as int, $bitstr_to_int(w_from as int, i))
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:601.1-601.68
+  ;; ../../../../spec-concrete/3-numerics.watsup:600.1-600.68
   clause 3 : (typeIR', w, i) = $cast_fixint(typeIR, w, i)
   -- if typeIR' <: newTypeIR
   -- let type _tid typeIR = typeIR' as newTypeIR
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:602.1-602.79
+  ;; ../../../../spec-concrete/3-numerics.watsup:601.1-601.79
   clause 4 : (typeIR'', w, i) = set{ $cast_fixint(typeIR, w, i) } as value
   -- if typeIR'' <: setTypeIR
   -- let set< typeIR'*{typeIR' <- typeIR'*} > = typeIR'' as setTypeIR
   -- if typeIR'*{typeIR' <- typeIR'*} matches [ _/1 ]
   -- let [typeIR] = typeIR'*{typeIR' <- typeIR'*}
 
-;; ../../../../spec-concrete/3-numerics.watsup:608.1-609.23
+;; ../../../../spec-concrete/3-numerics.watsup:607.1-608.23
 def $cast_varbit(typeIR, nat, nat, int) : value =
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:613.1-614.54
+  ;; ../../../../spec-concrete/3-numerics.watsup:612.1-613.54
   clause 0 : (typeIR, w_max, w, i) = $cast_varbit'($canon_typeIR(typeIR), w_max, w, i)
 
-;; ../../../../spec-concrete/3-numerics.watsup:610.1-611.23
+;; ../../../../spec-concrete/3-numerics.watsup:609.1-610.23
 def $cast_varbit'(typeIR, nat, nat, int) : value =
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:615.1-615.67
+  ;; ../../../../spec-concrete/3-numerics.watsup:614.1-614.67
   clause 0 : (typeIR, w_max', w, i) = w_max . w v i as value
   -- if typeIR <: integerTypeIR
   -- let integerTypeIR = typeIR as integerTypeIR
@@ -7968,84 +7983,84 @@ def $cast_varbit'(typeIR, nat, nat, int) : value =
   -- let varbit< w_max > = integerTypeIR
   -- if (w_max = w_max')
 
-;; ../../../../spec-concrete/3-numerics.watsup:621.1-622.23
+;; ../../../../spec-concrete/3-numerics.watsup:620.1-621.23
 def $cast_struct(typeIR, tid, (value, id)*) : value =
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:626.1-627.72
+  ;; ../../../../spec-concrete/3-numerics.watsup:625.1-626.72
   clause 0 : (typeIR, tid, (value_field, id_field)*{id_field <- id_field*, value_field <- value_field*}) = $cast_struct'($canon_typeIR(typeIR), tid, (value_field, id_field)*{id_field <- id_field*, value_field <- value_field*})
 
-;; ../../../../spec-concrete/3-numerics.watsup:623.1-624.23
+;; ../../../../spec-concrete/3-numerics.watsup:622.1-623.23
 def $cast_struct'(typeIR, tid, (value, id)*) : value =
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:629.1-630.47
+  ;; ../../../../spec-concrete/3-numerics.watsup:628.1-629.47
   clause 0 : (typeIR, tid', (value_field, id_field)*{id_field <- id_field*, value_field <- value_field*}) = struct tid { value_field id_field ;*{id_field <- id_field*, value_field <- value_field*} } as value
   -- if typeIR <: structTypeIR
   -- let struct tid { _fieldTypeIR*{_fieldTypeIR <- _fieldTypeIR*} } = typeIR as structTypeIR
   -- if (tid = tid')
 
-;; ../../../../spec-concrete/3-numerics.watsup:637.1-638.23
+;; ../../../../spec-concrete/3-numerics.watsup:636.1-637.23
 def $cast_header(typeIR, tid, bool, (value, id)*) : value =
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:642.1-643.75
+  ;; ../../../../spec-concrete/3-numerics.watsup:641.1-642.75
   clause 0 : (typeIR, tid, b, (value_field, id_field)*{id_field <- id_field*, value_field <- value_field*}) = $cast_header'($canon_typeIR(typeIR), tid, b, (value_field, id_field)*{id_field <- id_field*, value_field <- value_field*})
 
-;; ../../../../spec-concrete/3-numerics.watsup:639.1-640.23
+;; ../../../../spec-concrete/3-numerics.watsup:638.1-639.23
 def $cast_header'(typeIR, tid, bool, (value, id)*) : value =
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:645.1-646.52
+  ;; ../../../../spec-concrete/3-numerics.watsup:644.1-645.52
   clause 0 : (typeIR, tid', b, (value_field, id_field)*{id_field <- id_field*, value_field <- value_field*}) = header tid { b ; value_field id_field ;*{id_field <- id_field*, value_field <- value_field*} } as value
   -- if typeIR <: headerTypeIR
   -- let header tid { _fieldTypeIR*{_fieldTypeIR <- _fieldTypeIR*} } = typeIR as headerTypeIR
   -- if (tid = tid')
 
-;; ../../../../spec-concrete/3-numerics.watsup:657.1-658.23
+;; ../../../../spec-concrete/3-numerics.watsup:656.1-657.23
 def $cast_sequence(typeIR, value*) : value =
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:662.1-663.51
+  ;; ../../../../spec-concrete/3-numerics.watsup:661.1-662.51
   clause 0 : (typeIR, value*{value <- value*}) = $cast_sequence'($canon_typeIR(typeIR), value*{value <- value*})
 
-;; ../../../../spec-concrete/3-numerics.watsup:659.1-660.23
+;; ../../../../spec-concrete/3-numerics.watsup:658.1-659.23
 def $cast_sequence'(typeIR, value*) : value =
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:665.1-666.39
+  ;; ../../../../spec-concrete/3-numerics.watsup:664.1-665.39
   clause 0 : (typeIR', value*{value <- value*}) = list[ $cast_op(typeIR, value)*{value <- value*} ] as value
   -- if typeIR' <: listTypeIR
   -- let list< typeIR > = typeIR' as listTypeIR
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:668.1-669.40
+  ;; ../../../../spec-concrete/3-numerics.watsup:667.1-668.40
   clause 1 : (typeIR', value*{value <- value*}) = tuple( $cast_op(typeIR, value)*{typeIR <- typeIR*, value <- value*} ) as value
   -- if typeIR' <: tupleTypeIR
   -- let tuple< typeIR*{typeIR <- typeIR*} > = typeIR' as tupleTypeIR
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:671.1-674.25
+  ;; ../../../../spec-concrete/3-numerics.watsup:670.1-673.25
   clause 2 : (typeIR', value*{value <- value*}) = header_stack[ value_cast*{value_cast <- value_cast*} ( n_idx ; n_size )] as value
   -- if typeIR' <: headerStackTypeIR
   -- let typeIR [ n_size ] = typeIR' as headerStackTypeIR
   -- (let value_cast = $cast_op(typeIR, value))*{value <- value*, value_cast <- value_cast*}
   -- let n_idx = |value*{value <- value*}|
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:676.1-678.54
+  ;; ../../../../spec-concrete/3-numerics.watsup:675.1-677.54
   clause 3 : (typeIR, value*{value <- value*}) = struct tid { value_cast id_field ;*{id_field <- id_field*, value_cast <- value_cast*} } as value
   -- if typeIR <: structTypeIR
   -- let struct tid { typeIR_field id_field ;*{id_field <- id_field*, typeIR_field <- typeIR_field*} } = typeIR as structTypeIR
   -- (let value_cast = $cast_op(typeIR_field, value))*{typeIR_field <- typeIR_field*, value <- value*, value_cast <- value_cast*}
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:680.1-682.54
+  ;; ../../../../spec-concrete/3-numerics.watsup:679.1-681.54
   clause 4 : (typeIR, value*{value <- value*}) = header tid { true ; value_cast id_field ;*{id_field <- id_field*, value_cast <- value_cast*} } as value
   -- if typeIR <: headerTypeIR
   -- let header tid { typeIR_field id_field ;*{id_field <- id_field*, typeIR_field <- typeIR_field*} } = typeIR as headerTypeIR
   -- (let value_cast = $cast_op(typeIR_field, value))*{typeIR_field <- typeIR_field*, value <- value*, value_cast <- value_cast*}
 
-;; ../../../../spec-concrete/3-numerics.watsup:690.1-691.23
+;; ../../../../spec-concrete/3-numerics.watsup:689.1-690.23
 def $cast_record(typeIR, (value, id)*) : value =
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:695.1-696.55
+  ;; ../../../../spec-concrete/3-numerics.watsup:694.1-695.55
   clause 0 : (typeIR, (value, id)*{id <- id*, value <- value*}) = $cast_record'($canon_typeIR(typeIR), (value, id)*{id <- id*, value <- value*})
 
-;; ../../../../spec-concrete/3-numerics.watsup:692.1-693.23
+;; ../../../../spec-concrete/3-numerics.watsup:691.1-692.23
 def $cast_record'(typeIR, (value, id)*) : value =
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:698.1-705.69
+  ;; ../../../../spec-concrete/3-numerics.watsup:697.1-704.69
   clause 0 : (typeIR, (value_field, id_field)*{id_field <- id_field*, value_field <- value_field*}) = struct tid { value_field_cast id_field ;*{id_field <- id_field*, value_field_cast <- value_field_cast*} } as value
   -- if typeIR <: structTypeIR
   -- let struct tid { typeIR_t_field id_t_field ;*{id_t_field <- id_t_field*, typeIR_t_field <- typeIR_t_field*} } = typeIR as structTypeIR
@@ -8054,7 +8069,7 @@ def $cast_record'(typeIR, (value, id)*) : value =
   -- (let ?(value_field') = value?{value <- value?})*{value? <- value?*, value_field' <- value_field'*}
   -- (let value_field_cast = $cast_op(typeIR_t_field, value_field'))*{typeIR_t_field <- typeIR_t_field*, value_field' <- value_field'*, value_field_cast <- value_field_cast*}
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:707.1-714.69
+  ;; ../../../../spec-concrete/3-numerics.watsup:706.1-713.69
   clause 1 : (typeIR, (value_field, id_field)*{id_field <- id_field*, value_field <- value_field*}) = header tid { true ; value_field_cast id_field ;*{id_field <- id_field*, value_field_cast <- value_field_cast*} } as value
   -- if typeIR <: headerTypeIR
   -- let header tid { typeIR_t_field id_t_field ;*{id_t_field <- id_t_field*, typeIR_t_field <- typeIR_t_field*} } = typeIR as headerTypeIR
@@ -8063,53 +8078,53 @@ def $cast_record'(typeIR, (value, id)*) : value =
   -- (let ?(value_field') = value?{value <- value?})*{value? <- value?*, value_field' <- value_field'*}
   -- (let value_field_cast = $cast_op(typeIR_t_field, value_field'))*{typeIR_t_field <- typeIR_t_field*, value_field' <- value_field'*, value_field_cast <- value_field_cast*}
 
-;; ../../../../spec-concrete/3-numerics.watsup:727.1-727.34
+;; ../../../../spec-concrete/3-numerics.watsup:726.1-726.34
 def $cast_invalid(typeIR) : value =
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:730.1-730.66
+  ;; ../../../../spec-concrete/3-numerics.watsup:729.1-729.66
   clause 0 : (typeIR) = $cast_invalid'($canon_typeIR(typeIR))
 
-;; ../../../../spec-concrete/3-numerics.watsup:728.1-728.35
+;; ../../../../spec-concrete/3-numerics.watsup:727.1-727.35
 def $cast_invalid'(typeIR) : value =
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:732.1-733.41
+  ;; ../../../../spec-concrete/3-numerics.watsup:731.1-732.41
   clause 0 : (typeIR) = $default(typeIR)
   -- let typeIR' = typeIR
   -- if typeIR' <: headerTypeIR
   -- let header _tid { _typeIR _id ;*{_id <- _id*, _typeIR <- _typeIR*} } = typeIR' as headerTypeIR
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:735.1-736.47
+  ;; ../../../../spec-concrete/3-numerics.watsup:734.1-735.47
   clause 1 : (typeIR) = $default(typeIR)
   -- let typeIR' = typeIR
   -- if typeIR' <: headerUnionTypeIR
   -- let header_union _tid { _typeIR _id ;*{_id <- _id*, _typeIR <- _typeIR*} } = typeIR' as headerUnionTypeIR
 
-;; ../../../../spec-concrete/3-numerics.watsup:742.1-743.23
+;; ../../../../spec-concrete/3-numerics.watsup:741.1-742.23
 def $cast_set_singleton(typeIR, value) : value =
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:747.1-748.55
+  ;; ../../../../spec-concrete/3-numerics.watsup:746.1-747.55
   clause 0 : (typeIR, value) = $cast_set_singleton'($canon_typeIR(typeIR), value)
 
-;; ../../../../spec-concrete/3-numerics.watsup:744.1-745.23
+;; ../../../../spec-concrete/3-numerics.watsup:743.1-744.23
 def $cast_set_singleton'(typeIR, value) : value =
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:750.1-751.37
+  ;; ../../../../spec-concrete/3-numerics.watsup:749.1-750.37
   clause 0 : (typeIR'', value) = set{ $cast_op(typeIR, value) } as value
   -- if typeIR'' <: setTypeIR
   -- let set< typeIR'*{typeIR' <- typeIR'*} > = typeIR'' as setTypeIR
   -- if typeIR'*{typeIR' <- typeIR'*} matches [ _/1 ]
   -- let [typeIR] = typeIR'*{typeIR' <- typeIR'*}
 
-;; ../../../../spec-concrete/3-numerics.watsup:753.1-754.23
+;; ../../../../spec-concrete/3-numerics.watsup:752.1-753.23
 def $cast_set_mask(typeIR, value, value) : value =
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:758.1-759.61
+  ;; ../../../../spec-concrete/3-numerics.watsup:757.1-758.61
   clause 0 : (typeIR, value_b, value_m) = $cast_set_mask'($canon_typeIR(typeIR), value_b, value_m)
 
-;; ../../../../spec-concrete/3-numerics.watsup:755.1-756.23
+;; ../../../../spec-concrete/3-numerics.watsup:754.1-755.23
 def $cast_set_mask'(typeIR, value, value) : value =
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:761.1-764.49
+  ;; ../../../../spec-concrete/3-numerics.watsup:760.1-763.49
   clause 0 : (typeIR'', value_b, value_m) = set{ value_b_cast &&& value_m_cast } as value
   -- if typeIR'' <: setTypeIR
   -- let set< typeIR'*{typeIR' <- typeIR'*} > = typeIR'' as setTypeIR
@@ -8118,16 +8133,16 @@ def $cast_set_mask'(typeIR, value, value) : value =
   -- let value_b_cast = $cast_op(typeIR, value_b)
   -- let value_m_cast = $cast_op(typeIR, value_m)
 
-;; ../../../../spec-concrete/3-numerics.watsup:766.1-767.23
+;; ../../../../spec-concrete/3-numerics.watsup:765.1-766.23
 def $cast_set_range(typeIR, value, value) : value =
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:771.1-772.62
+  ;; ../../../../spec-concrete/3-numerics.watsup:770.1-771.62
   clause 0 : (typeIR, value_l, value_u) = $cast_set_range'($canon_typeIR(typeIR), value_l, value_u)
 
-;; ../../../../spec-concrete/3-numerics.watsup:768.1-769.23
+;; ../../../../spec-concrete/3-numerics.watsup:767.1-768.23
 def $cast_set_range'(typeIR, value, value) : value =
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:774.1-777.49
+  ;; ../../../../spec-concrete/3-numerics.watsup:773.1-776.49
   clause 0 : (typeIR'', value_l, value_u) = set{ value_l_cast .. value_u_cast } as value
   -- if typeIR'' <: setTypeIR
   -- let set< typeIR'*{typeIR' <- typeIR'*} > = typeIR'' as setTypeIR
@@ -8136,10 +8151,10 @@ def $cast_set_range'(typeIR, value, value) : value =
   -- let value_l_cast = $cast_op(typeIR, value_l)
   -- let value_u_cast = $cast_op(typeIR, value_u)
 
-;; ../../../../spec-concrete/3-numerics.watsup:834.1-835.23
+;; ../../../../spec-concrete/3-numerics.watsup:833.1-834.23
 def $bitacc_op(value, value, value) : value =
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:837.1-842.35
+  ;; ../../../../spec-concrete/3-numerics.watsup:836.1-841.35
   clause 0 : (value_b, value_h, value_l) = w w i as value
   -- let i_b = $int_of_value(value_b)
   -- let i_h = $int_of_value(value_h)
@@ -8149,10 +8164,10 @@ def $bitacc_op(value, value, value) : value =
   -- let w = int as nat
   -- let i = $bitacc(i_b, i_h, i_l)
 
-;; ../../../../spec-concrete/3-numerics.watsup:848.1-849.23
+;; ../../../../spec-concrete/3-numerics.watsup:847.1-848.23
 def $bitacc_replace_op(value, value, value, value) : value =
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:851.1-856.48
+  ;; ../../../../spec-concrete/3-numerics.watsup:850.1-855.48
   clause 0 : (value_b, value_h, value_l, value_r) = w w i as value
   -- let value = value_b
   -- if value <: integerLiteral
@@ -8168,194 +8183,194 @@ def $bitacc_replace_op(value, value, value, value) : value =
   -- let _nat w i_r = integerLiteral'
   -- let i = $bitacc_replace(i_b, i_h, i_l, i_r)
 
-;; ../../../../spec-concrete/3-numerics.watsup:862.1-863.23
+;; ../../../../spec-concrete/3-numerics.watsup:861.1-862.23
 def $sizeof(typeIR, id) : value =
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:902.1-902.69
+  ;; ../../../../spec-concrete/3-numerics.watsup:901.1-901.69
   clause 0 : (typeIR, text) = $sizeof_minSizeInBits(typeIR)
   -- if (text = "minSizeInBits")
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:909.1-909.71
+  ;; ../../../../spec-concrete/3-numerics.watsup:908.1-908.71
   clause 1 : (typeIR, text) = $sizeof_minSizeInBytes(typeIR)
   -- if (text = "minSizeInBytes")
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:928.1-928.69
+  ;; ../../../../spec-concrete/3-numerics.watsup:927.1-927.69
   clause 2 : (typeIR, text) = $sizeof_maxSizeInBits(typeIR)
   -- if (text = "maxSizeInBits")
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:935.1-935.71
+  ;; ../../../../spec-concrete/3-numerics.watsup:934.1-934.71
   clause 3 : (typeIR, text) = $sizeof_maxSizeInBytes(typeIR)
   -- if (text = "maxSizeInBytes")
 
-;; ../../../../spec-concrete/3-numerics.watsup:865.1-866.23
+;; ../../../../spec-concrete/3-numerics.watsup:864.1-865.23
 def $sizeof_minSizeInBits(typeIR) : value =
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:887.1-887.69
+  ;; ../../../../spec-concrete/3-numerics.watsup:886.1-886.69
   clause 0 : (typeIR) = d $sizeof_minSizeInBits'(typeIR) as int as value
 
-;; ../../../../spec-concrete/3-numerics.watsup:867.1-868.23
+;; ../../../../spec-concrete/3-numerics.watsup:866.1-867.23
 def $sizeof_minSizeInBits'(typeIR) : nat =
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:888.1-888.84
+  ;; ../../../../spec-concrete/3-numerics.watsup:887.1-887.84
   clause 0 : (typeIR) = $sizeof_minSizeInBits''($canon_typeIR(typeIR))
 
-;; ../../../../spec-concrete/3-numerics.watsup:869.1-870.23
+;; ../../../../spec-concrete/3-numerics.watsup:868.1-869.23
 def $sizeof_minSizeInBits''(typeIR) : nat =
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:890.1-890.38
+  ;; ../../../../spec-concrete/3-numerics.watsup:889.1-889.38
   clause 0 : (typeIR) = 1
   -- if typeIR <: boolTypeIR
   -- let boolTypeIR = typeIR as boolTypeIR
   -- if (boolTypeIR = bool)
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:891.1-891.44
+  ;; ../../../../spec-concrete/3-numerics.watsup:890.1-890.44
   clause 1 : (typeIR) = w
   -- if typeIR <: integerTypeIR
   -- let integerTypeIR = typeIR as integerTypeIR
   -- if integerTypeIR matches `INT<%>`
   -- let int< w > = integerTypeIR
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:892.1-892.44
+  ;; ../../../../spec-concrete/3-numerics.watsup:891.1-891.44
   clause 2 : (typeIR) = w
   -- if typeIR <: integerTypeIR
   -- let integerTypeIR = typeIR as integerTypeIR
   -- if integerTypeIR matches `BIT<%>`
   -- let bit< w > = integerTypeIR
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:893.1-893.47
+  ;; ../../../../spec-concrete/3-numerics.watsup:892.1-892.47
   clause 3 : (typeIR) = 0
   -- if typeIR <: integerTypeIR
   -- let integerTypeIR = typeIR as integerTypeIR
   -- if integerTypeIR matches `VARBIT<%>`
   -- let varbit< _nat > = integerTypeIR
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:894.1-894.76
+  ;; ../../../../spec-concrete/3-numerics.watsup:893.1-893.76
   clause 4 : (typeIR') = $sizeof_minSizeInBits'(typeIR)
   -- if typeIR' <: newTypeIR
   -- let type _tid typeIR = typeIR' as newTypeIR
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:895.1-895.88
+  ;; ../../../../spec-concrete/3-numerics.watsup:894.1-894.88
   clause 5 : (typeIR') = $sizeof_minSizeInBits'(typeIR)
   -- if typeIR' <: enumTypeIR
   -- let enumTypeIR = typeIR' as enumTypeIR
   -- if enumTypeIR matches `ENUM%<%>{%}`
   -- let enum _tid < typeIR >{ _valueFieldIR*{_valueFieldIR <- _valueFieldIR*} } = enumTypeIR
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:896.1-896.92
+  ;; ../../../../spec-concrete/3-numerics.watsup:895.1-895.92
   clause 6 : (typeIR') = $sum_nat($sizeof_minSizeInBits'(typeIR)*{typeIR <- typeIR*})
   -- if typeIR' <: tupleTypeIR
   -- let tuple< typeIR*{typeIR <- typeIR*} > = typeIR' as tupleTypeIR
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:897.1-897.93
+  ;; ../../../../spec-concrete/3-numerics.watsup:896.1-896.93
   clause 7 : (typeIR') = ($sizeof_minSizeInBits'(typeIR) * n_size)
   -- if typeIR' <: headerStackTypeIR
   -- let typeIR [ n_size ] = typeIR' as headerStackTypeIR
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:898.1-898.102
+  ;; ../../../../spec-concrete/3-numerics.watsup:897.1-897.102
   clause 8 : (typeIR') = $sum_nat($sizeof_minSizeInBits'(typeIR)*{typeIR <- typeIR*})
   -- if typeIR' <: structTypeIR
   -- let struct _tid { typeIR _id ;*{_id <- _id*, typeIR <- typeIR*} } = typeIR' as structTypeIR
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:899.1-899.102
+  ;; ../../../../spec-concrete/3-numerics.watsup:898.1-898.102
   clause 9 : (typeIR') = $sum_nat($sizeof_minSizeInBits'(typeIR)*{typeIR <- typeIR*})
   -- if typeIR' <: headerTypeIR
   -- let header _tid { typeIR _id ;*{_id <- _id*, typeIR <- typeIR*} } = typeIR' as headerTypeIR
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:900.1-900.108
+  ;; ../../../../spec-concrete/3-numerics.watsup:899.1-899.108
   clause 10 : (typeIR') = $min_nat($sizeof_minSizeInBits'(typeIR)*{typeIR <- typeIR*})
   -- if typeIR' <: headerUnionTypeIR
   -- let header_union _tid { typeIR _id ;*{_id <- _id*, typeIR <- typeIR*} } = typeIR' as headerUnionTypeIR
 
-;; ../../../../spec-concrete/3-numerics.watsup:872.1-873.23
+;; ../../../../spec-concrete/3-numerics.watsup:871.1-872.23
 def $sizeof_minSizeInBytes(typeIR) : value =
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:906.1-907.48
+  ;; ../../../../spec-concrete/3-numerics.watsup:905.1-906.48
   clause 0 : (typeIR) = d (n_size / 8) as int as value
   -- let n_size = $sizeof_minSizeInBits'(typeIR)
 
-;; ../../../../spec-concrete/3-numerics.watsup:875.1-876.23
+;; ../../../../spec-concrete/3-numerics.watsup:874.1-875.23
 def $sizeof_maxSizeInBits(typeIR) : value =
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:913.1-913.69
+  ;; ../../../../spec-concrete/3-numerics.watsup:912.1-912.69
   clause 0 : (typeIR) = d $sizeof_maxSizeInBits'(typeIR) as int as value
 
-;; ../../../../spec-concrete/3-numerics.watsup:877.1-878.23
+;; ../../../../spec-concrete/3-numerics.watsup:876.1-877.23
 def $sizeof_maxSizeInBits'(typeIR) : nat =
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:914.1-914.84
+  ;; ../../../../spec-concrete/3-numerics.watsup:913.1-913.84
   clause 0 : (typeIR) = $sizeof_maxSizeInBits''($canon_typeIR(typeIR))
 
-;; ../../../../spec-concrete/3-numerics.watsup:879.1-880.23
+;; ../../../../spec-concrete/3-numerics.watsup:878.1-879.23
 def $sizeof_maxSizeInBits''(typeIR) : nat =
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:916.1-916.38
+  ;; ../../../../spec-concrete/3-numerics.watsup:915.1-915.38
   clause 0 : (typeIR) = 1
   -- if typeIR <: boolTypeIR
   -- let boolTypeIR = typeIR as boolTypeIR
   -- if (boolTypeIR = bool)
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:917.1-917.44
+  ;; ../../../../spec-concrete/3-numerics.watsup:916.1-916.44
   clause 1 : (typeIR) = w
   -- if typeIR <: integerTypeIR
   -- let integerTypeIR = typeIR as integerTypeIR
   -- if integerTypeIR matches `INT<%>`
   -- let int< w > = integerTypeIR
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:918.1-918.44
+  ;; ../../../../spec-concrete/3-numerics.watsup:917.1-917.44
   clause 2 : (typeIR) = w
   -- if typeIR <: integerTypeIR
   -- let integerTypeIR = typeIR as integerTypeIR
   -- if integerTypeIR matches `BIT<%>`
   -- let bit< w > = integerTypeIR
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:919.1-919.47
+  ;; ../../../../spec-concrete/3-numerics.watsup:918.1-918.47
   clause 3 : (typeIR) = w
   -- if typeIR <: integerTypeIR
   -- let integerTypeIR = typeIR as integerTypeIR
   -- if integerTypeIR matches `VARBIT<%>`
   -- let varbit< w > = integerTypeIR
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:920.1-920.76
+  ;; ../../../../spec-concrete/3-numerics.watsup:919.1-919.76
   clause 4 : (typeIR') = $sizeof_maxSizeInBits'(typeIR)
   -- if typeIR' <: newTypeIR
   -- let type _tid typeIR = typeIR' as newTypeIR
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:921.1-921.88
+  ;; ../../../../spec-concrete/3-numerics.watsup:920.1-920.88
   clause 5 : (typeIR') = $sizeof_maxSizeInBits'(typeIR)
   -- if typeIR' <: enumTypeIR
   -- let enumTypeIR = typeIR' as enumTypeIR
   -- if enumTypeIR matches `ENUM%<%>{%}`
   -- let enum _tid < typeIR >{ _valueFieldIR*{_valueFieldIR <- _valueFieldIR*} } = enumTypeIR
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:922.1-922.92
+  ;; ../../../../spec-concrete/3-numerics.watsup:921.1-921.92
   clause 6 : (typeIR') = $sum_nat($sizeof_maxSizeInBits'(typeIR)*{typeIR <- typeIR*})
   -- if typeIR' <: tupleTypeIR
   -- let tuple< typeIR*{typeIR <- typeIR*} > = typeIR' as tupleTypeIR
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:923.1-923.93
+  ;; ../../../../spec-concrete/3-numerics.watsup:922.1-922.93
   clause 7 : (typeIR') = ($sizeof_maxSizeInBits'(typeIR) * n_size)
   -- if typeIR' <: headerStackTypeIR
   -- let typeIR [ n_size ] = typeIR' as headerStackTypeIR
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:924.1-924.102
+  ;; ../../../../spec-concrete/3-numerics.watsup:923.1-923.102
   clause 8 : (typeIR') = $sum_nat($sizeof_maxSizeInBits'(typeIR)*{typeIR <- typeIR*})
   -- if typeIR' <: structTypeIR
   -- let struct _tid { typeIR _id ;*{_id <- _id*, typeIR <- typeIR*} } = typeIR' as structTypeIR
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:925.1-925.102
+  ;; ../../../../spec-concrete/3-numerics.watsup:924.1-924.102
   clause 9 : (typeIR') = $sum_nat($sizeof_maxSizeInBits'(typeIR)*{typeIR <- typeIR*})
   -- if typeIR' <: headerTypeIR
   -- let header _tid { typeIR _id ;*{_id <- _id*, typeIR <- typeIR*} } = typeIR' as headerTypeIR
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:926.1-926.108
+  ;; ../../../../spec-concrete/3-numerics.watsup:925.1-925.108
   clause 10 : (typeIR') = $max_nat($sizeof_maxSizeInBits'(typeIR)*{typeIR <- typeIR*})
   -- if typeIR' <: headerUnionTypeIR
   -- let header_union _tid { typeIR _id ;*{_id <- _id*, typeIR <- typeIR*} } = typeIR' as headerUnionTypeIR
 
-;; ../../../../spec-concrete/3-numerics.watsup:882.1-883.23
+;; ../../../../spec-concrete/3-numerics.watsup:881.1-882.23
 def $sizeof_maxSizeInBytes(typeIR) : value =
 
-  ;; ../../../../spec-concrete/3-numerics.watsup:932.1-933.48
+  ;; ../../../../spec-concrete/3-numerics.watsup:931.1-932.48
   clause 0 : (typeIR) = d (n_size / 8) as int as value
   -- let n_size = $sizeof_maxSizeInBits'(typeIR)
 

--- a/p4spec/test/elab.expected
+++ b/p4spec/test/elab.expected
@@ -16280,7 +16280,7 @@ relation ParserTransition_ok: typingContext nameIR* |- transitionStatement : tra
     -- let transitionStatementIR = transition nameIR ;
     -- output: % % |- % : transitionStatementIR
 
-  ;; ../../../../spec-concrete/5.13.1-typing-parser-statement.watsup:302.1-317.75
+  ;; ../../../../spec-concrete/5.13.1-typing-parser-statement.watsup:302.1-318.83
   rulegroup select
 
    match
@@ -16297,17 +16297,18 @@ relation ParserTransition_ok: typingContext nameIR* |- transitionStatement : tra
     rulepath select
     -- let expression_key*{expression_key <- expression_key*} = $flatten_expressionList(expressionList_key)
     -- (Expr_ok: local TC_0 |- expression_key : typedExpressionIR_key)*{expression_key <- expression_key*, typedExpressionIR_key <- typedExpressionIR_key*}
-    -- (let typeIR_key = $type_of_typedExpressionIR(typedExpressionIR_key))*{typeIR_key <- typeIR_key*, typedExpressionIR_key <- typedExpressionIR_key*}
-    -- (if Type_wf: $bound(local, TC_0) |- set< [typeIR_key] > as typeIR holds)*{typeIR_key <- typeIR_key*}
+    -- (let typedExpressionIR_key_reduced = $reduce_serenum(typedExpressionIR_key))*{typedExpressionIR_key <- typedExpressionIR_key*, typedExpressionIR_key_reduced <- typedExpressionIR_key_reduced*}
+    -- (let typeIR_key_reduced = $type_of_typedExpressionIR(typedExpressionIR_key_reduced))*{typeIR_key_reduced <- typeIR_key_reduced*, typedExpressionIR_key_reduced <- typedExpressionIR_key_reduced*}
+    -- (if Type_wf: $bound(local, TC_0) |- set< [typeIR_key_reduced] > as typeIR holds)*{typeIR_key_reduced <- typeIR_key_reduced*}
     -- let selectCase*{selectCase <- selectCase*} = $flatten_selectCaseList(selectCaseList)
-    -- (SelectCase_ok: TC_0 nameIR_state*{nameIR_state <- nameIR_state*} typeIR_key*{typeIR_key <- typeIR_key*} |- selectCase : selectCaseIR)*{selectCase <- selectCase*, selectCaseIR <- selectCaseIR*}
-    -- let transitionStatementIR = transition select( typedExpressionIR_key*{typedExpressionIR_key <- typedExpressionIR_key*} ){ selectCaseIR*{selectCaseIR <- selectCaseIR*} } as stateExpressionIR
+    -- (SelectCase_ok: TC_0 nameIR_state*{nameIR_state <- nameIR_state*} typeIR_key_reduced*{typeIR_key_reduced <- typeIR_key_reduced*} |- selectCase : selectCaseIR)*{selectCase <- selectCase*, selectCaseIR <- selectCaseIR*}
+    -- let transitionStatementIR = transition select( typedExpressionIR_key_reduced*{typedExpressionIR_key_reduced <- typedExpressionIR_key_reduced*} ){ selectCaseIR*{selectCaseIR <- selectCaseIR*} } as stateExpressionIR
     -- output: % % |- % : transitionStatementIR
 
 ;; ../../../../spec-concrete/5.04-typing-relation.watsup:220.1-224.86
 relation ParserStmt_ok: typingContext |- parserStatement : typingContext parserStatementIR
 
-  ;; ../../../../spec-concrete/5.13.1-typing-parser-statement.watsup:327.1-331.55
+  ;; ../../../../spec-concrete/5.13.1-typing-parser-statement.watsup:328.1-332.55
   rulegroup constantDeclaration
 
    match
@@ -16325,7 +16326,7 @@ relation ParserStmt_ok: typingContext |- parserStatement : typingContext parserS
     -- let constantDeclarationIR = declarationIR as constantDeclarationIR
     -- output: % |- % : TC_1 constantDeclarationIR as parserStatementIR
 
-  ;; ../../../../spec-concrete/5.13.1-typing-parser-statement.watsup:337.1-375.2
+  ;; ../../../../spec-concrete/5.13.1-typing-parser-statement.watsup:338.1-376.2
   rulegroup variableDeclaration
 
    match
@@ -16365,7 +16366,7 @@ relation ParserStmt_ok: typingContext |- parserStatement : typingContext parserS
     -- let variableDeclarationIR = annotationList typeIR nameIR ?(= typedExpressionIR_init_cast) ;
     -- output: % |- % : TC_1 variableDeclarationIR as parserStatementIR
 
-  ;; ../../../../spec-concrete/5.13.1-typing-parser-statement.watsup:379.1-383.63
+  ;; ../../../../spec-concrete/5.13.1-typing-parser-statement.watsup:380.1-384.63
   rulegroup emptyStatement
 
    match
@@ -16385,7 +16386,7 @@ relation ParserStmt_ok: typingContext |- parserStatement : typingContext parserS
     -- let emptyStatementIR = statementIR as emptyStatementIR
     -- output: % |- % : TC emptyStatementIR as parserStatementIR
 
-  ;; ../../../../spec-concrete/5.13.1-typing-parser-statement.watsup:387.1-391.72
+  ;; ../../../../spec-concrete/5.13.1-typing-parser-statement.watsup:388.1-392.72
   rulegroup assignmentStatement
 
    match
@@ -16404,7 +16405,7 @@ relation ParserStmt_ok: typingContext |- parserStatement : typingContext parserS
     -- let assignmentStatementIR = statementIR as assignmentStatementIR
     -- output: % |- % : TC_1 assignmentStatementIR as parserStatementIR
 
-  ;; ../../../../spec-concrete/5.13.1-typing-parser-statement.watsup:395.1-399.66
+  ;; ../../../../spec-concrete/5.13.1-typing-parser-statement.watsup:396.1-400.66
   rulegroup callStatement
 
    match
@@ -16423,7 +16424,7 @@ relation ParserStmt_ok: typingContext |- parserStatement : typingContext parserS
     -- let callStatementIR = statementIR as callStatementIR
     -- output: % |- % : TC_1 callStatementIR as parserStatementIR
 
-  ;; ../../../../spec-concrete/5.13.1-typing-parser-statement.watsup:403.1-407.79
+  ;; ../../../../spec-concrete/5.13.1-typing-parser-statement.watsup:404.1-408.79
   rulegroup directApplicationStatement
 
    match
@@ -16442,7 +16443,7 @@ relation ParserStmt_ok: typingContext |- parserStatement : typingContext parserS
     -- let directApplicationStatementIR = statementIR as directApplicationStatementIR
     -- output: % |- % : TC_1 directApplicationStatementIR as parserStatementIR
 
-  ;; ../../../../spec-concrete/5.13.1-typing-parser-statement.watsup:412.1-422.72
+  ;; ../../../../spec-concrete/5.13.1-typing-parser-statement.watsup:413.1-423.72
   rulegroup parserBlockStatement
 
    match
@@ -16462,7 +16463,7 @@ relation ParserStmt_ok: typingContext |- parserStatement : typingContext parserS
     -- let parserBlockStatementIR = annotationList { parserStatementIR*{parserStatementIR <- parserStatementIR*} }
     -- output: % |- % : TC_1 parserBlockStatementIR as parserStatementIR
 
-  ;; ../../../../spec-concrete/5.13.1-typing-parser-statement.watsup:430.1-462.2
+  ;; ../../../../spec-concrete/5.13.1-typing-parser-statement.watsup:431.1-463.2
   rulegroup parserConditionalStatement
 
    match
@@ -16498,7 +16499,7 @@ relation ParserStmt_ok: typingContext |- parserStatement : typingContext parserS
 ;; ../../../../spec-concrete/5.04-typing-relation.watsup:226.1-230.87
 relation ParserStmts_ok: typingContext |- parserStatement* : typingContext parserStatementIR*
 
-  ;; ../../../../spec-concrete/5.13.1-typing-parser-statement.watsup:470.1-471.21
+  ;; ../../../../spec-concrete/5.13.1-typing-parser-statement.watsup:471.1-472.21
   rulegroup nil
 
    match
@@ -16512,7 +16513,7 @@ relation ParserStmts_ok: typingContext |- parserStatement* : typingContext parse
     rulepath nil
     -- output: % |- % : TC []
 
-  ;; ../../../../spec-concrete/5.13.1-typing-parser-statement.watsup:473.1-479.55
+  ;; ../../../../spec-concrete/5.13.1-typing-parser-statement.watsup:474.1-480.55
   rulegroup cons
 
    match
@@ -16717,7 +16718,7 @@ relation ParserLocalDecls_ok: typingContext |- parserLocalDeclaration* : typingC
 ;; ../../../../spec-concrete/5.04-typing-relation.watsup:262.1-266.78
 relation TableKey_ok: typingContext tableContext |- tableKey : tableContext tableKeyIR
 
-  ;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:45.1-63.77
+  ;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:45.1-66.85
   rulegroup 
 
    match
@@ -16729,20 +16730,21 @@ relation TableKey_ok: typingContext tableContext |- tableKey : tableContext tabl
 
     rulepath 
     -- Expr_ok: local TC |- expression : typedExpressionIR
-    -- let typeIR = $type_of_typedExpressionIR(typedExpressionIR)
-    -- if Type_wf: $bound(local, TC) |- set< [typeIR] > as typeIR holds
+    -- let typedExpressionIR_reduced = $reduce_serenum(typedExpressionIR)
+    -- let typeIR_reduced = $type_of_typedExpressionIR(typedExpressionIR_reduced)
+    -- if Type_wf: $bound(local, TC) |- set< [typeIR_reduced] > as typeIR holds
     -- let nameIR_matchkind = $name(name_matchkind)
     -- if (match_kind. nameIR_matchkind as value = $find_var_value_t(local, TC, ` nameIR_matchkind))
-    -- if $compat_table_key(nameIR_matchkind, typeIR)
-    -- let TBLC_1 = $update_mode(TBLC_0, nameIR_matchkind, typeIR)
-    -- let TBLC_2 = $add_key(TBLC_1, nameIR_matchkind, typeIR)
-    -- let tableKeyIR = typedExpressionIR : nameIR_matchkind annotationList ;
+    -- if $compat_table_key(nameIR_matchkind, typeIR_reduced)
+    -- let TBLC_1 = $update_mode(TBLC_0, nameIR_matchkind, typeIR_reduced)
+    -- let TBLC_2 = $add_key(TBLC_1, nameIR_matchkind, typeIR_reduced)
+    -- let tableKeyIR = typedExpressionIR_reduced : nameIR_matchkind annotationList ;
     -- output: % % |- % : TBLC_2 tableKeyIR
 
 ;; ../../../../spec-concrete/5.04-typing-relation.watsup:268.1-272.79
 relation TableKeys_ok: typingContext tableContext |- tableKey* : tableContext tableKeyListIR
 
-  ;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:71.1-72.28
+  ;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:74.1-75.28
   rulegroup nil
 
    match
@@ -16756,7 +16758,7 @@ relation TableKeys_ok: typingContext tableContext |- tableKey* : tableContext ta
     rulepath nil
     -- output: % % |- % : TBLC []
 
-  ;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:74.1-78.67
+  ;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:77.1-81.67
   rulegroup cons
 
    match
@@ -16776,7 +16778,7 @@ relation TableKeys_ok: typingContext tableContext |- tableKey* : tableContext ta
 ;; ../../../../spec-concrete/5.04-typing-relation.watsup:274.1-279.47
 relation Call_action_partial_ok: typingContext |- parameterIR* @ argumentListIR : parameterIR* , parameterIR* @ argumentListIR
 
-  ;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:102.1-114.42
+  ;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:105.1-117.42
   rulegroup 
 
    match
@@ -16795,7 +16797,7 @@ relation Call_action_partial_ok: typingContext |- parameterIR* @ argumentListIR 
 ;; ../../../../spec-concrete/5.04-typing-relation.watsup:281.1-285.81
 relation TableAction_ok: typingContext tableContext |- tableAction : tableContext tableActionIR
 
-  ;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:121.1-137.63
+  ;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:124.1-140.63
   rulegroup prefixedNonTypeName
 
    match
@@ -16820,7 +16822,7 @@ relation TableAction_ok: typingContext tableContext |- tableAction : tableContex
     -- let tableActionIR = annotationList prefixedNameIR ( [] ) #( parameterIR_data*{parameterIR_data <- parameterIR_data*} , parameterIR_control*{parameterIR_control <- parameterIR_control*} );
     -- output: % % |- % : TBLC_1 tableActionIR
 
-  ;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:141.1-160.63
+  ;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:144.1-163.63
   rulegroup prefixedNonTypeName-argumentList
 
    match
@@ -16849,7 +16851,7 @@ relation TableAction_ok: typingContext tableContext |- tableAction : tableContex
 ;; ../../../../spec-concrete/5.04-typing-relation.watsup:287.1-291.82
 relation TableActions_ok: typingContext tableContext |- tableAction* : tableContext tableActionListIR
 
-  ;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:168.1-169.28
+  ;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:171.1-172.28
   rulegroup nil
 
    match
@@ -16863,7 +16865,7 @@ relation TableActions_ok: typingContext tableContext |- tableAction* : tableCont
     rulepath nil
     -- output: % % |- % : TBLC []
 
-  ;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:171.1-175.76
+  ;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:174.1-178.76
   rulegroup cons
 
    match
@@ -16883,7 +16885,7 @@ relation TableActions_ok: typingContext tableContext |- tableAction* : tableCont
 ;; ../../../../spec-concrete/5.04-typing-relation.watsup:293.1-298.47
 relation Call_action_default_ok: typingContext |- parameterIR* @ argumentListIR : parameterIR* , parameterIR* @ argumentListIR
 
-  ;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:183.1-193.42
+  ;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:186.1-196.42
   rulegroup 
 
    match
@@ -16901,7 +16903,7 @@ relation Call_action_default_ok: typingContext |- parameterIR* @ argumentListIR 
 ;; ../../../../spec-concrete/5.04-typing-relation.watsup:300.1-304.48
 relation TableDefaultAction_ok: typingContext tableContext |- initializer : tableActionReferenceIR
 
-  ;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:197.1-202.56
+  ;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:200.1-205.56
   rulegroup prefixedNonTypeName
 
    match
@@ -16918,7 +16920,7 @@ relation TableDefaultAction_ok: typingContext tableContext |- initializer : tabl
     -- if (?(([], [])) = $find_action(TBLC, prefixedNameIR))
     -- output: % % |- % : prefixedNameIR ( [] )
 
-  ;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:206.1-227.57
+  ;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:209.1-230.57
   rulegroup prefixedNonTypeName-argumentList
 
    match
@@ -16950,7 +16952,7 @@ relation TableDefaultAction_ok: typingContext tableContext |- initializer : tabl
 ;; ../../../../spec-concrete/5.04-typing-relation.watsup:306.1-310.86
 relation TableEntry_keyset_ok: typingContext tableContext |- keysetExpression : tableEntryState keysetExpressionIR
 
-  ;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:431.1-438.53
+  ;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:434.1-441.53
   rulegroup simpleKeysetExpression-expression
 
    match
@@ -16969,7 +16971,7 @@ relation TableEntry_keyset_ok: typingContext tableContext |- keysetExpression : 
     -- let [simpleKeysetExpressionIR] = simpleKeysetExpressionIR'*{simpleKeysetExpressionIR' <- simpleKeysetExpressionIR'*}
     -- output: % % |- % : TBLS simpleKeysetExpressionIR as keysetExpressionIR
 
-  ;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:442.1-449.53
+  ;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:445.1-452.53
   rulegroup simpleKeysetExpression-mask
 
    match
@@ -16990,7 +16992,7 @@ relation TableEntry_keyset_ok: typingContext tableContext |- keysetExpression : 
     -- let [simpleKeysetExpressionIR] = simpleKeysetExpressionIR'*{simpleKeysetExpressionIR' <- simpleKeysetExpressionIR'*}
     -- output: % % |- % : TBLS simpleKeysetExpressionIR as keysetExpressionIR
 
-  ;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:453.1-460.53
+  ;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:456.1-463.53
   rulegroup simpleKeysetExpression-range
 
    match
@@ -17011,7 +17013,7 @@ relation TableEntry_keyset_ok: typingContext tableContext |- keysetExpression : 
     -- let [simpleKeysetExpressionIR] = simpleKeysetExpressionIR'*{simpleKeysetExpressionIR' <- simpleKeysetExpressionIR'*}
     -- output: % % |- % : TBLS simpleKeysetExpressionIR as keysetExpressionIR
 
-  ;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:464.1-476.2
+  ;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:467.1-479.2
   rulegroup simpleKeysetExpression-default
 
    match
@@ -17036,7 +17038,7 @@ relation TableEntry_keyset_ok: typingContext tableContext |- keysetExpression : 
     -- let TBLS = nolpm
     -- output: % % |- % : TBLS default as keysetExpressionIR
 
-  ;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:480.1-492.2
+  ;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:483.1-495.2
   rulegroup simpleKeysetExpression-dontcare
 
    match
@@ -17061,7 +17063,7 @@ relation TableEntry_keyset_ok: typingContext tableContext |- keysetExpression : 
     -- let TBLS = nolpm
     -- output: % % |- % : TBLS _ as keysetExpressionIR
 
-  ;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:499.1-507.53
+  ;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:502.1-510.53
   rulegroup tupleKeysetExpression-mask
 
    match
@@ -17082,7 +17084,7 @@ relation TableEntry_keyset_ok: typingContext tableContext |- keysetExpression : 
     -- let [simpleKeysetExpressionIR] = simpleKeysetExpressionIR'*{simpleKeysetExpressionIR' <- simpleKeysetExpressionIR'*}
     -- output: % % |- % : TBLS ( [simpleKeysetExpressionIR] ) as keysetExpressionIR
 
-  ;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:511.1-519.53
+  ;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:514.1-522.53
   rulegroup tupleKeysetExpression-range
 
    match
@@ -17103,7 +17105,7 @@ relation TableEntry_keyset_ok: typingContext tableContext |- keysetExpression : 
     -- let [simpleKeysetExpressionIR] = simpleKeysetExpressionIR'*{simpleKeysetExpressionIR' <- simpleKeysetExpressionIR'*}
     -- output: % % |- % : TBLS ( [simpleKeysetExpressionIR] ) as keysetExpressionIR
 
-  ;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:523.1-535.2
+  ;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:526.1-538.2
   rulegroup tupleKeysetExpression-default
 
    match
@@ -17128,7 +17130,7 @@ relation TableEntry_keyset_ok: typingContext tableContext |- keysetExpression : 
     -- let TBLS = nolpm
     -- output: % % |- % : TBLS ( [default] ) as keysetExpressionIR
 
-  ;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:539.1-551.2
+  ;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:542.1-554.2
   rulegroup tupleKeysetExpression-dontcare
 
    match
@@ -17153,7 +17155,7 @@ relation TableEntry_keyset_ok: typingContext tableContext |- keysetExpression : 
     -- let TBLS = nolpm
     -- output: % % |- % : TBLS ( [_] ) as keysetExpressionIR
 
-  ;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:555.1-567.54
+  ;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:558.1-570.54
   rulegroup tupleKeysetExpression-list
 
    match
@@ -17177,7 +17179,7 @@ relation TableEntry_keyset_ok: typingContext tableContext |- keysetExpression : 
 ;; ../../../../spec-concrete/5.04-typing-relation.watsup:312.1-316.56
 relation TableEntry_action_ok: typingContext tableContext |- tableActionReference : tableActionReferenceIR
 
-  ;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:577.1-581.56
+  ;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:580.1-584.56
   rulegroup prefixedNonTypeName
 
    match
@@ -17194,7 +17196,7 @@ relation TableEntry_action_ok: typingContext tableContext |- tableActionReferenc
     -- if (?(([], [])) = $find_action(TBLC, prefixedNameIR))
     -- output: % % |- % : prefixedNameIR ( [] )
 
-  ;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:585.1-606.57
+  ;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:588.1-609.57
   rulegroup prefixedNonTypeName-argumentList
 
    match
@@ -17222,7 +17224,7 @@ relation TableEntry_action_ok: typingContext tableContext |- tableActionReferenc
 ;; ../../../../spec-concrete/5.04-typing-relation.watsup:318.1-324.89
 relation TableEntry_priority_ok: typingContext tableContext tableEntryState |- tableEntryPriority? : tableContext tableEntryPriorityOptIR
 
-  ;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:616.1-680.2
+  ;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:619.1-683.2
   rulegroup non-specified
 
    match
@@ -17293,7 +17295,7 @@ relation TableEntry_priority_ok: typingContext tableContext tableEntryState |- t
     -- let TBLC_1 = $add_table_priority(TBLC_0, n)
     -- output: % % % |- % : TBLC_1 ?(priority= d n as int :)
 
-  ;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:684.1-712.2
+  ;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:687.1-715.2
   rulegroup specified-number
 
    match
@@ -17329,7 +17331,7 @@ relation TableEntry_priority_ok: typingContext tableContext tableEntryState |- t
     -- let TBLC_1 = $add_table_priority(TBLC_0, n)
     -- output: % % % |- % : TBLC_1 ?(priority= integerLiteral :)
 
-  ;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:716.1-750.2
+  ;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:719.1-753.2
   rulegroup specified-expression
 
    match
@@ -17374,7 +17376,7 @@ relation TableEntry_priority_ok: typingContext tableContext tableEntryState |- t
 ;; ../../../../spec-concrete/5.04-typing-relation.watsup:326.1-330.80
 relation TableEntry_ok: typingContext tableContext |- tableEntry : tableContext tableEntryIR
 
-  ;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:755.1-770.73
+  ;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:758.1-773.73
   rulegroup priority
 
    match
@@ -17394,7 +17396,7 @@ relation TableEntry_ok: typingContext tableContext |- tableEntry : tableContext 
     -- let tableEntryIR = constOptIR tableEntryPriorityOptIR keysetExpressionIR : tableActionReferenceIR annotationList ;
     -- output: % % |- % : TBLC_1 tableEntryIR
 
-  ;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:774.1-788.73
+  ;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:777.1-791.73
   rulegroup non-priority
 
    match
@@ -17417,7 +17419,7 @@ relation TableEntry_ok: typingContext tableContext |- tableEntry : tableContext 
 ;; ../../../../spec-concrete/5.04-typing-relation.watsup:332.1-336.82
 relation TableEntries_ok: typingContext tableContext |- tableEntry* : tableContext tableEntryListIR
 
-  ;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:796.1-797.28
+  ;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:799.1-800.28
   rulegroup nil
 
    match
@@ -17431,7 +17433,7 @@ relation TableEntries_ok: typingContext tableContext |- tableEntry* : tableConte
     rulepath nil
     -- output: % % |- % : TBLC []
 
-  ;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:799.1-803.74
+  ;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:802.1-806.74
   rulegroup cons
 
    match
@@ -17451,7 +17453,7 @@ relation TableEntries_ok: typingContext tableContext |- tableEntry* : tableConte
 ;; ../../../../spec-concrete/5.04-typing-relation.watsup:338.1-342.83
 relation TableProperty_ok: typingContext tableContext |- tableProperty : tableContext tablePropertyIR
 
-  ;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:813.1-817.63
+  ;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:816.1-820.63
   rulegroup key
 
    match
@@ -17468,7 +17470,7 @@ relation TableProperty_ok: typingContext tableContext |- tableProperty : tableCo
     -- TableKeys_ok: TC TBLC_0 |- tableKey*{tableKey <- tableKey*} : TBLC_1 tableKeyIR*{tableKeyIR <- tableKeyIR*}
     -- output: % % |- % : TBLC_1 key={ tableKeyIR*{tableKeyIR <- tableKeyIR*} } as tablePropertyIR
 
-  ;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:821.1-825.72
+  ;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:824.1-828.72
   rulegroup actions
 
    match
@@ -17485,7 +17487,7 @@ relation TableProperty_ok: typingContext tableContext |- tableProperty : tableCo
     -- TableActions_ok: TC TBLC_0 |- tableAction*{tableAction <- tableAction*} : TBLC_1 tableActionIR*{tableActionIR <- tableActionIR*}
     -- output: % % |- % : TBLC_1 actions={ tableActionIR*{tableActionIR <- tableActionIR*} } as tablePropertyIR
 
-  ;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:829.1-841.70
+  ;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:832.1-844.70
   rulegroup entries
 
    match
@@ -17506,7 +17508,7 @@ relation TableProperty_ok: typingContext tableContext |- tableProperty : tableCo
     -- TableEntries_ok: TC TBLC_2 |- tableEntry*{tableEntry <- tableEntry*} : TBLC_3 tableEntryIR*{tableEntryIR <- tableEntryIR*}
     -- output: % % |- % : TBLC_3 annotationList constOptIR entries={ tableEntryIR*{tableEntryIR <- tableEntryIR*} } as tablePropertyIR
 
-  ;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:845.1-855.78
+  ;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:848.1-858.78
   rulegroup default-action
 
    match
@@ -17525,7 +17527,7 @@ relation TableProperty_ok: typingContext tableContext |- tableProperty : tableCo
     -- let tablePropertyIR = annotationList constOptIR default_action= tableActionReferenceIR ; as tablePropertyIR
     -- output: % % |- % : TBLC tablePropertyIR
 
-  ;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:857.1-932.2
+  ;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:860.1-935.2
   rulegroup custom
 
    match
@@ -17591,7 +17593,7 @@ relation TableProperty_ok: typingContext tableContext |- tableProperty : tableCo
 ;; ../../../../spec-concrete/5.04-typing-relation.watsup:344.1-348.85
 relation TableProperties_ok: typingContext tableContext |- tableProperty* : tableContext tablePropertyListIR
 
-  ;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:940.1-941.28
+  ;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:943.1-944.28
   rulegroup nil
 
    match
@@ -17605,7 +17607,7 @@ relation TableProperties_ok: typingContext tableContext |- tableProperty* : tabl
     rulepath nil
     -- output: % % |- % : TBLC []
 
-  ;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:943.1-947.83
+  ;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:946.1-950.83
   rulegroup cons
 
    match
@@ -17625,7 +17627,7 @@ relation TableProperties_ok: typingContext tableContext |- tableProperty* : tabl
 ;; ../../../../spec-concrete/5.04-typing-relation.watsup:350.1-354.75
 relation Table_ok: typingContext |- tableProperty* : tableContext tablePropertyListIR
 
-  ;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:1010.1-1042.2
+  ;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:1013.1-1045.2
   rulegroup 
 
    match
@@ -17656,7 +17658,7 @@ relation Table_ok: typingContext |- tableProperty* : tableContext tablePropertyL
 ;; ../../../../spec-concrete/5.04-typing-relation.watsup:356.1-360.74
 relation TableType_ok: typingContext tableContext |- name : typingContext typeIR
 
-  ;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:1045.1-1069.67
+  ;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:1047.1-1071.67
   rulegroup 
 
    match
@@ -19558,15 +19560,33 @@ relation Inst_ok: cursor typingContext instctxt |- constructorTypeIR < typeArgum
     -- Call_convention_ok: p TC noaction |- parameterIR_aligned_inferred*{parameterIR_aligned_inferred <- parameterIR_aligned_inferred*} @ argumentIR*{argumentIR <- argumentIR*} : argumentIR_cast*{argumentIR_cast <- argumentIR_cast*}
     -- output: % % % |- % < % # % >( % # % ): typeIR_object_inferred < typeArgumentIR_inferred*{typeArgumentIR_inferred <- typeArgumentIR_inferred*} >( argumentIR_cast*{argumentIR_cast <- argumentIR_cast*} )
 
-;; ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:420.1-424.23
+;; ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:418.1-418.59
+def $reduce_serenum(typedExpressionIR) : typedExpressionIR =
+
+  ;; ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:420.1-425.79
+  clause 0 : (typedExpressionIR) = typedExpressionIR_reduced
+  -- let typeIR = $type_of_typedExpressionIR(typedExpressionIR)
+  -- let ctk = $ctk_of_typedExpressionIR(typedExpressionIR)
+  -- let typeIR' = $canon_typeIR(typeIR)
+  -- if typeIR' <: enumTypeIR
+  -- let enumTypeIR = typeIR' as enumTypeIR
+  -- if enumTypeIR matches `ENUM%<%>{%}`
+  -- let enum _tid < typeIR_underlying >{ _valueFieldIR*{_valueFieldIR <- _valueFieldIR*} } = enumTypeIR
+  -- let typedExpressionIR_reduced = ( typeIR_underlying ) typedExpressionIR as expressionIR # ( typeIR_underlying ctk )
+
+  ;; ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:426.1-427.15
+  clause 1 : (typedExpressionIR) = typedExpressionIR
+  -- otherwise
+
+;; ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:431.1-434.23
 def $reduce_serenum_unary(typedExpressionIR, $check(typeIR) : bool) : typedExpressionIR? =
 
-  ;; ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:427.1-430.23
+  ;; ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:436.1-439.23
   clause 0 : (typedExpressionIR, $check) = ?(typedExpressionIR)
   -- let _expressionIR # ( typeIR _ctk ) = typedExpressionIR
   -- if $check(typeIR)
 
-  ;; ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:432.1-438.79
+  ;; ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:441.1-447.79
   clause 1 : (typedExpressionIR, $check) = $reduce_serenum_unary(typedExpressionIR_cast, $check)
   -- let _expressionIR # ( typeIR ctk ) = typedExpressionIR
   -- if ~$check(typeIR)
@@ -19577,20 +19597,20 @@ def $reduce_serenum_unary(typedExpressionIR, $check(typeIR) : bool) : typedExpre
   -- let enum _tid < typeIR_underlying >{ _valueFieldIR*{_valueFieldIR <- _valueFieldIR*} } = enumTypeIR
   -- let typedExpressionIR_cast = ( typeIR_underlying ) typedExpressionIR as expressionIR # ( typeIR_underlying ctk )
 
-  ;; ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:440.1-441.15
+  ;; ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:449.1-450.15
   clause 2 : (typedExpressionIR, $check) = ?()
   -- otherwise
 
-;; ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:445.1-450.44
+;; ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:454.1-458.44
 def $reduce_serenum_binary(typedExpressionIR, typedExpressionIR, $check(typeIR, typeIR) : bool) : (typedExpressionIR, typedExpressionIR)? =
 
-  ;; ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:452.1-456.35
+  ;; ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:460.1-464.35
   clause 0 : (typedExpressionIR_l, typedExpressionIR_r, $check) = ?((typedExpressionIR_l, typedExpressionIR_r))
   -- let _expressionIR # ( typeIR_l _ctk ) = typedExpressionIR_l
   -- let _expressionIR' # ( typeIR_r _ctk' ) = typedExpressionIR_r
   -- if $check(typeIR_l, typeIR_r)
 
-  ;; ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:458.1-466.87
+  ;; ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:466.1-474.87
   clause 1 : (typedExpressionIR_l, typedExpressionIR_r, $check) = $reduce_serenum_binary(typedExpressionIR_l_cast, typedExpressionIR_r, $check)
   -- let _expressionIR # ( typeIR_l ctk_l ) = typedExpressionIR_l
   -- let _expressionIR' # ( typeIR_r _ctk ) = typedExpressionIR_r
@@ -19602,7 +19622,7 @@ def $reduce_serenum_binary(typedExpressionIR, typedExpressionIR, $check(typeIR, 
   -- let enum _tid < typeIR_l_underlying >{ _valueFieldIR*{_valueFieldIR <- _valueFieldIR*} } = enumTypeIR
   -- let typedExpressionIR_l_cast = ( typeIR_l_underlying ) typedExpressionIR_l as expressionIR # ( typeIR_l_underlying ctk_l )
 
-  ;; ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:468.1-476.87
+  ;; ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:476.1-484.87
   clause 2 : (typedExpressionIR_l, typedExpressionIR_r, $check) = $reduce_serenum_binary(typedExpressionIR_l, typedExpressionIR_r_cast, $check)
   -- let _expressionIR # ( typeIR_l _ctk ) = typedExpressionIR_l
   -- let _expressionIR' # ( typeIR_r ctk_r ) = typedExpressionIR_r
@@ -19614,35 +19634,35 @@ def $reduce_serenum_binary(typedExpressionIR, typedExpressionIR, $check(typeIR, 
   -- let enum _tid < typeIR_r_underlying >{ _valueFieldIR*{_valueFieldIR <- _valueFieldIR*} } = enumTypeIR
   -- let typedExpressionIR_r_cast = ( typeIR_r_underlying ) typedExpressionIR_r as expressionIR # ( typeIR_r_underlying ctk_r )
 
-  ;; ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:478.1-479.15
+  ;; ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:486.1-487.15
   clause 3 : (typedExpressionIR_l, typedExpressionIR_r, $check) = ?()
   -- otherwise
 
-;; ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:490.1-491.44
+;; ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:498.1-499.44
 def $coerce_unary(typedExpressionIR, typeIR) : typedExpressionIR? =
 
-  ;; ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:493.1-495.37
+  ;; ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:501.1-503.37
   clause 0 : (typedExpressionIR, typeIR_to) = ?(typedExpressionIR)
   -- let _expressionIR # ( typeIR _ctk ) = typedExpressionIR
   -- if Type_alpha: typeIR ~~ typeIR_to holds
 
-  ;; ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:497.1-502.63
+  ;; ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:505.1-510.63
   clause 1 : (typedExpressionIR, typeIR_to) = ?(typedExpressionIR_cast)
   -- let _expressionIR # ( typeIR ctk ) = typedExpressionIR
   -- if Type_alpha: typeIR ~~ typeIR_to does not hold
   -- if Sub_impl: typeIR <: typeIR_to holds
   -- let typedExpressionIR_cast = ( typeIR_to ) typedExpressionIR as expressionIR # ( typeIR_to ctk )
 
-;; ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:506.1-508.62
+;; ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:514.1-516.62
 def $coerce_binary(typedExpressionIR, typedExpressionIR) : (typedExpressionIR, typedExpressionIR)? =
 
-  ;; ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:510.1-514.38
+  ;; ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:518.1-522.38
   clause 0 : (typedExpressionIR_l, typedExpressionIR_r) = ?((typedExpressionIR_l, typedExpressionIR_r))
   -- let _expressionIR # ( typeIR_l _ctk ) = typedExpressionIR_l
   -- let _expressionIR' # ( typeIR_r _ctk' ) = typedExpressionIR_r
   -- if Type_alpha: typeIR_l ~~ typeIR_r holds
 
-  ;; ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:516.1-523.65
+  ;; ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:524.1-531.65
   clause 1 : (typedExpressionIR_l, typedExpressionIR_r) = ?((typedExpressionIR_l_cast, typedExpressionIR_r))
   -- let _expressionIR # ( typeIR_l ctk_l ) = typedExpressionIR_l
   -- let _expressionIR' # ( typeIR_r _ctk ) = typedExpressionIR_r
@@ -19650,7 +19670,7 @@ def $coerce_binary(typedExpressionIR, typedExpressionIR) : (typedExpressionIR, t
   -- if Sub_impl: typeIR_l <: typeIR_r holds
   -- let typedExpressionIR_l_cast = ( typeIR_r ) typedExpressionIR_l as expressionIR # ( typeIR_r ctk_l )
 
-  ;; ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:525.1-533.65
+  ;; ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:533.1-541.65
   clause 2 : (typedExpressionIR_l, typedExpressionIR_r) = ?((typedExpressionIR_l, typedExpressionIR_r_cast))
   -- let _expressionIR # ( typeIR_l _ctk ) = typedExpressionIR_l
   -- let _expressionIR' # ( typeIR_r ctk_r ) = typedExpressionIR_r
@@ -19659,8 +19679,29 @@ def $coerce_binary(typedExpressionIR, typedExpressionIR) : (typedExpressionIR, t
   -- if Sub_impl: typeIR_r <: typeIR_l holds
   -- let typedExpressionIR_r_cast = ( typeIR_l ) typedExpressionIR_r as expressionIR # ( typeIR_l ctk_r )
 
-  ;; ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:535.1-536.15
-  clause 3 : (typedExpressionIR_l, typedExpressionIR_r) = ?()
+  ;; ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:543.1-551.57
+  clause 3 : (typedExpressionIR_l, typedExpressionIR_r) = $coerce_binary(typedExpressionIR_l_cast, typedExpressionIR_r)
+  -- let _expressionIR # ( typeIR_l ctk_l ) = typedExpressionIR_l
+  -- let _expressionIR' # ( typeIR_r _ctk ) = typedExpressionIR_r
+  -- if Type_alpha: typeIR_l ~~ typeIR_r does not hold
+  -- if Sub_impl: typeIR_l <: typeIR_r does not hold
+  -- if Sub_impl: typeIR_r <: typeIR_l does not hold
+  -- let typedExpressionIR_l_cast = $reduce_serenum(typedExpressionIR_l)
+  -- if (typedExpressionIR_l =/= typedExpressionIR_l_cast)
+
+  ;; ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:553.1-562.57
+  clause 4 : (typedExpressionIR_l, typedExpressionIR_r) = $coerce_binary(typedExpressionIR_l, typedExpressionIR_r_cast)
+  -- let _expressionIR # ( typeIR_l _ctk ) = typedExpressionIR_l
+  -- let _expressionIR' # ( typeIR_r ctk_r ) = typedExpressionIR_r
+  -- if Type_alpha: typeIR_l ~~ typeIR_r does not hold
+  -- if Sub_impl: typeIR_l <: typeIR_r does not hold
+  -- if Sub_impl: typeIR_r <: typeIR_l does not hold
+  -- if (typedExpressionIR_l = $reduce_serenum(typedExpressionIR_l))
+  -- let typedExpressionIR_r_cast = $reduce_serenum(typedExpressionIR_r)
+  -- if (typedExpressionIR_r =/= typedExpressionIR_r_cast)
+
+  ;; ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:564.1-565.15
+  clause 5 : (typedExpressionIR_l, typedExpressionIR_r) = ?()
   -- otherwise
 
 ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:80.1-80.32
@@ -21659,14 +21700,14 @@ def $compat_table_key(nameIR, typeIR) : bool =
   clause 2 : (nameIR, typeIR) = false
   -- otherwise
 
-;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:86.1-87.33
+;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:89.1-90.33
 def $split_dataplane_parameters(parameterIR*) : (parameterIR*, parameterIR*) =
 
-  ;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:89.1-89.50
+  ;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:92.1-92.50
   clause 0 : (parameterIR*{parameterIR <- parameterIR*}) = ([], [])
   -- if parameterIR*{parameterIR <- parameterIR*} matches []
 
-  ;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:90.1-94.52
+  ;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:93.1-97.52
   clause 1 : (parameterIR*{parameterIR <- parameterIR*}) = (parameterIR_data*{parameterIR_data <- parameterIR_data*}, parameterIR_h :: parameterIR_control*{parameterIR_control <- parameterIR_control*})
   -- if parameterIR*{parameterIR <- parameterIR*} matches _ :: _
   -- let parameterIR_h :: parameterIR_t*{parameterIR_t <- parameterIR_t*} = parameterIR*{parameterIR <- parameterIR*}
@@ -21674,7 +21715,7 @@ def $split_dataplane_parameters(parameterIR*) : (parameterIR*, parameterIR*) =
   -- if direction matches ``EMPTY`
   -- let (parameterIR_data*{parameterIR_data <- parameterIR_data*}, parameterIR_control*{parameterIR_control <- parameterIR_control*}) = $split_dataplane_parameters(parameterIR_t*{parameterIR_t <- parameterIR_t*})
 
-  ;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:95.1-100.52
+  ;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:98.1-103.52
   clause 2 : (parameterIR*{parameterIR <- parameterIR*}) = (parameterIR_h :: parameterIR_data*{parameterIR_data <- parameterIR_data*}, parameterIR_control*{parameterIR_control <- parameterIR_control*})
   -- if parameterIR*{parameterIR <- parameterIR*} matches _ :: _
   -- let parameterIR_h :: parameterIR_t*{parameterIR_t <- parameterIR_t*} = parameterIR*{parameterIR <- parameterIR*}
@@ -21682,10 +21723,10 @@ def $split_dataplane_parameters(parameterIR*) : (parameterIR*, parameterIR*) =
   -- if (direction =/= )
   -- let (parameterIR_data*{parameterIR_data <- parameterIR_data*}, parameterIR_control*{parameterIR_control <- parameterIR_control*}) = $split_dataplane_parameters(parameterIR_t*{parameterIR_t <- parameterIR_t*})
 
-;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:241.1-244.26
+;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:244.1-247.26
 relation TableEntry_keyset_simple_ok: typingContext tableContext |- matchKey @ simpleKeysetExpression : tableEntryState simpleKeysetExpressionIR
 
-  ;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:248.1-282.2
+  ;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:251.1-285.2
   rulegroup expression
 
    match
@@ -21721,7 +21762,7 @@ relation TableEntry_keyset_simple_ok: typingContext tableContext |- matchKey @ s
     -- let typedExpressionIR_set = ( typeIR_set ) typedExpressionIR as expressionIR # ( typeIR_set ctk )
     -- output: % % |- % @ % : nolpm typedExpressionIR_set as simpleKeysetExpressionIR
 
-  ;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:286.1-337.2
+  ;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:289.1-340.2
   rulegroup mask
 
    match
@@ -21771,7 +21812,7 @@ relation TableEntry_keyset_simple_ok: typingContext tableContext |- matchKey @ s
     -- let ?((typedExpressionIR_l_reduced, typedExpressionIR_r_reduced)) = (typedExpressionIR, typedExpressionIR)?{(typedExpressionIR, typedExpressionIR) <- (typedExpressionIR, typedExpressionIR)?}
     -- output: % % |- % @ % : nolpm typedExpressionIR_l_reduced &&& typedExpressionIR_r_reduced
 
-  ;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:341.1-358.12
+  ;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:344.1-361.12
   rulegroup range-range
 
    match
@@ -21798,7 +21839,7 @@ relation TableEntry_keyset_simple_ok: typingContext tableContext |- matchKey @ s
     -- let ?((typedExpressionIR_l_reduced, typedExpressionIR_r_reduced)) = (typedExpressionIR, typedExpressionIR)?{(typedExpressionIR, typedExpressionIR) <- (typedExpressionIR, typedExpressionIR)?}
     -- output: % % |- % @ % : nolpm typedExpressionIR_l_reduced .. typedExpressionIR_r_reduced
 
-  ;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:362.1-375.2
+  ;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:365.1-378.2
   rulegroup default
 
    match
@@ -21822,7 +21863,7 @@ relation TableEntry_keyset_simple_ok: typingContext tableContext |- matchKey @ s
     -- if (nameIR_matchkind =/= "exact")
     -- output: % % |- % @ % : nolpm default
 
-  ;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:379.1-392.2
+  ;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:382.1-395.2
   rulegroup dontcare
 
    match
@@ -21846,10 +21887,10 @@ relation TableEntry_keyset_simple_ok: typingContext tableContext |- matchKey @ s
     -- if (nameIR_matchkind =/= "exact")
     -- output: % % |- % @ % : nolpm _
 
-;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:400.1-403.29
+;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:403.1-406.29
 relation TableEntry_keysets_simple_ok: typingContext tableContext tableEntryState |- matchKey* @ simpleKeysetExpression* : tableEntryState simpleKeysetExpressionIR*
 
-  ;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:405.1-406.40
+  ;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:408.1-409.40
   rulegroup nil
 
    match
@@ -21864,7 +21905,7 @@ relation TableEntry_keysets_simple_ok: typingContext tableContext tableEntryStat
     rulepath nil
     -- output: % % % |- % @ % : TBLS []
 
-  ;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:408.1-418.59
+  ;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:411.1-421.59
   rulegroup cons
 
    match
@@ -21884,51 +21925,51 @@ relation TableEntry_keysets_simple_ok: typingContext tableContext tableEntryStat
     -- TableEntry_keysets_simple_ok: TC TBLC TBLS_2 |- matchKey_t*{matchKey_t <- matchKey_t*} @ simpleKeysetExpression_t*{simpleKeysetExpression_t <- simpleKeysetExpression_t*} : TBLS_3 simpleKeysetExpressionIR_t*{simpleKeysetExpressionIR_t <- simpleKeysetExpressionIR_t*}
     -- output: % % % |- % @ % : TBLS_3 simpleKeysetExpressionIR_h :: simpleKeysetExpressionIR_t*{simpleKeysetExpressionIR_t <- simpleKeysetExpressionIR_t*}
 
-;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:955.1-955.48
+;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:958.1-958.48
 def $is_tableKeysProperty(tableProperty) : bool =
 
-  ;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:956.1-956.48
+  ;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:959.1-959.48
   clause 0 : (tableProperty) = true
   -- if tableProperty matches `KEY={%}`
   -- let key={ _tableKeyList } = tableProperty
 
-  ;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:957.1-958.15
+  ;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:960.1-961.15
   clause 1 : (_tableProperty) = false
   -- otherwise
 
-;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:960.1-960.51
+;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:963.1-963.51
 def $is_tableActionsProperty(tableProperty) : bool =
 
-  ;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:961.1-961.55
+  ;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:964.1-964.55
   clause 0 : (tableProperty) = true
   -- if tableProperty matches `ACTIONS={%}`
   -- let actions={ _tableActionList } = tableProperty
 
-  ;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:962.1-963.15
+  ;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:965.1-966.15
   clause 1 : (_tableProperty) = false
   -- otherwise
 
-;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:965.1-965.57
+;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:968.1-968.57
 def $is_tableDefaultActionProperty(tableProperty) : bool =
 
-  ;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:966.1-967.61
+  ;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:969.1-970.61
   clause 0 : (tableProperty) = true
   -- if tableProperty matches `%%%%;`
   -- let _annotationList _constOpt tableCustomName _initializer ; = tableProperty
   -- if ("default_action" = $tableCustomName(tableCustomName))
 
-  ;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:968.1-969.15
+  ;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:971.1-972.15
   clause 1 : (_tableProperty) = false
   -- otherwise
 
-;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:971.1-974.37
+;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:974.1-977.37
 def $insert_NoAction_tablePropertyIR(tableContext, tablePropertyIR*) : (tableContext, tablePropertyIR*) =
 
-  ;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:976.1-976.62
+  ;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:979.1-979.62
   clause 0 : (TBLC, tablePropertyIR*{tablePropertyIR <- tablePropertyIR*}) = (TBLC, [])
   -- if tablePropertyIR*{tablePropertyIR <- tablePropertyIR*} matches []
 
-  ;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:977.1-991.69
+  ;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:980.1-994.69
   clause 1 : (TBLC_0, tablePropertyIR*{tablePropertyIR <- tablePropertyIR*}) = (TBLC_1, tablePropertyIR_h_updated :: tablePropertyIR_t*{tablePropertyIR_t <- tablePropertyIR_t*})
   -- if tablePropertyIR*{tablePropertyIR <- tablePropertyIR*} matches _ :: _
   -- let tablePropertyIR_h :: tablePropertyIR_t*{tablePropertyIR_t <- tablePropertyIR_t*} = tablePropertyIR*{tablePropertyIR <- tablePropertyIR*}
@@ -21942,7 +21983,7 @@ def $insert_NoAction_tablePropertyIR(tableContext, tablePropertyIR*) : (tableCon
   -- let tableActionIR_NoAction = tableActionReferenceIR_NoAction #( [] , [] );
   -- let tablePropertyIR_h_updated = actions={ tableActionIR*{tableActionIR <- tableActionIR*} ++ [tableActionIR_NoAction] } as tablePropertyIR
 
-  ;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:992.1-1001.69
+  ;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:995.1-1004.69
   clause 2 : (TBLC_0, tablePropertyIR*{tablePropertyIR <- tablePropertyIR*}) = (TBLC_0, tablePropertyIR_h :: tablePropertyIR_t*{tablePropertyIR_t <- tablePropertyIR_t*})
   -- if tablePropertyIR*{tablePropertyIR <- tablePropertyIR*} matches _ :: _
   -- let tablePropertyIR_h :: tablePropertyIR_t*{tablePropertyIR_t <- tablePropertyIR_t*} = tablePropertyIR*{tablePropertyIR <- tablePropertyIR*}
@@ -21953,7 +21994,7 @@ def $insert_NoAction_tablePropertyIR(tableContext, tablePropertyIR*) : (tableCon
   -- let tableActionReferenceIR_NoAction = . "NoAction" ( [] )
   -- if tableActionReferenceIR_NoAction <- tableActionReferenceIR*{tableActionReferenceIR <- tableActionReferenceIR*}
 
-  ;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:1002.1-1008.38
+  ;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:1005.1-1011.38
   clause 3 : (TBLC_0, tablePropertyIR*{tablePropertyIR <- tablePropertyIR*}) = (TBLC_1, tablePropertyIR_h :: tablePropertyIR_t_updated*{tablePropertyIR_t_updated <- tablePropertyIR_t_updated*})
   -- if tablePropertyIR*{tablePropertyIR <- tablePropertyIR*} matches _ :: _
   -- let tablePropertyIR_h :: tablePropertyIR_t*{tablePropertyIR_t <- tablePropertyIR_t*} = tablePropertyIR*{tablePropertyIR <- tablePropertyIR*}

--- a/p4spec/test/prose.expected
+++ b/p4spec/test/prose.expected
@@ -3388,23 +3388,30 @@ relation ParserTransition_ok: `TC~0~`, `nameIR~state~^{asterisk}^`, and `transit
 --
 +
 for each `expression~key~` in `expression~key~^{asterisk}^`
-   .... Let `typeIR~key~^{asterisk}^` be the list of `typeIR~key~`, obtained by repeating:
+   .... Let `typedExpressionIR~key_reduced~^{asterisk}^` be the list of `typedExpressionIR~key_reduced~`, obtained by repeating:
 +
 --
-        * Let `typeIR~key~` be <<type_of_typedExpressionIR, the type of  `typedExpressionIR~key~`>>.
+        * Let `typedExpressionIR~key_reduced~` be `<<reduce_serenum, $reduce_serenum(typedExpressionIR~key~)>>`.
 --
 +
 for each `typedExpressionIR~key~` in `typedExpressionIR~key~^{asterisk}^`
-   .... Check that <<Type_wf, `SET < [typeIR~key~] >` is a well-formed type, assuming bound type ids `$bound(LOCAL, TC~0~)`>>, for all `typeIR~key~` in `typeIR~key~^{asterisk}^`.
+   .... Let `typeIR~key_reduced~^{asterisk}^` be the list of `typeIR~key_reduced~`, obtained by repeating:
++
+--
+        * Let `typeIR~key_reduced~` be <<type_of_typedExpressionIR, the type of  `typedExpressionIR~key_reduced~`>>.
+--
++
+for each `typedExpressionIR~key_reduced~` in `typedExpressionIR~key_reduced~^{asterisk}^`
+   .... Check that <<Type_wf, `SET < [typeIR~key_reduced~] >` is a well-formed type, assuming bound type ids `$bound(LOCAL, TC~0~)`>>, for all `typeIR~key_reduced~` in `typeIR~key_reduced~^{asterisk}^`.
    .... Let `selectCase^{asterisk}^` be <<flatten_selectCaseList, the list of select cases in `selectCaseList`>>.
    .... Let `selectCaseIR^{asterisk}^` be the list of `selectCaseIR`, obtained by repeating:
 +
 --
-        * Let <<SelectCase_ok, `TC~0~ nameIR~state~^{asterisk}^ typeIR~key~^{asterisk}^ |- selectCase : selectCaseIR`>>.
+        * Let <<SelectCase_ok, `TC~0~ nameIR~state~^{asterisk}^ typeIR~key_reduced~^{asterisk}^ |- selectCase : selectCaseIR`>>.
 --
 +
 for each `selectCase` in `selectCase^{asterisk}^`
-   .... Let `transitionStatementIR` be `TRANSITION SELECT ( typedExpressionIR~key~^{asterisk}^ ) { selectCaseIR^{asterisk}^ }`.
+   .... Let `transitionStatementIR` be `TRANSITION SELECT ( typedExpressionIR~key_reduced~^{asterisk}^ ) { selectCaseIR^{asterisk}^ }`.
    .... Result in the typed transition statement `transitionStatementIR`.
 
 
@@ -3623,14 +3630,15 @@ relation TableKey_ok: `TC`, `TBLC~0~`, and `expression : name~matchkind~ annotat
 
 . Group :
  .. Let `typedExpressionIR` be the result of <<Expr_ok, typing `expression`, under cursor `LOCAL` and typing context `TC`>>.
- .. Let `typeIR` be <<type_of_typedExpressionIR, the type of  `typedExpressionIR`>>.
- .. Check that <<Type_wf, `SET < [typeIR] >` is a well-formed type, assuming bound type ids `$bound(LOCAL, TC)`>>.
+ .. Let `typedExpressionIR~reduced~` be `<<reduce_serenum, $reduce_serenum(typedExpressionIR)>>`.
+ .. Let `typeIR~reduced~` be <<type_of_typedExpressionIR, the type of  `typedExpressionIR~reduced~`>>.
+ .. Check that <<Type_wf, `SET < [typeIR~reduced~] >` is a well-formed type, assuming bound type ids `$bound(LOCAL, TC)`>>.
  .. Let `nameIR~matchkind~` be <<name, the name of `name~matchkind~`>>.
  .. Check that `MATCH_KIND . nameIR~matchkind~` is equal to <<find_var_value_t, the value of variable `nameIR~matchkind~` in the `LOCAL` layer of `TC`>>.
- .. Check that `<<compat_table_key, $compat_table_key(nameIR~matchkind~, typeIR)>>`.
- .. Let `TBLC~1~` be `<<update_mode, $update_mode(TBLC~0~, nameIR~matchkind~, typeIR)>>`.
- .. Let `TBLC~2~` be `<<add_key, $add_key(TBLC~1~, nameIR~matchkind~, typeIR)>>`.
- .. Let `tableKeyIR` be `typedExpressionIR : nameIR~matchkind~ annotationList ;`.
+ .. Check that `<<compat_table_key, $compat_table_key(nameIR~matchkind~, typeIR~reduced~)>>`.
+ .. Let `TBLC~1~` be `<<update_mode, $update_mode(TBLC~0~, nameIR~matchkind~, typeIR~reduced~)>>`.
+ .. Let `TBLC~2~` be `<<add_key, $add_key(TBLC~1~, nameIR~matchkind~, typeIR~reduced~)>>`.
+ .. Let `tableKeyIR` be `typedExpressionIR~reduced~ : nameIR~matchkind~ annotationList ;`.
  .. Result in the updated table context `TBLC~2~` and the typed table key `tableKeyIR`.
 
 

--- a/p4spec/test/run_il_inst_p4c.expected
+++ b/p4spec/test/run_il_inst_p4c.expected
@@ -2375,10 +2375,10 @@ Run success: ../../../../p4c/testdata/p4_16_samples/list7.p4
 >>> Running interpreter test (Program_inst) on ../../../../p4c/testdata/p4_16_samples/list8.p4
 Error on run: ../../../../p4c/testdata/p4_16_samples/list8.p4
 tracing backtrack logs:
-../../../../spec-concrete/3-numerics.watsup:666.14-666.22
+../../../../spec-concrete/3-numerics.watsup:665.14-665.22
 invocation of function $cast_op(typeIR, value) failed
 │ ··· omitting -1 traces ···
-└── ../../../../spec-concrete/3-numerics.watsup:666.14-666.22
+└── ../../../../spec-concrete/3-numerics.watsup:665.14-665.22
     application of clause cast_op(typeIR, value) failed
     └── ../../../../spec-concrete/2.1.1-value.watsup:9.20-9.21
         condition value <: boolValue was not met

--- a/p4spec/test/run_il_inst_p4c.expected
+++ b/p4spec/test/run_il_inst_p4c.expected
@@ -419,7 +419,7 @@ Run success: ../../../../p4c/testdata/p4_16_samples/enum-folding.p4
 Run success: ../../../../p4c/testdata/p4_16_samples/enum.p4
 
 >>> Running interpreter test (Program_inst) on ../../../../p4c/testdata/p4_16_samples/enumCast.p4
-Excluding file: ../../../../p4c/testdata/p4_16_samples/enumCast.p4
+Run success: ../../../../p4c/testdata/p4_16_samples/enumCast.p4
 
 >>> Running interpreter test (Program_inst) on ../../../../p4c/testdata/p4_16_samples/equality-bmv2.p4
 Run success: ../../../../p4c/testdata/p4_16_samples/equality-bmv2.p4
@@ -1891,7 +1891,7 @@ Run success: ../../../../p4c/testdata/p4_16_samples/issue3324.p4
 Run success: ../../../../p4c/testdata/p4_16_samples/issue3329-bmv2.p4
 
 >>> Running interpreter test (Program_inst) on ../../../../p4c/testdata/p4_16_samples/issue3333.p4
-Excluding file: ../../../../p4c/testdata/p4_16_samples/issue3333.p4
+Run success: ../../../../p4c/testdata/p4_16_samples/issue3333.p4
 
 >>> Running interpreter test (Program_inst) on ../../../../p4c/testdata/p4_16_samples/issue3343.p4
 Run success: ../../../../p4c/testdata/p4_16_samples/issue3343.p4
@@ -3689,7 +3689,7 @@ Run success: ../../../../p4c/testdata/p4_16_samples/table-entries-priority-bmv2.
 Run success: ../../../../p4c/testdata/p4_16_samples/table-entries-range-bmv2.p4
 
 >>> Running interpreter test (Program_inst) on ../../../../p4c/testdata/p4_16_samples/table-entries-ser-enum-bmv2.p4
-Excluding file: ../../../../p4c/testdata/p4_16_samples/table-entries-ser-enum-bmv2.p4
+Run success: ../../../../p4c/testdata/p4_16_samples/table-entries-ser-enum-bmv2.p4
 
 >>> Running interpreter test (Program_inst) on ../../../../p4c/testdata/p4_16_samples/table-entries-ternary-bmv2.p4
 Run success: ../../../../p4c/testdata/p4_16_samples/table-entries-ternary-bmv2.p4
@@ -3886,4 +3886,4 @@ Run success: ../../../../p4c/testdata/p4_16_samples/xdp_vlan_push_pop_ebpf-kerne
 >>> Running interpreter test (Program_inst) on ../../../../p4c/testdata/p4_16_samples/xor_test.p4
 Run success: ../../../../p4c/testdata/p4_16_samples/xor_test.p4
 
-Running interpreter test (Program_inst): [EXCLUDE] 99/1278 (7.75%) [PASS] 1174/1278 (91.86%) [FAIL] 5/1278 (0.39%)
+Running interpreter test (Program_inst): [EXCLUDE] 96/1278 (7.51%) [PASS] 1177/1278 (92.10%) [FAIL] 5/1278 (0.39%)

--- a/p4spec/test/run_il_type_neg_p4c.expected
+++ b/p4spec/test/run_il_type_neg_p4c.expected
@@ -28,19 +28,19 @@ Error on run: ../../../../p4c/testdata/p4_16_errors/action-bind.p4
 tracing backtrack logs:
 invocation of relation Program_ok failed
 │ ··· omitting 16 traces ···
-../../../../spec-concrete/5.14.1-typing-control-table.watsup:1040.8-1040.26
+../../../../spec-concrete/5.14.1-typing-control-table.watsup:1043.8-1043.26
 application of rule TableProperties_ok/cons/cons failed
-└── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:947.6-947.24
+└── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:950.6-950.24
     invocation of relation TableProperties_ok failed
-    └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:947.6-947.24
+    └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:950.6-950.24
         application of rule TableProperties_ok/cons/cons failed
-        └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:946.6-946.22
+        └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:949.6-949.22
             invocation of relation TableProperty_ok failed
-            └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:946.6-946.22
+            └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:949.6-949.22
                 application of rule TableProperty_ok/custom/unknown failed
-                └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:926.8-926.15
+                └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:929.8-929.15
                     invocation of relation Expr_ok failed
-                    └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:926.8-926.15
+                    └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:929.8-929.15
                         application of rule Expr_ok/callExpression-callable/non-typeArgumentList failed
                         └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:1189.8-1189.15
                             invocation of relation Call_ok failed
@@ -73,7 +73,7 @@ application of rule Decl_ok/controlDeclaration/controlDeclaration failed
                             invocation of relation Table_ok failed
                             └── ../../../../spec-concrete/5.14.2-typing-control-declaration.watsup:82.6-82.14
                                 application of rule Table_ok//zero-default-action failed
-                                └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:1020.11-1020.92
+                                └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:1023.11-1023.92
                                     condition (|$filter_<tableProperty>(tableProperty*{tableProperty <- tableProperty*}, $is_tableDefaultActionProperty)| = 0) was not met
 
 
@@ -100,7 +100,7 @@ application of rule Decl_ok/controlDeclaration/controlDeclaration failed
                             invocation of relation Table_ok failed
                             └── ../../../../spec-concrete/5.14.2-typing-control-declaration.watsup:82.6-82.14
                                 application of rule Table_ok//zero-default-action failed
-                                └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:1020.11-1020.92
+                                └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:1023.11-1023.92
                                     condition (|$filter_<tableProperty>(tableProperty*{tableProperty <- tableProperty*}, $is_tableDefaultActionProperty)| = 0) was not met
 
 
@@ -127,7 +127,7 @@ application of rule Decl_ok/controlDeclaration/controlDeclaration failed
                             invocation of relation Table_ok failed
                             └── ../../../../spec-concrete/5.14.2-typing-control-declaration.watsup:82.6-82.14
                                 application of rule Table_ok//zero-default-action failed
-                                └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:1020.11-1020.92
+                                └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:1023.11-1023.92
                                     condition (|$filter_<tableProperty>(tableProperty*{tableProperty <- tableProperty*}, $is_tableDefaultActionProperty)| = 0) was not met
 
 
@@ -338,11 +338,11 @@ invocation of function $coerce_unary(typedExpressionIR_value, typeIR) failed
 │ ··· omitting -1 traces ···
 ├── ../../../../spec-concrete/5.11-typing-declaration.watsup:21.10-21.23
     1. application of clause coerce_unary(typedExpressionIR, typeIR_to) failed
-│   └── ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:495.6-495.16
+│   └── ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:503.6-503.16
 │       condition hold Type_alpha was not met
 └── ../../../../spec-concrete/5.11-typing-declaration.watsup:21.10-21.23
     2. application of clause coerce_unary(typedExpressionIR, typeIR_to) failed
-    └── ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:500.6-500.14
+    └── ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:508.6-508.14
         condition hold Sub_impl was not met
 
 
@@ -411,11 +411,11 @@ invocation of function $coerce_unary(typedExpressionIR_arg, typeIR_param) failed
 │ ··· omitting -1 traces ···
 ├── ../../../../spec-concrete/5.15.1-typing-call-convention.watsup:132.12-132.25
     1. application of clause coerce_unary(typedExpressionIR, typeIR_to) failed
-│   └── ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:495.6-495.16
+│   └── ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:503.6-503.16
 │       condition hold Type_alpha was not met
 └── ../../../../spec-concrete/5.15.1-typing-call-convention.watsup:132.12-132.25
     2. application of clause coerce_unary(typedExpressionIR, typeIR_to) failed
-    └── ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:500.6-500.14
+    └── ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:508.6-508.14
         condition hold Sub_impl was not met
 
 
@@ -571,7 +571,7 @@ application of rule ControlLocalDecls_ok/cons/cons failed
                             invocation of relation Table_ok failed
                             └── ../../../../spec-concrete/5.14.2-typing-control-declaration.watsup:82.6-82.14
                                 application of rule Table_ok//zero-default-action failed
-                                └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:1020.11-1020.92
+                                └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:1023.11-1023.92
                                     condition (|$filter_<tableProperty>(tableProperty*{tableProperty <- tableProperty*}, $is_tableDefaultActionProperty)| = 0) was not met
 
 
@@ -896,16 +896,16 @@ application of rule Decl_ok/controlDeclaration/controlDeclaration failed
 >>> Running interpreter test (Program_ok) on ../../../../p4c/testdata/p4_16_errors/enumCast.p4
 Error on run: ../../../../p4c/testdata/p4_16_errors/enumCast.p4
 tracing backtrack logs:
-../../../../spec-concrete/5.13.1-typing-parser-statement.watsup:367.12-367.25
+../../../../spec-concrete/5.13.1-typing-parser-statement.watsup:368.12-368.25
 invocation of function $coerce_unary(typedExpressionIR_init, typeIR) failed
 │ ··· omitting -1 traces ···
-├── ../../../../spec-concrete/5.13.1-typing-parser-statement.watsup:367.12-367.25
+├── ../../../../spec-concrete/5.13.1-typing-parser-statement.watsup:368.12-368.25
     1. application of clause coerce_unary(typedExpressionIR, typeIR_to) failed
-│   └── ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:495.6-495.16
+│   └── ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:503.6-503.16
 │       condition hold Type_alpha was not met
-└── ../../../../spec-concrete/5.13.1-typing-parser-statement.watsup:367.12-367.25
+└── ../../../../spec-concrete/5.13.1-typing-parser-statement.watsup:368.12-368.25
     2. application of clause coerce_unary(typedExpressionIR, typeIR_to) failed
-    └── ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:500.6-500.14
+    └── ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:508.6-508.14
         condition hold Sub_impl was not met
 
 
@@ -1155,11 +1155,11 @@ invocation of function $coerce_unary(typedExpressionIR_value, typeIR) failed
 │ ··· omitting -1 traces ···
 ├── ../../../../spec-concrete/5.11-typing-declaration.watsup:21.10-21.23
     1. application of clause coerce_unary(typedExpressionIR, typeIR_to) failed
-│   └── ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:495.6-495.16
+│   └── ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:503.6-503.16
 │       condition hold Type_alpha was not met
 └── ../../../../spec-concrete/5.11-typing-declaration.watsup:21.10-21.23
     2. application of clause coerce_unary(typedExpressionIR, typeIR_to) failed
-    └── ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:500.6-500.14
+    └── ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:508.6-508.14
         condition hold Sub_impl was not met
 
 
@@ -1251,11 +1251,11 @@ invocation of function $coerce_unary(typedExpressionIR_init, typeIR) failed
 │ ··· omitting -1 traces ···
 ├── ../../../../spec-concrete/5.10-typing-statement.watsup:735.12-735.25
     1. application of clause coerce_unary(typedExpressionIR, typeIR_to) failed
-│   └── ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:495.6-495.16
+│   └── ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:503.6-503.16
 │       condition hold Type_alpha was not met
 └── ../../../../spec-concrete/5.10-typing-statement.watsup:735.12-735.25
     2. application of clause coerce_unary(typedExpressionIR, typeIR_to) failed
-    └── ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:500.6-500.14
+    └── ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:508.6-508.14
         condition hold Sub_impl was not met
 
 
@@ -1309,7 +1309,7 @@ application of rule ControlLocalDecls_ok/cons/cons failed
                             invocation of relation Table_ok failed
                             └── ../../../../spec-concrete/5.14.2-typing-control-declaration.watsup:82.6-82.14
                                 application of rule Table_ok//zero-default-action failed
-                                └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:1020.11-1020.92
+                                └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:1023.11-1023.92
                                     condition (|$filter_<tableProperty>(tableProperty*{tableProperty <- tableProperty*}, $is_tableDefaultActionProperty)| = 0) was not met
 
 
@@ -1336,7 +1336,7 @@ application of rule ControlLocalDecls_ok/cons/cons failed
                             invocation of relation Table_ok failed
                             └── ../../../../spec-concrete/5.14.2-typing-control-declaration.watsup:82.6-82.14
                                 application of rule Table_ok//zero-default-action failed
-                                └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:1020.11-1020.92
+                                └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:1023.11-1023.92
                                     condition (|$filter_<tableProperty>(tableProperty*{tableProperty <- tableProperty*}, $is_tableDefaultActionProperty)| = 0) was not met
 
 
@@ -1363,7 +1363,7 @@ application of rule ControlLocalDecls_ok/cons/cons failed
                             invocation of relation Table_ok failed
                             └── ../../../../spec-concrete/5.14.2-typing-control-declaration.watsup:82.6-82.14
                                 application of rule Table_ok//zero-default-action failed
-                                └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:1020.11-1020.92
+                                └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:1023.11-1023.92
                                     condition (|$filter_<tableProperty>(tableProperty*{tableProperty <- tableProperty*}, $is_tableDefaultActionProperty)| = 0) was not met
 
 
@@ -1463,11 +1463,11 @@ invocation of function $coerce_unary(typedExpressionIR_arg, typeIR_param) failed
 │ ··· omitting -1 traces ···
 ├── ../../../../spec-concrete/5.15.1-typing-call-convention.watsup:132.12-132.25
     1. application of clause coerce_unary(typedExpressionIR, typeIR_to) failed
-│   └── ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:495.6-495.16
+│   └── ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:503.6-503.16
 │       condition hold Type_alpha was not met
 └── ../../../../spec-concrete/5.15.1-typing-call-convention.watsup:132.12-132.25
     2. application of clause coerce_unary(typedExpressionIR, typeIR_to) failed
-    └── ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:500.6-500.14
+    └── ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:508.6-508.14
         condition hold Sub_impl was not met
 
 
@@ -1516,19 +1516,19 @@ application of rule ControlLocalDecl_ok/tableDeclaration/tableDeclaration failed
     invocation of relation Table_ok failed
     └── ../../../../spec-concrete/5.14.2-typing-control-declaration.watsup:82.6-82.14
         application of rule Table_ok//zero-default-action failed
-        └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:1023.8-1023.26
+        └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:1026.8-1026.26
             invocation of relation TableProperties_ok failed
-            └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:1023.8-1023.26
+            └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:1026.8-1026.26
                 application of rule TableProperties_ok/cons/cons failed
-                └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:947.6-947.24
+                └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:950.6-950.24
                     invocation of relation TableProperties_ok failed
-                    └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:947.6-947.24
+                    └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:950.6-950.24
                         application of rule TableProperties_ok/cons/cons failed
-                        └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:946.6-946.22
+                        └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:949.6-949.22
                             invocation of relation TableProperty_ok failed
-                            └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:946.6-946.22
+                            └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:949.6-949.22
                                 application of rule TableProperty_ok/custom/size failed
-                                └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:867.11-869.55
+                                └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:870.11-872.55
                                     condition (($is_arbitraryIntTypeIR($canon_typeIR(typeIR)) \/ $is_fixedIntTypeIR($canon_typeIR(typeIR))) \/ $is_fixedBitTypeIR($canon_typeIR(typeIR))) was not met
 
 
@@ -1613,7 +1613,7 @@ application of rule ControlLocalDecls_ok/cons/cons failed
                             invocation of relation Table_ok failed
                             └── ../../../../spec-concrete/5.14.2-typing-control-declaration.watsup:82.6-82.14
                                 application of rule Table_ok//zero-default-action failed
-                                └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:1020.11-1020.92
+                                └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:1023.11-1023.92
                                     condition (|$filter_<tableProperty>(tableProperty*{tableProperty <- tableProperty*}, $is_tableDefaultActionProperty)| = 0) was not met
 
 
@@ -1700,9 +1700,9 @@ application of rule ParserState_ok// failed
     invocation of relation ParserTransition_ok failed
     └── ../../../../spec-concrete/5.13.2-typing-parser-state.watsup:20.6-20.25
         application of rule ParserTransition_ok/select/select failed
-        └── ../../../../spec-concrete/5.13.1-typing-parser-statement.watsup:314.7-314.20
+        └── ../../../../spec-concrete/5.13.1-typing-parser-statement.watsup:315.7-315.20
             invocation of relation SelectCase_ok failed
-            └── ../../../../spec-concrete/5.13.1-typing-parser-statement.watsup:314.7-314.20
+            └── ../../../../spec-concrete/5.13.1-typing-parser-statement.watsup:315.7-315.20
                 application of rule SelectCase_ok// failed
                 └── ../../../../spec-concrete/5.13.1-typing-parser-statement.watsup:296.6-296.26
                     invocation of relation SelectCase_keyset_ok failed
@@ -1727,9 +1727,9 @@ application of rule ParserState_ok// failed
     invocation of relation ParserTransition_ok failed
     └── ../../../../spec-concrete/5.13.2-typing-parser-state.watsup:20.6-20.25
         application of rule ParserTransition_ok/select/select failed
-        └── ../../../../spec-concrete/5.13.1-typing-parser-statement.watsup:314.7-314.20
+        └── ../../../../spec-concrete/5.13.1-typing-parser-statement.watsup:315.7-315.20
             invocation of relation SelectCase_ok failed
-            └── ../../../../spec-concrete/5.13.1-typing-parser-statement.watsup:314.7-314.20
+            └── ../../../../spec-concrete/5.13.1-typing-parser-statement.watsup:315.7-315.20
                 application of rule SelectCase_ok// failed
                 └── ../../../../spec-concrete/5.13.1-typing-parser-statement.watsup:296.6-296.26
                     invocation of relation SelectCase_keyset_ok failed
@@ -1793,7 +1793,7 @@ application of rule Decl_ok/controlDeclaration/controlDeclaration failed
                             invocation of relation Table_ok failed
                             └── ../../../../spec-concrete/5.14.2-typing-control-declaration.watsup:82.6-82.14
                                 application of rule Table_ok//zero-default-action failed
-                                └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:1020.11-1020.92
+                                └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:1023.11-1023.92
                                     condition (|$filter_<tableProperty>(tableProperty*{tableProperty <- tableProperty*}, $is_tableDefaultActionProperty)| = 0) was not met
 
 
@@ -1805,11 +1805,11 @@ invocation of function $coerce_unary(typedExpressionIR_arg, typeIR_param) failed
 │ ··· omitting -1 traces ···
 ├── ../../../../spec-concrete/5.15.1-typing-call-convention.watsup:60.10-60.23
     1. application of clause coerce_unary(typedExpressionIR, typeIR_to) failed
-│   └── ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:495.6-495.16
+│   └── ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:503.6-503.16
 │       condition hold Type_alpha was not met
 └── ../../../../spec-concrete/5.15.1-typing-call-convention.watsup:60.10-60.23
     2. application of clause coerce_unary(typedExpressionIR, typeIR_to) failed
-    └── ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:500.6-500.14
+    └── ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:508.6-508.14
         condition hold Sub_impl was not met
 
 
@@ -1848,11 +1848,11 @@ invocation of function $coerce_unary(typedExpressionIR_arg, typeIR_param) failed
 │ ··· omitting -1 traces ···
 ├── ../../../../spec-concrete/5.15.1-typing-call-convention.watsup:60.10-60.23
     1. application of clause coerce_unary(typedExpressionIR, typeIR_to) failed
-│   └── ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:495.6-495.16
+│   └── ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:503.6-503.16
 │       condition hold Type_alpha was not met
 └── ../../../../spec-concrete/5.15.1-typing-call-convention.watsup:60.10-60.23
     2. application of clause coerce_unary(typedExpressionIR, typeIR_to) failed
-    └── ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:500.6-500.14
+    └── ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:508.6-508.14
         condition hold Sub_impl was not met
 
 
@@ -1867,11 +1867,11 @@ invocation of function $coerce_unary(typedExpressionIR_init, typeIR) failed
 │ ··· omitting -1 traces ···
 ├── ../../../../spec-concrete/5.10-typing-statement.watsup:735.12-735.25
     1. application of clause coerce_unary(typedExpressionIR, typeIR_to) failed
-│   └── ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:495.6-495.16
+│   └── ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:503.6-503.16
 │       condition hold Type_alpha was not met
 └── ../../../../spec-concrete/5.10-typing-statement.watsup:735.12-735.25
     2. application of clause coerce_unary(typedExpressionIR, typeIR_to) failed
-    └── ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:500.6-500.14
+    └── ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:508.6-508.14
         condition hold Sub_impl was not met
 
 
@@ -1910,11 +1910,11 @@ invocation of function $coerce_unary(typedExpressionIR, typeIR_l) failed
 │ ··· omitting -1 traces ···
 ├── ../../../../spec-concrete/5.10-typing-statement.watsup:34.37-34.50
     1. application of clause coerce_unary(typedExpressionIR, typeIR_to) failed
-│   └── ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:495.6-495.16
+│   └── ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:503.6-503.16
 │       condition hold Type_alpha was not met
 └── ../../../../spec-concrete/5.10-typing-statement.watsup:34.37-34.50
     2. application of clause coerce_unary(typedExpressionIR, typeIR_to) failed
-    └── ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:500.6-500.14
+    └── ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:508.6-508.14
         condition hold Sub_impl was not met
 
 
@@ -1998,11 +1998,11 @@ invocation of function $coerce_unary(typedExpressionIR_value, typeIR) failed
 │ ··· omitting -1 traces ···
 ├── ../../../../spec-concrete/5.11-typing-declaration.watsup:21.10-21.23
     1. application of clause coerce_unary(typedExpressionIR, typeIR_to) failed
-│   └── ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:495.6-495.16
+│   └── ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:503.6-503.16
 │       condition hold Type_alpha was not met
 └── ../../../../spec-concrete/5.11-typing-declaration.watsup:21.10-21.23
     2. application of clause coerce_unary(typedExpressionIR, typeIR_to) failed
-    └── ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:500.6-500.14
+    └── ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:508.6-508.14
         condition hold Sub_impl was not met
 
 
@@ -2343,11 +2343,11 @@ invocation of function $coerce_unary(typedExpressionIR_value, typeIR) failed
 │ ··· omitting -1 traces ···
 ├── ../../../../spec-concrete/5.11-typing-declaration.watsup:21.10-21.23
     1. application of clause coerce_unary(typedExpressionIR, typeIR_to) failed
-│   └── ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:495.6-495.16
+│   └── ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:503.6-503.16
 │       condition hold Type_alpha was not met
 └── ../../../../spec-concrete/5.11-typing-declaration.watsup:21.10-21.23
     2. application of clause coerce_unary(typedExpressionIR, typeIR_to) failed
-    └── ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:500.6-500.14
+    └── ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:508.6-508.14
         condition hold Sub_impl was not met
 
 
@@ -2564,11 +2564,11 @@ Error on run: ../../../../p4c/testdata/p4_16_errors/issue306.p4
 tracing backtrack logs:
 invocation of relation Program_ok failed
 │ ··· omitting 122 traces ···
-../../../../spec-concrete/5.13.1-typing-parser-statement.watsup:476.6-476.19
+../../../../spec-concrete/5.13.1-typing-parser-statement.watsup:477.6-477.19
 application of rule ParserStmt_ok/callStatement/callStatement failed
-└── ../../../../spec-concrete/5.13.1-typing-parser-statement.watsup:398.6-398.13
+└── ../../../../spec-concrete/5.13.1-typing-parser-statement.watsup:399.6-399.13
     invocation of relation Stmt_ok failed
-    └── ../../../../spec-concrete/5.13.1-typing-parser-statement.watsup:398.6-398.13
+    └── ../../../../spec-concrete/5.13.1-typing-parser-statement.watsup:399.6-399.13
         application of rule Stmt_ok/callStatement/callStatement-no-typeArgumentList failed
         └── ../../../../spec-concrete/5.10-typing-statement.watsup:72.9-72.20
             invocation of relation Argument_ok failed
@@ -2985,7 +2985,7 @@ application of rule Decls_ok/cons/cons failed
                             │       condition stateExpression matches `%;` was not met
                             └── ../../../../spec-concrete/5.13.2-typing-parser-state.watsup:20.6-20.25
                                 2. application of rule ParserTransition_ok/select/select failed
-                                └── ../../../../spec-concrete/5.13.1-typing-parser-statement.watsup:311.7-311.14
+                                └── ../../../../spec-concrete/5.13.1-typing-parser-statement.watsup:312.7-312.14
                                     condition hold Type_wf was not met
 
 
@@ -3022,9 +3022,9 @@ application of rule ParserState_ok// failed
     invocation of relation ParserTransition_ok failed
     └── ../../../../spec-concrete/5.13.2-typing-parser-state.watsup:20.6-20.25
         application of rule ParserTransition_ok/select/select failed
-        └── ../../../../spec-concrete/5.13.1-typing-parser-statement.watsup:314.7-314.20
+        └── ../../../../spec-concrete/5.13.1-typing-parser-statement.watsup:315.7-315.20
             invocation of relation SelectCase_ok failed
-            └── ../../../../spec-concrete/5.13.1-typing-parser-statement.watsup:314.7-314.20
+            └── ../../../../spec-concrete/5.13.1-typing-parser-statement.watsup:315.7-315.20
                 application of rule SelectCase_ok// failed
                 └── ../../../../spec-concrete/5.13.1-typing-parser-statement.watsup:296.6-296.26
                     invocation of relation SelectCase_keyset_ok failed
@@ -3163,7 +3163,7 @@ application of rule ControlLocalDecls_ok/cons/cons failed
                             invocation of relation Table_ok failed
                             └── ../../../../spec-concrete/5.14.2-typing-control-declaration.watsup:82.6-82.14
                                 application of rule Table_ok//one-default-action failed
-                                └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:1037.11-1037.92
+                                └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:1040.11-1040.92
                                     condition (|$filter_<tableProperty>(tableProperty*{tableProperty <- tableProperty*}, $is_tableDefaultActionProperty)| = 1) was not met
 
 
@@ -3220,11 +3220,11 @@ invocation of function $coerce_unary(typedExpressionIR, typeIR_ret) failed
 │ ··· omitting -1 traces ···
 ├── ../../../../spec-concrete/5.10-typing-statement.watsup:169.37-169.50
     1. application of clause coerce_unary(typedExpressionIR, typeIR_to) failed
-│   └── ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:495.6-495.16
+│   └── ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:503.6-503.16
 │       condition hold Type_alpha was not met
 └── ../../../../spec-concrete/5.10-typing-statement.watsup:169.37-169.50
     2. application of clause coerce_unary(typedExpressionIR, typeIR_to) failed
-    └── ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:500.6-500.14
+    └── ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:508.6-508.14
         condition hold Sub_impl was not met
 
 
@@ -3320,11 +3320,11 @@ invocation of function $coerce_unary(typedExpressionIR_label, typeIR_switch) fai
 │ ··· omitting -1 traces ···
 ├── ../../../../spec-concrete/5.10-typing-statement.watsup:601.12-601.25
     1. application of clause coerce_unary(typedExpressionIR, typeIR_to) failed
-│   └── ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:495.6-495.16
+│   └── ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:503.6-503.16
 │       condition hold Type_alpha was not met
 └── ../../../../spec-concrete/5.10-typing-statement.watsup:601.12-601.25
     2. application of clause coerce_unary(typedExpressionIR, typeIR_to) failed
-    └── ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:500.6-500.14
+    └── ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:508.6-508.14
         condition hold Sub_impl was not met
 
 
@@ -3336,11 +3336,11 @@ invocation of function $coerce_unary(typedExpressionIR_label, typeIR_switch) fai
 │ ··· omitting -1 traces ···
 ├── ../../../../spec-concrete/5.10-typing-statement.watsup:601.12-601.25
     1. application of clause coerce_unary(typedExpressionIR, typeIR_to) failed
-│   └── ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:495.6-495.16
+│   └── ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:503.6-503.16
 │       condition hold Type_alpha was not met
 └── ../../../../spec-concrete/5.10-typing-statement.watsup:601.12-601.25
     2. application of clause coerce_unary(typedExpressionIR, typeIR_to) failed
-    └── ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:500.6-500.14
+    └── ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:508.6-508.14
         condition hold Sub_impl was not met
 
 
@@ -3385,19 +3385,19 @@ Error on run: ../../../../p4c/testdata/p4_16_errors/issue3671-2.p4
 tracing backtrack logs:
 invocation of relation Program_ok failed
 │ ··· omitting 22 traces ···
-../../../../spec-concrete/5.14.1-typing-control-table.watsup:1040.8-1040.26
+../../../../spec-concrete/5.14.1-typing-control-table.watsup:1043.8-1043.26
 application of rule TableProperties_ok/cons/cons failed
-└── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:947.6-947.24
+└── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:950.6-950.24
     invocation of relation TableProperties_ok failed
-    └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:947.6-947.24
+    └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:950.6-950.24
         application of rule TableProperties_ok/cons/cons failed
-        └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:946.6-946.22
+        └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:949.6-949.22
             invocation of relation TableProperty_ok failed
-            └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:946.6-946.22
+            └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:949.6-949.22
                 application of rule TableProperty_ok/custom/unknown failed
-                └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:926.8-926.15
+                └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:929.8-929.15
                     invocation of relation Expr_ok failed
-                    └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:926.8-926.15
+                    └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:929.8-929.15
                         application of rule Expr_ok/callExpression-callable/non-typeArgumentList failed
                         └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:1189.8-1189.15
                             invocation of relation Call_ok failed
@@ -3414,23 +3414,23 @@ invocation of relation Program_ok failed
 │ ··· omitting 16 traces ···
 ../../../../spec-concrete/5.14.2-typing-control-declaration.watsup:82.6-82.14
 application of rule Table_ok//zero-default-action failed
-└── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:1023.8-1023.26
+└── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:1026.8-1026.26
     invocation of relation TableProperties_ok failed
-    └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:1023.8-1023.26
+    └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:1026.8-1026.26
         application of rule TableProperties_ok/cons/cons failed
-        └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:946.6-946.22
+        └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:949.6-949.22
             invocation of relation TableProperty_ok failed
-            └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:946.6-946.22
+            └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:949.6-949.22
                 application of rule TableProperty_ok/actions/actions failed
-                └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:825.6-825.21
+                └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:828.6-828.21
                     invocation of relation TableActions_ok failed
-                    └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:825.6-825.21
+                    └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:828.6-828.21
                         application of rule TableActions_ok/cons/cons failed
-                        └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:174.6-174.20
+                        └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:177.6-177.20
                             invocation of relation TableAction_ok failed
-                            └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:174.6-174.20
+                            └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:177.6-177.20
                                 application of rule TableAction_ok/prefixedNonTypeName-argumentList/prefixedNonTypeName-argumentList failed
-                                └── ../../../../spec-concrete/2.3.1-type-callable.watsup:20.23-146.37
+                                └── ../../../../spec-concrete/2.3.1-type-callable.watsup:20.23-149.37
                                     condition callableTypeDefIR <: actionTypeIR was not met
 
 
@@ -3816,17 +3816,17 @@ invocation of relation Program_ok failed
 │ ··· omitting 124 traces ···
 ../../../../spec-concrete/5.13.2-typing-parser-state.watsup:18.6-18.20
 application of rule ParserStmts_ok/cons/cons failed
-└── ../../../../spec-concrete/5.13.1-typing-parser-statement.watsup:478.6-478.20
+└── ../../../../spec-concrete/5.13.1-typing-parser-statement.watsup:479.6-479.20
     invocation of relation ParserStmts_ok failed
-    └── ../../../../spec-concrete/5.13.1-typing-parser-statement.watsup:478.6-478.20
+    └── ../../../../spec-concrete/5.13.1-typing-parser-statement.watsup:479.6-479.20
         application of rule ParserStmts_ok/cons/cons failed
-        └── ../../../../spec-concrete/5.13.1-typing-parser-statement.watsup:476.6-476.19
+        └── ../../../../spec-concrete/5.13.1-typing-parser-statement.watsup:477.6-477.19
             invocation of relation ParserStmt_ok failed
-            └── ../../../../spec-concrete/5.13.1-typing-parser-statement.watsup:476.6-476.19
+            └── ../../../../spec-concrete/5.13.1-typing-parser-statement.watsup:477.6-477.19
                 application of rule ParserStmt_ok/callStatement/callStatement failed
-                └── ../../../../spec-concrete/5.13.1-typing-parser-statement.watsup:398.6-398.13
+                └── ../../../../spec-concrete/5.13.1-typing-parser-statement.watsup:399.6-399.13
                     invocation of relation Stmt_ok failed
-                    └── ../../../../spec-concrete/5.13.1-typing-parser-statement.watsup:398.6-398.13
+                    └── ../../../../spec-concrete/5.13.1-typing-parser-statement.watsup:399.6-399.13
                         application of rule Stmt_ok/callStatement/callStatement-no-typeArgumentList failed
                         └── ../../../../spec-concrete/5.10-typing-statement.watsup:78.8-78.15
                             invocation of relation Call_ok failed
@@ -4012,11 +4012,11 @@ invocation of function $coerce_unary(typedExpressionIR_init, typeIR) failed
 │ ··· omitting -1 traces ···
 ├── ../../../../spec-concrete/5.10-typing-statement.watsup:735.12-735.25
     1. application of clause coerce_unary(typedExpressionIR, typeIR_to) failed
-│   └── ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:495.6-495.16
+│   └── ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:503.6-503.16
 │       condition hold Type_alpha was not met
 └── ../../../../spec-concrete/5.10-typing-statement.watsup:735.12-735.25
     2. application of clause coerce_unary(typedExpressionIR, typeIR_to) failed
-    └── ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:500.6-500.14
+    └── ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:508.6-508.14
         condition hold Sub_impl was not met
 
 
@@ -4058,11 +4058,11 @@ invocation of function $coerce_unary(typedExpressionIR_value, typeIR) failed
 │ ··· omitting -1 traces ···
 ├── ../../../../spec-concrete/5.11-typing-declaration.watsup:21.10-21.23
     1. application of clause coerce_unary(typedExpressionIR, typeIR_to) failed
-│   └── ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:495.6-495.16
+│   └── ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:503.6-503.16
 │       condition hold Type_alpha was not met
 └── ../../../../spec-concrete/5.11-typing-declaration.watsup:21.10-21.23
     2. application of clause coerce_unary(typedExpressionIR, typeIR_to) failed
-    └── ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:500.6-500.14
+    └── ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:508.6-508.14
         condition hold Sub_impl was not met
 
 
@@ -4108,13 +4108,13 @@ application of rule ParserStates_ok// failed
             invocation of relation ParserStmts_ok failed
             └── ../../../../spec-concrete/5.13.2-typing-parser-state.watsup:18.6-18.20
                 application of rule ParserStmts_ok/cons/cons failed
-                └── ../../../../spec-concrete/5.13.1-typing-parser-statement.watsup:476.6-476.19
+                └── ../../../../spec-concrete/5.13.1-typing-parser-statement.watsup:477.6-477.19
                     invocation of relation ParserStmt_ok failed
-                    └── ../../../../spec-concrete/5.13.1-typing-parser-statement.watsup:476.6-476.19
+                    └── ../../../../spec-concrete/5.13.1-typing-parser-statement.watsup:477.6-477.19
                         application of rule ParserStmt_ok/callStatement/callStatement failed
-                        └── ../../../../spec-concrete/5.13.1-typing-parser-statement.watsup:398.6-398.13
+                        └── ../../../../spec-concrete/5.13.1-typing-parser-statement.watsup:399.6-399.13
                             invocation of relation Stmt_ok failed
-                            └── ../../../../spec-concrete/5.13.1-typing-parser-statement.watsup:398.6-398.13
+                            └── ../../../../spec-concrete/5.13.1-typing-parser-statement.watsup:399.6-399.13
                                 application of rule Stmt_ok/callStatement/callStatement-typeArgumentList failed
                                 └── ../../../../spec-concrete/1-syntax.watsup:703.52-85.72
                                     condition callStatement' matches `%<%>(%);` was not met
@@ -4336,11 +4336,11 @@ invocation of function $coerce_unary(typedExpressionIR_arg, typeIR_param) failed
 │ ··· omitting -1 traces ···
 ├── ../../../../spec-concrete/5.15.1-typing-call-convention.watsup:132.12-132.25
     1. application of clause coerce_unary(typedExpressionIR, typeIR_to) failed
-│   └── ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:495.6-495.16
+│   └── ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:503.6-503.16
 │       condition hold Type_alpha was not met
 └── ../../../../spec-concrete/5.15.1-typing-call-convention.watsup:132.12-132.25
     2. application of clause coerce_unary(typedExpressionIR, typeIR_to) failed
-    └── ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:500.6-500.14
+    └── ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:508.6-508.14
         condition hold Sub_impl was not met
 
 
@@ -4379,11 +4379,11 @@ invocation of function $coerce_unary(typedExpressionIR_l, typeIR_var) failed
 │ ··· omitting -1 traces ···
 ├── ../../../../spec-concrete/5.10-typing-statement.watsup:417.40-417.53
     1. application of clause coerce_unary(typedExpressionIR, typeIR_to) failed
-│   └── ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:495.6-495.16
+│   └── ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:503.6-503.16
 │       condition hold Type_alpha was not met
 └── ../../../../spec-concrete/5.10-typing-statement.watsup:417.40-417.53
     2. application of clause coerce_unary(typedExpressionIR, typeIR_to) failed
-    └── ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:500.6-500.14
+    └── ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:508.6-508.14
         condition hold Sub_impl was not met
 
 
@@ -4468,17 +4468,17 @@ application of rule Decls_ok/cons/cons failed
                             invocation of relation Table_ok failed
                             └── ../../../../spec-concrete/5.14.2-typing-control-declaration.watsup:82.6-82.14
                                 application of rule Table_ok//zero-default-action failed
-                                └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:1018.11-1018.86
+                                └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:1021.11-1021.86
                                     condition (|$filter_<tableProperty>(tableProperty*{tableProperty <- tableProperty*}, $is_tableActionsProperty)| = 1) was not met
 
 
 >>> Running interpreter test (Program_ok) on ../../../../p4c/testdata/p4_16_errors/missing_match.p4
 Error on run: ../../../../p4c/testdata/p4_16_errors/missing_match.p4
 tracing backtrack logs:
-../../../../spec-concrete/5.14.1-typing-control-table.watsup:56.10-56.27
+../../../../spec-concrete/5.14.1-typing-control-table.watsup:59.10-59.27
 invocation of function $find_var_value_t(local, TC, ` nameIR_matchkind) failed
 │ ··· omitting -1 traces ···
-└── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:56.10-56.27
+└── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:59.10-59.27
     application of clause find_var_value_t(p, TC, prefixedNameIR) failed
     └── ../../../../spec-concrete/5.02.1-typing-context.watsup:352.9-352.20
         condition varTypeIR?{varTypeIR <- varTypeIR?} matches (_) was not met
@@ -4492,11 +4492,11 @@ invocation of function $coerce_unary(typedExpressionIR_arg, typeIR_param) failed
 │ ··· omitting -1 traces ···
 ├── ../../../../spec-concrete/5.15.1-typing-call-convention.watsup:132.12-132.25
     1. application of clause coerce_unary(typedExpressionIR, typeIR_to) failed
-│   └── ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:495.6-495.16
+│   └── ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:503.6-503.16
 │       condition hold Type_alpha was not met
 └── ../../../../spec-concrete/5.15.1-typing-call-convention.watsup:132.12-132.25
     2. application of clause coerce_unary(typedExpressionIR, typeIR_to) failed
-    └── ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:500.6-500.14
+    └── ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:508.6-508.14
         condition hold Sub_impl was not met
 
 
@@ -4604,11 +4604,11 @@ invocation of function $coerce_unary(typedExpressionIR, typeIR_l) failed
 │ ··· omitting -1 traces ···
 ├── ../../../../spec-concrete/5.10-typing-statement.watsup:34.37-34.50
     1. application of clause coerce_unary(typedExpressionIR, typeIR_to) failed
-│   └── ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:495.6-495.16
+│   └── ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:503.6-503.16
 │       condition hold Type_alpha was not met
 └── ../../../../spec-concrete/5.10-typing-statement.watsup:34.37-34.50
     2. application of clause coerce_unary(typedExpressionIR, typeIR_to) failed
-    └── ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:500.6-500.14
+    └── ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:508.6-508.14
         condition hold Sub_impl was not met
 
 
@@ -4922,7 +4922,7 @@ application of rule Decls_ok/cons/cons failed
                             │       condition stateExpression matches `%;` was not met
                             └── ../../../../spec-concrete/5.13.2-typing-parser-state.watsup:20.6-20.25
                                 2. application of rule ParserTransition_ok/select/select failed
-                                └── ../../../../spec-concrete/5.13.1-typing-parser-statement.watsup:311.7-311.14
+                                └── ../../../../spec-concrete/5.13.1-typing-parser-statement.watsup:312.7-312.14
                                     condition hold Type_wf was not met
 
 
@@ -4988,11 +4988,11 @@ invocation of function $coerce_unary(typedExpressionIR_arg, typeIR_param) failed
 │ ··· omitting -1 traces ···
 ├── ../../../../spec-concrete/5.15.1-typing-call-convention.watsup:132.12-132.25
     1. application of clause coerce_unary(typedExpressionIR, typeIR_to) failed
-│   └── ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:495.6-495.16
+│   └── ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:503.6-503.16
 │       condition hold Type_alpha was not met
 └── ../../../../spec-concrete/5.15.1-typing-call-convention.watsup:132.12-132.25
     2. application of clause coerce_unary(typedExpressionIR, typeIR_to) failed
-    └── ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:500.6-500.14
+    └── ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:508.6-508.14
         condition hold Sub_impl was not met
 
 
@@ -5007,9 +5007,9 @@ application of rule ParserState_ok// failed
     invocation of relation ParserTransition_ok failed
     └── ../../../../spec-concrete/5.13.2-typing-parser-state.watsup:20.6-20.25
         application of rule ParserTransition_ok/select/select failed
-        └── ../../../../spec-concrete/5.13.1-typing-parser-statement.watsup:314.7-314.20
+        └── ../../../../spec-concrete/5.13.1-typing-parser-statement.watsup:315.7-315.20
             invocation of relation SelectCase_ok failed
-            └── ../../../../spec-concrete/5.13.1-typing-parser-statement.watsup:314.7-314.20
+            └── ../../../../spec-concrete/5.13.1-typing-parser-statement.watsup:315.7-315.20
                 application of rule SelectCase_ok// failed
                 └── ../../../../spec-concrete/5.13.1-typing-parser-statement.watsup:296.6-296.26
                     invocation of relation SelectCase_keyset_ok failed
@@ -5077,7 +5077,7 @@ application of rule Decls_ok/cons/cons failed
                             │       condition stateExpression matches `%;` was not met
                             └── ../../../../spec-concrete/5.13.2-typing-parser-state.watsup:20.6-20.25
                                 2. application of rule ParserTransition_ok/select/select failed
-                                └── ../../../../spec-concrete/5.13.1-typing-parser-statement.watsup:311.7-311.14
+                                └── ../../../../spec-concrete/5.13.1-typing-parser-statement.watsup:312.7-312.14
                                     condition hold Type_wf was not met
 
 
@@ -5108,7 +5108,7 @@ application of rule Decls_ok/cons/cons failed
                             │       condition stateExpression matches `%;` was not met
                             └── ../../../../spec-concrete/5.13.2-typing-parser-state.watsup:20.6-20.25
                                 2. application of rule ParserTransition_ok/select/select failed
-                                └── ../../../../spec-concrete/5.13.1-typing-parser-statement.watsup:311.7-311.14
+                                └── ../../../../spec-concrete/5.13.1-typing-parser-statement.watsup:312.7-312.14
                                     condition hold Type_wf was not met
 
 
@@ -5147,11 +5147,11 @@ invocation of function $coerce_unary(typedExpressionIR_arg, typeIR_param) failed
 │ ··· omitting -1 traces ···
 ├── ../../../../spec-concrete/5.15.1-typing-call-convention.watsup:125.12-125.25
     1. application of clause coerce_unary(typedExpressionIR, typeIR_to) failed
-│   └── ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:495.6-495.16
+│   └── ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:503.6-503.16
 │       condition hold Type_alpha was not met
 └── ../../../../spec-concrete/5.15.1-typing-call-convention.watsup:125.12-125.25
     2. application of clause coerce_unary(typedExpressionIR, typeIR_to) failed
-    └── ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:500.6-500.14
+    └── ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:508.6-508.14
         condition hold Sub_impl was not met
 
 
@@ -5163,11 +5163,11 @@ invocation of function $coerce_unary(typedExpressionIR, typeIR) failed
 │ ··· omitting -1 traces ···
 ├── ../../../../spec-concrete/5.11-typing-declaration.watsup:666.35-666.48
     1. application of clause coerce_unary(typedExpressionIR, typeIR_to) failed
-│   └── ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:495.6-495.16
+│   └── ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:503.6-503.16
 │       condition hold Type_alpha was not met
 └── ../../../../spec-concrete/5.11-typing-declaration.watsup:666.35-666.48
     2. application of clause coerce_unary(typedExpressionIR, typeIR_to) failed
-    └── ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:500.6-500.14
+    └── ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:508.6-508.14
         condition hold Sub_impl was not met
 
 
@@ -5179,11 +5179,11 @@ invocation of function $coerce_unary(typedExpressionIR, typeIR) failed
 │ ··· omitting -1 traces ···
 ├── ../../../../spec-concrete/5.11-typing-declaration.watsup:666.35-666.48
     1. application of clause coerce_unary(typedExpressionIR, typeIR_to) failed
-│   └── ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:495.6-495.16
+│   └── ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:503.6-503.16
 │       condition hold Type_alpha was not met
 └── ../../../../spec-concrete/5.11-typing-declaration.watsup:666.35-666.48
     2. application of clause coerce_unary(typedExpressionIR, typeIR_to) failed
-    └── ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:500.6-500.14
+    └── ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:508.6-508.14
         condition hold Sub_impl was not met
 
 
@@ -5202,11 +5202,11 @@ invocation of function $coerce_unary(typedExpressionIR, typeIR_l) failed
 │ ··· omitting -1 traces ···
 ├── ../../../../spec-concrete/5.10-typing-statement.watsup:34.37-34.50
     1. application of clause coerce_unary(typedExpressionIR, typeIR_to) failed
-│   └── ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:495.6-495.16
+│   └── ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:503.6-503.16
 │       condition hold Type_alpha was not met
 └── ../../../../spec-concrete/5.10-typing-statement.watsup:34.37-34.50
     2. application of clause coerce_unary(typedExpressionIR, typeIR_to) failed
-    └── ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:500.6-500.14
+    └── ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:508.6-508.14
         condition hold Sub_impl was not met
 
 
@@ -5218,11 +5218,11 @@ invocation of function $coerce_unary(typedExpressionIR_init, typeIR) failed
 │ ··· omitting -1 traces ···
 ├── ../../../../spec-concrete/5.10-typing-statement.watsup:735.12-735.25
     1. application of clause coerce_unary(typedExpressionIR, typeIR_to) failed
-│   └── ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:495.6-495.16
+│   └── ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:503.6-503.16
 │       condition hold Type_alpha was not met
 └── ../../../../spec-concrete/5.10-typing-statement.watsup:735.12-735.25
     2. application of clause coerce_unary(typedExpressionIR, typeIR_to) failed
-    └── ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:500.6-500.14
+    └── ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:508.6-508.14
         condition hold Sub_impl was not met
 
 
@@ -5405,11 +5405,11 @@ invocation of function $coerce_unary(typedExpressionIR, typeIR_l) failed
 │ ··· omitting -1 traces ···
 ├── ../../../../spec-concrete/5.10-typing-statement.watsup:34.37-34.50
     1. application of clause coerce_unary(typedExpressionIR, typeIR_to) failed
-│   └── ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:495.6-495.16
+│   └── ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:503.6-503.16
 │       condition hold Type_alpha was not met
 └── ../../../../spec-concrete/5.10-typing-statement.watsup:34.37-34.50
     2. application of clause coerce_unary(typedExpressionIR, typeIR_to) failed
-    └── ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:500.6-500.14
+    └── ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:508.6-508.14
         condition hold Sub_impl was not met
 
 
@@ -5550,11 +5550,11 @@ invocation of function $coerce_unary(typedExpressionIR, typeIR_l) failed
 │ ··· omitting -1 traces ···
 ├── ../../../../spec-concrete/5.10-typing-statement.watsup:34.37-34.50
     1. application of clause coerce_unary(typedExpressionIR, typeIR_to) failed
-│   └── ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:495.6-495.16
+│   └── ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:503.6-503.16
 │       condition hold Type_alpha was not met
 └── ../../../../spec-concrete/5.10-typing-statement.watsup:34.37-34.50
     2. application of clause coerce_unary(typedExpressionIR, typeIR_to) failed
-    └── ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:500.6-500.14
+    └── ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:508.6-508.14
         condition hold Sub_impl was not met
 
 
@@ -5598,7 +5598,7 @@ application of rule ControlLocalDecls_ok/cons/cons failed
                             invocation of relation Table_ok failed
                             └── ../../../../spec-concrete/5.14.2-typing-control-declaration.watsup:82.6-82.14
                                 application of rule Table_ok//zero-default-action failed
-                                └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:1020.11-1020.92
+                                └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:1023.11-1023.92
                                     condition (|$filter_<tableProperty>(tableProperty*{tableProperty <- tableProperty*}, $is_tableDefaultActionProperty)| = 0) was not met
 
 
@@ -5625,7 +5625,7 @@ application of rule ControlLocalDecls_ok/cons/cons failed
                             invocation of relation Table_ok failed
                             └── ../../../../spec-concrete/5.14.2-typing-control-declaration.watsup:82.6-82.14
                                 application of rule Table_ok//zero-default-action failed
-                                └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:1020.11-1020.92
+                                └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:1023.11-1023.92
                                     condition (|$filter_<tableProperty>(tableProperty*{tableProperty <- tableProperty*}, $is_tableDefaultActionProperty)| = 0) was not met
 
 
@@ -5652,7 +5652,7 @@ application of rule ControlLocalDecls_ok/cons/cons failed
                             invocation of relation Table_ok failed
                             └── ../../../../spec-concrete/5.14.2-typing-control-declaration.watsup:82.6-82.14
                                 application of rule Table_ok//zero-default-action failed
-                                └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:1020.11-1020.92
+                                └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:1023.11-1023.92
                                     condition (|$filter_<tableProperty>(tableProperty*{tableProperty <- tableProperty*}, $is_tableDefaultActionProperty)| = 0) was not met
 
 
@@ -5703,7 +5703,7 @@ application of rule ControlLocalDecls_ok/cons/cons failed
                             invocation of relation Table_ok failed
                             └── ../../../../spec-concrete/5.14.2-typing-control-declaration.watsup:82.6-82.14
                                 application of rule Table_ok//zero-default-action failed
-                                └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:1020.11-1020.92
+                                └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:1023.11-1023.92
                                     condition (|$filter_<tableProperty>(tableProperty*{tableProperty <- tableProperty*}, $is_tableDefaultActionProperty)| = 0) was not met
 
 
@@ -5734,7 +5734,7 @@ application of rule ControlLocalDecls_ok/cons/cons failed
                             invocation of relation Table_ok failed
                             └── ../../../../spec-concrete/5.14.2-typing-control-declaration.watsup:82.6-82.14
                                 application of rule Table_ok//zero-default-action failed
-                                └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:1020.11-1020.92
+                                └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:1023.11-1023.92
                                     condition (|$filter_<tableProperty>(tableProperty*{tableProperty <- tableProperty*}, $is_tableDefaultActionProperty)| = 0) was not met
 
 
@@ -5761,7 +5761,7 @@ application of rule ControlLocalDecls_ok/cons/cons failed
                             invocation of relation Table_ok failed
                             └── ../../../../spec-concrete/5.14.2-typing-control-declaration.watsup:82.6-82.14
                                 application of rule Table_ok//zero-default-action failed
-                                └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:1020.11-1020.92
+                                └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:1023.11-1023.92
                                     condition (|$filter_<tableProperty>(tableProperty*{tableProperty <- tableProperty*}, $is_tableDefaultActionProperty)| = 0) was not met
 
 
@@ -5816,11 +5816,11 @@ invocation of function $coerce_unary(typedExpressionIR, typeIR_l) failed
 │ ··· omitting -1 traces ···
 ├── ../../../../spec-concrete/5.10-typing-statement.watsup:34.37-34.50
     1. application of clause coerce_unary(typedExpressionIR, typeIR_to) failed
-│   └── ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:495.6-495.16
+│   └── ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:503.6-503.16
 │       condition hold Type_alpha was not met
 └── ../../../../spec-concrete/5.10-typing-statement.watsup:34.37-34.50
     2. application of clause coerce_unary(typedExpressionIR, typeIR_to) failed
-    └── ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:500.6-500.14
+    └── ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:508.6-508.14
         condition hold Sub_impl was not met
 
 
@@ -6016,11 +6016,11 @@ invocation of function $coerce_unary(typedExpressionIR, typeIR_ret) failed
 │ ··· omitting -1 traces ···
 ├── ../../../../spec-concrete/5.10-typing-statement.watsup:169.37-169.50
     1. application of clause coerce_unary(typedExpressionIR, typeIR_to) failed
-│   └── ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:495.6-495.16
+│   └── ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:503.6-503.16
 │       condition hold Type_alpha was not met
 └── ../../../../spec-concrete/5.10-typing-statement.watsup:169.37-169.50
     2. application of clause coerce_unary(typedExpressionIR, typeIR_to) failed
-    └── ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:500.6-500.14
+    └── ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:508.6-508.14
         condition hold Sub_impl was not met
 
 
@@ -6032,11 +6032,11 @@ invocation of function $coerce_unary(typedExpressionIR, typeIR_ret) failed
 │ ··· omitting -1 traces ···
 ├── ../../../../spec-concrete/5.10-typing-statement.watsup:169.37-169.50
     1. application of clause coerce_unary(typedExpressionIR, typeIR_to) failed
-│   └── ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:495.6-495.16
+│   └── ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:503.6-503.16
 │       condition hold Type_alpha was not met
 └── ../../../../spec-concrete/5.10-typing-statement.watsup:169.37-169.50
     2. application of clause coerce_unary(typedExpressionIR, typeIR_to) failed
-    └── ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:500.6-500.14
+    └── ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:508.6-508.14
         condition hold Sub_impl was not met
 
 

--- a/p4spec/test/run_il_type_pos_p4c.expected
+++ b/p4spec/test/run_il_type_pos_p4c.expected
@@ -419,7 +419,7 @@ Run success: ../../../../p4c/testdata/p4_16_samples/enum-folding.p4
 Run success: ../../../../p4c/testdata/p4_16_samples/enum.p4
 
 >>> Running interpreter test (Program_ok) on ../../../../p4c/testdata/p4_16_samples/enumCast.p4
-Excluding file: ../../../../p4c/testdata/p4_16_samples/enumCast.p4
+Run success: ../../../../p4c/testdata/p4_16_samples/enumCast.p4
 
 >>> Running interpreter test (Program_ok) on ../../../../p4c/testdata/p4_16_samples/equality-bmv2.p4
 Run success: ../../../../p4c/testdata/p4_16_samples/equality-bmv2.p4
@@ -1880,7 +1880,7 @@ Run success: ../../../../p4c/testdata/p4_16_samples/issue3324.p4
 Run success: ../../../../p4c/testdata/p4_16_samples/issue3329-bmv2.p4
 
 >>> Running interpreter test (Program_ok) on ../../../../p4c/testdata/p4_16_samples/issue3333.p4
-Excluding file: ../../../../p4c/testdata/p4_16_samples/issue3333.p4
+Run success: ../../../../p4c/testdata/p4_16_samples/issue3333.p4
 
 >>> Running interpreter test (Program_ok) on ../../../../p4c/testdata/p4_16_samples/issue3343.p4
 Run success: ../../../../p4c/testdata/p4_16_samples/issue3343.p4
@@ -3638,7 +3638,7 @@ Run success: ../../../../p4c/testdata/p4_16_samples/table-entries-priority-bmv2.
 Run success: ../../../../p4c/testdata/p4_16_samples/table-entries-range-bmv2.p4
 
 >>> Running interpreter test (Program_ok) on ../../../../p4c/testdata/p4_16_samples/table-entries-ser-enum-bmv2.p4
-Excluding file: ../../../../p4c/testdata/p4_16_samples/table-entries-ser-enum-bmv2.p4
+Run success: ../../../../p4c/testdata/p4_16_samples/table-entries-ser-enum-bmv2.p4
 
 >>> Running interpreter test (Program_ok) on ../../../../p4c/testdata/p4_16_samples/table-entries-ternary-bmv2.p4
 Run success: ../../../../p4c/testdata/p4_16_samples/table-entries-ternary-bmv2.p4
@@ -3835,4 +3835,4 @@ Run success: ../../../../p4c/testdata/p4_16_samples/xdp_vlan_push_pop_ebpf-kerne
 >>> Running interpreter test (Program_ok) on ../../../../p4c/testdata/p4_16_samples/xor_test.p4
 Run success: ../../../../p4c/testdata/p4_16_samples/xor_test.p4
 
-Running interpreter test (Program_ok): [EXCLUDE] 99/1278 (7.75%) [PASS] 1179/1278 (92.25%) [FAIL] 0/1278 (0.00%)
+Running interpreter test (Program_ok): [EXCLUDE] 96/1278 (7.51%) [PASS] 1182/1278 (92.49%) [FAIL] 0/1278 (0.00%)

--- a/p4spec/test/run_sl_inst_p4c.expected
+++ b/p4spec/test/run_sl_inst_p4c.expected
@@ -2414,25 +2414,25 @@ Run success: ../../../../p4c/testdata/p4_16_samples/list7.p4
 Error on run: ../../../../p4c/testdata/p4_16_samples/list8.p4
 relation Program_inst failed
 │ ··· omitting 138 traces ···
-../../../../spec-concrete/3-numerics.watsup:663.5-663.51
+../../../../spec-concrete/3-numerics.watsup:662.5-662.51
 $cast_sequence'($canon_typeIR(typeIR), (value)*{value <- value*}) failed
-└── ../../../../spec-concrete/3-numerics.watsup:663.6-663.21
+└── ../../../../spec-concrete/3-numerics.watsup:662.6-662.21
     function cast_sequence' failed
-    └── ../../../../spec-concrete/2.2.1-type.watsup:64.21-665.37
+    └── ../../../../spec-concrete/2.2.1-type.watsup:64.21-664.37
         Case analysis on typeIR' failed
-        └── ../../../../spec-concrete/2.1.1-value.watsup:31.20-666.39
+        └── ../../../../spec-concrete/2.1.1-value.watsup:31.20-665.39
             Return ((list[ ($cast_op(typeIR, value))*{value <- value*} ]) as value) failed
-            └── ../../../../spec-concrete/2.1.1-value.watsup:31.20-666.39
+            └── ../../../../spec-concrete/2.1.1-value.watsup:31.20-665.39
                 ((list[ ($cast_op(typeIR, value))*{value <- value*} ]) as value) failed
-                └── ../../../../spec-concrete/2.1.1-value.watsup:31.20-666.39
+                └── ../../../../spec-concrete/2.1.1-value.watsup:31.20-665.39
                     (list[ ($cast_op(typeIR, value))*{value <- value*} ]) failed
-                    └── ../../../../spec-concrete/3-numerics.watsup:666.13-666.37
+                    └── ../../../../spec-concrete/3-numerics.watsup:665.13-665.37
                         ($cast_op(typeIR, value))*{value <- value*} failed
-                        └── ../../../../spec-concrete/3-numerics.watsup:666.13-666.36
+                        └── ../../../../spec-concrete/3-numerics.watsup:665.13-665.36
                             $cast_op(typeIR, value) failed
-                            └── ../../../../spec-concrete/3-numerics.watsup:666.14-666.22
+                            └── ../../../../spec-concrete/3-numerics.watsup:665.14-665.22
                                 function cast_op failed
-                                └── ../../../../spec-concrete/3-numerics.watsup:666.14-666.22
+                                └── ../../../../spec-concrete/3-numerics.watsup:665.14-665.22
                                     function did not return a value
 
 

--- a/p4spec/test/run_sl_inst_p4c.expected
+++ b/p4spec/test/run_sl_inst_p4c.expected
@@ -419,7 +419,7 @@ Run success: ../../../../p4c/testdata/p4_16_samples/enum-folding.p4
 Run success: ../../../../p4c/testdata/p4_16_samples/enum.p4
 
 >>> Running interpreter test (Program_inst) on ../../../../p4c/testdata/p4_16_samples/enumCast.p4
-Excluding file: ../../../../p4c/testdata/p4_16_samples/enumCast.p4
+Run success: ../../../../p4c/testdata/p4_16_samples/enumCast.p4
 
 >>> Running interpreter test (Program_inst) on ../../../../p4c/testdata/p4_16_samples/equality-bmv2.p4
 Run success: ../../../../p4c/testdata/p4_16_samples/equality-bmv2.p4
@@ -1903,7 +1903,7 @@ Run success: ../../../../p4c/testdata/p4_16_samples/issue3324.p4
 Run success: ../../../../p4c/testdata/p4_16_samples/issue3329-bmv2.p4
 
 >>> Running interpreter test (Program_inst) on ../../../../p4c/testdata/p4_16_samples/issue3333.p4
-Excluding file: ../../../../p4c/testdata/p4_16_samples/issue3333.p4
+Run success: ../../../../p4c/testdata/p4_16_samples/issue3333.p4
 
 >>> Running interpreter test (Program_inst) on ../../../../p4c/testdata/p4_16_samples/issue3343.p4
 Run success: ../../../../p4c/testdata/p4_16_samples/issue3343.p4
@@ -3753,7 +3753,7 @@ Run success: ../../../../p4c/testdata/p4_16_samples/table-entries-priority-bmv2.
 Run success: ../../../../p4c/testdata/p4_16_samples/table-entries-range-bmv2.p4
 
 >>> Running interpreter test (Program_inst) on ../../../../p4c/testdata/p4_16_samples/table-entries-ser-enum-bmv2.p4
-Excluding file: ../../../../p4c/testdata/p4_16_samples/table-entries-ser-enum-bmv2.p4
+Run success: ../../../../p4c/testdata/p4_16_samples/table-entries-ser-enum-bmv2.p4
 
 >>> Running interpreter test (Program_inst) on ../../../../p4c/testdata/p4_16_samples/table-entries-ternary-bmv2.p4
 Run success: ../../../../p4c/testdata/p4_16_samples/table-entries-ternary-bmv2.p4
@@ -3950,4 +3950,4 @@ Run success: ../../../../p4c/testdata/p4_16_samples/xdp_vlan_push_pop_ebpf-kerne
 >>> Running interpreter test (Program_inst) on ../../../../p4c/testdata/p4_16_samples/xor_test.p4
 Run success: ../../../../p4c/testdata/p4_16_samples/xor_test.p4
 
-Running interpreter test (Program_inst): [EXCLUDE] 99/1278 (7.75%) [PASS] 1174/1278 (91.86%) [FAIL] 5/1278 (0.39%)
+Running interpreter test (Program_inst): [EXCLUDE] 96/1278 (7.51%) [PASS] 1177/1278 (92.10%) [FAIL] 5/1278 (0.39%)

--- a/p4spec/test/run_sl_type_neg_p4c.expected
+++ b/p4spec/test/run_sl_type_neg_p4c.expected
@@ -31,25 +31,25 @@ relation Decl_ok failed
 Error on run: ../../../../p4c/testdata/p4_16_errors/action-bind.p4
 relation Program_ok failed
 │ ··· omitting 41 traces ···
-../../../../spec-concrete/5.14.1-typing-control-table.watsup:941.14-941.17
+../../../../spec-concrete/5.14.1-typing-control-table.watsup:944.14-944.17
 Case analysis on (tableProperty)*{tableProperty <- tableProperty*} failed
-└── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:943.24-943.29
+└── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:946.24-946.29
     Group cons failed
-    └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:946.6-946.79
+    └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:949.6-949.79
         TableProperty_ok: TC TBLC |- tableProperty_h : TBLC_1 tablePropertyIR_h failed
-        └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:946.6-946.22
+        └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:949.6-949.22
             relation TableProperty_ok failed
-            └── ../../../../spec-concrete/1-syntax.watsup:1249.5-814.40
+            └── ../../../../spec-concrete/1-syntax.watsup:1249.5-817.40
                 Case analysis on tableProperty failed
-                └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:845.22-845.37
+                └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:848.22-848.37
                     Group default-action failed
-                    └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:849.6-849.61
+                    └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:852.6-852.61
                         If ("default_action" = $tableCustomName(tableCustomName)) failed
-                        └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:851.6-851.76
+                        └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:854.6-854.76
                             TableDefaultAction_ok: TC TBLC_0 |- initializer : tableActionReferenceIR failed
-                            └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:851.6-851.27
+                            └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:854.6-854.27
                                 relation TableDefaultAction_ok failed
-                                └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:851.6-851.27
+                                └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:854.6-854.27
                                     relation did not produce results
 
 
@@ -57,25 +57,25 @@ Case analysis on (tableProperty)*{tableProperty <- tableProperty*} failed
 Error on run: ../../../../p4c/testdata/p4_16_errors/action-bind1.p4
 relation Program_ok failed
 │ ··· omitting 47 traces ···
-../../../../spec-concrete/5.14.1-typing-control-table.watsup:207.38-207.55
+../../../../spec-concrete/5.14.1-typing-control-table.watsup:210.38-210.55
 If (callExpression matches pattern `%(%)`) failed
-└── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:207.18-207.37
+└── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:210.18-210.37
     If (callTarget has type prefixedNonTypeName) failed
-    └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:206.27-206.60
+    └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:209.27-209.60
         Group prefixedNonTypeName-argumentList failed
-        └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:211.9-211.50
+        └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:214.9-214.50
             If (((parameterIR*, argumentListIR))?{(parameterIR*, argumentListIR) <- (parameterIR*, argumentListIR)?} matches pattern (_)) failed
-            └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:217.6-220.32
+            └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:220.6-223.32
                 Call_action_default_ok: TC |- (parameterIR_action)*{parameterIR_action <- parameterIR_action*} @ (argumentIR)*{argumentIR <- argumentIR*} : (parameterIR_action_data)*{parameterIR_action_data <- parameterIR_action_data*} , (parameterIR_action_control)*{parameterIR_action_control <- parameterIR_action_control*} @ (argumentIR_cast)*{argumentIR_cast <- argumentIR_cast*} failed
-                └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:217.6-217.28
+                └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:220.6-220.28
                     relation Call_action_default_ok failed
-                    └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:183.28
+                    └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:186.28
                         Group  failed
-                        └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:191.6-193.42
+                        └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:194.6-196.42
                             Call_convention_ok: (local) TC (action) |- (parameterIR)*{parameterIR <- parameterIR*} @ (argumentIR)*{argumentIR <- argumentIR*} : (argumentIR_cast)*{argumentIR_cast <- argumentIR_cast*} failed
-                            └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:191.6-191.24
+                            └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:194.6-194.24
                                 relation Call_convention_ok failed
-                                └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:191.6-191.24
+                                └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:194.6-194.24
                                     relation did not produce results
 
 
@@ -83,25 +83,25 @@ If (callExpression matches pattern `%(%)`) failed
 Error on run: ../../../../p4c/testdata/p4_16_errors/action-bind2.p4
 relation Program_ok failed
 │ ··· omitting 42 traces ···
-../../../../spec-concrete/5.14.1-typing-control-table.watsup:171.21-171.26
+../../../../spec-concrete/5.14.1-typing-control-table.watsup:174.21-174.26
 Group cons failed
-└── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:174.6-174.73
+└── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:177.6-177.73
     TableAction_ok: TC TBLC |- tableAction_h : TBLC_1 tableActionIR_h failed
-    └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:174.6-174.20
+    └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:177.6-177.20
         relation TableAction_ok failed
-        └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:122.31-122.50
+        └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:125.31-125.50
             If (tableActionReference has type prefixedNonTypeName) failed
-            └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:121.20-121.40
+            └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:124.20-124.40
                 Group prefixedNonTypeName failed
-                └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:126.9-126.38
+                └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:129.9-129.38
                     If (((cid, callableTypeDefIR))?{(cid, callableTypeDefIR) <- (cid, callableTypeDefIR)?} matches pattern (_)) failed
-                    └── ../../../../spec-concrete/2.3.1-type-callable.watsup:20.23-126.37
+                    └── ../../../../spec-concrete/2.3.1-type-callable.watsup:20.23-129.37
                         If (callableTypeDefIR has type actionTypeIR) failed
-                        └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:129.6-131.42
+                        └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:132.6-134.42
                             Call_action_partial_ok: TC |- (parameterIR)*{parameterIR <- parameterIR*} @ [] : (parameterIR_data)*{parameterIR_data <- parameterIR_data*} , (parameterIR_control)*{parameterIR_control <- parameterIR_control*} @ (argumentIR)*{argumentIR <- argumentIR*} failed
-                            └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:129.6-129.28
+                            └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:132.6-132.28
                                 relation Call_action_partial_ok failed
-                                └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:129.6-129.28
+                                └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:132.6-132.28
                                     relation did not produce results
 
 
@@ -109,25 +109,25 @@ Group cons failed
 Error on run: ../../../../p4c/testdata/p4_16_errors/action-bind3.p4
 relation Program_ok failed
 │ ··· omitting 42 traces ···
-../../../../spec-concrete/5.14.1-typing-control-table.watsup:171.21-171.26
+../../../../spec-concrete/5.14.1-typing-control-table.watsup:174.21-174.26
 Group cons failed
-└── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:174.6-174.73
+└── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:177.6-177.73
     TableAction_ok: TC TBLC |- tableAction_h : TBLC_1 tableActionIR_h failed
-    └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:174.6-174.20
+    └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:177.6-177.20
         relation TableAction_ok failed
-        └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:142.52-142.69
+        └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:145.52-145.69
             If (tableActionReference matches pattern `%(%)`) failed
-            └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:141.20-141.53
+            └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:144.20-144.53
                 Group prefixedNonTypeName-argumentList failed
-                └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:146.9-146.38
+                └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:149.9-149.38
                     If (((cid, callableTypeDefIR))?{(cid, callableTypeDefIR) <- (cid, callableTypeDefIR)?} matches pattern (_)) failed
-                    └── ../../../../spec-concrete/2.3.1-type-callable.watsup:20.23-146.37
+                    └── ../../../../spec-concrete/2.3.1-type-callable.watsup:20.23-149.37
                         If (callableTypeDefIR has type actionTypeIR) failed
-                        └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:152.6-154.55
+                        └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:155.6-157.55
                             Call_action_partial_ok: TC |- (parameterIR)*{parameterIR <- parameterIR*} @ (argumentIR)*{argumentIR <- argumentIR*} : (parameterIR_data)*{parameterIR_data <- parameterIR_data*} , (parameterIR_control)*{parameterIR_control <- parameterIR_control*} @ (argumentIR_cast)*{argumentIR_cast <- argumentIR_cast*} failed
-                            └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:152.6-152.28
+                            └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:155.6-155.28
                                 relation Call_action_partial_ok failed
-                                └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:152.6-152.28
+                                └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:155.6-155.28
                                     relation did not produce results
 
 
@@ -569,25 +569,25 @@ relation Program_ok failed
 Error on run: ../../../../p4c/testdata/p4_16_errors/default_action.p4
 relation Program_ok failed
 │ ··· omitting 41 traces ···
-../../../../spec-concrete/5.14.1-typing-control-table.watsup:941.14-941.17
+../../../../spec-concrete/5.14.1-typing-control-table.watsup:944.14-944.17
 Case analysis on (tableProperty)*{tableProperty <- tableProperty*} failed
-└── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:943.24-943.29
+└── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:946.24-946.29
     Group cons failed
-    └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:946.6-946.79
+    └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:949.6-949.79
         TableProperty_ok: TC TBLC |- tableProperty_h : TBLC_1 tablePropertyIR_h failed
-        └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:946.6-946.22
+        └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:949.6-949.22
             relation TableProperty_ok failed
-            └── ../../../../spec-concrete/1-syntax.watsup:1249.5-814.40
+            └── ../../../../spec-concrete/1-syntax.watsup:1249.5-817.40
                 Case analysis on tableProperty failed
-                └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:845.22-845.37
+                └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:848.22-848.37
                     Group default-action failed
-                    └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:849.6-849.61
+                    └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:852.6-852.61
                         If ("default_action" = $tableCustomName(tableCustomName)) failed
-                        └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:851.6-851.76
+                        └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:854.6-854.76
                             TableDefaultAction_ok: TC TBLC_0 |- initializer : tableActionReferenceIR failed
-                            └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:851.6-851.27
+                            └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:854.6-854.27
                                 relation TableDefaultAction_ok failed
-                                └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:851.6-851.27
+                                └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:854.6-854.27
                                     relation did not produce results
 
 
@@ -595,25 +595,25 @@ Case analysis on (tableProperty)*{tableProperty <- tableProperty*} failed
 Error on run: ../../../../p4c/testdata/p4_16_errors/default_action1.p4
 relation Program_ok failed
 │ ··· omitting 45 traces ···
-../../../../spec-concrete/5.14.1-typing-control-table.watsup:941.14-941.17
+../../../../spec-concrete/5.14.1-typing-control-table.watsup:944.14-944.17
 Case analysis on (tableProperty)*{tableProperty <- tableProperty*} failed
-└── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:943.24-943.29
+└── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:946.24-946.29
     Group cons failed
-    └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:946.6-946.79
+    └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:949.6-949.79
         TableProperty_ok: TC TBLC |- tableProperty_h : TBLC_1 tablePropertyIR_h failed
-        └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:946.6-946.22
+        └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:949.6-949.22
             relation TableProperty_ok failed
-            └── ../../../../spec-concrete/1-syntax.watsup:1249.5-814.40
+            └── ../../../../spec-concrete/1-syntax.watsup:1249.5-817.40
                 Case analysis on tableProperty failed
-                └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:845.22-845.37
+                └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:848.22-848.37
                     Group default-action failed
-                    └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:849.6-849.61
+                    └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:852.6-852.61
                         If ("default_action" = $tableCustomName(tableCustomName)) failed
-                        └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:851.6-851.76
+                        └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:854.6-854.76
                             TableDefaultAction_ok: TC TBLC_0 |- initializer : tableActionReferenceIR failed
-                            └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:851.6-851.27
+                            └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:854.6-854.27
                                 relation TableDefaultAction_ok failed
-                                └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:851.6-851.27
+                                └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:854.6-854.27
                                     relation did not produce results
 
 
@@ -857,25 +857,25 @@ relation BlockElementStmts_ok failed
 Error on run: ../../../../p4c/testdata/p4_16_errors/enumCast.p4
 relation Program_ok failed
 │ ··· omitting 80 traces ···
-../../../../spec-concrete/5.13.1-typing-parser-statement.watsup:328.11-328.30
+../../../../spec-concrete/5.13.1-typing-parser-statement.watsup:329.11-329.30
 Case analysis on parserStatement' failed
-└── ../../../../spec-concrete/5.13.1-typing-parser-statement.watsup:337.24-337.44
+└── ../../../../spec-concrete/5.13.1-typing-parser-statement.watsup:338.24-338.44
     Group variableDeclaration failed
     └── ../../../../spec-concrete/1-syntax.watsup:856.22-856.24
         If (initializerOpt has type initializer) failed
-        └── ../../../../spec-concrete/5.13.1-typing-parser-statement.watsup:358.48-358.51
+        └── ../../../../spec-concrete/5.13.1-typing-parser-statement.watsup:359.48-359.51
             If ((tid)*{tid <- tid*} matches pattern []) failed
-            └── ../../../../spec-concrete/5.13.1-typing-parser-statement.watsup:359.8-359.46
+            └── ../../../../spec-concrete/5.13.1-typing-parser-statement.watsup:360.8-360.46
                 If Type_wf: $bound((local), TC_0) |- typeIR holds failed
-                └── ../../../../spec-concrete/5.13.1-typing-parser-statement.watsup:361.8-361.40
+                └── ../../../../spec-concrete/5.13.1-typing-parser-statement.watsup:362.8-362.40
                     If $is_assignable_typeIR(typeIR) failed
-                    └── ../../../../spec-concrete/5.13.1-typing-parser-statement.watsup:366.8-367.56
+                    └── ../../../../spec-concrete/5.13.1-typing-parser-statement.watsup:367.8-368.56
                         Let (typedExpressionIR)?{typedExpressionIR <- typedExpressionIR?} be $coerce_unary(typedExpressionIR_init, typeIR) failed
-                        └── ../../../../spec-concrete/5.13.1-typing-parser-statement.watsup:367.11-367.56
+                        └── ../../../../spec-concrete/5.13.1-typing-parser-statement.watsup:368.11-368.56
                             $coerce_unary(typedExpressionIR_init, typeIR) failed
-                            └── ../../../../spec-concrete/5.13.1-typing-parser-statement.watsup:367.12-367.25
+                            └── ../../../../spec-concrete/5.13.1-typing-parser-statement.watsup:368.12-368.25
                                 function coerce_unary failed
-                                └── ../../../../spec-concrete/5.13.1-typing-parser-statement.watsup:367.12-367.25
+                                └── ../../../../spec-concrete/5.13.1-typing-parser-statement.watsup:368.12-368.25
                                     function did not return a value
 
 
@@ -1283,25 +1283,25 @@ relation SwitchCases_table_ok failed
 Error on run: ../../../../p4c/testdata/p4_16_errors/init-entries-error1-bmv2.p4
 relation Program_ok failed
 │ ··· omitting 293 traces ···
-../../../../spec-concrete/5.14.1-typing-control-table.watsup:841.6-841.21
+../../../../spec-concrete/5.14.1-typing-control-table.watsup:844.6-844.21
 relation TableEntries_ok failed
-└── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:797.14-797.17
+└── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:800.14-800.17
     Case analysis on (tableEntry)*{tableEntry <- tableEntry*} failed
-    └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:799.21-799.26
+    └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:802.21-802.26
         Group cons failed
-        └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:802.6-802.70
+        └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:805.6-805.70
             TableEntry_ok: TC TBLC |- tableEntry_h : TBLC_1 tableEntryIR_h failed
-            └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:802.6-802.19
+            └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:805.6-805.19
                 relation TableEntry_ok failed
                 └── ../../../../spec-concrete/1-syntax.watsup:1231.50-1231.91
                     Case analysis on tableEntry failed
-                    └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:755.19-755.28
+                    └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:758.19-758.28
                         Group priority failed
-                        └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:764.6-765.78
+                        └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:767.6-768.78
                             TableEntry_priority_ok: TC TBLC_0 TBLS |- ?(tableEntryPriority) : TBLC_1 tableEntryPriorityOptIR failed
-                            └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:764.6-764.28
+                            └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:767.6-767.28
                                 relation TableEntry_priority_ok failed
-                                └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:764.6-764.28
+                                └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:767.6-767.28
                                     relation did not produce results
 
 
@@ -1309,25 +1309,25 @@ relation TableEntries_ok failed
 Error on run: ../../../../p4c/testdata/p4_16_errors/init-entries-error2-bmv2.p4
 relation Program_ok failed
 │ ··· omitting 309 traces ···
-../../../../spec-concrete/5.14.1-typing-control-table.watsup:803.6-803.21
+../../../../spec-concrete/5.14.1-typing-control-table.watsup:806.6-806.21
 relation TableEntries_ok failed
-└── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:797.14-797.17
+└── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:800.14-800.17
     Case analysis on (tableEntry)*{tableEntry <- tableEntry*} failed
-    └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:799.21-799.26
+    └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:802.21-802.26
         Group cons failed
-        └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:802.6-802.70
+        └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:805.6-805.70
             TableEntry_ok: TC TBLC |- tableEntry_h : TBLC_1 tableEntryIR_h failed
-            └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:802.6-802.19
+            └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:805.6-805.19
                 relation TableEntry_ok failed
                 └── ../../../../spec-concrete/1-syntax.watsup:1231.50-1231.91
                     Case analysis on tableEntry failed
-                    └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:755.19-755.28
+                    └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:758.19-758.28
                         Group priority failed
-                        └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:764.6-765.78
+                        └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:767.6-768.78
                             TableEntry_priority_ok: TC TBLC_0 TBLS |- ?(tableEntryPriority) : TBLC_1 tableEntryPriorityOptIR failed
-                            └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:764.6-764.28
+                            └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:767.6-767.28
                                 relation TableEntry_priority_ok failed
-                                └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:764.6-764.28
+                                └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:767.6-767.28
                                     relation did not produce results
 
 
@@ -1335,25 +1335,25 @@ relation TableEntries_ok failed
 Error on run: ../../../../p4c/testdata/p4_16_errors/init-entries-error3-bmv2.p4
 relation Program_ok failed
 │ ··· omitting 309 traces ···
-../../../../spec-concrete/5.14.1-typing-control-table.watsup:803.6-803.21
+../../../../spec-concrete/5.14.1-typing-control-table.watsup:806.6-806.21
 relation TableEntries_ok failed
-└── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:797.14-797.17
+└── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:800.14-800.17
     Case analysis on (tableEntry)*{tableEntry <- tableEntry*} failed
-    └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:799.21-799.26
+    └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:802.21-802.26
         Group cons failed
-        └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:802.6-802.70
+        └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:805.6-805.70
             TableEntry_ok: TC TBLC |- tableEntry_h : TBLC_1 tableEntryIR_h failed
-            └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:802.6-802.19
+            └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:805.6-805.19
                 relation TableEntry_ok failed
                 └── ../../../../spec-concrete/1-syntax.watsup:1231.50-1231.91
                     Case analysis on tableEntry failed
-                    └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:774.19-774.32
+                    └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:777.19-777.32
                         Group non-priority failed
-                        └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:783.6-783.84
+                        └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:786.6-786.84
                             TableEntry_priority_ok: TC TBLC_0 TBLS |- ?() : TBLC_1 tableEntryPriorityOptIR failed
-                            └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:783.6-783.28
+                            └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:786.6-786.28
                                 relation TableEntry_priority_ok failed
-                                └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:783.6-783.28
+                                └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:786.6-786.28
                                     relation did not produce results
 
 
@@ -1505,25 +1505,25 @@ Excluding file: ../../../../p4c/testdata/p4_16_errors/issue122.p4
 Error on run: ../../../../p4c/testdata/p4_16_errors/issue1230.p4
 relation Program_ok failed
 │ ··· omitting 60 traces ···
-../../../../spec-concrete/5.14.1-typing-control-table.watsup:1023.8-1023.26
+../../../../spec-concrete/5.14.1-typing-control-table.watsup:1026.8-1026.26
 relation TableProperties_ok failed
-└── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:941.14-941.17
+└── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:944.14-944.17
     Case analysis on (tableProperty)*{tableProperty <- tableProperty*} failed
-    └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:943.24-943.29
+    └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:946.24-946.29
         Group cons failed
-        └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:947.6-947.83
+        └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:950.6-950.83
             TableProperties_ok: TC TBLC_1 |- (tableProperty_t)*{tableProperty_t <- tableProperty_t*} : TBLC_2 (tablePropertyIR_t)*{tablePropertyIR_t <- tablePropertyIR_t*} failed
-            └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:947.6-947.24
+            └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:950.6-950.24
                 relation TableProperties_ok failed
-                └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:941.14-941.17
+                └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:944.14-944.17
                     Case analysis on (tableProperty)*{tableProperty <- tableProperty*} failed
-                    └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:943.24-943.29
+                    └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:946.24-946.29
                         Group cons failed
-                        └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:946.6-946.79
+                        └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:949.6-949.79
                             TableProperty_ok: TC TBLC |- tableProperty_h : TBLC_1 tablePropertyIR_h failed
-                            └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:946.6-946.22
+                            └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:949.6-949.22
                                 relation TableProperty_ok failed
-                                └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:946.6-946.22
+                                └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:949.6-949.22
                                     relation did not produce results
 
 
@@ -1587,25 +1587,25 @@ Error on run: ../../../../p4c/testdata/p4_16_errors/issue1336.p4
 Error on run: ../../../../p4c/testdata/p4_16_errors/issue1542.p4
 relation Program_ok failed
 │ ··· omitting 97 traces ···
-../../../../spec-concrete/5.14.1-typing-control-table.watsup:841.6-841.21
+../../../../spec-concrete/5.14.1-typing-control-table.watsup:844.6-844.21
 relation TableEntries_ok failed
-└── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:797.14-797.17
+└── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:800.14-800.17
     Case analysis on (tableEntry)*{tableEntry <- tableEntry*} failed
-    └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:799.21-799.26
+    └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:802.21-802.26
         Group cons failed
-        └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:802.6-802.70
+        └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:805.6-805.70
             TableEntry_ok: TC TBLC |- tableEntry_h : TBLC_1 tableEntryIR_h failed
-            └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:802.6-802.19
+            └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:805.6-805.19
                 relation TableEntry_ok failed
                 └── ../../../../spec-concrete/1-syntax.watsup:1231.50-1231.91
                     Case analysis on tableEntry failed
-                    └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:774.19-774.32
+                    └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:777.19-777.32
                         Group non-priority failed
-                        └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:781.6-781.86
+                        └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:784.6-784.86
                             TableEntry_action_ok: TC TBLC_0 |- tableActionReference : tableActionReferenceIR failed
-                            └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:781.6-781.26
+                            └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:784.6-784.26
                                 relation TableEntry_action_ok failed
-                                └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:781.6-781.26
+                                └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:784.6-784.26
                                     relation did not produce results
 
 
@@ -1712,7 +1712,7 @@ Excluding file: ../../../../p4c/testdata/p4_16_errors/issue1949-bmv2.p4
 Error on run: ../../../../p4c/testdata/p4_16_errors/issue1986-1.p4
 relation Program_ok failed
 │ ··· omitting 249 traces ···
-../../../../spec-concrete/5.13.1-typing-parser-statement.watsup:314.7-314.20
+../../../../spec-concrete/5.13.1-typing-parser-statement.watsup:315.7-315.20
 relation SelectCase_ok failed
 └── ../../../../spec-concrete/5.13.1-typing-parser-statement.watsup:292.19
     Group  failed
@@ -1738,7 +1738,7 @@ relation SelectCase_ok failed
 Error on run: ../../../../p4c/testdata/p4_16_errors/issue1986.p4
 relation Program_ok failed
 │ ··· omitting 245 traces ···
-../../../../spec-concrete/5.13.1-typing-parser-statement.watsup:314.7-314.20
+../../../../spec-concrete/5.13.1-typing-parser-statement.watsup:315.7-315.20
 relation SelectCase_ok failed
 └── ../../../../spec-concrete/5.13.1-typing-parser-statement.watsup:292.19
     Group  failed
@@ -1790,25 +1790,25 @@ Case analysis on blockElementStatement failed
 Error on run: ../../../../p4c/testdata/p4_16_errors/issue2033.p4
 relation Program_ok failed
 │ ··· omitting 41 traces ···
-../../../../spec-concrete/5.14.1-typing-control-table.watsup:941.14-941.17
+../../../../spec-concrete/5.14.1-typing-control-table.watsup:944.14-944.17
 Case analysis on (tableProperty)*{tableProperty <- tableProperty*} failed
-└── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:943.24-943.29
+└── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:946.24-946.29
     Group cons failed
-    └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:946.6-946.79
+    └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:949.6-949.79
         TableProperty_ok: TC TBLC |- tableProperty_h : TBLC_1 tablePropertyIR_h failed
-        └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:946.6-946.22
+        └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:949.6-949.22
             relation TableProperty_ok failed
-            └── ../../../../spec-concrete/1-syntax.watsup:1249.5-814.40
+            └── ../../../../spec-concrete/1-syntax.watsup:1249.5-817.40
                 Case analysis on tableProperty failed
-                └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:845.22-845.37
+                └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:848.22-848.37
                     Group default-action failed
-                    └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:849.6-849.61
+                    └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:852.6-852.61
                         If ("default_action" = $tableCustomName(tableCustomName)) failed
-                        └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:851.6-851.76
+                        └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:854.6-854.76
                             TableDefaultAction_ok: TC TBLC_0 |- initializer : tableActionReferenceIR failed
-                            └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:851.6-851.27
+                            └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:854.6-854.27
                                 relation TableDefaultAction_ok failed
-                                └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:851.6-851.27
+                                └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:854.6-854.27
                                     relation did not produce results
 
 
@@ -2889,7 +2889,7 @@ relation Decl_ok failed
 Error on run: ../../../../p4c/testdata/p4_16_errors/issue3345.p4
 relation Program_ok failed
 │ ··· omitting 29 traces ···
-../../../../spec-concrete/5.13.1-typing-parser-statement.watsup:314.7-314.20
+../../../../spec-concrete/5.13.1-typing-parser-statement.watsup:315.7-315.20
 relation SelectCase_ok failed
 └── ../../../../spec-concrete/5.13.1-typing-parser-statement.watsup:292.19
     Group  failed
@@ -2999,25 +2999,25 @@ Excluding file: ../../../../p4c/testdata/p4_16_errors/issue3430.p4
 Error on run: ../../../../p4c/testdata/p4_16_errors/issue3442.p4
 relation Program_ok failed
 │ ··· omitting 80 traces ···
-../../../../spec-concrete/5.14.1-typing-control-table.watsup:947.6-947.24
+../../../../spec-concrete/5.14.1-typing-control-table.watsup:950.6-950.24
 relation TableProperties_ok failed
-└── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:941.14-941.17
+└── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:944.14-944.17
     Case analysis on (tableProperty)*{tableProperty <- tableProperty*} failed
-    └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:943.24-943.29
+    └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:946.24-946.29
         Group cons failed
-        └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:947.6-947.83
+        └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:950.6-950.83
             TableProperties_ok: TC TBLC_1 |- (tableProperty_t)*{tableProperty_t <- tableProperty_t*} : TBLC_2 (tablePropertyIR_t)*{tablePropertyIR_t <- tablePropertyIR_t*} failed
-            └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:947.6-947.24
+            └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:950.6-950.24
                 relation TableProperties_ok failed
-                └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:941.14-941.17
+                └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:944.14-944.17
                     Case analysis on (tableProperty)*{tableProperty <- tableProperty*} failed
-                    └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:943.24-943.29
+                    └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:946.24-946.29
                         Group cons failed
-                        └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:946.6-946.79
+                        └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:949.6-949.79
                             TableProperty_ok: TC TBLC |- tableProperty_h : TBLC_1 tablePropertyIR_h failed
-                            └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:946.6-946.22
+                            └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:949.6-949.22
                                 relation TableProperty_ok failed
-                                └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:946.6-946.22
+                                └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:949.6-949.22
                                     relation did not produce results
 
 
@@ -3267,25 +3267,25 @@ Case analysis on blockElementStatement failed
 Error on run: ../../../../p4c/testdata/p4_16_errors/issue3671-2.p4
 relation Program_ok failed
 │ ··· omitting 53 traces ···
-../../../../spec-concrete/5.14.1-typing-control-table.watsup:941.14-941.17
+../../../../spec-concrete/5.14.1-typing-control-table.watsup:944.14-944.17
 Case analysis on (tableProperty)*{tableProperty <- tableProperty*} failed
-└── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:943.24-943.29
+└── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:946.24-946.29
     Group cons failed
-    └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:946.6-946.79
+    └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:949.6-949.79
         TableProperty_ok: TC TBLC |- tableProperty_h : TBLC_1 tablePropertyIR_h failed
-        └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:946.6-946.22
+        └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:949.6-949.22
             relation TableProperty_ok failed
-            └── ../../../../spec-concrete/1-syntax.watsup:1249.5-814.40
+            └── ../../../../spec-concrete/1-syntax.watsup:1249.5-817.40
                 Case analysis on tableProperty failed
-                └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:845.22-845.37
+                └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:848.22-848.37
                     Group default-action failed
-                    └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:849.6-849.61
+                    └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:852.6-852.61
                         If ("default_action" = $tableCustomName(tableCustomName)) failed
-                        └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:851.6-851.76
+                        └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:854.6-854.76
                             TableDefaultAction_ok: TC TBLC_0 |- initializer : tableActionReferenceIR failed
-                            └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:851.6-851.27
+                            └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:854.6-854.27
                                 relation TableDefaultAction_ok failed
-                                └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:851.6-851.27
+                                └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:854.6-854.27
                                     relation did not produce results
 
 
@@ -3293,25 +3293,25 @@ Case analysis on (tableProperty)*{tableProperty <- tableProperty*} failed
 Error on run: ../../../../p4c/testdata/p4_16_errors/issue3727.p4
 relation Program_ok failed
 │ ··· omitting 44 traces ···
-../../../../spec-concrete/5.14.1-typing-control-table.watsup:946.6-946.22
+../../../../spec-concrete/5.14.1-typing-control-table.watsup:949.6-949.22
 relation TableProperty_ok failed
-└── ../../../../spec-concrete/1-syntax.watsup:1249.5-814.40
+└── ../../../../spec-concrete/1-syntax.watsup:1249.5-817.40
     Case analysis on tableProperty failed
-    └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:821.22-821.30
+    └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:824.22-824.30
         Group actions failed
-        └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:825.6-825.72
+        └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:828.6-828.72
             TableActions_ok: TC TBLC_0 |- (tableAction)*{tableAction <- tableAction*} : TBLC_1 (tableActionIR)*{tableActionIR <- tableActionIR*} failed
-            └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:825.6-825.21
+            └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:828.6-828.21
                 relation TableActions_ok failed
-                └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:169.14-169.17
+                └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:172.14-172.17
                     Case analysis on (tableAction)*{tableAction <- tableAction*} failed
-                    └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:171.21-171.26
+                    └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:174.21-174.26
                         Group cons failed
-                        └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:174.6-174.73
+                        └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:177.6-177.73
                             TableAction_ok: TC TBLC |- tableAction_h : TBLC_1 tableActionIR_h failed
-                            └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:174.6-174.20
+                            └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:177.6-177.20
                                 relation TableAction_ok failed
-                                └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:174.6-174.20
+                                └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:177.6-177.20
                                     relation did not produce results
 
 
@@ -3683,13 +3683,13 @@ relation Decls_ok failed
 Error on run: ../../../../p4c/testdata/p4_16_errors/issue413.p4
 relation Program_ok failed
 │ ··· omitting 260 traces ···
-../../../../spec-concrete/5.13.1-typing-parser-statement.watsup:328.11-328.30
+../../../../spec-concrete/5.13.1-typing-parser-statement.watsup:329.11-329.30
 Case analysis on parserStatement' failed
-└── ../../../../spec-concrete/5.13.1-typing-parser-statement.watsup:395.19-395.33
+└── ../../../../spec-concrete/5.13.1-typing-parser-statement.watsup:396.19-396.33
     Group callStatement failed
-    └── ../../../../spec-concrete/5.13.1-typing-parser-statement.watsup:398.6-399.66
+    └── ../../../../spec-concrete/5.13.1-typing-parser-statement.watsup:399.6-400.66
         Stmt_ok: (local) TC_0 (cont) (noloop) |- (callStatement as statement) : TC_1 flow statementIR failed
-        └── ../../../../spec-concrete/5.13.1-typing-parser-statement.watsup:398.6-398.13
+        └── ../../../../spec-concrete/5.13.1-typing-parser-statement.watsup:399.6-399.13
             relation Stmt_ok failed
             └── ../../../../spec-concrete/1-syntax.watsup:667.25-667.27
                 Case analysis on statement' failed
@@ -4409,25 +4409,25 @@ relation ControlLocalDecls_ok failed
 Error on run: ../../../../p4c/testdata/p4_16_errors/missing_match.p4
 relation Program_ok failed
 │ ··· omitting 70 traces ···
-../../../../spec-concrete/5.14.1-typing-control-table.watsup:74.18-74.23
+../../../../spec-concrete/5.14.1-typing-control-table.watsup:77.18-77.23
 Group cons failed
-└── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:77.6-77.64
+└── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:80.6-80.64
     TableKey_ok: TC TBLC |- tableKey_h : TBLC_1 tableKeyIR_h failed
-    └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:77.6-77.17
+    └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:80.6-80.17
         relation TableKey_ok failed
         └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:45.17
             Group  failed
-            └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:52.6-52.51
-                If Type_wf: $bound((local), TC) |- ((set< [typeIR] >) as typeIR) holds failed
-                └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:55.6-56.58
+            └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:55.6-55.59
+                If Type_wf: $bound((local), TC) |- ((set< [typeIR_reduced] >) as typeIR) holds failed
+                └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:58.6-59.58
                     If (((match_kind. nameIR_matchkind) as value) = $find_var_value_t((local), TC, (` nameIR_matchkind))) failed
-                    └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:55.9-56.58
+                    └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:58.9-59.58
                         (((match_kind. nameIR_matchkind) as value) = $find_var_value_t((local), TC, (` nameIR_matchkind))) failed
-                        └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:56.9-56.58
+                        └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:59.9-59.58
                             $find_var_value_t((local), TC, (` nameIR_matchkind)) failed
-                            └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:56.10-56.27
+                            └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:59.10-59.27
                                 function find_var_value_t failed
-                                └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:56.10-56.27
+                                └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:59.10-59.27
                                     function did not return a value
 
 
@@ -5533,25 +5533,25 @@ Excluding file: ../../../../p4c/testdata/p4_16_errors/structured-annotation-e3.p
 Error on run: ../../../../p4c/testdata/p4_16_errors/table-entries-decl-order.p4
 relation Program_ok failed
 │ ··· omitting 268 traces ···
-../../../../spec-concrete/5.14.1-typing-control-table.watsup:1016.8-1016.87
+../../../../spec-concrete/5.14.1-typing-control-table.watsup:1019.8-1019.87
 If (|$filter_<tableProperty>((tableProperty)*{tableProperty <- tableProperty*}, $is_tableKeysProperty)| <= 1) failed
-└── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:1018.8-1018.86
+└── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:1021.8-1021.86
     If (|$filter_<tableProperty>((tableProperty)*{tableProperty <- tableProperty*}, $is_tableActionsProperty)| = 1) failed
-    └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:1020.8-1020.92
+    └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:1023.8-1023.92
         Case analysis on |$filter_<tableProperty>((tableProperty)*{tableProperty <- tableProperty*}, $is_tableDefaultActionProperty)| failed
-        └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:1040.8-1040.81
+        └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:1043.8-1043.81
             TableProperties_ok: TC TBLC_0 |- (tableProperty)*{tableProperty <- tableProperty*} : TBLC_1 (tablePropertyIR)*{tablePropertyIR <- tablePropertyIR*} failed
-            └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:1040.8-1040.26
+            └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:1043.8-1043.26
                 relation TableProperties_ok failed
-                └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:941.14-941.17
+                └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:944.14-944.17
                     Case analysis on (tableProperty)*{tableProperty <- tableProperty*} failed
-                    └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:943.24-943.29
+                    └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:946.24-946.29
                         Group cons failed
-                        └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:946.6-946.79
+                        └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:949.6-949.79
                             TableProperty_ok: TC TBLC |- tableProperty_h : TBLC_1 tablePropertyIR_h failed
-                            └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:946.6-946.22
+                            └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:949.6-949.22
                                 relation TableProperty_ok failed
-                                └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:946.6-946.22
+                                └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:949.6-949.22
                                     relation did not produce results
 
 
@@ -5559,25 +5559,25 @@ If (|$filter_<tableProperty>((tableProperty)*{tableProperty <- tableProperty*}, 
 Error on run: ../../../../p4c/testdata/p4_16_errors/table-entries-exact-ternary.p4
 relation Program_ok failed
 │ ··· omitting 309 traces ···
-../../../../spec-concrete/5.14.1-typing-control-table.watsup:803.6-803.21
+../../../../spec-concrete/5.14.1-typing-control-table.watsup:806.6-806.21
 relation TableEntries_ok failed
-└── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:797.14-797.17
+└── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:800.14-800.17
     Case analysis on (tableEntry)*{tableEntry <- tableEntry*} failed
-    └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:799.21-799.26
+    └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:802.21-802.26
         Group cons failed
-        └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:802.6-802.70
+        └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:805.6-805.70
             TableEntry_ok: TC TBLC |- tableEntry_h : TBLC_1 tableEntryIR_h failed
-            └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:802.6-802.19
+            └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:805.6-805.19
                 relation TableEntry_ok failed
                 └── ../../../../spec-concrete/1-syntax.watsup:1231.50-1231.91
                     Case analysis on tableEntry failed
-                    └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:774.19-774.32
+                    └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:777.19-777.32
                         Group non-priority failed
-                        └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:779.6-779.83
+                        └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:782.6-782.83
                             TableEntry_keyset_ok: TC TBLC_0 |- keysetExpression : TBLS keysetExpressionIR failed
-                            └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:779.6-779.26
+                            └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:782.6-782.26
                                 relation TableEntry_keyset_ok failed
-                                └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:779.6-779.26
+                                └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:782.6-782.26
                                     relation did not produce results
 
 
@@ -5585,25 +5585,25 @@ relation TableEntries_ok failed
 Error on run: ../../../../p4c/testdata/p4_16_errors/table-entries-exact.p4
 relation Program_ok failed
 │ ··· omitting 305 traces ···
-../../../../spec-concrete/5.14.1-typing-control-table.watsup:803.6-803.21
+../../../../spec-concrete/5.14.1-typing-control-table.watsup:806.6-806.21
 relation TableEntries_ok failed
-└── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:797.14-797.17
+└── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:800.14-800.17
     Case analysis on (tableEntry)*{tableEntry <- tableEntry*} failed
-    └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:799.21-799.26
+    └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:802.21-802.26
         Group cons failed
-        └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:802.6-802.70
+        └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:805.6-805.70
             TableEntry_ok: TC TBLC |- tableEntry_h : TBLC_1 tableEntryIR_h failed
-            └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:802.6-802.19
+            └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:805.6-805.19
                 relation TableEntry_ok failed
                 └── ../../../../spec-concrete/1-syntax.watsup:1231.50-1231.91
                     Case analysis on tableEntry failed
-                    └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:774.19-774.32
+                    └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:777.19-777.32
                         Group non-priority failed
-                        └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:779.6-779.83
+                        └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:782.6-782.83
                             TableEntry_keyset_ok: TC TBLC_0 |- keysetExpression : TBLS keysetExpressionIR failed
-                            └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:779.6-779.26
+                            └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:782.6-782.26
                                 relation TableEntry_keyset_ok failed
-                                └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:779.6-779.26
+                                └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:782.6-782.26
                                     relation did not produce results
 
 
@@ -5663,25 +5663,25 @@ If (integerLiteral matches pattern `%W%`) failed
 Error on run: ../../../../p4c/testdata/p4_16_errors/table-entries-optional-2-bmv2.p4
 relation Program_ok failed
 │ ··· omitting 304 traces ···
-../../../../spec-concrete/5.14.1-typing-control-table.watsup:555.26-555.53
+../../../../spec-concrete/5.14.1-typing-control-table.watsup:558.26-558.53
 Group tupleKeysetExpression-list failed
-└── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:563.6-563.48
+└── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:566.6-566.48
     If (|TBLC.keys| = |(simpleKeysetExpression)*{simpleKeysetExpression <- simpleKeysetExpression*}|) failed
-    └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:565.6-567.54
+    └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:568.6-570.54
         TableEntry_keysets_simple_ok: TC TBLC (nolpm) |- TBLC.keys @ (simpleKeysetExpression)*{simpleKeysetExpression <- simpleKeysetExpression*} : TBLS (simpleKeysetExpressionIR)*{simpleKeysetExpressionIR <- simpleKeysetExpressionIR*} failed
-        └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:565.6-565.34
+        └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:568.6-568.34
             relation TableEntry_keysets_simple_ok failed
-            └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:406.19-406.22
+            └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:409.19-409.22
                 Case analysis on (matchKey)*{matchKey <- matchKey*} failed
-                └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:410.24-410.79
+                └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:413.24-413.79
                     If ((simpleKeysetExpression)*{simpleKeysetExpression <- simpleKeysetExpression*} matches pattern _ :: _) failed
-                    └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:408.34-408.39
+                    └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:411.34-411.39
                         Group cons failed
-                        └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:412.6-414.51
+                        └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:415.6-417.51
                             TableEntry_keyset_simple_ok: TC TBLC |- matchKey_h @ simpleKeysetExpression_h : TBLS_1 simpleKeysetExpressionIR_h failed
-                            └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:412.6-412.33
+                            └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:415.6-415.33
                                 relation TableEntry_keyset_simple_ok failed
-                                └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:412.6-412.33
+                                └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:415.6-415.33
                                     relation did not produce results
 
 
@@ -5693,25 +5693,25 @@ Error on run: ../../../../p4c/testdata/p4_16_errors/table-entries-outside-table.
 Error on run: ../../../../p4c/testdata/p4_16_errors/table-entries-range.p4
 relation Program_ok failed
 │ ··· omitting 305 traces ···
-../../../../spec-concrete/5.14.1-typing-control-table.watsup:803.6-803.21
+../../../../spec-concrete/5.14.1-typing-control-table.watsup:806.6-806.21
 relation TableEntries_ok failed
-└── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:797.14-797.17
+└── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:800.14-800.17
     Case analysis on (tableEntry)*{tableEntry <- tableEntry*} failed
-    └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:799.21-799.26
+    └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:802.21-802.26
         Group cons failed
-        └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:802.6-802.70
+        └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:805.6-805.70
             TableEntry_ok: TC TBLC |- tableEntry_h : TBLC_1 tableEntryIR_h failed
-            └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:802.6-802.19
+            └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:805.6-805.19
                 relation TableEntry_ok failed
                 └── ../../../../spec-concrete/1-syntax.watsup:1231.50-1231.91
                     Case analysis on tableEntry failed
-                    └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:774.19-774.32
+                    └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:777.19-777.32
                         Group non-priority failed
-                        └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:779.6-779.83
+                        └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:782.6-782.83
                             TableEntry_keyset_ok: TC TBLC_0 |- keysetExpression : TBLS keysetExpressionIR failed
-                            └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:779.6-779.26
+                            └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:782.6-782.26
                                 relation TableEntry_keyset_ok failed
-                                └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:779.6-779.26
+                                └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:782.6-782.26
                                     relation did not produce results
 
 
@@ -5719,25 +5719,25 @@ relation TableEntries_ok failed
 Error on run: ../../../../p4c/testdata/p4_16_errors/table-entries-ternary.p4
 relation Program_ok failed
 │ ··· omitting 320 traces ···
-../../../../spec-concrete/5.14.1-typing-control-table.watsup:453.26-453.55
+../../../../spec-concrete/5.14.1-typing-control-table.watsup:456.26-456.55
 Group simpleKeysetExpression-range failed
-└── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:456.6-456.27
+└── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:459.6-459.27
     If (|TBLC.keys| = 1) failed
-    └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:458.6-460.53
+    └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:461.6-463.53
         TableEntry_keysets_simple_ok: TC TBLC (nolpm) |- TBLC.keys @ [(expression_l .. expression_r)] : TBLS (simpleKeysetExpressionIR')*{simpleKeysetExpressionIR' <- simpleKeysetExpressionIR'*} failed
-        └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:458.6-458.34
+        └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:461.6-461.34
             relation TableEntry_keysets_simple_ok failed
-            └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:406.19-406.22
+            └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:409.19-409.22
                 Case analysis on (matchKey)*{matchKey <- matchKey*} failed
-                └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:410.24-410.79
+                └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:413.24-413.79
                     If ((simpleKeysetExpression)*{simpleKeysetExpression <- simpleKeysetExpression*} matches pattern _ :: _) failed
-                    └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:408.34-408.39
+                    └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:411.34-411.39
                         Group cons failed
-                        └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:412.6-414.51
+                        └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:415.6-417.51
                             TableEntry_keyset_simple_ok: TC TBLC |- matchKey_h @ simpleKeysetExpression_h : TBLS_1 simpleKeysetExpressionIR_h failed
-                            └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:412.6-412.33
+                            └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:415.6-415.33
                                 relation TableEntry_keyset_simple_ok failed
-                                └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:412.6-412.33
+                                └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:415.6-415.33
                                     relation did not produce results
 
 

--- a/p4spec/test/run_sl_type_pos_p4c.expected
+++ b/p4spec/test/run_sl_type_pos_p4c.expected
@@ -419,7 +419,7 @@ Run success: ../../../../p4c/testdata/p4_16_samples/enum-folding.p4
 Run success: ../../../../p4c/testdata/p4_16_samples/enum.p4
 
 >>> Running interpreter test (Program_ok) on ../../../../p4c/testdata/p4_16_samples/enumCast.p4
-Excluding file: ../../../../p4c/testdata/p4_16_samples/enumCast.p4
+Run success: ../../../../p4c/testdata/p4_16_samples/enumCast.p4
 
 >>> Running interpreter test (Program_ok) on ../../../../p4c/testdata/p4_16_samples/equality-bmv2.p4
 Run success: ../../../../p4c/testdata/p4_16_samples/equality-bmv2.p4
@@ -1880,7 +1880,7 @@ Run success: ../../../../p4c/testdata/p4_16_samples/issue3324.p4
 Run success: ../../../../p4c/testdata/p4_16_samples/issue3329-bmv2.p4
 
 >>> Running interpreter test (Program_ok) on ../../../../p4c/testdata/p4_16_samples/issue3333.p4
-Excluding file: ../../../../p4c/testdata/p4_16_samples/issue3333.p4
+Run success: ../../../../p4c/testdata/p4_16_samples/issue3333.p4
 
 >>> Running interpreter test (Program_ok) on ../../../../p4c/testdata/p4_16_samples/issue3343.p4
 Run success: ../../../../p4c/testdata/p4_16_samples/issue3343.p4
@@ -3638,7 +3638,7 @@ Run success: ../../../../p4c/testdata/p4_16_samples/table-entries-priority-bmv2.
 Run success: ../../../../p4c/testdata/p4_16_samples/table-entries-range-bmv2.p4
 
 >>> Running interpreter test (Program_ok) on ../../../../p4c/testdata/p4_16_samples/table-entries-ser-enum-bmv2.p4
-Excluding file: ../../../../p4c/testdata/p4_16_samples/table-entries-ser-enum-bmv2.p4
+Run success: ../../../../p4c/testdata/p4_16_samples/table-entries-ser-enum-bmv2.p4
 
 >>> Running interpreter test (Program_ok) on ../../../../p4c/testdata/p4_16_samples/table-entries-ternary-bmv2.p4
 Run success: ../../../../p4c/testdata/p4_16_samples/table-entries-ternary-bmv2.p4
@@ -3835,4 +3835,4 @@ Run success: ../../../../p4c/testdata/p4_16_samples/xdp_vlan_push_pop_ebpf-kerne
 >>> Running interpreter test (Program_ok) on ../../../../p4c/testdata/p4_16_samples/xor_test.p4
 Run success: ../../../../p4c/testdata/p4_16_samples/xor_test.p4
 
-Running interpreter test (Program_ok): [EXCLUDE] 99/1278 (7.75%) [PASS] 1179/1278 (92.25%) [FAIL] 0/1278 (0.00%)
+Running interpreter test (Program_ok): [EXCLUDE] 96/1278 (7.51%) [PASS] 1182/1278 (92.49%) [FAIL] 0/1278 (0.00%)

--- a/p4spec/test/sim_sl_v1model_p4c.expected
+++ b/p4spec/test/sim_sl_v1model_p4c.expected
@@ -1114,7 +1114,30 @@ Run success: ../../../../patches/v1model/table-entries-priority-bmv2.p4
 Run success: ../../../../p4c/testdata/p4_16_samples/table-entries-range-bmv2.p4
 
 >>> Running simulation test (v1model) on ../../../../p4c/testdata/p4_16_samples/table-entries-ser-enum-bmv2.p4
-Excluding file: ../../../../p4c/testdata/p4_16_samples/table-entries-ser-enum-bmv2.p4
+Error on run: ../../../../p4c/testdata/p4_16_samples/table-entries-ser-enum-bmv2.p4
+function write_value_from_bits failed
+│ ··· omitting 5 traces ···
+../../../../spec-concrete/2.1.2-value-aux.watsup:196.9-196.63
+$write_value_fields_from_bits'((fieldValue)*{fieldValue <- fieldValue*}, n_var, (bool)*{bool <- bool*}) failed
+└── ../../../../spec-concrete/2.1.2-value-aux.watsup:196.10-196.40
+    function write_value_fields_from_bits' failed
+    └── ../../../../spec-concrete/2.1.2-value-aux.watsup:170.36-170.39
+        Case analysis on (fieldValue)*{fieldValue <- fieldValue*} failed
+        └── ../../../../spec-concrete/2.1.2-value-aux.watsup:175.6-176.63
+            Let (fieldValue_h_updated, (b_t)*{b_t <- b_t*}) be $write_value_field_from_bits'(fieldValue_h, n_var, (b)*{b <- b*}) failed
+            └── ../../../../spec-concrete/2.1.2-value-aux.watsup:176.9-176.63
+                $write_value_field_from_bits'(fieldValue_h, n_var, (b)*{b <- b*}) failed
+                └── ../../../../spec-concrete/2.1.2-value-aux.watsup:176.10-176.39
+                    function write_value_field_from_bits' failed
+                    └── ../../../../spec-concrete/2.1.2-value-aux.watsup:184.6-185.50
+                        Let (value_updated, (b_rest)*{b_rest <- b_rest*}) be $write_value_from_bits'(value, n_var, (b)*{b <- b*}) failed
+                        └── ../../../../spec-concrete/2.1.2-value-aux.watsup:185.9-185.50
+                            $write_value_from_bits'(value, n_var, (b)*{b <- b*}) failed
+                            └── ../../../../spec-concrete/2.1.2-value-aux.watsup:185.10-185.33
+                                function write_value_from_bits' failed
+                                └── ../../../../spec-concrete/2.1.2-value-aux.watsup:185.10-185.33
+                                    function did not return a value
+
 
 >>> Running simulation test (v1model) on ../../../../p4c/testdata/p4_16_samples/table-entries-ternary-bmv2.p4
 [PASS] Transmitted (1) 01**********
@@ -1177,4 +1200,4 @@ Run success: ../../../../p4c/testdata/p4_16_samples/v1model-const-entries-bmv2.p
 Error on run: ../../../../p4c/testdata/p4_16_samples/v1model-special-ops-bmv2.p4
 parser error
 
-Running simulation test (v1model): [EXCLUDE] 4/203 (1.97%) [PASS] 196/203 (96.55%) [FAIL] 3/203 (1.48%)
+Running simulation test (v1model): [EXCLUDE] 3/203 (1.48%) [PASS] 196/203 (96.55%) [FAIL] 4/203 (1.97%)

--- a/p4spec/test/sim_sl_v1model_p4c.expected
+++ b/p4spec/test/sim_sl_v1model_p4c.expected
@@ -1114,30 +1114,12 @@ Run success: ../../../../patches/v1model/table-entries-priority-bmv2.p4
 Run success: ../../../../p4c/testdata/p4_16_samples/table-entries-range-bmv2.p4
 
 >>> Running simulation test (v1model) on ../../../../p4c/testdata/p4_16_samples/table-entries-ser-enum-bmv2.p4
-Error on run: ../../../../p4c/testdata/p4_16_samples/table-entries-ser-enum-bmv2.p4
-function write_value_from_bits failed
-│ ··· omitting 5 traces ···
-../../../../spec-concrete/2.1.2-value-aux.watsup:196.9-196.63
-$write_value_fields_from_bits'((fieldValue)*{fieldValue <- fieldValue*}, n_var, (bool)*{bool <- bool*}) failed
-└── ../../../../spec-concrete/2.1.2-value-aux.watsup:196.10-196.40
-    function write_value_fields_from_bits' failed
-    └── ../../../../spec-concrete/2.1.2-value-aux.watsup:170.36-170.39
-        Case analysis on (fieldValue)*{fieldValue <- fieldValue*} failed
-        └── ../../../../spec-concrete/2.1.2-value-aux.watsup:175.6-176.63
-            Let (fieldValue_h_updated, (b_t)*{b_t <- b_t*}) be $write_value_field_from_bits'(fieldValue_h, n_var, (b)*{b <- b*}) failed
-            └── ../../../../spec-concrete/2.1.2-value-aux.watsup:176.9-176.63
-                $write_value_field_from_bits'(fieldValue_h, n_var, (b)*{b <- b*}) failed
-                └── ../../../../spec-concrete/2.1.2-value-aux.watsup:176.10-176.39
-                    function write_value_field_from_bits' failed
-                    └── ../../../../spec-concrete/2.1.2-value-aux.watsup:184.6-185.50
-                        Let (value_updated, (b_rest)*{b_rest <- b_rest*}) be $write_value_from_bits'(value, n_var, (b)*{b <- b*}) failed
-                        └── ../../../../spec-concrete/2.1.2-value-aux.watsup:185.9-185.50
-                            $write_value_from_bits'(value, n_var, (b)*{b <- b*}) failed
-                            └── ../../../../spec-concrete/2.1.2-value-aux.watsup:185.10-185.33
-                                function write_value_from_bits' failed
-                                └── ../../../../spec-concrete/2.1.2-value-aux.watsup:185.10-185.33
-                                    function did not return a value
-
+[PASS] Transmitted (1) 001111
+[PASS] Transmitted (2) FFAB00
+[PASS] Transmitted (2) FFABCD
+[PASS] Transmitted (3) FFAFFF
+[PASS] Transmitted (0) AB0000
+Run success: ../../../../p4c/testdata/p4_16_samples/table-entries-ser-enum-bmv2.p4
 
 >>> Running simulation test (v1model) on ../../../../p4c/testdata/p4_16_samples/table-entries-ternary-bmv2.p4
 [PASS] Transmitted (1) 01**********
@@ -1200,4 +1182,4 @@ Run success: ../../../../p4c/testdata/p4_16_samples/v1model-const-entries-bmv2.p
 Error on run: ../../../../p4c/testdata/p4_16_samples/v1model-special-ops-bmv2.p4
 parser error
 
-Running simulation test (v1model): [EXCLUDE] 3/203 (1.48%) [PASS] 196/203 (96.55%) [FAIL] 4/203 (1.97%)
+Running simulation test (v1model): [EXCLUDE] 3/203 (1.48%) [PASS] 197/203 (97.04%) [FAIL] 3/203 (1.48%)

--- a/p4spec/test/struct.expected
+++ b/p4spec/test/struct.expected
@@ -3458,13 +3458,13 @@ def $write_value_from_bits(value, n_var, (b)*{b <- b*})
   1. Return value_updated
 
 ;; ../../../../spec-concrete/2.1.2-value-aux.watsup:141.1-141.64
-def $write_value_from_bits'(value, n_var, (bool)*{bool <- bool*})
+def $write_value_from_bits'(value', n_var, (bool)*{bool <- bool*})
 
-1. Case analysis on value
+1. Case analysis on value'
 
   1. Case (% has type boolValue)
 
-    1. (Let (b _bool) be (value as boolValue))
+    1. (Let (b _bool) be (value' as boolValue))
 
     2. If (((bool)*{bool <- bool*} matches pattern _ :: _)), then
 
@@ -3474,7 +3474,7 @@ def $write_value_from_bits'(value, n_var, (bool)*{bool <- bool*})
 
   2. Case (% has type integerLiteral)
 
-    1. (Let integerLiteral be (value as integerLiteral))
+    1. (Let integerLiteral be (value' as integerLiteral))
 
     2. Case analysis on integerLiteral
 
@@ -3520,7 +3520,7 @@ def $write_value_from_bits'(value, n_var, (bool)*{bool <- bool*})
 
   3. Case (% has type structValue)
 
-    1. (Let (struct tid { (fieldValue)*{fieldValue <- fieldValue*} }) be (value as structValue))
+    1. (Let (struct tid { (fieldValue)*{fieldValue <- fieldValue*} }) be (value' as structValue))
 
     2. (Let ((fieldValue_updated)*{fieldValue_updated <- fieldValue_updated*}, (b_rest)*{b_rest <- b_rest*}) be $write_value_fields_from_bits'((fieldValue)*{fieldValue <- fieldValue*}, n_var, (bool)*{bool <- bool*}))
 
@@ -3528,15 +3528,27 @@ def $write_value_from_bits'(value, n_var, (bool)*{bool <- bool*})
 
   4. Case (% has type headerValue)
 
-    1. (Let (header tid { _bool ; (fieldValue)*{fieldValue <- fieldValue*} }) be (value as headerValue))
+    1. (Let (header tid { _bool ; (fieldValue)*{fieldValue <- fieldValue*} }) be (value' as headerValue))
 
     2. (Let ((fieldValue_updated)*{fieldValue_updated <- fieldValue_updated*}, (b_rest)*{b_rest <- b_rest*}) be $write_value_fields_from_bits'((fieldValue)*{fieldValue <- fieldValue*}, n_var, (bool)*{bool <- bool*}))
 
     3. Return (((header tid { true ; (fieldValue_updated)*{fieldValue_updated <- fieldValue_updated*} }) as value), (b_rest)*{b_rest <- b_rest*})
 
-2. If ((value has type integerValue)), then
+  5. Case (% has type enumValue)
 
-  1. (Let integerValue be (value as integerValue))
+    1. (Let enumValue be (value' as enumValue))
+
+    2. If ((enumValue matches pattern `%.%.%`)), then
+
+      1. (Let (tid . id . value) be enumValue)
+
+      2. (Let (value_updated, (b_rest)*{b_rest <- b_rest*}) be $write_value_from_bits'(value, n_var, (bool)*{bool <- bool*}))
+
+      3. Return (((tid . "__UNSPECIFIED" . value_updated) as value), (b_rest)*{b_rest <- b_rest*})
+
+2. If ((value' has type integerValue)), then
+
+  1. (Let integerValue be (value' as integerValue))
 
   2. If ((integerValue matches pattern `%.%V%`)), then
 
@@ -3588,7 +3600,7 @@ def $write_value_field_from_bits'((value id ;), n_var, (b)*{b <- b*})
 
 2. Return ((value_updated id ;), (b_rest)*{b_rest <- b_rest*})
 
-;; ../../../../spec-concrete/2.1.2-value-aux.watsup:202.1-202.42
+;; ../../../../spec-concrete/2.1.2-value-aux.watsup:205.1-205.42
 def $write_bits_from_value(value')
 
 1. Case analysis on value'
@@ -3648,6 +3660,16 @@ def $write_bits_from_value(value')
     1. (Let (header_union _tid { ((value id ;))*{id <- id*, value <- value*} }) be (value' as headerUnionValue))
 
     2. Return $concat_<bool>(($write_bits_from_value(value))*{value <- value*})
+
+  7. Case (% has type enumValue)
+
+    1. (Let enumValue be (value' as enumValue))
+
+    2. If ((enumValue matches pattern `%.%.%`)), then
+
+      1. (Let (tid . id . value) be enumValue)
+
+      2. Return $write_bits_from_value(value)
 
 2. If ((value' has type integerValue)), then
 
@@ -8229,7 +8251,7 @@ def $bin_eq(value, value')
 
             1. (Let (tid_b . id_field_b . value_field_b) be enumValue')
 
-            2. Return (((tid_a = tid_b) /\ (id_field_a = id_field_b)) /\ $bin_eq(value_field_a, value_field_b))
+            2. Return ((tid_a = tid_b) /\ $bin_eq(value_field_a, value_field_b))
 
   13. Case (% has type invalidHeaderValue)
 
@@ -8329,12 +8351,12 @@ def $bin_eqs_fields(((value, id))*{(value, id) <- (value, id)*}, ((value, id)')*
 
       2. Return (((id_a_h = id_b_h) /\ $bin_eq(value_a_h, value_b_h)) /\ $bin_eqs_fields(((value_a_t, id_a_t))*{id_a_t <- id_a_t*, value_a_t <- value_a_t*}, ((value_b_t, id_b_t))*{id_b_t <- id_b_t*, value_b_t <- value_b_t*}))
 
-;; ../../../../spec-concrete/3-numerics.watsup:426.1-427.23
+;; ../../../../spec-concrete/3-numerics.watsup:425.1-426.23
 def $bin_ne(value_l, value_r)
 
 1. Return ~$bin_eq(value_l, value_r)
 
-;; ../../../../spec-concrete/3-numerics.watsup:435.1-436.23
+;; ../../../../spec-concrete/3-numerics.watsup:434.1-435.23
 def $bin_band(value, value')
 
 1. If ((value has type integerLiteral)), then
@@ -8383,7 +8405,7 @@ def $bin_band(value, value')
 
             4. Return ((w s i') as value)
 
-;; ../../../../spec-concrete/3-numerics.watsup:449.1-450.23
+;; ../../../../spec-concrete/3-numerics.watsup:448.1-449.23
 def $bin_bxor(value, value')
 
 1. If ((value has type integerLiteral)), then
@@ -8432,7 +8454,7 @@ def $bin_bxor(value, value')
 
             4. Return ((w s i') as value)
 
-;; ../../../../spec-concrete/3-numerics.watsup:463.1-464.23
+;; ../../../../spec-concrete/3-numerics.watsup:462.1-463.23
 def $bin_bor(value, value')
 
 1. If ((value has type integerLiteral)), then
@@ -8481,7 +8503,7 @@ def $bin_bor(value, value')
 
             4. Return ((w s i') as value)
 
-;; ../../../../spec-concrete/3-numerics.watsup:477.1-478.23
+;; ../../../../spec-concrete/3-numerics.watsup:476.1-477.23
 def $bin_concat(value, value')
 
 1. Case analysis on value
@@ -8582,7 +8604,7 @@ def $bin_concat(value, value')
 
               7. Return ((w s i''') as value)
 
-;; ../../../../spec-concrete/3-numerics.watsup:508.1-509.23
+;; ../../../../spec-concrete/3-numerics.watsup:507.1-508.23
 def $bin_land(value, value')
 
 1. If ((value has type boolValue)), then
@@ -8595,7 +8617,7 @@ def $bin_land(value, value')
 
     2. Return ((b (b_l /\ b_r)) as value)
 
-;; ../../../../spec-concrete/3-numerics.watsup:515.1-516.23
+;; ../../../../spec-concrete/3-numerics.watsup:514.1-515.23
 def $bin_lor(value, value')
 
 1. If ((value has type boolValue)), then
@@ -8608,7 +8630,7 @@ def $bin_lor(value, value')
 
     2. Return ((b (b_l \/ b_r)) as value)
 
-;; ../../../../spec-concrete/3-numerics.watsup:524.1-526.40
+;; ../../../../spec-concrete/3-numerics.watsup:523.1-525.40
 def $cast_op(typeIR, value')
 
 1. Case analysis on value'
@@ -8731,12 +8753,12 @@ def $cast_op(typeIR, value')
 
     2. Return $cast_varbit(typeIR, w_max, w, i)
 
-;; ../../../../spec-concrete/3-numerics.watsup:528.1-529.49
+;; ../../../../spec-concrete/3-numerics.watsup:527.1-528.49
 def $default(typeIR)
 
 1. Return $default'($canon_typeIR(typeIR))
 
-;; ../../../../spec-concrete/3-numerics.watsup:530.1-531.49
+;; ../../../../spec-concrete/3-numerics.watsup:529.1-530.49
 def $default'(typeIR')
 
 1. Case analysis on typeIR'
@@ -8857,12 +8879,12 @@ def $default'(typeIR')
 
           2. Return ((tid . id_zero . value_zero) as value)
 
-;; ../../../../spec-concrete/3-numerics.watsup:535.1-536.23
+;; ../../../../spec-concrete/3-numerics.watsup:534.1-535.23
 def $cast_bool(typeIR, b)
 
 1. Return $cast_bool'($canon_typeIR(typeIR), b)
 
-;; ../../../../spec-concrete/3-numerics.watsup:537.1-538.23
+;; ../../../../spec-concrete/3-numerics.watsup:536.1-537.23
 def $cast_bool'(typeIR', b)
 
 1. Case analysis on typeIR'
@@ -8897,12 +8919,12 @@ def $cast_bool'(typeIR', b)
 
     2. Return $cast_bool(typeIR, b)
 
-;; ../../../../spec-concrete/3-numerics.watsup:551.1-552.23
+;; ../../../../spec-concrete/3-numerics.watsup:550.1-551.23
 def $cast_arbint(typeIR, i)
 
 1. Return $cast_arbint'($canon_typeIR(typeIR), i)
 
-;; ../../../../spec-concrete/3-numerics.watsup:553.1-554.23
+;; ../../../../spec-concrete/3-numerics.watsup:552.1-553.23
 def $cast_arbint'(typeIR'', i)
 
 1. Case analysis on typeIR''
@@ -8951,12 +8973,12 @@ def $cast_arbint'(typeIR'', i)
 
       2. Return ((set{ $cast_arbint(typeIR, i) }) as value)
 
-;; ../../../../spec-concrete/3-numerics.watsup:569.1-570.23
+;; ../../../../spec-concrete/3-numerics.watsup:568.1-569.23
 def $cast_fixbit(typeIR, w, i)
 
 1. Return $cast_fixbit'($canon_typeIR(typeIR), w, i)
 
-;; ../../../../spec-concrete/3-numerics.watsup:571.1-572.23
+;; ../../../../spec-concrete/3-numerics.watsup:570.1-571.23
 def $cast_fixbit'(typeIR'', w, i)
 
 1. Case analysis on typeIR''
@@ -9009,12 +9031,12 @@ def $cast_fixbit'(typeIR'', w, i)
 
       2. Return ((set{ $cast_fixbit(typeIR, w, i) }) as value)
 
-;; ../../../../spec-concrete/3-numerics.watsup:589.1-590.23
+;; ../../../../spec-concrete/3-numerics.watsup:588.1-589.23
 def $cast_fixint(typeIR, w, i)
 
 1. Return $cast_fixint'($canon_typeIR(typeIR), w, i)
 
-;; ../../../../spec-concrete/3-numerics.watsup:591.1-592.23
+;; ../../../../spec-concrete/3-numerics.watsup:590.1-591.23
 def $cast_fixint'(typeIR'', w, i)
 
 1. Case analysis on typeIR''
@@ -9061,12 +9083,12 @@ def $cast_fixint'(typeIR'', w, i)
 
       2. Return ((set{ $cast_fixint(typeIR, w, i) }) as value)
 
-;; ../../../../spec-concrete/3-numerics.watsup:608.1-609.23
+;; ../../../../spec-concrete/3-numerics.watsup:607.1-608.23
 def $cast_varbit(typeIR, w_max, w, i)
 
 1. Return $cast_varbit'($canon_typeIR(typeIR), w_max, w, i)
 
-;; ../../../../spec-concrete/3-numerics.watsup:610.1-611.23
+;; ../../../../spec-concrete/3-numerics.watsup:609.1-610.23
 def $cast_varbit'(typeIR, w_max', w, i)
 
 1. If ((typeIR has type integerTypeIR)), then
@@ -9081,12 +9103,12 @@ def $cast_varbit'(typeIR, w_max', w, i)
 
       1. Return ((w_max . w v i) as value)
 
-;; ../../../../spec-concrete/3-numerics.watsup:621.1-622.23
+;; ../../../../spec-concrete/3-numerics.watsup:620.1-621.23
 def $cast_struct(typeIR, tid, ((value_field, id_field))*{id_field <- id_field*, value_field <- value_field*})
 
 1. Return $cast_struct'($canon_typeIR(typeIR), tid, ((value_field, id_field))*{id_field <- id_field*, value_field <- value_field*})
 
-;; ../../../../spec-concrete/3-numerics.watsup:623.1-624.23
+;; ../../../../spec-concrete/3-numerics.watsup:622.1-623.23
 def $cast_struct'(typeIR, tid', ((value_field, id_field))*{id_field <- id_field*, value_field <- value_field*})
 
 1. If ((typeIR has type structTypeIR)), then
@@ -9097,12 +9119,12 @@ def $cast_struct'(typeIR, tid', ((value_field, id_field))*{id_field <- id_field*
 
     1. Return ((struct tid { ((value_field id_field ;))*{id_field <- id_field*, value_field <- value_field*} }) as value)
 
-;; ../../../../spec-concrete/3-numerics.watsup:637.1-638.23
+;; ../../../../spec-concrete/3-numerics.watsup:636.1-637.23
 def $cast_header(typeIR, tid, b, ((value_field, id_field))*{id_field <- id_field*, value_field <- value_field*})
 
 1. Return $cast_header'($canon_typeIR(typeIR), tid, b, ((value_field, id_field))*{id_field <- id_field*, value_field <- value_field*})
 
-;; ../../../../spec-concrete/3-numerics.watsup:639.1-640.23
+;; ../../../../spec-concrete/3-numerics.watsup:638.1-639.23
 def $cast_header'(typeIR, tid', b, ((value_field, id_field))*{id_field <- id_field*, value_field <- value_field*})
 
 1. If ((typeIR has type headerTypeIR)), then
@@ -9113,12 +9135,12 @@ def $cast_header'(typeIR, tid', b, ((value_field, id_field))*{id_field <- id_fie
 
     1. Return ((header tid { b ; ((value_field id_field ;))*{id_field <- id_field*, value_field <- value_field*} }) as value)
 
-;; ../../../../spec-concrete/3-numerics.watsup:657.1-658.23
+;; ../../../../spec-concrete/3-numerics.watsup:656.1-657.23
 def $cast_sequence(typeIR, (value)*{value <- value*})
 
 1. Return $cast_sequence'($canon_typeIR(typeIR), (value)*{value <- value*})
 
-;; ../../../../spec-concrete/3-numerics.watsup:659.1-660.23
+;; ../../../../spec-concrete/3-numerics.watsup:658.1-659.23
 def $cast_sequence'(typeIR', (value)*{value <- value*})
 
 1. Case analysis on typeIR'
@@ -9161,12 +9183,12 @@ def $cast_sequence'(typeIR', (value)*{value <- value*})
 
     3. Return ((header tid { true ; ((value_cast id_field ;))*{id_field <- id_field*, value_cast <- value_cast*} }) as value)
 
-;; ../../../../spec-concrete/3-numerics.watsup:690.1-691.23
+;; ../../../../spec-concrete/3-numerics.watsup:689.1-690.23
 def $cast_record(typeIR, ((value, id))*{id <- id*, value <- value*})
 
 1. Return $cast_record'($canon_typeIR(typeIR), ((value, id))*{id <- id*, value <- value*})
 
-;; ../../../../spec-concrete/3-numerics.watsup:692.1-693.23
+;; ../../../../spec-concrete/3-numerics.watsup:691.1-692.23
 def $cast_record'(typeIR, ((value_field, id_field))*{id_field <- id_field*, value_field <- value_field*})
 
 1. Case analysis on typeIR
@@ -9199,12 +9221,12 @@ def $cast_record'(typeIR, ((value_field, id_field))*{id_field <- id_field*, valu
 
       3. Return ((header tid { true ; ((value_field_cast id_field ;))*{id_field <- id_field*, value_field_cast <- value_field_cast*} }) as value)
 
-;; ../../../../spec-concrete/3-numerics.watsup:727.1-727.34
+;; ../../../../spec-concrete/3-numerics.watsup:726.1-726.34
 def $cast_invalid(typeIR)
 
 1. Return $cast_invalid'($canon_typeIR(typeIR))
 
-;; ../../../../spec-concrete/3-numerics.watsup:728.1-728.35
+;; ../../../../spec-concrete/3-numerics.watsup:727.1-727.35
 def $cast_invalid'(typeIR)
 
 1. Case analysis on typeIR
@@ -9221,12 +9243,12 @@ def $cast_invalid'(typeIR)
 
     2. Return $default(typeIR)
 
-;; ../../../../spec-concrete/3-numerics.watsup:742.1-743.23
+;; ../../../../spec-concrete/3-numerics.watsup:741.1-742.23
 def $cast_set_singleton(typeIR, value)
 
 1. Return $cast_set_singleton'($canon_typeIR(typeIR), value)
 
-;; ../../../../spec-concrete/3-numerics.watsup:744.1-745.23
+;; ../../../../spec-concrete/3-numerics.watsup:743.1-744.23
 def $cast_set_singleton'(typeIR'', value)
 
 1. If ((typeIR'' has type setTypeIR)), then
@@ -9239,12 +9261,12 @@ def $cast_set_singleton'(typeIR'', value)
 
     2. Return ((set{ $cast_op(typeIR, value) }) as value)
 
-;; ../../../../spec-concrete/3-numerics.watsup:753.1-754.23
+;; ../../../../spec-concrete/3-numerics.watsup:752.1-753.23
 def $cast_set_mask(typeIR, value_b, value_m)
 
 1. Return $cast_set_mask'($canon_typeIR(typeIR), value_b, value_m)
 
-;; ../../../../spec-concrete/3-numerics.watsup:755.1-756.23
+;; ../../../../spec-concrete/3-numerics.watsup:754.1-755.23
 def $cast_set_mask'(typeIR'', value_b, value_m)
 
 1. If ((typeIR'' has type setTypeIR)), then
@@ -9261,12 +9283,12 @@ def $cast_set_mask'(typeIR'', value_b, value_m)
 
     4. Return ((set{ value_b_cast &&& value_m_cast }) as value)
 
-;; ../../../../spec-concrete/3-numerics.watsup:766.1-767.23
+;; ../../../../spec-concrete/3-numerics.watsup:765.1-766.23
 def $cast_set_range(typeIR, value_l, value_u)
 
 1. Return $cast_set_range'($canon_typeIR(typeIR), value_l, value_u)
 
-;; ../../../../spec-concrete/3-numerics.watsup:768.1-769.23
+;; ../../../../spec-concrete/3-numerics.watsup:767.1-768.23
 def $cast_set_range'(typeIR'', value_l, value_u)
 
 1. If ((typeIR'' has type setTypeIR)), then
@@ -9283,7 +9305,7 @@ def $cast_set_range'(typeIR'', value_l, value_u)
 
     4. Return ((set{ value_l_cast .. value_u_cast }) as value)
 
-;; ../../../../spec-concrete/3-numerics.watsup:834.1-835.23
+;; ../../../../spec-concrete/3-numerics.watsup:833.1-834.23
 def $bitacc_op(value_b, value_h, value_l)
 
 1. (Let i_b be $int_of_value(value_b))
@@ -9302,7 +9324,7 @@ def $bitacc_op(value_b, value_h, value_l)
 
   3. Return ((w w i) as value)
 
-;; ../../../../spec-concrete/3-numerics.watsup:848.1-849.23
+;; ../../../../spec-concrete/3-numerics.watsup:847.1-848.23
 def $bitacc_replace_op(value_b, value_h, value_l, value_r)
 
 1. If ((value_b has type integerLiteral)), then
@@ -9329,7 +9351,7 @@ def $bitacc_replace_op(value_b, value_h, value_l, value_r)
 
         3. Return ((w w i) as value)
 
-;; ../../../../spec-concrete/3-numerics.watsup:862.1-863.23
+;; ../../../../spec-concrete/3-numerics.watsup:861.1-862.23
 def $sizeof(typeIR, text)
 
 1. Case analysis on text
@@ -9350,17 +9372,17 @@ def $sizeof(typeIR, text)
 
     1. Return $sizeof_maxSizeInBytes(typeIR)
 
-;; ../../../../spec-concrete/3-numerics.watsup:865.1-866.23
+;; ../../../../spec-concrete/3-numerics.watsup:864.1-865.23
 def $sizeof_minSizeInBits(typeIR)
 
 1. Return ((d ($sizeof_minSizeInBits'(typeIR) as int)) as value)
 
-;; ../../../../spec-concrete/3-numerics.watsup:867.1-868.23
+;; ../../../../spec-concrete/3-numerics.watsup:866.1-867.23
 def $sizeof_minSizeInBits'(typeIR)
 
 1. Return $sizeof_minSizeInBits''($canon_typeIR(typeIR))
 
-;; ../../../../spec-concrete/3-numerics.watsup:869.1-870.23
+;; ../../../../spec-concrete/3-numerics.watsup:868.1-869.23
 def $sizeof_minSizeInBits''(typeIR')
 
 1. Case analysis on typeIR'
@@ -9441,24 +9463,24 @@ def $sizeof_minSizeInBits''(typeIR')
 
     2. Return $min_nat(($sizeof_minSizeInBits'(typeIR))*{typeIR <- typeIR*})
 
-;; ../../../../spec-concrete/3-numerics.watsup:872.1-873.23
+;; ../../../../spec-concrete/3-numerics.watsup:871.1-872.23
 def $sizeof_minSizeInBytes(typeIR)
 
 1. (Let n_size be $sizeof_minSizeInBits'(typeIR))
 
 2. Return ((d ((n_size / 8) as int)) as value)
 
-;; ../../../../spec-concrete/3-numerics.watsup:875.1-876.23
+;; ../../../../spec-concrete/3-numerics.watsup:874.1-875.23
 def $sizeof_maxSizeInBits(typeIR)
 
 1. Return ((d ($sizeof_maxSizeInBits'(typeIR) as int)) as value)
 
-;; ../../../../spec-concrete/3-numerics.watsup:877.1-878.23
+;; ../../../../spec-concrete/3-numerics.watsup:876.1-877.23
 def $sizeof_maxSizeInBits'(typeIR)
 
 1. Return $sizeof_maxSizeInBits''($canon_typeIR(typeIR))
 
-;; ../../../../spec-concrete/3-numerics.watsup:879.1-880.23
+;; ../../../../spec-concrete/3-numerics.watsup:878.1-879.23
 def $sizeof_maxSizeInBits''(typeIR')
 
 1. Case analysis on typeIR'
@@ -9539,7 +9561,7 @@ def $sizeof_maxSizeInBits''(typeIR')
 
     2. Return $max_nat(($sizeof_maxSizeInBits'(typeIR))*{typeIR <- typeIR*})
 
-;; ../../../../spec-concrete/3-numerics.watsup:882.1-883.23
+;; ../../../../spec-concrete/3-numerics.watsup:881.1-882.23
 def $sizeof_maxSizeInBytes(typeIR)
 
 1. (Let n_size be $sizeof_maxSizeInBits'(typeIR))

--- a/p4spec/test/struct.expected
+++ b/p4spec/test/struct.expected
@@ -18143,15 +18143,17 @@ relation ParserTransition_ok: TC_0 (nameIR_state)*{nameIR_state <- nameIR_state*
 
         2. (Expr_ok: (local) TC_0 |- expression_key : typedExpressionIR_key)*{expression_key <- expression_key*, typedExpressionIR_key <- typedExpressionIR_key*}
 
-        3. (Let typeIR_key be $type_of_typedExpressionIR(typedExpressionIR_key))*{typeIR_key <- typeIR_key*, typedExpressionIR_key <- typedExpressionIR_key*}
+        3. (Let typedExpressionIR_key_reduced be $reduce_serenum(typedExpressionIR_key))*{typedExpressionIR_key <- typedExpressionIR_key*, typedExpressionIR_key_reduced <- typedExpressionIR_key_reduced*}
 
-        4. If (Type_wf: $bound((local), TC_0) |- ((set< [typeIR_key] >) as typeIR))*{typeIR_key <- typeIR_key*} holds, then
+        4. (Let typeIR_key_reduced be $type_of_typedExpressionIR(typedExpressionIR_key_reduced))*{typeIR_key_reduced <- typeIR_key_reduced*, typedExpressionIR_key_reduced <- typedExpressionIR_key_reduced*}
+
+        5. If (Type_wf: $bound((local), TC_0) |- ((set< [typeIR_key_reduced] >) as typeIR))*{typeIR_key_reduced <- typeIR_key_reduced*} holds, then
 
           1. (Let (selectCase)*{selectCase <- selectCase*} be $flatten_selectCaseList(selectCaseList))
 
-          2. (SelectCase_ok: TC_0 (nameIR_state)*{nameIR_state <- nameIR_state*} (typeIR_key)*{typeIR_key <- typeIR_key*} |- selectCase : selectCaseIR)*{selectCase <- selectCase*, selectCaseIR <- selectCaseIR*}
+          2. (SelectCase_ok: TC_0 (nameIR_state)*{nameIR_state <- nameIR_state*} (typeIR_key_reduced)*{typeIR_key_reduced <- typeIR_key_reduced*} |- selectCase : selectCaseIR)*{selectCase <- selectCase*, selectCaseIR <- selectCaseIR*}
 
-          3. (Let transitionStatementIR be (transition ((select( (typedExpressionIR_key)*{typedExpressionIR_key <- typedExpressionIR_key*} ){ (selectCaseIR)*{selectCaseIR <- selectCaseIR*} }) as stateExpressionIR)))
+          3. (Let transitionStatementIR be (transition ((select( (typedExpressionIR_key_reduced)*{typedExpressionIR_key_reduced <- typedExpressionIR_key_reduced*} ){ (selectCaseIR)*{selectCaseIR <- selectCaseIR*} }) as stateExpressionIR)))
 
           4. Result in : % % |- % : transitionStatementIR
 
@@ -18558,21 +18560,23 @@ relation TableKey_ok: TC TBLC_0 |- (expression : name_matchkind annotationList ;
 
   1. (Expr_ok: (local) TC |- expression : typedExpressionIR)
 
-  2. (Let typeIR be $type_of_typedExpressionIR(typedExpressionIR))
+  2. (Let typedExpressionIR_reduced be $reduce_serenum(typedExpressionIR))
 
-  3. If (Type_wf: $bound((local), TC) |- ((set< [typeIR] >) as typeIR)) holds, then
+  3. (Let typeIR_reduced be $type_of_typedExpressionIR(typedExpressionIR_reduced))
+
+  4. If (Type_wf: $bound((local), TC) |- ((set< [typeIR_reduced] >) as typeIR)) holds, then
 
     1. (Let nameIR_matchkind be $name(name_matchkind))
 
     2. If ((((match_kind. nameIR_matchkind) as value) = $find_var_value_t((local), TC, (` nameIR_matchkind)))), then
 
-      1. If ($compat_table_key(nameIR_matchkind, typeIR)), then
+      1. If ($compat_table_key(nameIR_matchkind, typeIR_reduced)), then
 
-        1. (Let TBLC_1 be $update_mode(TBLC_0, nameIR_matchkind, typeIR))
+        1. (Let TBLC_1 be $update_mode(TBLC_0, nameIR_matchkind, typeIR_reduced))
 
-        2. (Let TBLC_2 be $add_key(TBLC_1, nameIR_matchkind, typeIR))
+        2. (Let TBLC_2 be $add_key(TBLC_1, nameIR_matchkind, typeIR_reduced))
 
-        3. (Let tableKeyIR be (typedExpressionIR : nameIR_matchkind annotationList ;))
+        3. (Let tableKeyIR be (typedExpressionIR_reduced : nameIR_matchkind annotationList ;))
 
         4. Result in : % % |- % : TBLC_2 tableKeyIR
 
@@ -21790,7 +21794,32 @@ relation Inst_ok: cursor TC instctxt |- constructorTypeIR < (typeArgumentIR)*{ty
 
             2. Result in : % % % |- % < % # % >( % # % ): typeIR_object_inferred < (typeArgumentIR_inferred)*{typeArgumentIR_inferred <- typeArgumentIR_inferred*} >( (argumentIR_cast)*{argumentIR_cast <- argumentIR_cast*} )
 
-;; ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:420.1-424.23
+;; ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:418.1-418.59
+def $reduce_serenum(typedExpressionIR)
+
+1. (Let typeIR be $type_of_typedExpressionIR(typedExpressionIR))
+
+2. (Let ctk be $ctk_of_typedExpressionIR(typedExpressionIR))
+
+3. (Let typeIR' be $canon_typeIR(typeIR))
+
+4. If ((typeIR' has type enumTypeIR)), then
+
+  1. (Let enumTypeIR be (typeIR' as enumTypeIR))
+
+  2. If ((enumTypeIR matches pattern `ENUM%<%>{%}`)), then
+
+    1. (Let (enum _tid < typeIR_underlying >{ (_valueFieldIR)*{_valueFieldIR <- _valueFieldIR*} }) be enumTypeIR)
+
+    2. (Let typedExpressionIR_reduced be (((( typeIR_underlying ) typedExpressionIR) as expressionIR) # (( typeIR_underlying ctk ))))
+
+    3. Return typedExpressionIR_reduced
+
+5. Otherwise
+
+  1. Return typedExpressionIR
+
+;; ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:431.1-434.23
 def $reduce_serenum_unary(typedExpressionIR, $check)
 
 1. (Let (_expressionIR # (( typeIR _ctk ))) be typedExpressionIR)
@@ -21821,7 +21850,7 @@ def $reduce_serenum_unary(typedExpressionIR, $check)
 
   1. Return ?()
 
-;; ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:445.1-450.44
+;; ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:454.1-458.44
 def $reduce_serenum_binary(typedExpressionIR_l, typedExpressionIR_r, $check)
 
 1. (Let (_expressionIR # (( typeIR_l _ctk ))) be typedExpressionIR_l)
@@ -21868,7 +21897,7 @@ def $reduce_serenum_binary(typedExpressionIR_l, typedExpressionIR_r, $check)
 
   1. Return ?()
 
-;; ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:490.1-491.44
+;; ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:498.1-499.44
 def $coerce_unary(typedExpressionIR, typeIR_to)
 
 1. (Let (_expressionIR # (( typeIR _ctk ))) be typedExpressionIR)
@@ -21885,7 +21914,7 @@ def $coerce_unary(typedExpressionIR, typeIR_to)
 
     2. Return ?(typedExpressionIR_cast)
 
-;; ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:506.1-508.62
+;; ../../../../spec-concrete/5.05.2-typing-subtyping.watsup:514.1-516.62
 def $coerce_binary(typedExpressionIR_l, typedExpressionIR_r)
 
 1. (Let (_expressionIR # (( typeIR_l _ctk ))) be typedExpressionIR_l)
@@ -21911,6 +21940,22 @@ def $coerce_binary(typedExpressionIR_l, typedExpressionIR_r)
       1. (Let typedExpressionIR_r_cast be (((( typeIR_l ) typedExpressionIR_r) as expressionIR) # (( typeIR_l _ctk' ))))
 
       2. Return ?((typedExpressionIR_l, typedExpressionIR_r_cast))
+
+    1. Else,
+
+      1. (Let typedExpressionIR_l_cast be $reduce_serenum(typedExpressionIR_l))
+
+      2. If ((typedExpressionIR_l =/= typedExpressionIR_l_cast)), then
+
+        1. Return $coerce_binary(typedExpressionIR_l_cast, typedExpressionIR_r)
+
+      3. If ((typedExpressionIR_l = $reduce_serenum(typedExpressionIR_l))), then
+
+        1. (Let typedExpressionIR_r_cast be $reduce_serenum(typedExpressionIR_r))
+
+        2. If ((typedExpressionIR_r =/= typedExpressionIR_r_cast)), then
+
+          1. Return $coerce_binary(typedExpressionIR_l, typedExpressionIR_r_cast)
 
 4. Otherwise
 
@@ -24065,7 +24110,7 @@ def $compat_table_key(nameIR, typeIR)
 
   1. Return false
 
-;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:86.1-87.33
+;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:89.1-90.33
 def $split_dataplane_parameters((parameterIR)*{parameterIR <- parameterIR*})
 
 1. Case analysis on (parameterIR)*{parameterIR <- parameterIR*}
@@ -24094,7 +24139,7 @@ def $split_dataplane_parameters((parameterIR)*{parameterIR <- parameterIR*})
 
         2. Return (parameterIR_h :: (parameterIR_data)*{parameterIR_data <- parameterIR_data*}, (parameterIR_control)*{parameterIR_control <- parameterIR_control*})
 
-;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:241.1-244.26
+;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:244.1-247.26
 relation TableEntry_keyset_simple_ok: TC TBLC |- (typeIR_key, text) @ simpleKeysetExpression : % %
 
 1. If ((simpleKeysetExpression has type expression)), then
@@ -24297,7 +24342,7 @@ relation TableEntry_keyset_simple_ok: TC TBLC |- (typeIR_key, text) @ simpleKeys
 
             2. Result in : % % |- % @ % : (nolpm) (typedExpressionIR_l_reduced .. typedExpressionIR_r_reduced)
 
-;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:400.1-403.29
+;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:403.1-406.29
 relation TableEntry_keysets_simple_ok: TC TBLC TBLS |- (matchKey)*{matchKey <- matchKey*} @ (simpleKeysetExpression)*{simpleKeysetExpression <- simpleKeysetExpression*} : % %
 
 1. Case analysis on (matchKey)*{matchKey <- matchKey*}
@@ -24328,7 +24373,7 @@ relation TableEntry_keysets_simple_ok: TC TBLC TBLS |- (matchKey)*{matchKey <- m
 
         4. Result in : % % % |- % @ % : TBLS_3 simpleKeysetExpressionIR_h :: (simpleKeysetExpressionIR_t)*{simpleKeysetExpressionIR_t <- simpleKeysetExpressionIR_t*}
 
-;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:955.1-955.48
+;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:958.1-958.48
 def $is_tableKeysProperty(tableProperty)
 
 1. If ((tableProperty matches pattern `KEY={%}`)), then
@@ -24341,7 +24386,7 @@ def $is_tableKeysProperty(tableProperty)
 
   1. Return false
 
-;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:960.1-960.51
+;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:963.1-963.51
 def $is_tableActionsProperty(tableProperty)
 
 1. If ((tableProperty matches pattern `ACTIONS={%}`)), then
@@ -24354,7 +24399,7 @@ def $is_tableActionsProperty(tableProperty)
 
   1. Return false
 
-;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:965.1-965.57
+;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:968.1-968.57
 def $is_tableDefaultActionProperty(tableProperty)
 
 1. If ((tableProperty matches pattern `%%%%;`)), then
@@ -24369,7 +24414,7 @@ def $is_tableDefaultActionProperty(tableProperty)
 
   1. Return false
 
-;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:971.1-974.37
+;; ../../../../spec-concrete/5.14.1-typing-control-table.watsup:974.1-977.37
 def $insert_NoAction_tablePropertyIR(TBLC, (tablePropertyIR)*{tablePropertyIR <- tablePropertyIR*})
 
 1. Case analysis on (tablePropertyIR)*{tablePropertyIR <- tablePropertyIR*}

--- a/spec-concrete/2.1.2-value-aux.watsup
+++ b/spec-concrete/2.1.2-value-aux.watsup
@@ -169,8 +169,7 @@ def $write_value_from_bits'(n_max `. _ V _, n_var, b*) = (n_max `. n_var V i, b_
 
 def $write_value_fields_from_bits'(eps, n_var, b*) = (eps, b*)
 def $write_value_fields_from_bits'(
-    fieldValue_h :: fieldValue_t*, n_var, b*
-  )
+    fieldValue_h :: fieldValue_t*, n_var, b*)
   = (fieldValue_h_updated :: fieldValue_t_updated*, b_rest*)
   -- if (fieldValue_h_updated, b_t*)
       = $write_value_field_from_bits'(fieldValue_h, n_var, b*)
@@ -178,22 +177,26 @@ def $write_value_fields_from_bits'(
       = $write_value_fields_from_bits'(fieldValue_t*, n_var, b_t*)
 
 def $write_value_field_from_bits'(
-    value id `;, n_var, b*
-  )
+    value id `;, n_var, b*)
   = (value_updated id `;, b_rest*)
   -- if (value_updated, b_rest*)
       = $write_value_from_bits'(value, n_var, b*)
 
 def $write_value_from_bits'(
-    STRUCT tid `{ fieldValue* }, n_var, b*
-  ) = (STRUCT tid `{ fieldValue_updated* }, b_rest*)
+    STRUCT tid `{ fieldValue* }, n_var, b*)
+  = (STRUCT tid `{ fieldValue_updated* }, b_rest*)
   -- if (fieldValue_updated*, b_rest*)
       = $write_value_fields_from_bits'(fieldValue*, n_var, b*) 
 def $write_value_from_bits'(
-    HEADER tid `{ _ `; fieldValue* }, n_var, b*
-  ) = (HEADER tid `{ true `; fieldValue_updated* }, b_rest*)
+    HEADER tid `{ _ `; fieldValue* }, n_var, b*)
+  = (HEADER tid `{ true `; fieldValue_updated* }, b_rest*)
   -- if (fieldValue_updated*, b_rest*)
-      = $write_value_fields_from_bits'(fieldValue*, n_var, b*) 
+      = $write_value_fields_from_bits'(fieldValue*, n_var, b*)
+
+def $write_value_from_bits'(
+    tid `. id `. value, n_var, b*)
+  = (tid `. "__UNSPECIFIED" `. value_updated, b_rest*)
+  -- if (value_updated, b_rest*) = $write_value_from_bits'(value, n_var, b*)
 
 ;;
 ;; Write bits from a value
@@ -210,19 +213,19 @@ def $write_bits_from_value(_ `. w V i)
   = $int_to_bits_unsigned(w, i)
 
 def $write_bits_from_value(
-    HEADER_STACK `[ value_element* `( _; _ ) ]
-  )
+    HEADER_STACK `[ value_element* `( _; _ ) ])
   = $concat_<bool>($write_bits_from_value(value_element)*)
+
 def $write_bits_from_value(
-    STRUCT _ `{ (value_field id_field `;)* }
-  )
+    STRUCT _ `{ (value_field id_field `;)* })
   = $concat_<bool>($write_bits_from_value(value_field)*)
 def $write_bits_from_value(
-    HEADER _ `{ true `; (value_field id_field `;)* }
-  )
+    HEADER _ `{ true `; (value_field id_field `;)* })
   = $concat_<bool>($write_bits_from_value(value_field)*)
 def $write_bits_from_value(HEADER _ `{ false `; _ }) = eps
 def $write_bits_from_value(
-    HEADER_UNION _ `{ (value id `;)* }
-  )
+    HEADER_UNION _ `{ (value id `;)* })
   = $concat_<bool>($write_bits_from_value(value)*)
+
+def $write_bits_from_value(tid `. id `. value)
+  = $write_bits_from_value(value) 

--- a/spec-concrete/3-numerics.watsup
+++ b/spec-concrete/3-numerics.watsup
@@ -399,8 +399,7 @@ def $bin_eq(
     tid_a `. id_field_a `. value_field_a,
     tid_b `. id_field_b `. value_field_b
   )
-  = (tid_a = tid_b) /\ (id_field_a = id_field_b)
-    /\ $bin_eq(value_field_a, value_field_b)
+  = (tid_a = tid_b) /\ $bin_eq(value_field_a, value_field_b)
 
 def $bin_eq(`{#}, `{#}) = true
 

--- a/spec-concrete/5.05.2-typing-subtyping.watsup
+++ b/spec-concrete/5.05.2-typing-subtyping.watsup
@@ -415,14 +415,23 @@ rulegroup Sub_impl_canon_neq/recordTypeIR-default {
 ;; until the expression satisfies the given check
 ;;
 
+dec $reduce_serenum(typedExpressionIR) : typedExpressionIR
+
+def $reduce_serenum(typedExpressionIR) = typedExpressionIR_reduced
+  -- if typeIR = $type_of_typedExpressionIR(typedExpressionIR)
+  -- if ctk = $ctk_of_typedExpressionIR(typedExpressionIR)
+  -- if ENUM _ `< typeIR_underlying > `{ _ } = $canon_typeIR(typeIR)
+  -- if typedExpressionIR_reduced
+      = (`(typeIR_underlying) typedExpressionIR) `# `( typeIR_underlying ctk )
+def $reduce_serenum(typedExpressionIR) = typedExpressionIR
+  -- otherwise
+
 ;;; Unary case
 
 dec $reduce_serenum_unary(
     typedExpressionIR,
-    def $check(typeIR) : bool
-  )
+    def $check(typeIR) : bool)
   : typedExpressionIR?
-
 
 def $reduce_serenum_unary(typedExpressionIR, def $check)
   = typedExpressionIR
@@ -445,8 +454,7 @@ def $reduce_serenum_unary(typedExpressionIR, def $check) = eps
 dec $reduce_serenum_binary(
     typedExpressionIR,
     typedExpressionIR,
-    def $check(typeIR, typeIR) : bool
-  )
+    def $check(typeIR, typeIR) : bool)
   : (typedExpressionIR, typedExpressionIR)?
 
 def $reduce_serenum_binary(typedExpressionIR_l, typedExpressionIR_r, def $check)
@@ -531,6 +539,27 @@ def $coerce_binary(typedExpressionIR_l, typedExpressionIR_r)
   -- Sub_impl: typeIR_r <: typeIR_l
   -- if typedExpressionIR_r_cast
       = (`(typeIR_l) typedExpressionIR_r) `# `( typeIR_l ctk_r )
+
+def $coerce_binary(typedExpressionIR_l, typedExpressionIR_r)
+  = $coerce_binary(typedExpressionIR_l_cast, typedExpressionIR_r)
+  -- if _ `# `( typeIR_l ctk_l ) = typedExpressionIR_l
+  -- if _ `# `( typeIR_r _ ) = typedExpressionIR_r
+  -- Type_alpha:/ typeIR_l ~~ typeIR_r
+  -- Sub_impl:/ typeIR_l <: typeIR_r
+  -- Sub_impl:/ typeIR_r <: typeIR_l
+  -- if typedExpressionIR_l_cast = $reduce_serenum(typedExpressionIR_l)
+  -- if typedExpressionIR_l =/= typedExpressionIR_l_cast
+
+def $coerce_binary(typedExpressionIR_l, typedExpressionIR_r)
+  = $coerce_binary(typedExpressionIR_l, typedExpressionIR_r_cast)
+  -- if _ `# `( typeIR_l _ ) = typedExpressionIR_l
+  -- if _ `# `( typeIR_r ctk_r ) = typedExpressionIR_r
+  -- Type_alpha:/ typeIR_l ~~ typeIR_r
+  -- Sub_impl:/ typeIR_l <: typeIR_r
+  -- Sub_impl:/ typeIR_r <: typeIR_l
+  -- if typedExpressionIR_l = $reduce_serenum(typedExpressionIR_l)
+  -- if typedExpressionIR_r_cast = $reduce_serenum(typedExpressionIR_r)
+  -- if typedExpressionIR_r =/= typedExpressionIR_r_cast
 
 def $coerce_binary(typedExpressionIR_l, typedExpressionIR_r) = eps
   -- otherwise

--- a/spec-concrete/5.13.1-typing-parser-statement.watsup
+++ b/spec-concrete/5.13.1-typing-parser-statement.watsup
@@ -305,16 +305,17 @@ rule ParserTransition_ok/select:
   ---- ;; check select key expressions
   -- if expression_key* = $flatten_expressionList(expressionList_key)
   -- (Expr_ok: LOCAL TC_0 |- expression_key : typedExpressionIR_key)*
-  -- if (typeIR_key
-      = $type_of_typedExpressionIR(typedExpressionIR_key))*
+  ---- ;; reduce serializable enums
+  -- if (typedExpressionIR_key_reduced = $reduce_serenum(typedExpressionIR_key))*
+  -- if (typeIR_key_reduced = $type_of_typedExpressionIR(typedExpressionIR_key_reduced))*
   ---- ;; check that the keys form a valid set type
-  -- (Type_wf: $bound(LOCAL, TC_0) |- SET `< typeIR_key >)*
+  -- (Type_wf: $bound(LOCAL, TC_0) |- SET `< typeIR_key_reduced >)*
   ---- ;; check select cases
   -- if selectCase* = $flatten_selectCaseList(selectCaseList)
-  -- (SelectCase_ok: TC_0 nameIR_state* typeIR_key* |- selectCase : selectCaseIR)*
+  -- (SelectCase_ok: TC_0 nameIR_state* typeIR_key_reduced* |- selectCase : selectCaseIR)*
   ---- ;; create IR
   -- if transitionStatementIR
-      = TRANSITION (SELECT `( typedExpressionIR_key* ) `{ selectCaseIR* })
+      = TRANSITION (SELECT `( typedExpressionIR_key_reduced* ) `{ selectCaseIR* })
 
 ;;
 ;; Parser statement typing

--- a/spec-concrete/5.14.1-typing-control-table.watsup
+++ b/spec-concrete/5.14.1-typing-control-table.watsup
@@ -47,20 +47,23 @@ rule TableKey_ok:
              : TBLC_2 tableKeyIR
   ---- ;; check expression
   -- Expr_ok: LOCAL TC |- expression : typedExpressionIR
-  -- if typeIR = $type_of_typedExpressionIR(typedExpressionIR)
+  ---- ;; reduce serializable enums
+  -- if typedExpressionIR_reduced
+      = $reduce_serenum(typedExpressionIR)
+  -- if typeIR_reduced = $type_of_typedExpressionIR(typedExpressionIR_reduced)
   ---- ;; check that the expression can be embedded in a set
-  -- Type_wf: $bound(LOCAL, TC) |- SET `< typeIR >
+  -- Type_wf: $bound(LOCAL, TC) |- SET `< typeIR_reduced >
   ---- ;; check match kind
   -- if nameIR_matchkind = $name(name_matchkind)
   -- if MATCH_KIND `. nameIR_matchkind
       = $find_var_value_t(LOCAL, TC, `` nameIR_matchkind)
   ---- ;; check compatibility with the match kind
-  -- if $compat_table_key(nameIR_matchkind, typeIR)
+  -- if $compat_table_key(nameIR_matchkind, typeIR_reduced)
   ---- ;; update table context
-  -- if TBLC_1 = $update_mode(TBLC_0, nameIR_matchkind, typeIR)
-  -- if TBLC_2 = $add_key(TBLC_1, nameIR_matchkind, typeIR)
+  -- if TBLC_1 = $update_mode(TBLC_0, nameIR_matchkind, typeIR_reduced)
+  -- if TBLC_2 = $add_key(TBLC_1, nameIR_matchkind, typeIR_reduced)
   ---- ;; create IR
-  -- if tableKeyIR = typedExpressionIR `: nameIR_matchkind annotationList `;
+  -- if tableKeyIR = typedExpressionIR_reduced `: nameIR_matchkind annotationList `;
 
 ;;
 ;; Table key property list typing
@@ -1040,7 +1043,6 @@ rulegroup Table_ok {
     -- TableProperties_ok: TC TBLC_0 |- tableProperty* : TBLC_1 tablePropertyIR*
 
 }
-
 
 rule TableType_ok:
   TC_0 TBLC |- name : TC_1 typeIR_table


### PR DESCRIPTION
This PR improves https://github.com/kaist-plrg/p4-spectec/pull/1.

### Binary coercion involving serializable enums

Serializable enums are quite tricky, because it can be *implicitly* cast to its underlying type when necessary. This complicates binary coercion, because there may be the case where `x` and `y` (i) have unequal types, and (ii) neither is the subtype of the another (i.e., `x </: y` and `y <:/ x`) but the two have a common super-type.

For instance, binary coercion of `bit<8>` and `int` is easy because the rhs, `int`, can be implicitly cast to `bit<8>`. The case for `int` and `bit<8>` works vice-versa.

Now consider the case with serializable enums:

```p4
enum bit<8> E1 {
   e1 = 0, e2 = 1, e3 = 2
}

enum bit<8> E2 {
   e1 = 10, e2 = 11, e3 = 12
}

control c() {
    apply {
        E1 a = E1.e1;
        E2 b = E2.e2;
        bool x = (a == b); // HERE
   }
}
```

The `HERE` part is legal, because this can be implicitly cast to `(bit<8>) a == (bit<8> b)`. But implementing such is tricky. Notice that `a`'s type, `E1`, and `b`'s type, `E2`, are unequal and also neither is the subtype of another. The type checker should somehow figure out their common super-type, `bit<8>`.

AFAIK, serializable enums are the only type that introduces such behavior. So the mechanized spec special-cases on serializable enum types on coercion. Here is the overall process for `$coerce_binary`:

```
dec $coerce_binary(typedExpressionIR, typedExpressionIR)
  : (typedExpressionIR, typedExpressionIR)?
  hint(prose_in %0 "and" %1 "implicitly cast to equal types")
```

* If the two expressions' types are alpha-equivalent, then the result is the same.
* If the left is a subtype of the right, cast left to right.
* If the right is a subtype of left, cast right to left.
* Try reducing serializable enums on the left side, then re-try coercion.
* Try reducing serializable enums on the right side, then re-try coercion.

With the above process, `a == b` is coerced as:

* Reduce lhs to `(bit<8>) a`. And re-try coercion of `(bit<8>) a` and `b`.
* Because rhs is a subtype of lhs, cast rhs to `(bit<8>) b`.
* Now the two types are the same as: `bit<8>`.

### Special-casing key types in `select` and `table`s

Some programs use serializable enums as `select` or `table` keys, where the match-entries use the reduced type. e.g.,

```p4
E1 a = E1.e1;
transition select (a) {
    0x01: accept;
    default: getopt;
}
```

In this case, the match-entry `0x01` is expected to be *implicitly* cast to the key type, `E1`. However, such is prohibited as per the spec, since serializable enums can only be implicitly cast to the underlying type, but not vice-versa.

But to support such uses, key types in `select` and `table` are reduced to their underlying types. Thus, the above snippet is type-checked as:

```p4
E1 a = E1.e1;
transition select ((bit<8>) a) {
    0x01: accept;
    default: getopt;
}
```

Both parts are required to pass tests:

* [p4c/testdata/p4_16_samples/enumCast.p4](https://github.com/p4lang/p4c/blob/main/testdata/p4_16_samples/enumCast.p4)
* [p4c/testdata/p4_16_samples/issue3333.p4](https://github.com/p4lang/p4c/blob/main/testdata/p4_16_samples/issue3333.p4)
* [p4c/testdata/p4_16_samples/table-entries-ser-enum-bmv2.p4](https://github.com/p4lang/p4c/blob/main/testdata/p4_16_samples/table-entries-ser-enum-bmv2.p4)