### PR TITLE
Disallow non-(local)-compile-time known `int`-typed expressions

### DIFF
--- a/excludes/bug/bigint-timeout.exclude
+++ b/excludes/bug/bigint-timeout.exclude
@@ -1,3 +1,4 @@
 p4c/testdata/p4_16_errors/issue1944.p4
+p4c/testdata/p4_16_errors/issue2496.p4
 p4c/testdata/p4_16_errors/width_e.p4
 p4c/testdata/p4_16_errors/width1_e.p4

--- a/excludes/bug/int-returning-callables.exclude
+++ b/excludes/bug/int-returning-callables.exclude
@@ -1,2 +1,0 @@
-p4c/testdata/p4_16_errors/issue3273.p4
-p4c/testdata/p4_16_errors/issue2260-1.p4

--- a/excludes/bug/int-typed-exprs-must-be-local-compile-time-known.exclude
+++ b/excludes/bug/int-typed-exprs-must-be-local-compile-time-known.exclude
@@ -1,3 +1,0 @@
-p4c/testdata/p4_16_errors/issue2206.p4
-p4c/testdata/p4_16_errors/issue2496.p4
-p4c/testdata/p4_16_errors/shift-int-non-const.p4

--- a/excludes/ldwg/todo/object-returning-function-as-compile-time-known.exclude
+++ b/excludes/ldwg/todo/object-returning-function-as-compile-time-known.exclude
@@ -1,2 +1,3 @@
 p4c/testdata/p4_16_samples/factory1.p4
 p4c/testdata/p4_16_samples/factory2.p4
+p4c/testdata/p4_16_samples/hashext.p4

--- a/p4spec/test/elab.expected
+++ b/p4spec/test/elab.expected
@@ -14412,7 +14412,7 @@ relation Expr_ok: cursor typingContext |- expression : typedExpressionIR
     -- let expressionNoteIR = ( typeIR_reduced ctk_reduced )
     -- output: % % |- % : typedExpressionIR_l_reduced binop typedExpressionIR_r_reduced as expressionIR # expressionNoteIR
 
-  ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:320.1-376.2
+  ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:320.1-377.2
   rulegroup binaryExpression-shift
 
    match
@@ -14436,6 +14436,7 @@ relation Expr_ok: cursor typingContext |- expression : typedExpressionIR
     -- let typeIR_r_reduced = $type_of_typedExpressionIR(typedExpressionIR_r_reduced)
     -- let ctk_r_reduced = $ctk_of_typedExpressionIR(typedExpressionIR_r_reduced)
     -- if $is_fixedBitTypeIR(typeIR_r_reduced)
+    -- if ($is_arbitraryIntTypeIR(typeIR_l_reduced) => (ctk_r_reduced = lctk))
     -- let ctk_reduced = $join_ctk(ctk_l_reduced, ctk_r_reduced)
     -- let expressionNoteIR = ( typeIR_l_reduced ctk_reduced )
     -- output: % % |- % : typedExpressionIR_l_reduced binop typedExpressionIR_r_reduced as expressionIR # expressionNoteIR
@@ -14457,7 +14458,7 @@ relation Expr_ok: cursor typingContext |- expression : typedExpressionIR
     -- let expressionNoteIR = ( typeIR_l_reduced ctk_reduced )
     -- output: % % |- % : typedExpressionIR_l_reduced binop typedExpressionIR_r_reduced as expressionIR # expressionNoteIR
 
-  ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:380.1-399.46
+  ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:381.1-400.46
   rulegroup binaryExpression-equality
 
    match
@@ -14484,7 +14485,7 @@ relation Expr_ok: cursor typingContext |- expression : typedExpressionIR
     -- let expressionNoteIR = ( bool as typeIR ctk_cast )
     -- output: % % |- % : typedExpressionIR_l_cast binop typedExpressionIR_r_cast as expressionIR # expressionNoteIR
 
-  ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:414.1-437.49
+  ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:415.1-438.49
   rulegroup binaryExpression-comparison
 
    match
@@ -14513,7 +14514,7 @@ relation Expr_ok: cursor typingContext |- expression : typedExpressionIR
     -- let expressionNoteIR = ( bool as typeIR ctk_reduced )
     -- output: % % |- % : typedExpressionIR_l_reduced binop typedExpressionIR_r_reduced as expressionIR # expressionNoteIR
 
-  ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:451.1-474.59
+  ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:452.1-475.59
   rulegroup binaryExpression-bitwise
 
    match
@@ -14542,7 +14543,7 @@ relation Expr_ok: cursor typingContext |- expression : typedExpressionIR
     -- let expressionNoteIR = ( typeIR_reduced ctk_reduced )
     -- output: % % |- % : typedExpressionIR_l_reduced binop typedExpressionIR_r_reduced as expressionIR # expressionNoteIR
 
-  ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:504.1-531.59
+  ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:505.1-532.59
   rulegroup binaryExpression-concat
 
    match
@@ -14573,7 +14574,7 @@ relation Expr_ok: cursor typingContext |- expression : typedExpressionIR
     -- let expressionNoteIR = ( typeIR_reduced ctk_reduced )
     -- output: % % |- % : typedExpressionIR_l_reduced ++ typedExpressionIR_r_reduced as expressionIR # expressionNoteIR
 
-  ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:544.1-566.59
+  ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:545.1-567.59
   rulegroup binaryExpression-logical
 
    match
@@ -14602,7 +14603,7 @@ relation Expr_ok: cursor typingContext |- expression : typedExpressionIR
     -- let expressionNoteIR = ( typeIR_reduced ctk_reduced )
     -- output: % % |- % : typedExpressionIR_l_reduced binop typedExpressionIR_r_reduced as expressionIR # expressionNoteIR
 
-  ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:572.1-594.48
+  ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:573.1-595.48
   rulegroup ternaryExpression
 
    match
@@ -14633,7 +14634,7 @@ relation Expr_ok: cursor typingContext |- expression : typedExpressionIR
     -- let expressionNoteIR = ( typeIR_cast ctk )
     -- output: % % |- % : typedExpressionIR_cond ? typedExpressionIR_true_cast : typedExpressionIR_false_cast as expressionIR # expressionNoteIR
 
-  ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:599.1-613.45
+  ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:600.1-614.45
   rulegroup castExpression
 
    match
@@ -14656,7 +14657,7 @@ relation Expr_ok: cursor typingContext |- expression : typedExpressionIR
     -- let expressionNoteIR = ( typeIR_t ctk )
     -- output: % % |- % : ( typeIR_t ) typedExpressionIR as expressionIR # expressionNoteIR
 
-  ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:620.1-622.52
+  ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:621.1-623.52
   rulegroup dataExpression-invalid
 
    match
@@ -14673,7 +14674,7 @@ relation Expr_ok: cursor typingContext |- expression : typedExpressionIR
     -- let expressionNoteIR = ( header_invalid as typeIR lctk )
     -- output: % % |- % : {#} as expressionIR # expressionNoteIR
 
-  ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:630.1-668.2
+  ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:631.1-669.2
   rulegroup dataExpression-sequence
 
    match
@@ -14720,7 +14721,7 @@ relation Expr_ok: cursor typingContext |- expression : typedExpressionIR
     -- let expressionNoteIR = ( typeIR ctk )
     -- output: % % |- % : seq{ typedExpressionIR_e_h*{typedExpressionIR_e_h <- typedExpressionIR_e_h*} ,...} as expressionIR # expressionNoteIR
 
-  ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:678.1-746.2
+  ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:679.1-747.2
   rulegroup dataExpression-record
 
    match
@@ -14792,7 +14793,7 @@ relation Expr_ok: cursor typingContext |- expression : typedExpressionIR
     -- let expressionNoteIR = ( typeIR ctk )
     -- output: % % |- % : record{ nameIR_f = typedExpressionIR_f*{nameIR_f <- nameIR_f*, typedExpressionIR_f <- typedExpressionIR_f*} ,...} as expressionIR # expressionNoteIR
 
-  ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:754.1-761.43
+  ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:755.1-762.43
   rulegroup errorAccessExpression
 
    match
@@ -14811,7 +14812,7 @@ relation Expr_ok: cursor typingContext |- expression : typedExpressionIR
     -- let expressionNoteIR = ( error as typeIR lctk )
     -- output: % % |- % : error. nameIR as expressionIR # expressionNoteIR
 
-  ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:769.1-803.2
+  ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:770.1-804.2
   rulegroup memberAccessExpression-type
 
    match
@@ -14859,7 +14860,7 @@ relation Expr_ok: cursor typingContext |- expression : typedExpressionIR
     -- let expressionNoteIR = ( typeIR_base lctk )
     -- output: % % |- % : type prefixedNameIR_base . nameIR as expressionIR # expressionNoteIR
 
-  ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:807.1-970.2
+  ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:808.1-971.2
   rulegroup memberAccessExpression-expression
 
    match
@@ -14991,7 +14992,7 @@ relation Expr_ok: cursor typingContext |- expression : typedExpressionIR
     -- let expressionNoteIR = ( tableMetadataEnumTypeIR as typeIR dyn )
     -- output: % % |- % : typedExpressionIR_base as memberAccessBaseIR . nameIR as expressionIR # expressionNoteIR
 
-  ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:987.1-1074.2
+  ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:988.1-1075.2
   rulegroup indexAccessExpression
 
    match
@@ -15065,7 +15066,7 @@ relation Expr_ok: cursor typingContext |- expression : typedExpressionIR
     -- let expressionNoteIR = ( typeIR ctk )
     -- output: % % |- % : typedExpressionIR_base [ typedExpressionIR_index_reduced ] as expressionIR # expressionNoteIR
 
-  ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:1117.1-1165.56
+  ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:1118.1-1166.56
   rulegroup sliceAccessExpression
 
    match
@@ -15114,7 +15115,7 @@ relation Expr_ok: cursor typingContext |- expression : typedExpressionIR
     -- let expressionNoteIR = ( typeIR ctk_base_reduced )
     -- output: % % |- % : typedExpressionIR_base [ typedExpressionIR_hi_reduced : typedExpressionIR_lo_reduced ] as expressionIR # expressionNoteIR
 
-  ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:1173.1-1229.2
+  ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:1174.1-1230.2
   rulegroup callExpression-callable
 
    match
@@ -15162,7 +15163,7 @@ relation Expr_ok: cursor typingContext |- expression : typedExpressionIR
     -- let expressionNoteIR = ( typeIR_ret ctk )
     -- output: % % |- % : callExpressionIR as expressionIR # expressionNoteIR
 
-  ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:1256.1-1305.2
+  ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:1257.1-1306.2
   rulegroup callExpression-constructor
 
    match
@@ -15207,7 +15208,7 @@ relation Expr_ok: cursor typingContext |- expression : typedExpressionIR
     -- let expressionNoteIR = ( typeIR_object ctk )
     -- output: % % |- % : callExpressionIR as expressionIR # expressionNoteIR
 
-  ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:1310.1-1315.43
+  ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:1311.1-1316.43
   rulegroup parenthesizedExpression
 
    match
@@ -20021,16 +20022,16 @@ def $compat'_shift(typeIR, typeIR) : bool =
   clause 9 : (typeIR_l, typeIR_r) = false
   -- otherwise
 
-;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:403.1-403.43
+;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:404.1-404.43
 def $compat_compare(typeIR, typeIR) : bool =
 
-  ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:406.1-407.71
+  ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:407.1-408.71
   clause 0 : (typeIR_l, typeIR_r) = $compat'_compare($canon_typeIR(typeIR_l), $canon_typeIR(typeIR_r))
 
-;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:404.1-404.44
+;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:405.1-405.44
 def $compat'_compare(typeIR, typeIR) : bool =
 
-  ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:408.1-408.38
+  ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:409.1-409.38
   clause 0 : (typeIR, typeIR') = true
   -- if typeIR <: integerTypeIR
   -- let integerTypeIR = typeIR as integerTypeIR
@@ -20039,7 +20040,7 @@ def $compat'_compare(typeIR, typeIR) : bool =
   -- let integerTypeIR' = typeIR' as integerTypeIR
   -- if integerTypeIR' matches `INT`
 
-  ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:409.1-409.52
+  ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:410.1-410.52
   clause 1 : (typeIR, typeIR') = true
   -- if typeIR <: integerTypeIR
   -- let integerTypeIR = typeIR as integerTypeIR
@@ -20051,7 +20052,7 @@ def $compat'_compare(typeIR, typeIR) : bool =
   -- let int< w' > = integerTypeIR'
   -- if (w = w')
 
-  ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:410.1-410.52
+  ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:411.1-411.52
   clause 2 : (typeIR, typeIR') = true
   -- if typeIR <: integerTypeIR
   -- let integerTypeIR = typeIR as integerTypeIR
@@ -20063,20 +20064,20 @@ def $compat'_compare(typeIR, typeIR) : bool =
   -- let bit< w' > = integerTypeIR'
   -- if (w = w')
 
-  ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:411.1-412.15
+  ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:412.1-413.15
   clause 3 : (typeIR_l, typeIR_r) = false
   -- otherwise
 
-;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:441.1-441.43
+;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:442.1-442.43
 def $compat_bitwise(typeIR, typeIR) : bool =
 
-  ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:444.1-445.71
+  ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:445.1-446.71
   clause 0 : (typeIR_l, typeIR_r) = $compat'_bitwise($canon_typeIR(typeIR_l), $canon_typeIR(typeIR_r))
 
-;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:442.1-442.44
+;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:443.1-443.44
 def $compat'_bitwise(typeIR, typeIR) : bool =
 
-  ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:446.1-446.52
+  ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:447.1-447.52
   clause 0 : (typeIR, typeIR') = true
   -- if typeIR <: integerTypeIR
   -- let integerTypeIR = typeIR as integerTypeIR
@@ -20088,7 +20089,7 @@ def $compat'_bitwise(typeIR, typeIR) : bool =
   -- let int< w' > = integerTypeIR'
   -- if (w = w')
 
-  ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:447.1-447.52
+  ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:448.1-448.52
   clause 1 : (typeIR, typeIR') = true
   -- if typeIR <: integerTypeIR
   -- let integerTypeIR = typeIR as integerTypeIR
@@ -20100,20 +20101,20 @@ def $compat'_bitwise(typeIR, typeIR) : bool =
   -- let bit< w' > = integerTypeIR'
   -- if (w = w')
 
-  ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:448.1-449.15
+  ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:449.1-450.15
   clause 2 : (typeIR_l, typeIR_r) = false
   -- otherwise
 
-;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:478.1-478.42
+;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:479.1-479.42
 def $compat_concat(typeIR, typeIR) : bool =
 
-  ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:481.1-482.70
+  ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:482.1-483.70
   clause 0 : (typeIR_l, typeIR_r) = $compat'_concat($canon_typeIR(typeIR_l), $canon_typeIR(typeIR_r))
 
-;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:479.1-479.43
+;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:480.1-480.43
 def $compat'_concat(typeIR, typeIR) : bool =
 
-  ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:483.1-483.43
+  ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:484.1-484.43
   clause 0 : (typeIR, typeIR') = true
   -- if typeIR <: stringTypeIR
   -- let stringTypeIR = typeIR as stringTypeIR
@@ -20122,7 +20123,7 @@ def $compat'_concat(typeIR, typeIR) : bool =
   -- let stringTypeIR' = typeIR' as stringTypeIR
   -- if (stringTypeIR' = string)
 
-  ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:484.1-484.51
+  ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:485.1-485.51
   clause 1 : (typeIR, typeIR') = true
   -- if typeIR <: integerTypeIR
   -- let integerTypeIR = typeIR as integerTypeIR
@@ -20133,7 +20134,7 @@ def $compat'_concat(typeIR, typeIR) : bool =
   -- if integerTypeIR' matches `INT<%>`
   -- let int< _nat' > = integerTypeIR'
 
-  ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:485.1-485.51
+  ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:486.1-486.51
   clause 2 : (typeIR, typeIR') = true
   -- if typeIR <: integerTypeIR
   -- let integerTypeIR = typeIR as integerTypeIR
@@ -20144,7 +20145,7 @@ def $compat'_concat(typeIR, typeIR) : bool =
   -- if integerTypeIR' matches `BIT<%>`
   -- let bit< _nat' > = integerTypeIR'
 
-  ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:486.1-486.51
+  ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:487.1-487.51
   clause 3 : (typeIR, typeIR') = true
   -- if typeIR <: integerTypeIR
   -- let integerTypeIR = typeIR as integerTypeIR
@@ -20155,7 +20156,7 @@ def $compat'_concat(typeIR, typeIR) : bool =
   -- if integerTypeIR' matches `INT<%>`
   -- let int< _nat' > = integerTypeIR'
 
-  ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:487.1-487.51
+  ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:488.1-488.51
   clause 4 : (typeIR, typeIR') = true
   -- if typeIR <: integerTypeIR
   -- let integerTypeIR = typeIR as integerTypeIR
@@ -20166,20 +20167,20 @@ def $compat'_concat(typeIR, typeIR) : bool =
   -- if integerTypeIR' matches `BIT<%>`
   -- let bit< _nat' > = integerTypeIR'
 
-  ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:488.1-489.15
+  ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:489.1-490.15
   clause 5 : (typeIR_l, typeIR_r) = false
   -- otherwise
 
-;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:491.1-491.45
+;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:492.1-492.45
 def $result_concat(typeIR, typeIR) : typeIR? =
 
-  ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:494.1-495.70
+  ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:495.1-496.70
   clause 0 : (typeIR_l, typeIR_r) = $result'_concat($canon_typeIR(typeIR_l), $canon_typeIR(typeIR_r))
 
-;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:492.1-492.46
+;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:493.1-493.46
 def $result'_concat(typeIR, typeIR) : typeIR? =
 
-  ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:496.1-496.45
+  ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:497.1-497.45
   clause 0 : (typeIR, typeIR') = ?(string as typeIR)
   -- if typeIR <: stringTypeIR
   -- let stringTypeIR = typeIR as stringTypeIR
@@ -20188,7 +20189,7 @@ def $result'_concat(typeIR, typeIR) : typeIR? =
   -- let stringTypeIR' = typeIR' as stringTypeIR
   -- if (stringTypeIR' = string)
 
-  ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:497.1-497.72
+  ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:498.1-498.72
   clause 1 : (typeIR, typeIR') = ?(int< (w_a + w_b) > as typeIR)
   -- if typeIR <: integerTypeIR
   -- let integerTypeIR = typeIR as integerTypeIR
@@ -20199,7 +20200,7 @@ def $result'_concat(typeIR, typeIR) : typeIR? =
   -- if integerTypeIR' matches `INT<%>`
   -- let int< w_b > = integerTypeIR'
 
-  ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:498.1-498.72
+  ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:499.1-499.72
   clause 2 : (typeIR, typeIR') = ?(int< (w_a + w_b) > as typeIR)
   -- if typeIR <: integerTypeIR
   -- let integerTypeIR = typeIR as integerTypeIR
@@ -20210,7 +20211,7 @@ def $result'_concat(typeIR, typeIR) : typeIR? =
   -- if integerTypeIR' matches `BIT<%>`
   -- let bit< w_b > = integerTypeIR'
 
-  ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:499.1-499.72
+  ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:500.1-500.72
   clause 3 : (typeIR, typeIR') = ?(bit< (w_a + w_b) > as typeIR)
   -- if typeIR <: integerTypeIR
   -- let integerTypeIR = typeIR as integerTypeIR
@@ -20221,7 +20222,7 @@ def $result'_concat(typeIR, typeIR) : typeIR? =
   -- if integerTypeIR' matches `INT<%>`
   -- let int< w_b > = integerTypeIR'
 
-  ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:500.1-500.72
+  ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:501.1-501.72
   clause 4 : (typeIR, typeIR') = ?(bit< (w_a + w_b) > as typeIR)
   -- if typeIR <: integerTypeIR
   -- let integerTypeIR = typeIR as integerTypeIR
@@ -20232,20 +20233,20 @@ def $result'_concat(typeIR, typeIR) : typeIR? =
   -- if integerTypeIR' matches `BIT<%>`
   -- let bit< w_b > = integerTypeIR'
 
-  ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:501.1-502.15
+  ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:502.1-503.15
   clause 5 : (typeIR_l, typeIR_r) = ?()
   -- otherwise
 
-;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:535.1-535.43
+;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:536.1-536.43
 def $compat_logical(typeIR, typeIR) : bool =
 
-  ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:538.1-539.71
+  ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:539.1-540.71
   clause 0 : (typeIR_l, typeIR_r) = $compat'_logical($canon_typeIR(typeIR_l), $canon_typeIR(typeIR_r))
 
-;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:536.1-536.44
+;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:537.1-537.44
 def $compat'_logical(typeIR, typeIR) : bool =
 
-  ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:540.1-540.40
+  ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:541.1-541.40
   clause 0 : (typeIR, typeIR') = true
   -- if typeIR <: boolTypeIR
   -- let boolTypeIR = typeIR as boolTypeIR
@@ -20254,125 +20255,125 @@ def $compat'_logical(typeIR, typeIR) : bool =
   -- let boolTypeIR' = typeIR' as boolTypeIR
   -- if (boolTypeIR' = bool)
 
-  ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:541.1-542.15
+  ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:542.1-543.15
   clause 1 : (typeIR_l, typeIR_r) = false
   -- otherwise
 
-;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:976.1-976.39
+;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:977.1-977.39
 def $compat_array_index(typeIR) : bool =
 
-  ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:979.1-980.47
+  ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:980.1-981.47
   clause 0 : (typeIR) = $compat'_arrayindex($canon_typeIR(typeIR))
 
-;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:977.1-977.39
+;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:978.1-978.39
 def $compat'_arrayindex(typeIR) : bool =
 
-  ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:981.1-981.36
+  ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:982.1-982.36
   clause 0 : (typeIR) = true
   -- if typeIR <: integerTypeIR
   -- let integerTypeIR = typeIR as integerTypeIR
   -- if integerTypeIR matches `INT`
 
-  ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:982.1-982.43
+  ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:983.1-983.43
   clause 1 : (typeIR) = true
   -- if typeIR <: integerTypeIR
   -- let integerTypeIR = typeIR as integerTypeIR
   -- if integerTypeIR matches `INT<%>`
   -- let int< _nat > = integerTypeIR
 
-  ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:983.1-983.43
+  ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:984.1-984.43
   clause 2 : (typeIR) = true
   -- if typeIR <: integerTypeIR
   -- let integerTypeIR = typeIR as integerTypeIR
   -- if integerTypeIR matches `BIT<%>`
   -- let bit< _nat > = integerTypeIR
 
-  ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:984.1-985.15
+  ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:985.1-986.15
   clause 3 : (typeIR) = false
   -- otherwise
 
-;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:1080.1-1080.41
+;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:1081.1-1081.41
 def $compat_bitslice_base(typeIR) : bool =
 
-  ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:1083.1-1084.50
+  ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:1084.1-1085.50
   clause 0 : (typeIR) = $compat'_bitslice_base($canon_typeIR(typeIR))
 
-;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:1081.1-1081.42
+;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:1082.1-1082.42
 def $compat'_bitslice_base(typeIR) : bool =
 
-  ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:1085.1-1085.39
+  ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:1086.1-1086.39
   clause 0 : (typeIR) = true
   -- if typeIR <: integerTypeIR
   -- let integerTypeIR = typeIR as integerTypeIR
   -- if integerTypeIR matches `INT`
 
-  ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:1086.1-1086.50
+  ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:1087.1-1087.50
   clause 1 : (typeIR) = (w > 0)
   -- if typeIR <: integerTypeIR
   -- let integerTypeIR = typeIR as integerTypeIR
   -- if integerTypeIR matches `INT<%>`
   -- let int< w > = integerTypeIR
 
-  ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:1087.1-1087.46
+  ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:1088.1-1088.46
   clause 2 : (typeIR) = true
   -- if typeIR <: integerTypeIR
   -- let integerTypeIR = typeIR as integerTypeIR
   -- if integerTypeIR matches `BIT<%>`
   -- let bit< _nat > = integerTypeIR
 
-  ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:1088.1-1089.15
+  ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:1089.1-1090.15
   clause 3 : (typeIR) = false
   -- otherwise
 
-;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:1091.1-1091.42
+;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:1092.1-1092.42
 def $compat_bitslice_index(typeIR) : bool =
 
-  ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:1094.1-1095.51
+  ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:1095.1-1096.51
   clause 0 : (typeIR) = $compat'_bitslice_index($canon_typeIR(typeIR))
 
-;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:1092.1-1092.43
+;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:1093.1-1093.43
 def $compat'_bitslice_index(typeIR) : bool =
 
-  ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:1096.1-1096.40
+  ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:1097.1-1097.40
   clause 0 : (typeIR) = true
   -- if typeIR <: integerTypeIR
   -- let integerTypeIR = typeIR as integerTypeIR
   -- if integerTypeIR matches `INT`
 
-  ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:1097.1-1097.47
+  ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:1098.1-1098.47
   clause 1 : (typeIR) = true
   -- if typeIR <: integerTypeIR
   -- let integerTypeIR = typeIR as integerTypeIR
   -- if integerTypeIR matches `INT<%>`
   -- let int< _nat > = integerTypeIR
 
-  ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:1098.1-1098.47
+  ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:1099.1-1099.47
   clause 2 : (typeIR) = true
   -- if typeIR <: integerTypeIR
   -- let integerTypeIR = typeIR as integerTypeIR
   -- if integerTypeIR matches `BIT<%>`
   -- let bit< _nat > = integerTypeIR
 
-  ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:1099.1-1100.15
+  ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:1100.1-1101.15
   clause 3 : (typeIR) = false
   -- otherwise
 
-;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:1102.1-1102.48
+;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:1103.1-1103.48
 def $is_valid_bitslice(typeIR, nat, nat) : bool =
 
-  ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:1105.1-1106.78
+  ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:1106.1-1107.78
   clause 0 : (typeIR, n_lo, n_hi) = ((n_lo <= n_hi) /\ $is_valid_bitslice'($canon_typeIR(typeIR), n_lo, n_hi))
 
-;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:1103.1-1103.49
+;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:1104.1-1104.49
 def $is_valid_bitslice'(typeIR, nat, nat) : bool =
 
-  ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:1107.1-1107.42
+  ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:1108.1-1108.42
   clause 0 : (typeIR, _nat, _nat') = true
   -- if typeIR <: integerTypeIR
   -- let integerTypeIR = typeIR as integerTypeIR
   -- if integerTypeIR matches `INT`
 
-  ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:1108.1-1110.37
+  ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:1109.1-1111.37
   clause 1 : (typeIR, n_lo, n_hi) = ((n_hi <= w) /\ (w_slice <= w))
   -- if typeIR <: integerTypeIR
   -- let integerTypeIR = typeIR as integerTypeIR
@@ -20382,7 +20383,7 @@ def $is_valid_bitslice'(typeIR, nat, nat) : bool =
   -- if int <: nat
   -- let w_slice = int as nat
 
-  ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:1111.1-1113.37
+  ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:1112.1-1114.37
   clause 2 : (typeIR, n_lo, n_hi) = ((n_hi <= w) /\ (w_slice <= w))
   -- if typeIR <: integerTypeIR
   -- let integerTypeIR = typeIR as integerTypeIR
@@ -20392,42 +20393,42 @@ def $is_valid_bitslice'(typeIR, nat, nat) : bool =
   -- if int <: nat
   -- let w_slice = int as nat
 
-  ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:1114.1-1115.15
+  ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:1115.1-1116.15
   clause 3 : (_typeIR, _nat, _nat') = false
   -- otherwise
 
-;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:1235.1-1235.46
+;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:1236.1-1236.46
 def $is_concrete_extern_object(typeIR) : bool =
 
-  ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:1239.1-1240.57
+  ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:1240.1-1241.57
   clause 0 : (typeIR) = $is_concrete_extern_object'($canon_typeIR(typeIR))
 
-;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:1236.1-1236.47
+;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:1237.1-1237.47
 def $is_concrete_extern_object'(typeIR) : bool =
 
-  ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:1242.1-1243.40
+  ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:1243.1-1244.40
   clause 0 : (typeIR) = true
   -- if ~$is_externObjectTypeIR(typeIR)
 
-  ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:1244.1-1245.63
+  ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:1245.1-1246.63
   clause 1 : (typeIR) = true
   -- if typeIR <: externObjectTypeIR
   -- let extern _tid { _cid : externMethodTypeDefIR*{_cid <- _cid*, externMethodTypeDefIR <- externMethodTypeDefIR*} } = typeIR as externObjectTypeIR
   -- (if $is_concrete_extern_object''(externMethodTypeDefIR))*{externMethodTypeDefIR <- externMethodTypeDefIR*}
 
-  ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:1246.1-1247.15
+  ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:1247.1-1248.15
   clause 2 : (typeIR) = false
   -- otherwise
 
-;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:1237.1-1237.63
+;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:1238.1-1238.63
 def $is_concrete_extern_object''(externMethodTypeDefIR) : bool =
 
-  ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:1249.1-1249.79
+  ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:1250.1-1250.79
   clause 0 : (externMethodTypeDefIR) = true
   -- if externMethodTypeDefIR matches `EXTERN_METHOD<%,%>(%):%`
   -- let extern_method< _tid*{_tid <- _tid*} , _tid'*{_tid' <- _tid'*} >( _parameterIR*{_parameterIR <- _parameterIR*} ): _typeIR = externMethodTypeDefIR
 
-  ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:1250.1-1251.15
+  ;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:1251.1-1252.15
   clause 1 : (externMethodTypeDefIR) = false
   -- otherwise
 

--- a/p4spec/test/elab.expected
+++ b/p4spec/test/elab.expected
@@ -10431,7 +10431,7 @@ def $tableEntry_lpm_prefix'(value, nat) : nat =
 ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:5.1-8.74
 relation Type_wf: bound |- typeIR
 
-  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:61.1-62.22
+  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:66.1-67.22
   rulegroup baseTypeIR
 
    match
@@ -10446,7 +10446,7 @@ relation Type_wf: bound |- typeIR
     rulepath baseTypeIR
     -- the relation holds
 
-  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:66.1-68.33
+  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:71.1-73.33
   rulegroup nameTypeIR
 
    match
@@ -10462,7 +10462,7 @@ relation Type_wf: bound |- typeIR
     -- if $in_set<tid>(tid, bound)
     -- the relation holds
 
-  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:70.1-73.35
+  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:75.1-78.35
   rulegroup specializedTypeIR
 
    match
@@ -10479,7 +10479,7 @@ relation Type_wf: bound |- typeIR
     -- if Type_wf: bound |- typeIR_spec holds
     -- the relation holds
 
-  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:100.1-103.30
+  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:105.1-108.30
   rulegroup typedefTypeIR
 
    match
@@ -10496,7 +10496,7 @@ relation Type_wf: bound |- typeIR
     -- if Type_wf: bound |- typeIR holds
     -- the relation holds
 
-  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:122.1-125.30
+  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:127.1-130.30
   rulegroup newTypeIR
 
    match
@@ -10513,7 +10513,7 @@ relation Type_wf: bound |- typeIR
     -- if Type_wf: bound |- typeIR holds
     -- the relation holds
 
-  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:149.1-152.30
+  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:154.1-157.30
   rulegroup listTypeIR
 
    match
@@ -10530,7 +10530,7 @@ relation Type_wf: bound |- typeIR
     -- if Type_wf: bound |- typeIR holds
     -- the relation holds
 
-  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:179.1-182.33
+  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:184.1-187.33
   rulegroup tupleTypeIR
 
    match
@@ -10547,7 +10547,7 @@ relation Type_wf: bound |- typeIR
     -- (if Type_wf: bound |- typeIR holds)*{typeIR <- typeIR*}
     -- the relation holds
 
-  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:201.1-204.30
+  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:206.1-209.30
   rulegroup headerStackTypeIR
 
    match
@@ -10564,7 +10564,7 @@ relation Type_wf: bound |- typeIR
     -- if Type_wf: bound |- typeIR holds
     -- the relation holds
 
-  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:217.1-221.39
+  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:222.1-226.39
   rulegroup structTypeIR
 
    match
@@ -10582,7 +10582,7 @@ relation Type_wf: bound |- typeIR
     -- (if Type_wf: bound |- typeIR_field holds)*{typeIR_field <- typeIR_field*}
     -- the relation holds
 
-  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:265.1-269.39
+  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:270.1-274.39
   rulegroup headerTypeIR
 
    match
@@ -10600,7 +10600,7 @@ relation Type_wf: bound |- typeIR
     -- (if Type_wf: bound |- typeIR_field holds)*{typeIR_field <- typeIR_field*}
     -- the relation holds
 
-  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:287.1-291.39
+  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:292.1-296.39
   rulegroup headerUnionTypeIR
 
    match
@@ -10618,7 +10618,7 @@ relation Type_wf: bound |- typeIR
     -- (if Type_wf: bound |- typeIR_field holds)*{typeIR_field <- typeIR_field*}
     -- the relation holds
 
-  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:326.1-338.2
+  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:331.1-343.2
   rulegroup enumTypeIR
 
    match
@@ -10646,7 +10646,7 @@ relation Type_wf: bound |- typeIR
     -- if Type_wf: bound |- typeIR holds
     -- the relation holds
 
-  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:342.1-344.59
+  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:347.1-349.59
   rulegroup externObjectTypeIR
 
    match
@@ -10662,7 +10662,7 @@ relation Type_wf: bound |- typeIR
     -- (if CallableTypeDef_wf: bound |- externMethodTypeDefIR as callableTypeDefIR holds)*{externMethodTypeDefIR <- externMethodTypeDefIR*}
     -- the relation holds
 
-  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:346.1-348.46
+  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:351.1-353.46
   rulegroup parserObjectTypeIR
 
    match
@@ -10678,7 +10678,7 @@ relation Type_wf: bound |- typeIR
     -- if ParameterTypes_wf: bound |- parameterIR*{parameterIR <- parameterIR*} holds
     -- the relation holds
 
-  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:350.1-352.46
+  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:355.1-357.46
   rulegroup controlObjectTypeIR
 
    match
@@ -10694,7 +10694,7 @@ relation Type_wf: bound |- typeIR
     -- if ParameterTypes_wf: bound |- parameterIR*{parameterIR <- parameterIR*} holds
     -- the relation holds
 
-  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:354.1-356.33
+  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:359.1-361.33
   rulegroup packageObjectTypeIR
 
    match
@@ -10710,7 +10710,7 @@ relation Type_wf: bound |- typeIR
     -- (if Type_wf: bound |- typeIR holds)*{typeIR <- typeIR*}
     -- the relation holds
 
-  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:358.1-360.49
+  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:363.1-365.49
   rulegroup tableObjectTypeIR
 
    match
@@ -10726,7 +10726,7 @@ relation Type_wf: bound |- typeIR
     -- if Type_wf: bound |- tableMetadataStructTypeIR as typeIR holds
     -- the relation holds
 
-  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:364.1-365.19
+  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:369.1-370.19
   rulegroup defaultTypeIR
 
    match
@@ -10742,7 +10742,7 @@ relation Type_wf: bound |- typeIR
     rulepath defaultTypeIR
     -- the relation holds
 
-  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:367.1-368.26
+  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:372.1-373.26
   rulegroup invalidHeaderTypeIR
 
    match
@@ -10758,7 +10758,7 @@ relation Type_wf: bound |- typeIR
     rulepath invalidHeaderTypeIR
     -- the relation holds
 
-  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:370.1-380.2
+  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:375.1-385.2
   rulegroup sequenceTypeIR
 
    match
@@ -10784,7 +10784,7 @@ relation Type_wf: bound |- typeIR
     -- (if Type_wf: bound |- typeIR holds)*{typeIR <- typeIR*}
     -- the relation holds
 
-  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:382.1-394.2
+  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:387.1-399.2
   rulegroup recordTypeIR
 
    match
@@ -10812,7 +10812,7 @@ relation Type_wf: bound |- typeIR
     -- (if Type_wf: bound |- typeIR_field holds)*{typeIR_field <- typeIR_field*}
     -- the relation holds
 
-  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:456.1-459.30
+  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:461.1-464.30
   rulegroup setTypeIR
 
    match
@@ -10831,7 +10831,7 @@ relation Type_wf: bound |- typeIR
     -- if Type_wf: bound |- typeIR holds
     -- the relation holds
 
-  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:461.1-473.2
+  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:466.1-478.2
   rulegroup tableMetadataTypeIR
 
    match
@@ -10858,7 +10858,7 @@ relation Type_wf: bound |- typeIR
 ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:10.1-13.74
 relation TypeDef_wf: bound |- typeDefIR
 
-  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:479.1-487.41
+  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:484.1-492.41
   rulegroup 
 
    match
@@ -10879,7 +10879,7 @@ relation TypeDef_wf: bound |- typeDefIR
 ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:15.1-18.74
 relation ParameterType_wf: bound |- parameterIR
 
-  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:493.1-516.2
+  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:498.1-521.2
   rulegroup 
 
    match
@@ -10911,7 +10911,7 @@ relation ParameterType_wf: bound |- parameterIR
 ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:20.1-23.74
 relation ParameterTypes_wf: bound |- parameterIR*
 
-  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:518.1-522.47
+  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:523.1-527.47
   rulegroup 
 
    match
@@ -10927,10 +10927,29 @@ relation ParameterTypes_wf: bound |- parameterIR*
     -- (if ParameterType_wf: bound |- parameterIR holds)*{parameterIR <- parameterIR*}
     -- the relation holds
 
-;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:25.1-28.74
+;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:25.1-28.81
+relation ReturnType_wf: bound |- typeIR
+
+  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:533.1-539.43
+  rulegroup 
+
+   match
+
+    (signature) bound |- typeIR_ret
+    bound |- typeIR_ret
+
+   paths
+
+    rulepath 
+    -- if Type_wf: bound |- typeIR_ret holds
+    -- let typeIR_canon = $canon_typeIR(typeIR_ret)
+    -- if ((~$is_stringTypeIR(typeIR_canon) /\ ~$is_arbitraryIntTypeIR(typeIR_canon)) /\ ~$is_objectTypeIR(typeIR_canon))
+    -- the relation holds
+
+;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:30.1-33.74
 relation CallableType_wf: bound |- callableTypeIR
 
-  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:561.1-566.34
+  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:578.1-583.34
   rulegroup actionTypeIR
 
    match
@@ -10949,7 +10968,7 @@ relation CallableType_wf: bound |- callableTypeIR
     -- (if $nestable_action(typeIR))*{typeIR <- typeIR*}
     -- the relation holds
 
-  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:585.1-590.34
+  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:602.1-607.40
   rulegroup definedFunctionTypeIR
 
    match
@@ -10965,10 +10984,10 @@ relation CallableType_wf: bound |- callableTypeIR
     -- if ParameterTypes_wf: bound |- parameterIR*{parameterIR <- parameterIR*} holds
     -- (let _annotationList _direction typeIR _nameIR _constantInitializerOptIR = parameterIR)*{_annotationList <- _annotationList*, _constantInitializerOptIR <- _constantInitializerOptIR*, _direction <- _direction*, _nameIR <- _nameIR*, parameterIR <- parameterIR*, typeIR <- typeIR*}
     -- (if $nestable_definedFunction(typeIR))*{typeIR <- typeIR*}
-    -- if Type_wf: bound |- typeIR_ret holds
+    -- if ReturnType_wf: bound |- typeIR_ret holds
     -- the relation holds
 
-  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:609.1-614.34
+  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:626.1-631.40
   rulegroup externFunctionTypeIR
 
    match
@@ -10984,10 +11003,10 @@ relation CallableType_wf: bound |- callableTypeIR
     -- if ParameterTypes_wf: bound |- parameterIR*{parameterIR <- parameterIR*} holds
     -- (let _annotationList _direction typeIR _nameIR _constantInitializerOptIR = parameterIR)*{_annotationList <- _annotationList*, _constantInitializerOptIR <- _constantInitializerOptIR*, _direction <- _direction*, _nameIR <- _nameIR*, parameterIR <- parameterIR*, typeIR <- typeIR*}
     -- (if $nestable_externFunction(typeIR))*{typeIR <- typeIR*}
-    -- if Type_wf: bound |- typeIR_ret holds
+    -- if ReturnType_wf: bound |- typeIR_ret holds
     -- the relation holds
 
-  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:618.1-621.34
+  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:635.1-638.40
   rulegroup builtinMethodTypeIR
 
    match
@@ -11001,10 +11020,10 @@ relation CallableType_wf: bound |- callableTypeIR
 
     rulepath builtinMethodTypeIR
     -- if ParameterTypes_wf: bound |- parameterIR*{parameterIR <- parameterIR*} holds
-    -- if Type_wf: bound |- typeIR_ret holds
+    -- if ReturnType_wf: bound |- typeIR_ret holds
     -- the relation holds
 
-  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:640.1-656.2
+  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:657.1-673.2
   rulegroup externMethodTypeIR
 
    match
@@ -11023,7 +11042,7 @@ relation CallableType_wf: bound |- callableTypeIR
     -- if ParameterTypes_wf: bound |- parameterIR*{parameterIR <- parameterIR*} holds
     -- (let _annotationList _direction typeIR _nameIR _constantInitializerOptIR = parameterIR)*{_annotationList <- _annotationList*, _constantInitializerOptIR <- _constantInitializerOptIR*, _direction <- _direction*, _nameIR <- _nameIR*, parameterIR <- parameterIR*, typeIR <- typeIR*}
     -- (if $nestable_externMethod(typeIR))*{typeIR <- typeIR*}
-    -- if Type_wf: bound |- typeIR_ret holds
+    -- if ReturnType_wf: bound |- typeIR_ret holds
     -- the relation holds
 
     rulepath abstract
@@ -11033,10 +11052,10 @@ relation CallableType_wf: bound |- callableTypeIR
     -- if ParameterTypes_wf: bound |- parameterIR*{parameterIR <- parameterIR*} holds
     -- (let _annotationList _direction typeIR _nameIR _constantInitializerOptIR = parameterIR)*{_annotationList <- _annotationList*, _constantInitializerOptIR <- _constantInitializerOptIR*, _direction <- _direction*, _nameIR <- _nameIR*, parameterIR <- parameterIR*, typeIR <- typeIR*}
     -- (if $nestable_externMethod(typeIR))*{typeIR <- typeIR*}
-    -- if Type_wf: bound |- typeIR_ret holds
+    -- if ReturnType_wf: bound |- typeIR_ret holds
     -- the relation holds
 
-  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:675.1-679.45
+  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:692.1-696.45
   rulegroup parserApplyMethodTypeIR
 
    match
@@ -11054,7 +11073,7 @@ relation CallableType_wf: bound |- callableTypeIR
     -- (if $nestable_parserApplyMethod(typeIR))*{typeIR <- typeIR*}
     -- the relation holds
 
-  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:697.1-701.46
+  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:714.1-718.46
   rulegroup controlApplyMethodTypeIR
 
    match
@@ -11072,7 +11091,7 @@ relation CallableType_wf: bound |- callableTypeIR
     -- (if $nestable_controlApplyMethod(typeIR))*{typeIR <- typeIR*}
     -- the relation holds
 
-  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:703.1-704.52
+  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:720.1-721.52
   rulegroup tableApplyMethodTypeIR
 
    match
@@ -11087,10 +11106,10 @@ relation CallableType_wf: bound |- callableTypeIR
     rulepath tableApplyMethodTypeIR
     -- the relation holds
 
-;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:30.1-33.74
+;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:35.1-38.74
 relation CallableTypeDef_wf: bound |- callableTypeDefIR
 
-  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:710.1-719.57
+  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:727.1-736.57
   rulegroup 
 
    match
@@ -11108,10 +11127,10 @@ relation CallableTypeDef_wf: bound |- callableTypeDefIR
     -- if CallableType_wf: bound_inner |- callableTypeIR_base holds
     -- the relation holds
 
-;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:35.1-38.74
+;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:40.1-43.74
 relation ConstructorParameterType_wf: bound |- parameterIR
 
-  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:725.1-728.54
+  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:742.1-745.54
   rulegroup 
 
    match
@@ -11127,10 +11146,10 @@ relation ConstructorParameterType_wf: bound |- parameterIR
     -- if ~$is_synthesizedTypeIR($canon_typeIR(typeIR))
     -- the relation holds
 
-;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:40.1-43.74
+;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:45.1-48.74
 relation ConstructorParameterTypes_wf: bound |- parameterIR*
 
-  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:730.1-734.58
+  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:747.1-751.58
   rulegroup 
 
    match
@@ -11146,10 +11165,10 @@ relation ConstructorParameterTypes_wf: bound |- parameterIR*
     -- (if ConstructorParameterType_wf: bound |- parameterIR holds)*{parameterIR <- parameterIR*}
     -- the relation holds
 
-;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:45.1-48.74
+;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:50.1-53.74
 relation ConstructorType_wf: bound |- constructorTypeIR
 
-  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:752.1-758.46
+  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:769.1-775.46
   rulegroup externObjectTypeIR
 
    match
@@ -11169,7 +11188,7 @@ relation ConstructorType_wf: bound |- constructorTypeIR
     -- (if $nestable_constructor_extern(typeIR))*{typeIR <- typeIR*}
     -- the relation holds
 
-  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:771.1-777.46
+  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:788.1-794.46
   rulegroup parserObjectTypeIR
 
    match
@@ -11189,7 +11208,7 @@ relation ConstructorType_wf: bound |- constructorTypeIR
     -- (if $nestable_constructor_parser(typeIR))*{typeIR <- typeIR*}
     -- the relation holds
 
-  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:790.1-796.47
+  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:807.1-813.47
   rulegroup controlObjectTypeIR
 
    match
@@ -11209,7 +11228,7 @@ relation ConstructorType_wf: bound |- constructorTypeIR
     -- (if $nestable_constructor_control(typeIR))*{typeIR <- typeIR*}
     -- the relation holds
 
-  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:807.1-813.47
+  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:824.1-830.47
   rulegroup packageObjectTypeIR
 
    match
@@ -11229,10 +11248,10 @@ relation ConstructorType_wf: bound |- constructorTypeIR
     -- (if $nestable_constructor_package(typeIR))*{typeIR <- typeIR*}
     -- the relation holds
 
-;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:50.1-53.74
+;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:55.1-58.74
 relation ConstructorTypeDef_wf: bound |- constructorTypeDefIR
 
-  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:831.1-839.68
+  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:848.1-856.68
   rulegroup 
 
    match
@@ -11249,14 +11268,14 @@ relation ConstructorTypeDef_wf: bound |- constructorTypeDefIR
     -- if ConstructorType_wf: bound_inner |- constructor( parameterIR*{parameterIR <- parameterIR*} ): typeIR_object holds
     -- the relation holds
 
-;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:77.1-79.53
+;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:82.1-84.53
 def $nestable_typedef(typeIR) : bool =
 
-  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:84.1-85.45
+  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:89.1-90.45
   clause 0 : (typeIR) = $nestable'_typedef(typeIR_canon)
   -- let typeIR_canon = $canon_typeIR(typeIR)
 
-;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:80.1-82.53
+;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:85.1-87.53
 tbl def $nestable'_typedef(typeIR) : bool =
   row 0 :
     (signature) bool as typeIR
@@ -11320,14 +11339,14 @@ tbl def $nestable'_typedef(typeIR) : bool =
     (signature) _typeIR
     (_typeIR) -> false
 
-;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:105.1-107.54
+;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:110.1-112.54
 def $nestable_new(typeIR) : bool =
 
-  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:112.1-113.45
+  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:117.1-118.45
   clause 0 : (typeIR) = $nestable'_new(typeIR_canon)
   -- let typeIR_canon = $canon_typeIR(typeIR)
 
-;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:108.1-110.54
+;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:113.1-115.54
 tbl def $nestable'_new(typeIR) : bool =
   row 0 :
     (signature) bool as typeIR
@@ -11363,14 +11382,14 @@ tbl def $nestable'_new(typeIR) : bool =
     (signature) _typeIR
     (_typeIR) -> false
 
-;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:129.1-131.57
+;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:134.1-136.57
 def $nestable_list(typeIR) : bool =
 
-  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:136.1-137.45
+  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:141.1-142.45
   clause 0 : (typeIR) = $nestable'_list(typeIR_canon)
   -- let typeIR_canon = $canon_typeIR(typeIR)
 
-;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:132.1-134.57
+;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:137.1-139.57
 tbl def $nestable'_list(typeIR) : bool =
   row 0 :
     (signature) bool as typeIR
@@ -11420,14 +11439,14 @@ tbl def $nestable'_list(typeIR) : bool =
     (signature) _typeIR
     (_typeIR) -> false
 
-;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:154.1-156.58
+;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:159.1-161.58
 def $nestable_tuple(typeIR) : bool =
 
-  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:161.1-162.45
+  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:166.1-167.45
   clause 0 : (typeIR) = $nestable'_tuple(typeIR_canon)
   -- let typeIR_canon = $canon_typeIR(typeIR)
 
-;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:157.1-159.58
+;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:162.1-164.58
 tbl def $nestable'_tuple(typeIR) : bool =
   row 0 :
     (signature) bool as typeIR
@@ -11506,14 +11525,14 @@ tbl def $nestable'_tuple(typeIR) : bool =
     (signature) _typeIR
     (_typeIR) -> false
 
-;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:184.1-186.65
+;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:189.1-191.65
 def $nestable_headerStack(typeIR) : bool =
 
-  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:191.1-193.45
+  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:196.1-198.45
   clause 0 : (typeIR) = $nestable'_headerStack(typeIR_canon)
   -- let typeIR_canon = $canon_typeIR(typeIR)
 
-;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:187.1-189.65
+;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:192.1-194.65
 tbl def $nestable'_headerStack(typeIR) : bool =
   row 0 :
     (signature) nameTypeIR as typeIR
@@ -11534,27 +11553,27 @@ tbl def $nestable'_headerStack(typeIR) : bool =
     (signature) _typeIR
     (_typeIR) -> false
 
-;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:206.1-208.59
+;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:211.1-213.59
 def $nestable_struct(typeIR) : bool =
 
-  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:213.1-214.45
+  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:218.1-219.45
   clause 0 : (typeIR) = $nestable'_struct(typeIR_canon)
   -- let typeIR_canon = $canon_typeIR(typeIR)
 
-;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:209.1-211.59
+;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:214.1-216.59
 def $nestable'_struct(typeIR) : bool =
 
-  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:215.1-215.57
+  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:220.1-220.57
   clause 0 : (typeIR) = $nestable'_tuple(typeIR)
 
-;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:223.1-225.57
+;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:228.1-230.57
 def $nestable_header(typeIR) : bool =
 
-  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:236.1-238.45
+  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:241.1-243.45
   clause 0 : (typeIR) = $nestable'_header(typeIR_canon)
   -- let typeIR_canon = $canon_typeIR(typeIR)
 
-;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:226.1-228.57
+;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:231.1-233.57
 tbl def $nestable'_header(typeIR) : bool =
   row 0 :
     (signature) bool as typeIR
@@ -11609,14 +11628,14 @@ tbl def $nestable'_header(typeIR) : bool =
     (signature) _typeIR
     (_typeIR) -> false
 
-;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:229.1-231.76
+;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:234.1-236.76
 def $nestable_struct_in_header(typeIR) : bool =
 
-  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:251.1-253.45
+  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:256.1-258.45
   clause 0 : (typeIR) = $nestable'_struct_in_header(typeIR_canon)
   -- let typeIR_canon = $canon_typeIR(typeIR)
 
-;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:232.1-234.76
+;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:237.1-239.76
 tbl def $nestable'_struct_in_header(typeIR) : bool =
   row 0 :
     (signature) bool as typeIR
@@ -11664,14 +11683,14 @@ tbl def $nestable'_struct_in_header(typeIR) : bool =
     (signature) _typeIR
     (_typeIR) -> false
 
-;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:271.1-273.63
+;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:276.1-278.63
 def $nestable_headerUnion(typeIR) : bool =
 
-  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:278.1-280.45
+  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:283.1-285.45
   clause 0 : (typeIR) = $nestable'_headerUnion(typeIR_canon)
   -- let typeIR_canon = $canon_typeIR(typeIR)
 
-;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:274.1-276.63
+;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:279.1-281.63
 tbl def $nestable'_headerUnion(typeIR) : bool =
   row 0 :
     (signature) nameTypeIR as typeIR
@@ -11692,14 +11711,14 @@ tbl def $nestable'_headerUnion(typeIR) : bool =
     (signature) _typeIR
     (_typeIR) -> false
 
-;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:293.1-295.68
+;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:298.1-300.68
 def $nestable_enum_serializable(typeIR) : bool =
 
-  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:306.1-308.45
+  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:311.1-313.45
   clause 0 : (typeIR) = $nestable'_enum_serializable(typeIR_canon)
   -- let typeIR_canon = $canon_typeIR(typeIR)
 
-;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:296.1-298.68
+;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:301.1-303.68
 tbl def $nestable'_enum_serializable(typeIR) : bool =
   row 0 :
     (signature) int< _nat > as typeIR
@@ -11729,14 +11748,14 @@ tbl def $nestable'_enum_serializable(typeIR) : bool =
     (signature) _typeIR
     (_typeIR) -> false
 
-;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:299.1-301.89
+;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:304.1-306.89
 def $nestable_new_in_enum_serializable(typeIR) : bool =
 
-  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:316.1-318.45
+  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:321.1-323.45
   clause 0 : (typeIR) = $nestable'_new_in_enum_serializable(typeIR_canon)
   -- let typeIR_canon = $canon_typeIR(typeIR)
 
-;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:302.1-304.89
+;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:307.1-309.89
 tbl def $nestable'_new_in_enum_serializable(typeIR) : bool =
   row 0 :
     (signature) int< _nat > as typeIR
@@ -11766,14 +11785,14 @@ tbl def $nestable'_new_in_enum_serializable(typeIR) : bool =
     (signature) _typeIR
     (_typeIR) -> false
 
-;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:396.1-398.54
+;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:401.1-403.54
 def $nestable_set(typeIR) : bool =
 
-  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:415.1-416.45
+  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:420.1-421.45
   clause 0 : (typeIR) = $nestable'_set(typeIR_canon)
   -- let typeIR_canon = $canon_typeIR(typeIR)
 
-;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:399.1-401.54
+;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:404.1-406.54
 tbl def $nestable'_set(typeIR) : bool =
   row 0 :
     (signature) bool as typeIR
@@ -11832,14 +11851,14 @@ tbl def $nestable'_set(typeIR) : bool =
     (signature) _typeIR
     (_typeIR) -> false
 
-;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:402.1-404.72
+;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:407.1-409.72
 def $nestable_tuple_in_set(typeIR) : bool =
 
-  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:429.1-431.45
+  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:434.1-436.45
   clause 0 : (typeIR) = $nestable'_tuple_in_set(typeIR_canon)
   -- let typeIR_canon = $canon_typeIR(typeIR)
 
-;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:405.1-407.72
+;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:410.1-412.72
 tbl def $nestable'_tuple_in_set(typeIR) : bool =
   row 0 :
     (signature) bool as typeIR
@@ -11885,14 +11904,14 @@ tbl def $nestable'_tuple_in_set(typeIR) : bool =
     (signature) _typeIR
     (_typeIR) -> false
 
-;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:408.1-410.75
+;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:413.1-415.75
 def $nestable_sequence_in_set(typeIR) : bool =
 
-  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:442.1-444.45
+  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:447.1-449.45
   clause 0 : (typeIR) = $nestable'_sequence_in_set(typeIR_canon)
   -- let typeIR_canon = $canon_typeIR(typeIR)
 
-;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:411.1-413.75
+;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:416.1-418.75
 tbl def $nestable'_sequence_in_set(typeIR) : bool =
   row 0 :
     (signature) bool as typeIR
@@ -11945,47 +11964,47 @@ tbl def $nestable'_sequence_in_set(typeIR) : bool =
     (signature) _typeIR
     (_typeIR) -> false
 
-;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:530.1-532.85
+;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:547.1-549.85
 def $directionless_trailing(direction*) : bool =
 
-  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:535.1-536.65
+  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:552.1-553.65
   clause 0 : (direction*{direction <- direction*}) = $directionless_trailing'(true, $rev_<direction>(direction*{direction <- direction*}))
 
-;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:533.1-533.54
+;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:550.1-550.54
 def $directionless_trailing'(bool, direction*) : bool =
 
-  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:538.1-538.44
+  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:555.1-555.44
   clause 0 : (_bool, direction*{direction <- direction*}) = true
   -- if direction*{direction <- direction*} matches []
 
-  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:539.1-540.49
+  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:556.1-557.49
   clause 1 : (bool, direction'*{direction' <- direction'*}) = $directionless_trailing'(true, direction_t*{direction_t <- direction_t*})
   -- if (bool = true)
   -- if direction'*{direction' <- direction'*} matches _ :: _
   -- let direction :: direction_t*{direction_t <- direction_t*} = direction'*{direction' <- direction'*}
   -- if direction matches ``EMPTY`
 
-  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:541.1-541.68
+  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:558.1-558.68
   clause 2 : (bool, direction'*{direction' <- direction'*}) = false
   -- if (bool = false)
   -- if direction'*{direction' <- direction'*} matches _ :: _
   -- let direction :: direction_t*{direction_t <- direction_t*} = direction'*{direction' <- direction'*}
   -- if direction matches ``EMPTY`
 
-  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:542.1-544.31
+  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:559.1-561.31
   clause 3 : (_bool, direction*{direction <- direction*}) = $directionless_trailing'(false, direction_t*{direction_t <- direction_t*})
   -- if direction*{direction <- direction*} matches _ :: _
   -- let direction_h :: direction_t*{direction_t <- direction_t*} = direction*{direction <- direction*}
   -- if (direction_h =/= )
 
-;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:546.1-548.58
+;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:563.1-565.58
 def $nestable_action(typeIR) : bool =
 
-  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:553.1-554.45
+  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:570.1-571.45
   clause 0 : (typeIR) = $nestable'_action(typeIR_canon)
   -- let typeIR_canon = $canon_typeIR(typeIR)
 
-;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:549.1-551.58
+;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:566.1-568.58
 tbl def $nestable'_action(typeIR) : bool =
   row 0 :
     (signature) int as typeIR
@@ -12007,14 +12026,14 @@ tbl def $nestable'_action(typeIR) : bool =
     (signature) _typeIR
     (_typeIR) -> true
 
-;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:570.1-572.67
+;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:587.1-589.67
 def $nestable_definedFunction(typeIR) : bool =
 
-  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:577.1-579.45
+  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:594.1-596.45
   clause 0 : (typeIR) = $nestable'_definedFunction(typeIR_canon)
   -- let typeIR_canon = $canon_typeIR(typeIR)
 
-;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:573.1-575.67
+;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:590.1-592.67
 tbl def $nestable'_definedFunction(typeIR) : bool =
   row 0 :
     (signature) objectTypeIR as typeIR
@@ -12030,14 +12049,14 @@ tbl def $nestable'_definedFunction(typeIR) : bool =
     (signature) _typeIR
     (_typeIR) -> true
 
-;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:592.1-594.67
+;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:609.1-611.67
 def $nestable_externFunction(typeIR) : bool =
 
-  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:599.1-601.45
+  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:616.1-618.45
   clause 0 : (typeIR) = $nestable'_externFunction(typeIR_canon)
   -- let typeIR_canon = $canon_typeIR(typeIR)
 
-;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:595.1-597.67
+;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:612.1-614.67
 tbl def $nestable'_externFunction(typeIR) : bool =
   row 0 :
     (signature) parserObjectTypeIR as typeIR
@@ -12063,14 +12082,14 @@ tbl def $nestable'_externFunction(typeIR) : bool =
     (signature) _typeIR
     (_typeIR) -> true
 
-;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:623.1-625.65
+;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:640.1-642.65
 def $nestable_externMethod(typeIR) : bool =
 
-  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:630.1-632.45
+  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:647.1-649.45
   clause 0 : (typeIR) = $nestable'_externMethod(typeIR_canon)
   -- let typeIR_canon = $canon_typeIR(typeIR)
 
-;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:626.1-628.65
+;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:643.1-645.65
 tbl def $nestable'_externMethod(typeIR) : bool =
   row 0 :
     (signature) parserObjectTypeIR as typeIR
@@ -12096,14 +12115,14 @@ tbl def $nestable'_externMethod(typeIR) : bool =
     (signature) _typeIR
     (_typeIR) -> true
 
-;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:658.1-660.70
+;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:675.1-677.70
 def $nestable_parserApplyMethod(typeIR) : bool =
 
-  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:665.1-667.45
+  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:682.1-684.45
   clause 0 : (typeIR) = $nestable'_parserApplyMethod(typeIR_canon)
   -- let typeIR_canon = $canon_typeIR(typeIR)
 
-;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:661.1-663.70
+;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:678.1-680.70
 tbl def $nestable'_parserApplyMethod(typeIR) : bool =
   row 0 :
     (signature) parserObjectTypeIR as typeIR
@@ -12129,14 +12148,14 @@ tbl def $nestable'_parserApplyMethod(typeIR) : bool =
     (signature) _typeIR
     (_typeIR) -> true
 
-;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:681.1-683.71
+;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:698.1-700.71
 def $nestable_controlApplyMethod(typeIR) : bool =
 
-  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:688.1-690.45
+  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:705.1-707.45
   clause 0 : (typeIR) = $nestable'_controlApplyMethod(typeIR_canon)
   -- let typeIR_canon = $canon_typeIR(typeIR)
 
-;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:684.1-686.71
+;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:701.1-703.71
 tbl def $nestable'_controlApplyMethod(typeIR) : bool =
   row 0 :
     (signature) parserObjectTypeIR as typeIR
@@ -12157,13 +12176,13 @@ tbl def $nestable'_controlApplyMethod(typeIR) : bool =
     (signature) _typeIR
     (_typeIR) -> true
 
-;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:740.1-740.48
+;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:757.1-757.48
 def $nestable_constructor_extern(typeIR) : bool =
 
-  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:743.1-744.57
+  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:760.1-761.57
   clause 0 : (typeIR) = $nestable'_constructor_extern($canon_typeIR(typeIR))
 
-;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:741.1-741.53
+;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:758.1-758.53
 tbl def $nestable'_constructor_extern(typeIR) : bool =
   row 0 :
     (signature) parserObjectTypeIR as typeIR
@@ -12189,13 +12208,13 @@ tbl def $nestable'_constructor_extern(typeIR) : bool =
     (signature) _typeIR
     (_typeIR) -> true
 
-;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:760.1-760.48
+;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:777.1-777.48
 def $nestable_constructor_parser(typeIR) : bool =
 
-  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:763.1-764.57
+  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:780.1-781.57
   clause 0 : (typeIR) = $nestable'_constructor_parser($canon_typeIR(typeIR))
 
-;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:761.1-761.53
+;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:778.1-778.53
 tbl def $nestable'_constructor_parser(typeIR) : bool =
   row 0 :
     (signature) controlObjectTypeIR as typeIR
@@ -12216,13 +12235,13 @@ tbl def $nestable'_constructor_parser(typeIR) : bool =
     (signature) _typeIR
     (_typeIR) -> true
 
-;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:779.1-779.49
+;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:796.1-796.49
 def $nestable_constructor_control(typeIR) : bool =
 
-  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:782.1-783.58
+  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:799.1-800.58
   clause 0 : (typeIR) = $nestable'_constructor_control($canon_typeIR(typeIR))
 
-;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:780.1-780.54
+;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:797.1-797.54
 tbl def $nestable'_constructor_control(typeIR) : bool =
   row 0 :
     (signature) parserObjectTypeIR as typeIR
@@ -12243,31 +12262,31 @@ tbl def $nestable'_constructor_control(typeIR) : bool =
     (signature) _typeIR
     (_typeIR) -> true
 
-;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:798.1-798.49
+;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:815.1-815.49
 def $nestable_constructor_package(typeIR) : bool =
 
-  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:801.1-802.58
+  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:818.1-819.58
   clause 0 : (typeIR) = $nestable'_constructor_package($canon_typeIR(typeIR))
 
-;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:799.1-799.50
+;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:816.1-816.50
 def $nestable'_constructor_package(typeIR) : bool =
 
-  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:803.1-803.62
+  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:820.1-820.62
   clause 0 : (typeIR) = false
   -- if typeIR <: tableObjectTypeIR
   -- let tableObjectTypeIR = typeIR as tableObjectTypeIR
 
-  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:804.1-805.15
+  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:821.1-822.15
   clause 1 : (_typeIR) = true
   -- otherwise
 
-;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:819.1-819.42
+;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:836.1-836.42
 def $definable_constructor(typeIR) : bool =
 
-  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:822.1-823.51
+  ;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:839.1-840.51
   clause 0 : (typeIR) = $definable'_constructor($canon_typeIR(typeIR))
 
-;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:820.1-820.47
+;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:837.1-837.47
 tbl def $definable'_constructor(typeIR) : bool =
   row 0 :
     (signature) externObjectTypeIR as typeIR

--- a/p4spec/test/prose.expected
+++ b/p4spec/test/prose.expected
@@ -2234,6 +2234,7 @@ relation Expr_ok: `p`, `TC`, and `expression'''`
   ... Let `typeIR~r_reduced~` be <<type_of_typedExpressionIR, the type of  `typedExpressionIR~r_reduced~`>>.
   ... Let `ctk~r_reduced~` be <<ctk_of_typedExpressionIR, the compile-time known-ness of  `typedExpressionIR~r_reduced~`>>.
   ... Else if `<<is_fixedBitTypeIR, $is_fixedBitTypeIR(typeIR~r_reduced~)>>`:
+   .... Check that `<<is_arbitraryIntTypeIR, $is_arbitraryIntTypeIR(typeIR~l_reduced~)>>` *implies* `ctk~r_reduced~ = LCTK`.
    .... Let `ctk~reduced~` be `<<join_ctk, $join_ctk(ctk~l_reduced~, ctk~r_reduced~)>>`.
    .... Let `expressionNoteIR` be <<expressionNoteIR, type `typeIR~l_reduced~` and compile-time known-ness `ctk~reduced~`>>.
    .... Result in the typed expression <<typedExpressionIR, `typedExpressionIR~l_reduced~ binop typedExpressionIR~r_reduced~` annotated with `expressionNoteIR`>>.

--- a/p4spec/test/prose.expected
+++ b/p4spec/test/prose.expected
@@ -570,6 +570,16 @@ for each `parameterIR` in `parameterIR^{asterisk}^`
  .. The relation holds.
 
 
+relation ReturnType_wf: `bound` and `typeIR~ret~`
+
+
+. Group :
+ .. Check that <<Type_wf, `typeIR~ret~` is a well-formed type, assuming bound type ids `bound`>>.
+ .. Let `typeIR~canon~` be <<canon_typeIR, the canonicalized form of `typeIR~ret~`>>.
+ .. Check that `~<<is_stringTypeIR, $is_stringTypeIR(typeIR~canon~)>> /\ ~<<is_arbitraryIntTypeIR, $is_arbitraryIntTypeIR(typeIR~canon~)>>` *and* `~<<is_objectTypeIR, $is_objectTypeIR(typeIR~canon~)>>`.
+ .. The relation holds.
+
+
 relation CallableType_wf: `bound` and `callableTypeIR`
 
 
@@ -597,7 +607,7 @@ for each `parameterIR` in `parameterIR^{asterisk}^`
 +
 for each `parameterIR` in `parameterIR^{asterisk}^`
   ... Check that <<nestable_definedFunction, `typeIR` can be used in a defined function type>>, for all `typeIR` in `typeIR^{asterisk}^`.
-  ... Check that <<Type_wf, `typeIR~ret~` is a well-formed type, assuming bound type ids `bound`>>.
+  ... Check that <<ReturnType_wf, `typeIR~ret~` is a well-formed return type, assuming bound type ids `bound`>>.
   ... The relation holds.
 . Else if let `EXTERN_FUNCTION ( parameterIR^{asterisk}^ ) : typeIR~ret~` be `callableTypeIR`:
  .. Group externFunctionTypeIR:
@@ -610,12 +620,12 @@ for each `parameterIR` in `parameterIR^{asterisk}^`
 +
 for each `parameterIR` in `parameterIR^{asterisk}^`
   ... Check that <<nestable_externFunction, `typeIR` can be used in an extern function type>>, for all `typeIR` in `typeIR^{asterisk}^`.
-  ... Check that <<Type_wf, `typeIR~ret~` is a well-formed type, assuming bound type ids `bound`>>.
+  ... Check that <<ReturnType_wf, `typeIR~ret~` is a well-formed return type, assuming bound type ids `bound`>>.
   ... The relation holds.
 . Else if let `BUILTIN_METHOD ( parameterIR^{asterisk}^ ) : typeIR~ret~` be `callableTypeIR`:
  .. Group builtinMethodTypeIR:
   ... Check that <<ParameterTypes_wf, `parameterIR^{asterisk}^` is a well-formed type, assuming bound type ids `bound`>>.
-  ... Check that <<Type_wf, `typeIR~ret~` is a well-formed type, assuming bound type ids `bound`>>.
+  ... Check that <<ReturnType_wf, `typeIR~ret~` is a well-formed return type, assuming bound type ids `bound`>>.
   ... The relation holds.
 . Else if let `externMethodTypeIR` be `callableTypeIR`:
  .. Group externMethodTypeIR:
@@ -629,7 +639,7 @@ for each `parameterIR` in `parameterIR^{asterisk}^`
 +
 for each `parameterIR` in `parameterIR^{asterisk}^`
    .... Check that <<nestable_externMethod, `typeIR` can be used in an extern method type>>, for all `typeIR` in `typeIR^{asterisk}^`.
-   .... Check that <<Type_wf, `typeIR~ret~` is a well-formed type, assuming bound type ids `bound`>>.
+   .... Check that <<ReturnType_wf, `typeIR~ret~` is a well-formed return type, assuming bound type ids `bound`>>.
    .... The relation holds.
   ... Else let `EXTERN_METHOD ABSTRACT ( parameterIR^{asterisk}^ ) : typeIR~ret~` be `externMethodTypeIR`:
    .... Check that <<ParameterTypes_wf, `parameterIR^{asterisk}^` is a well-formed type, assuming bound type ids `bound`>>.
@@ -641,7 +651,7 @@ for each `parameterIR` in `parameterIR^{asterisk}^`
 +
 for each `parameterIR` in `parameterIR^{asterisk}^`
    .... Check that <<nestable_externMethod, `typeIR` can be used in an extern method type>>, for all `typeIR` in `typeIR^{asterisk}^`.
-   .... Check that <<Type_wf, `typeIR~ret~` is a well-formed type, assuming bound type ids `bound`>>.
+   .... Check that <<ReturnType_wf, `typeIR~ret~` is a well-formed return type, assuming bound type ids `bound`>>.
    .... The relation holds.
 . Else if let `PARSER_APPLY ( parameterIR^{asterisk}^ )` be `callableTypeIR`:
  .. Group parserApplyMethodTypeIR:

--- a/p4spec/test/run_il_inst_p4c.expected
+++ b/p4spec/test/run_il_inst_p4c.expected
@@ -886,7 +886,7 @@ Run success: ../../../../p4c/testdata/p4_16_samples/hash-extern-bmv2.p4
 Run success: ../../../../p4c/testdata/p4_16_samples/hash_ubpf.p4
 
 >>> Running interpreter test (Program_inst) on ../../../../p4c/testdata/p4_16_samples/hashext.p4
-Run success: ../../../../p4c/testdata/p4_16_samples/hashext.p4
+Excluding file: ../../../../p4c/testdata/p4_16_samples/hashext.p4
 
 >>> Running interpreter test (Program_inst) on ../../../../p4c/testdata/p4_16_samples/hashext2.p4
 Run success: ../../../../p4c/testdata/p4_16_samples/hashext2.p4
@@ -3886,4 +3886,4 @@ Run success: ../../../../p4c/testdata/p4_16_samples/xdp_vlan_push_pop_ebpf-kerne
 >>> Running interpreter test (Program_inst) on ../../../../p4c/testdata/p4_16_samples/xor_test.p4
 Run success: ../../../../p4c/testdata/p4_16_samples/xor_test.p4
 
-Running interpreter test (Program_inst): [EXCLUDE] 96/1278 (7.51%) [PASS] 1177/1278 (92.10%) [FAIL] 5/1278 (0.39%)
+Running interpreter test (Program_inst): [EXCLUDE] 97/1278 (7.59%) [PASS] 1176/1278 (92.02%) [FAIL] 5/1278 (0.39%)

--- a/p4spec/test/run_il_type_neg_p4c.expected
+++ b/p4spec/test/run_il_type_neg_p4c.expected
@@ -42,9 +42,9 @@ application of rule TableProperties_ok/cons/cons failed
                     invocation of relation Expr_ok failed
                     └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:929.8-929.15
                         application of rule Expr_ok/callExpression-callable/non-typeArgumentList failed
-                        └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:1189.8-1189.15
+                        └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:1190.8-1190.15
                             invocation of relation Call_ok failed
-                            └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:1189.8-1189.15
+                            └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:1190.8-1190.15
                                 application of rule Call_ok/action/action failed
                                 └── ../../../../spec-concrete/5.15.4-typing-callable-call.watsup:275.9-275.32
                                     condition $callable_action(p, TC) was not met
@@ -218,7 +218,7 @@ application of rule BlockElementStmts_ok/cons/cons failed
                             invocation of relation Expr_ok failed
                             └── ../../../../spec-concrete/5.10-typing-statement.watsup:731.8-731.15
                                 application of rule Expr_ok/sliceAccessExpression/sliceAccessExpression failed
-                                └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:1128.9-1128.39
+                                └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:1129.9-1129.39
                                     condition typedExpressionIR?{typedExpressionIR <- typedExpressionIR?} matches (_) was not met
 
 
@@ -495,9 +495,9 @@ application of rule Block_ok// failed
                     invocation of relation Expr_ok failed
                     └── ../../../../spec-concrete/5.10-typing-statement.watsup:731.8-731.15
                         application of rule Expr_ok/dataExpression-record/multiple-default failed
-                        └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:737.9-737.16
+                        └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:738.9-738.16
                             invocation of relation Expr_ok failed
-                            └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:737.9-737.16
+                            └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:738.9-738.16
                                 application of rule Expr_ok/dataExpression-sequence/default failed
                                 └── ../../../../spec-concrete/1-syntax.watsup:287.28-287.32
                                     condition expression' <: defaultExpression was not met
@@ -932,7 +932,7 @@ application of rule Block_ok// failed
                             invocation of relation Expr_ok failed
                             └── ../../../../spec-concrete/5.10-typing-statement.watsup:214.8-214.15
                                 application of rule Expr_ok/binaryExpression-equality/binaryExpression-equality failed
-                                └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:389.9-389.61
+                                └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:390.9-390.61
                                     condition (typedExpressionIR, typedExpressionIR)?{(typedExpressionIR, typedExpressionIR) <- (typedExpressionIR, typedExpressionIR)?} matches (_) was not met
 
 
@@ -1117,7 +1117,7 @@ application of rule Block_ok// failed
                             invocation of relation Expr_ok failed
                             └── ../../../../spec-concrete/5.10-typing-statement.watsup:126.6-126.13
                                 application of rule Expr_ok/callExpression-callable/non-typeArgumentList failed
-                                └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:1176.13-1176.27
+                                └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:1177.13-1177.27
                                     condition callTarget <: callableTarget was not met
 
 
@@ -1494,7 +1494,7 @@ application of rule BlockElementStmts_ok/cons/cons failed
                             invocation of relation Expr_ok failed
                             └── ../../../../spec-concrete/5.07.2-typing-argument.watsup:11.6-11.13
                                 application of rule Expr_ok/memberAccessExpression-expression/struct failed
-                                └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:886.11-886.17
+                                └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:887.11-887.17
                                     condition typeIR''?{typeIR'' <- typeIR''?} matches (_) was not met
 
 
@@ -1857,7 +1857,31 @@ invocation of function $coerce_unary(typedExpressionIR_arg, typeIR_param) failed
 
 
 >>> Running interpreter test (Program_ok) on ../../../../p4c/testdata/p4_16_errors/issue2206.p4
-Excluding file: ../../../../p4c/testdata/p4_16_errors/issue2206.p4
+Error on run: ../../../../p4c/testdata/p4_16_errors/issue2206.p4
+tracing backtrack logs:
+invocation of relation Program_ok failed
+│ ··· omitting 120 traces ···
+../../../../spec-concrete/5.10-typing-statement.watsup:761.6-761.25
+application of rule BlockElementStmt_ok/statement/statement failed
+└── ../../../../spec-concrete/5.10-typing-statement.watsup:749.6-749.13
+    invocation of relation Stmt_ok failed
+    └── ../../../../spec-concrete/5.10-typing-statement.watsup:749.6-749.13
+        application of rule Stmt_ok/asssignmentStatement/eq failed
+        └── ../../../../spec-concrete/5.10-typing-statement.watsup:28.8-28.15
+            invocation of relation Expr_ok failed
+            └── ../../../../spec-concrete/5.10-typing-statement.watsup:28.8-28.15
+                application of rule Expr_ok/binaryExpression-plusminusmult/binaryExpression-plusminusmult failed
+                └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:171.6-171.13
+                    invocation of relation Expr_ok failed
+                    └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:171.6-171.13
+                        application of rule Expr_ok/parenthesizedExpression/parenthesizedExpression failed
+                        └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:1313.6-1313.13
+                            invocation of relation Expr_ok failed
+                            └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:1313.6-1313.13
+                                application of rule Expr_ok/binaryExpression-shift/rhs-fixbit failed
+                                └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:345.11-345.77
+                                    condition ($is_arbitraryIntTypeIR(typeIR_l_reduced) => (ctk_r_reduced = lctk)) was not met
+
 
 >>> Running interpreter test (Program_ok) on ../../../../p4c/testdata/p4_16_errors/issue2220.p4
 Error on run: ../../../../p4c/testdata/p4_16_errors/issue2220.p4
@@ -1941,7 +1965,7 @@ application of rule Decl_ok/controlDeclaration/controlDeclaration failed
                             invocation of relation Expr_ok failed
                             └── ../../../../spec-concrete/5.10-typing-statement.watsup:731.8-731.15
                                 application of rule Expr_ok/callExpression-callable/typeArgumentList failed
-                                └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:1201.28-1201.71
+                                └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:1202.28-1202.71
                                     condition callExpression' matches `%<%>(%)` was not met
 
 
@@ -2006,11 +2030,11 @@ application of rule BlockElementStmts_ok/cons/cons failed
                     invocation of relation Expr_ok failed
                     └── ../../../../spec-concrete/5.10-typing-statement.watsup:201.8-201.15
                         application of rule Expr_ok/binaryExpression-equality/binaryExpression-equality failed
-                        └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:385.6-385.13
+                        └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:386.6-386.13
                             invocation of relation Expr_ok failed
-                            └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:385.6-385.13
+                            └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:386.6-386.13
                                 application of rule Expr_ok/callExpression-callable/non-typeArgumentList failed
-                                └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:1192.11-1192.30
+                                └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:1193.11-1193.30
                                     condition (typeIR_ret =/= void as typeIR) was not met
 
 
@@ -2602,11 +2626,11 @@ application of rule ParserStmt_ok/callStatement/callStatement failed
                     invocation of relation Expr_ok failed
                     └── ../../../../spec-concrete/5.07.2-typing-argument.watsup:11.6-11.13
                         application of rule Expr_ok/memberAccessExpression-expression/headerStack-next failed
-                        └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:866.8-866.15
+                        └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:867.8-867.15
                             invocation of relation Expr_ok failed
-                            └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:866.8-866.15
+                            └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:867.8-867.15
                                 application of rule Expr_ok/memberAccessExpression-expression/struct failed
-                                └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:886.11-886.17
+                                └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:887.11-887.17
                                     condition typeIR''?{typeIR'' <- typeIR''?} matches (_) was not met
 
 
@@ -2704,9 +2728,9 @@ application of rule Decls_ok/cons/cons failed
                     invocation of relation Expr_ok failed
                     └── ../../../../spec-concrete/5.11-typing-declaration.watsup:16.6-16.13
                         application of rule Expr_ok/callExpression-callable/non-typeArgumentList failed
-                        └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:1189.8-1189.15
+                        └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:1190.8-1190.15
                             invocation of relation Call_ok failed
-                            └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:1189.8-1189.15
+                            └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:1190.8-1190.15
                                 application of rule Call_ok/externFunctionTypeIR/externFunctionTypeIR failed
                                 └── ../../../../spec-concrete/5.15.4-typing-callable-call.watsup:368.9-368.40
                                     condition $callable_externFunction(p, TC) was not met
@@ -2792,9 +2816,9 @@ application of rule BlockElementStmts_ok/cons/cons failed
                     invocation of relation Expr_ok failed
                     └── ../../../../spec-concrete/5.10-typing-statement.watsup:162.8-162.15
                         application of rule Expr_ok/callExpression-callable/typeArgumentList failed
-                        └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:1212.8-1212.23
+                        └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:1213.8-1213.23
                             invocation of relation CallableType_ok failed
-                            └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:1212.8-1212.23
+                            └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:1213.8-1213.23
                                 application of rule CallableType_ok/typedExpressionIR-nameIR-extern-method/typedExpressionIR-nameIR-extern-method failed
                                 └── ../../../../spec-concrete/2.2.1-type.watsup:106.3-106.9
                                     condition typeIR <: externObjectTypeIR was not met
@@ -2888,7 +2912,7 @@ application of rule Decls_ok/cons/cons failed
                             invocation of relation Expr_ok failed
                             └── ../../../../spec-concrete/5.07.2-typing-argument.watsup:11.6-11.13
                                 application of rule Expr_ok/callExpression-constructor/prefixedTypeName failed
-                                └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:1273.11-1273.52
+                                └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:1274.11-1274.52
                                     condition $is_concrete_extern_object(typeIR_object) was not met
 
 
@@ -3259,7 +3283,7 @@ application of rule Decl_ok/actionDeclaration/actionDeclaration failed
                             invocation of relation Expr_ok failed
                             └── ../../../../spec-concrete/5.10-typing-statement.watsup:731.8-731.15
                                 application of rule Expr_ok/memberAccessExpression-expression/headerStack-lastIndex failed
-                                └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:829.11-830.70
+                                └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:830.11-831.70
                                     condition (((p = block) /\ $is_parser_blockKind(TC.block.kind)) \/ ((p = local) /\ $is_parser_state_localKind(TC.local.kind))) was not met
 
 
@@ -3302,7 +3326,7 @@ application of rule Decl_ok/controlDeclaration/controlDeclaration failed
                             invocation of relation Expr_ok failed
                             └── ../../../../spec-concrete/5.10-typing-statement.watsup:731.8-731.15
                                 application of rule Expr_ok/binaryExpression-equality/binaryExpression-equality failed
-                                └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:396.9-396.42
+                                └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:397.9-397.42
                                     condition $is_equalable_typeIR(typeIR_cast) was not met
 
 
@@ -3450,9 +3474,9 @@ application of rule TableProperties_ok/cons/cons failed
                     invocation of relation Expr_ok failed
                     └── ../../../../spec-concrete/5.14.1-typing-control-table.watsup:929.8-929.15
                         application of rule Expr_ok/callExpression-callable/non-typeArgumentList failed
-                        └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:1189.8-1189.15
+                        └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:1190.8-1190.15
                             invocation of relation Call_ok failed
-                            └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:1189.8-1189.15
+                            └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:1190.8-1190.15
                                 application of rule Call_ok/action/action failed
                                 └── ../../../../spec-concrete/5.15.4-typing-callable-call.watsup:275.9-275.32
                                     condition $callable_action(p, TC) was not met
@@ -3663,9 +3687,9 @@ application of rule BlockElementStmts_ok/cons/cons failed
                     invocation of relation Expr_ok failed
                     └── ../../../../spec-concrete/5.10-typing-statement.watsup:162.8-162.15
                         application of rule Expr_ok/callExpression-callable/non-typeArgumentList failed
-                        └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:1184.8-1184.23
+                        └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:1185.8-1185.23
                             invocation of relation CallableType_ok failed
-                            └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:1184.8-1184.23
+                            └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:1185.8-1185.23
                                 application of rule CallableType_ok/referenceExpressionIR/actionTypeIR failed
                                 └── ../../../../spec-concrete/5.15.4-typing-callable-call.watsup:81.11-81.43
                                     condition (cid, callableTypeDefIR, id*)'?{(cid, callableTypeDefIR, id*)' <- (cid, callableTypeDefIR, id*)'?} matches (_) was not met
@@ -3721,7 +3745,7 @@ application of rule Block_ok// failed
                             invocation of relation Expr_ok failed
                             └── ../../../../spec-concrete/5.10-typing-statement.watsup:201.8-201.15
                                 application of rule Expr_ok/binaryExpression-equality/binaryExpression-equality failed
-                                └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:396.9-396.42
+                                └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:397.9-397.42
                                     condition $is_equalable_typeIR(typeIR_cast) was not met
 
 
@@ -3748,7 +3772,7 @@ application of rule Block_ok// failed
                             invocation of relation Expr_ok failed
                             └── ../../../../spec-concrete/5.10-typing-statement.watsup:201.8-201.15
                                 application of rule Expr_ok/binaryExpression-equality/binaryExpression-equality failed
-                                └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:396.9-396.42
+                                └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:397.9-397.42
                                     condition $is_equalable_typeIR(typeIR_cast) was not met
 
 
@@ -3910,7 +3934,7 @@ application of rule Block_ok// failed
                             invocation of relation Expr_ok failed
                             └── ../../../../spec-concrete/5.10-typing-statement.watsup:28.8-28.15
                                 application of rule Expr_ok/sliceAccessExpression/sliceAccessExpression failed
-                                └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:1159.9-1159.13
+                                └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:1160.9-1160.13
                                     condition int' <: nat was not met
 
 
@@ -4488,9 +4512,9 @@ application of rule Decls_ok/cons/cons failed
                     invocation of relation Expr_ok failed
                     └── ../../../../spec-concrete/5.11-typing-declaration.watsup:16.6-16.13
                         application of rule Expr_ok/callExpression-callable/non-typeArgumentList failed
-                        └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:1184.8-1184.23
+                        └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:1185.8-1185.23
                             invocation of relation CallableType_ok failed
-                            └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:1184.8-1184.23
+                            └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:1185.8-1185.23
                                 application of rule CallableType_ok/typedExpressionIR-nameIR-extern-method/typedExpressionIR-nameIR-extern-method failed
                                 └── ../../../../spec-concrete/2.2.1-type.watsup:106.3-106.9
                                     condition typeIR <: externObjectTypeIR was not met
@@ -5089,15 +5113,15 @@ application of rule BlockElementStmts_ok/cons/cons failed
             invocation of relation Expr_ok failed
             └── ../../../../spec-concrete/5.10-typing-statement.watsup:731.8-731.15
                 application of rule Expr_ok/callExpression-callable/non-typeArgumentList failed
-                └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:1179.8-1179.25
+                └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:1180.8-1180.25
                     invocation of relation CallableTarget_ok failed
-                    └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:1179.8-1179.25
+                    └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:1180.8-1180.25
                         application of rule CallableTarget_ok/memberAccessExpression/memberAccessExpression-expression failed
                         └── ../../../../spec-concrete/5.15.4-typing-callable-call.watsup:45.8-45.15
                             invocation of relation Expr_ok failed
                             └── ../../../../spec-concrete/5.15.4-typing-callable-call.watsup:45.8-45.15
                                 application of rule Expr_ok/memberAccessExpression-type/enum failed
-                                └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:776.11-776.25
+                                └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:777.11-777.25
                                     condition typeDefIR?{typeDefIR <- typeDefIR?} matches (_) was not met
 
 
@@ -5239,7 +5263,31 @@ invocation of function $coerce_unary(typedExpressionIR, typeIR) failed
 
 
 >>> Running interpreter test (Program_ok) on ../../../../p4c/testdata/p4_16_errors/shift-int-non-const.p4
-Excluding file: ../../../../p4c/testdata/p4_16_errors/shift-int-non-const.p4
+Error on run: ../../../../p4c/testdata/p4_16_errors/shift-int-non-const.p4
+tracing backtrack logs:
+invocation of relation Program_ok failed
+│ ··· omitting 14 traces ···
+../../../../spec-concrete/5.10-typing-statement.watsup:761.6-761.25
+application of rule BlockElementStmt_ok/statement/statement failed
+└── ../../../../spec-concrete/5.10-typing-statement.watsup:749.6-749.13
+    invocation of relation Stmt_ok failed
+    └── ../../../../spec-concrete/5.10-typing-statement.watsup:749.6-749.13
+        application of rule Stmt_ok/asssignmentStatement/eq failed
+        └── ../../../../spec-concrete/5.10-typing-statement.watsup:28.8-28.15
+            invocation of relation Expr_ok failed
+            └── ../../../../spec-concrete/5.10-typing-statement.watsup:28.8-28.15
+                application of rule Expr_ok/castExpression/castExpression failed
+                └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:607.6-607.13
+                    invocation of relation Expr_ok failed
+                    └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:607.6-607.13
+                        application of rule Expr_ok/parenthesizedExpression/parenthesizedExpression failed
+                        └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:1313.6-1313.13
+                            invocation of relation Expr_ok failed
+                            └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:1313.6-1313.13
+                                application of rule Expr_ok/binaryExpression-shift/rhs-fixbit failed
+                                └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:345.11-345.77
+                                    condition ($is_arbitraryIntTypeIR(typeIR_l_reduced) => (ctk_r_reduced = lctk)) was not met
+
 
 >>> Running interpreter test (Program_ok) on ../../../../p4c/testdata/p4_16_errors/shift_e.p4
 Error on run: ../../../../p4c/testdata/p4_16_errors/shift_e.p4
@@ -5357,7 +5405,7 @@ application of rule BlockElementStmts_ok/cons/cons failed
                             invocation of relation Expr_ok failed
                             └── ../../../../spec-concrete/5.07.2-typing-argument.watsup:11.6-11.13
                                 application of rule Expr_ok/binaryExpression-concat/binaryExpression-concat failed
-                                └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:512.9-512.67
+                                └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:513.9-513.67
                                     condition (typedExpressionIR, typedExpressionIR)?{(typedExpressionIR, typedExpressionIR) <- (typedExpressionIR, typedExpressionIR)?} matches (_) was not met
 
 
@@ -5417,7 +5465,7 @@ application of rule BlockElementStmt_ok/statement/statement failed
                             invocation of relation Expr_ok failed
                             └── ../../../../spec-concrete/5.15.4-typing-callable-call.watsup:45.8-45.15
                                 application of rule Expr_ok/indexAccessExpression/headerStack-lctk failed
-                                └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:1042.11-1042.18
+                                └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:1043.11-1043.18
                                     condition int <: nat was not met
 
 
@@ -5901,7 +5949,7 @@ application of rule BlockElementStmts_ok/cons/cons failed
                             invocation of relation Expr_ok failed
                             └── ../../../../spec-concrete/5.07.2-typing-argument.watsup:11.6-11.13
                                 application of rule Expr_ok/memberAccessExpression-type/enum failed
-                                └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:777.11-777.52
+                                └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:778.11-778.52
                                     condition $is_monomorphic_typeDefIR(typeDefIR_base) was not met
 
 
@@ -6201,4 +6249,4 @@ application of rule Program_ok// failed
                                     condition expression' <: prefixedNonTypeName was not met
 
 
-Running interpreter test (Program_ok): [EXCLUDE] 51/310 (16.45%) [PASS] 0/310 (0.00%) [FAIL] 259/310 (83.55%)
+Running interpreter test (Program_ok): [EXCLUDE] 49/310 (15.81%) [PASS] 0/310 (0.00%) [FAIL] 261/310 (84.19%)

--- a/p4spec/test/run_il_type_neg_p4c.expected
+++ b/p4spec/test/run_il_type_neg_p4c.expected
@@ -972,7 +972,7 @@ Excluding file: ../../../../p4c/testdata/p4_16_errors/extract1.p4
 Error on run: ../../../../p4c/testdata/p4_16_errors/factory-err2.p4
 tracing backtrack logs:
 invocation of relation Program_ok failed
-│ ··· omitting 18 traces ···
+│ ··· omitting 14 traces ···
 ../../../../spec-concrete/5.11-typing-declaration.watsup:1001.6-1001.14
 application of rule Decls_ok/cons/cons failed
 └── ../../../../spec-concrete/5.11-typing-declaration.watsup:1001.6-1001.14
@@ -1919,7 +1919,31 @@ invocation of function $coerce_unary(typedExpressionIR, typeIR_l) failed
 
 
 >>> Running interpreter test (Program_ok) on ../../../../p4c/testdata/p4_16_errors/issue2260-1.p4
-Excluding file: ../../../../p4c/testdata/p4_16_errors/issue2260-1.p4
+Error on run: ../../../../p4c/testdata/p4_16_errors/issue2260-1.p4
+tracing backtrack logs:
+invocation of relation Program_ok failed
+│ ··· omitting 10 traces ···
+../../../../spec-concrete/5.11-typing-declaration.watsup:1000.6-1000.13
+application of rule Decl_ok/controlDeclaration/controlDeclaration failed
+└── ../../../../spec-concrete/5.11-typing-declaration.watsup:602.6-602.14
+    invocation of relation Block_ok failed
+    └── ../../../../spec-concrete/5.11-typing-declaration.watsup:602.6-602.14
+        application of rule Block_ok// failed
+        └── ../../../../spec-concrete/5.10-typing-statement.watsup:778.6-778.26
+            invocation of relation BlockElementStmts_ok failed
+            └── ../../../../spec-concrete/5.10-typing-statement.watsup:778.6-778.26
+                application of rule BlockElementStmts_ok/cons/cons failed
+                └── ../../../../spec-concrete/5.10-typing-statement.watsup:761.6-761.25
+                    invocation of relation BlockElementStmt_ok failed
+                    └── ../../../../spec-concrete/5.10-typing-statement.watsup:761.6-761.25
+                        application of rule BlockElementStmt_ok/variableDeclaration/initializer failed
+                        └── ../../../../spec-concrete/5.10-typing-statement.watsup:731.8-731.15
+                            invocation of relation Expr_ok failed
+                            └── ../../../../spec-concrete/5.10-typing-statement.watsup:731.8-731.15
+                                application of rule Expr_ok/callExpression-callable/typeArgumentList failed
+                                └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:1201.28-1201.71
+                                    condition callExpression' matches `%<%>(%)` was not met
+
 
 >>> Running interpreter test (Program_ok) on ../../../../p4c/testdata/p4_16_errors/issue2267.p4
 Error on run: ../../../../p4c/testdata/p4_16_errors/issue2267.p4
@@ -2812,7 +2836,34 @@ Error on run: ../../../../p4c/testdata/p4_16_errors/issue3271.p4
 ../../../../p4c/testdata/p4_16_errors/issue3271.p4:3.8-3.9: syntax error
 
 >>> Running interpreter test (Program_ok) on ../../../../p4c/testdata/p4_16_errors/issue3273.p4
-Excluding file: ../../../../p4c/testdata/p4_16_errors/issue3273.p4
+Error on run: ../../../../p4c/testdata/p4_16_errors/issue3273.p4
+tracing backtrack logs:
+invocation of relation Program_ok failed
+│ ··· omitting 0 traces ···
+application of rule Program_ok// failed
+└── ../../../../spec-concrete/5.11-typing-declaration.watsup:1011.6-1011.14
+    invocation of relation Decls_ok failed
+    └── ../../../../spec-concrete/5.11-typing-declaration.watsup:1011.6-1011.14
+        application of rule Decls_ok/cons/cons failed
+        └── ../../../../spec-concrete/5.11-typing-declaration.watsup:1000.6-1000.13
+            invocation of relation Decl_ok failed
+            └── ../../../../spec-concrete/5.11-typing-declaration.watsup:1000.6-1000.13
+                application of rule Decl_ok/externObjectDeclaration/externObjectDeclaration failed
+                └── ../../../../spec-concrete/5.11-typing-declaration.watsup:499.6-499.22
+                    invocation of relation ExternMethods_ok failed
+                    └── ../../../../spec-concrete/5.11-typing-declaration.watsup:499.6-499.22
+                        application of rule ExternMethods_ok/cons/cons failed
+                        └── ../../../../spec-concrete/5.12-typing-extern-method.watsup:87.6-87.21
+                            invocation of relation ExternMethod_ok failed
+                            ├── ../../../../spec-concrete/5.12-typing-extern-method.watsup:87.6-87.21
+                                1. application of rule ExternMethod_ok/non-abstract/non-abstract failed
+                            │   └── ../../../../spec-concrete/1-syntax.watsup:1012.38-1012.40
+                            │       condition externMethodPrototype matches `%%;` was not met
+                            └── ../../../../spec-concrete/5.12-typing-extern-method.watsup:87.6-87.21
+                                2. application of rule ExternMethod_ok/abstract/abstract failed
+                                └── ../../../../spec-concrete/5.12-typing-extern-method.watsup:67.6-67.24
+                                    condition hold CallableTypeDef_wf was not met
+
 
 >>> Running interpreter test (Program_ok) on ../../../../p4c/testdata/p4_16_errors/issue3282.p4
 Error on run: ../../../../p4c/testdata/p4_16_errors/issue3282.p4
@@ -6150,4 +6201,4 @@ application of rule Program_ok// failed
                                     condition expression' <: prefixedNonTypeName was not met
 
 
-Running interpreter test (Program_ok): [EXCLUDE] 53/310 (17.10%) [PASS] 0/310 (0.00%) [FAIL] 257/310 (82.90%)
+Running interpreter test (Program_ok): [EXCLUDE] 51/310 (16.45%) [PASS] 0/310 (0.00%) [FAIL] 259/310 (83.55%)

--- a/p4spec/test/run_il_type_pos_p4c.expected
+++ b/p4spec/test/run_il_type_pos_p4c.expected
@@ -875,7 +875,7 @@ Run success: ../../../../p4c/testdata/p4_16_samples/hash-extern-bmv2.p4
 Run success: ../../../../p4c/testdata/p4_16_samples/hash_ubpf.p4
 
 >>> Running interpreter test (Program_ok) on ../../../../p4c/testdata/p4_16_samples/hashext.p4
-Run success: ../../../../p4c/testdata/p4_16_samples/hashext.p4
+Excluding file: ../../../../p4c/testdata/p4_16_samples/hashext.p4
 
 >>> Running interpreter test (Program_ok) on ../../../../p4c/testdata/p4_16_samples/hashext2.p4
 Run success: ../../../../p4c/testdata/p4_16_samples/hashext2.p4
@@ -3835,4 +3835,4 @@ Run success: ../../../../p4c/testdata/p4_16_samples/xdp_vlan_push_pop_ebpf-kerne
 >>> Running interpreter test (Program_ok) on ../../../../p4c/testdata/p4_16_samples/xor_test.p4
 Run success: ../../../../p4c/testdata/p4_16_samples/xor_test.p4
 
-Running interpreter test (Program_ok): [EXCLUDE] 96/1278 (7.51%) [PASS] 1182/1278 (92.49%) [FAIL] 0/1278 (0.00%)
+Running interpreter test (Program_ok): [EXCLUDE] 97/1278 (7.59%) [PASS] 1181/1278 (92.41%) [FAIL] 0/1278 (0.00%)

--- a/p4spec/test/run_sl_inst_p4c.expected
+++ b/p4spec/test/run_sl_inst_p4c.expected
@@ -898,7 +898,7 @@ Run success: ../../../../p4c/testdata/p4_16_samples/hash-extern-bmv2.p4
 Run success: ../../../../p4c/testdata/p4_16_samples/hash_ubpf.p4
 
 >>> Running interpreter test (Program_inst) on ../../../../p4c/testdata/p4_16_samples/hashext.p4
-Run success: ../../../../p4c/testdata/p4_16_samples/hashext.p4
+Excluding file: ../../../../p4c/testdata/p4_16_samples/hashext.p4
 
 >>> Running interpreter test (Program_inst) on ../../../../p4c/testdata/p4_16_samples/hashext2.p4
 Run success: ../../../../p4c/testdata/p4_16_samples/hashext2.p4
@@ -3950,4 +3950,4 @@ Run success: ../../../../p4c/testdata/p4_16_samples/xdp_vlan_push_pop_ebpf-kerne
 >>> Running interpreter test (Program_inst) on ../../../../p4c/testdata/p4_16_samples/xor_test.p4
 Run success: ../../../../p4c/testdata/p4_16_samples/xor_test.p4
 
-Running interpreter test (Program_inst): [EXCLUDE] 96/1278 (7.51%) [PASS] 1177/1278 (92.10%) [FAIL] 5/1278 (0.39%)
+Running interpreter test (Program_inst): [EXCLUDE] 97/1278 (7.59%) [PASS] 1176/1278 (92.02%) [FAIL] 5/1278 (0.39%)

--- a/p4spec/test/run_sl_type_neg_p4c.expected
+++ b/p4spec/test/run_sl_type_neg_p4c.expected
@@ -503,17 +503,17 @@ Expr_ok: (local) TC_0 |- expression_init : typedExpressionIR_init failed
         Case analysis on expression''' failed
         └── ../../../../spec-concrete/1-syntax.watsup:328.5-328.9
             Case analysis on dataExpression failed
-            └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:633.16-633.30
+            └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:634.16-634.30
                 Case analysis on dataElementExpression failed
-                └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:678.18-678.40
+                └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:679.18-679.40
                     Group dataExpression-record failed
                     └── ../../../../spec-concrete/1-syntax.watsup:432.10-432.12
                         Case analysis on recordElementExpression failed
-                        └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:737.9-737.60
+                        └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:738.9-738.60
                             (Expr_ok: p TC |- expression_f : typedExpressionIR_f)*{expression_f <- expression_f*, typedExpressionIR_f <- typedExpressionIR_f*} failed
-                            └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:737.9-737.16
+                            └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:738.9-738.16
                                 relation Expr_ok failed
-                                └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:737.9-737.16
+                                └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:738.9-738.16
                                     relation did not produce results
 
 
@@ -1079,17 +1079,17 @@ Group directApplicationStatement-prefixedTypeName failed
         relation Expr_ok failed
         └── ../../../../spec-concrete/1-syntax.watsup:287.28-287.32
             Case analysis on expression''' failed
-            └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:1259.30-1259.47
+            └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:1260.30-1260.47
                 If (callExpression matches pattern `%(%)`) failed
-                └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:1256.18-1256.45
+                └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:1257.18-1257.45
                     Group callExpression-constructor failed
-                    └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:1259.13-1259.29
+                    └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:1260.13-1260.29
                         Case analysis on callTarget failed
-                        └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:1266.8-1267.91
+                        └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:1267.8-1268.91
                             ConstructorType_ok: p TC |- prefixedNameIR < [] >( (argumentIR)*{argumentIR <- argumentIR*} ): constructorTypeIR <# (tid_impl)*{tid_impl <- tid_impl*} >(# (id_default)*{id_default <- id_default*} ) failed
-                            └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:1266.8-1266.26
+                            └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:1267.8-1267.26
                                 relation ConstructorType_ok failed
-                                └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:1266.8-1266.26
+                                └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:1267.8-1267.26
                                     relation did not produce results
 
 
@@ -1891,7 +1891,30 @@ If (argumentIR has type typedExpressionIR) failed
 
 
 >>> Running interpreter test (Program_ok) on ../../../../p4c/testdata/p4_16_errors/issue2206.p4
-Excluding file: ../../../../p4c/testdata/p4_16_errors/issue2206.p4
+Error on run: ../../../../p4c/testdata/p4_16_errors/issue2206.p4
+relation Program_ok failed
+│ ··· omitting 251 traces ···
+../../../../spec-concrete/1-syntax.watsup:287.28-287.32
+Case analysis on expression''' failed
+└── ../../../../spec-concrete/5.06.1-typing-expression.watsup:166.13-166.44
+    Group binaryExpression-plusminusmult failed
+    └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:169.6-169.34
+        If binop is in [(+), (-), (*)] failed
+        └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:171.6-171.57
+            Expr_ok: p TC |- expression_l : typedExpressionIR_l failed
+            └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:171.6-171.13
+                relation Expr_ok failed
+                └── ../../../../spec-concrete/1-syntax.watsup:287.28-287.32
+                    Case analysis on expression''' failed
+                    └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:1311.13-1311.37
+                        Group parenthesizedExpression failed
+                        └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:1313.6-1313.53
+                            Expr_ok: p TC |- expression : typedExpressionIR failed
+                            └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:1313.6-1313.13
+                                relation Expr_ok failed
+                                └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:1313.6-1313.13
+                                    relation did not produce results
+
 
 >>> Running interpreter test (Program_ok) on ../../../../p4c/testdata/p4_16_errors/issue2220.p4
 Error on run: ../../../../p4c/testdata/p4_16_errors/issue2220.p4
@@ -1983,17 +2006,17 @@ If $is_assignable_typeIR(typeIR) failed
         relation Expr_ok failed
         └── ../../../../spec-concrete/1-syntax.watsup:287.28-287.32
             Case analysis on expression''' failed
-            └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:1173.18-1173.42
+            └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:1174.18-1174.42
                 Group callExpression-callable failed
-                └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:1176.28-1176.45
+                └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:1177.28-1177.45
                     Case analysis on callExpression failed
-                    └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:1176.13-1176.27
+                    └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:1177.13-1177.27
                         If (callTarget has type callableTarget) failed
-                        └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:1189.8-1190.87
+                        └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:1190.8-1191.87
                             Call_ok: p TC |- callableTypeIR < [] # (tid_infer)*{tid_infer <- tid_infer*} >( (argumentIR)*{argumentIR <- argumentIR*} # (id_default)*{id_default <- id_default*} ): typeIR_ret < (typeArgumentIR_inferred)*{typeArgumentIR_inferred <- typeArgumentIR_inferred*} >( (argumentIR_cast)*{argumentIR_cast <- argumentIR_cast*} ) failed
-                            └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:1189.8-1189.15
+                            └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:1190.8-1190.15
                                 relation Call_ok failed
-                                └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:1189.8-1189.15
+                                └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:1190.8-1190.15
                                     relation did not produce results
 
 
@@ -2066,15 +2089,15 @@ Group conditionalStatement failed
             relation Expr_ok failed
             └── ../../../../spec-concrete/1-syntax.watsup:287.28-287.32
                 Case analysis on expression''' failed
-                └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:380.13-380.39
+                └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:381.13-381.39
                     Group binaryExpression-equality failed
-                    └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:383.6-383.31
+                    └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:384.6-384.31
                         If binop is in [(==), (!=)] failed
-                        └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:385.6-385.57
+                        └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:386.6-386.57
                             Expr_ok: p TC |- expression_l : typedExpressionIR_l failed
-                            └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:385.6-385.13
+                            └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:386.6-386.13
                                 relation Expr_ok failed
-                                └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:385.6-385.13
+                                └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:386.6-386.13
                                     relation did not produce results
 
 
@@ -2474,19 +2497,19 @@ Expr_ok: p TC |- expression : typedExpressionIR failed
     relation Expr_ok failed
     └── ../../../../spec-concrete/1-syntax.watsup:287.28-287.32
         Case analysis on expression''' failed
-        └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:772.13-772.34
+        └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:773.13-773.34
             Case analysis on memberAccessBase failed
-            └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:807.18-807.52
+            └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:808.18-808.52
                 Group memberAccessExpression-expression failed
-                └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:861.8-861.33
+                └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:862.8-862.33
                     If ("next" = $name(member)) failed
-                    └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:863.8-864.70
+                    └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:864.8-865.70
                         If ((p = (local)) /\ $is_parser_state_localKind(TC.local.kind)) failed
-                        └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:866.8-866.65
+                        └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:867.8-867.65
                             Expr_ok: p TC |- expression_base : typedExpressionIR_base failed
-                            └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:866.8-866.15
+                            └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:867.8-867.15
                                 relation Expr_ok failed
-                                └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:866.8-866.15
+                                └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:867.8-867.15
                                     relation did not produce results
 
 
@@ -2580,17 +2603,17 @@ If Type_wf: $bound(p, TC_0) |- typeIR holds failed
         relation Expr_ok failed
         └── ../../../../spec-concrete/1-syntax.watsup:287.28-287.32
             Case analysis on expression''' failed
-            └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:1173.18-1173.42
+            └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:1174.18-1174.42
                 Group callExpression-callable failed
-                └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:1176.28-1176.45
+                └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:1177.28-1177.45
                     Case analysis on callExpression failed
-                    └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:1176.13-1176.27
+                    └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:1177.13-1177.27
                         If (callTarget has type callableTarget) failed
-                        └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:1189.8-1190.87
+                        └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:1190.8-1191.87
                             Call_ok: p TC |- callableTypeIR < [] # (tid_infer)*{tid_infer <- tid_infer*} >( (argumentIR)*{argumentIR <- argumentIR*} # (id_default)*{id_default <- id_default*} ): typeIR_ret < (typeArgumentIR_inferred)*{typeArgumentIR_inferred <- typeArgumentIR_inferred*} >( (argumentIR_cast)*{argumentIR_cast <- argumentIR_cast*} ) failed
-                            └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:1189.8-1189.15
+                            └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:1190.8-1190.15
                                 relation Call_ok failed
-                                └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:1189.8-1189.15
+                                └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:1190.8-1190.15
                                     relation did not produce results
 
 
@@ -2667,15 +2690,15 @@ Group returnStatement failed
             relation Expr_ok failed
             └── ../../../../spec-concrete/1-syntax.watsup:287.28-287.32
                 Case analysis on expression''' failed
-                └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:1173.18-1173.42
+                └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:1174.18-1174.42
                     Group callExpression-callable failed
-                    └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:1176.28-1176.45
+                    └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:1177.28-1177.45
                         Case analysis on callExpression failed
-                        └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:1212.8-1214.73
+                        └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:1213.8-1215.73
                             CallableType_ok: p TC |- callableTargetIR < (typeArgumentIR)*{typeArgumentIR <- typeArgumentIR*} >( (argumentIR)*{argumentIR <- argumentIR*} ): callableTypeIR <# (tid_inserted)*{tid_inserted <- tid_inserted*} >(# (id_default)*{id_default <- id_default*} ) failed
-                            └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:1212.8-1212.23
+                            └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:1213.8-1213.23
                                 relation CallableType_ok failed
-                                └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:1212.8-1212.23
+                                └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:1213.8-1213.23
                                     relation did not produce results
 
 
@@ -3529,17 +3552,17 @@ Case analysis on returnStatement failed
         relation Expr_ok failed
         └── ../../../../spec-concrete/1-syntax.watsup:287.28-287.32
             Case analysis on expression''' failed
-            └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:1173.18-1173.42
+            └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:1174.18-1174.42
                 Group callExpression-callable failed
-                └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:1176.28-1176.45
+                └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:1177.28-1177.45
                     Case analysis on callExpression failed
-                    └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:1176.13-1176.27
+                    └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:1177.13-1177.27
                         If (callTarget has type callableTarget) failed
-                        └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:1184.8-1186.72
+                        └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:1185.8-1187.72
                             CallableType_ok: p TC |- callableTargetIR < [] >( (argumentIR)*{argumentIR <- argumentIR*} ): callableTypeIR <# (tid_inserted)*{tid_inserted <- tid_inserted*} >(# (id_default)*{id_default <- id_default*} ) failed
-                            └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:1184.8-1184.23
+                            └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:1185.8-1185.23
                                 relation CallableType_ok failed
-                                └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:1184.8-1184.23
+                                └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:1185.8-1185.23
                                     relation did not produce results
 
 
@@ -4411,17 +4434,17 @@ If Type_wf: $bound(p, TC_0) |- typeIR holds failed
         relation Expr_ok failed
         └── ../../../../spec-concrete/1-syntax.watsup:287.28-287.32
             Case analysis on expression''' failed
-            └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:1173.18-1173.42
+            └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:1174.18-1174.42
                 Group callExpression-callable failed
-                └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:1176.28-1176.45
+                └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:1177.28-1177.45
                     Case analysis on callExpression failed
-                    └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:1176.13-1176.27
+                    └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:1177.13-1177.27
                         If (callTarget has type callableTarget) failed
-                        └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:1184.8-1186.72
+                        └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:1185.8-1187.72
                             CallableType_ok: p TC |- callableTargetIR < [] >( (argumentIR)*{argumentIR <- argumentIR*} ): callableTypeIR <# (tid_inserted)*{tid_inserted <- tid_inserted*} >(# (id_default)*{id_default <- id_default*} ) failed
-                            └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:1184.8-1184.23
+                            └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:1185.8-1185.23
                                 relation CallableType_ok failed
-                                └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:1184.8-1184.23
+                                └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:1185.8-1185.23
                                     relation did not produce results
 
 
@@ -4956,13 +4979,13 @@ Group  failed
 Error on run: ../../../../p4c/testdata/p4_16_errors/scope.p4
 relation Program_ok failed
 │ ··· omitting 40 traces ···
-../../../../spec-concrete/5.06.1-typing-expression.watsup:1176.28-1176.45
+../../../../spec-concrete/5.06.1-typing-expression.watsup:1177.28-1177.45
 Case analysis on callExpression failed
-└── ../../../../spec-concrete/5.06.1-typing-expression.watsup:1176.13-1176.27
+└── ../../../../spec-concrete/5.06.1-typing-expression.watsup:1177.13-1177.27
     If (callTarget has type callableTarget) failed
-    └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:1179.8-1179.68
+    └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:1180.8-1180.68
         CallableTarget_ok: p TC |- callableTarget : callableTargetIR failed
-        └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:1179.8-1179.25
+        └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:1180.8-1180.25
             relation CallableTarget_ok failed
             └── ../../../../spec-concrete/1-syntax.watsup:341.20-341.22
                 Case analysis on callableTarget failed
@@ -5135,7 +5158,30 @@ relation Enum_serializable_fields_ok failed
 
 
 >>> Running interpreter test (Program_ok) on ../../../../p4c/testdata/p4_16_errors/shift-int-non-const.p4
-Excluding file: ../../../../p4c/testdata/p4_16_errors/shift-int-non-const.p4
+Error on run: ../../../../p4c/testdata/p4_16_errors/shift-int-non-const.p4
+relation Program_ok failed
+│ ··· omitting 40 traces ···
+../../../../spec-concrete/5.06.1-typing-expression.watsup:600.13-600.28
+Group castExpression failed
+└── ../../../../spec-concrete/5.06.1-typing-expression.watsup:604.44-604.47
+    If ((tid)*{tid <- tid*} matches pattern []) failed
+    └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:605.6-605.40
+        If Type_wf: $bound(p, TC) |- typeIR_t holds failed
+        └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:607.6-607.53
+            Expr_ok: p TC |- expression : typedExpressionIR failed
+            └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:607.6-607.13
+                relation Expr_ok failed
+                └── ../../../../spec-concrete/1-syntax.watsup:287.28-287.32
+                    Case analysis on expression''' failed
+                    └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:1311.13-1311.37
+                        Group parenthesizedExpression failed
+                        └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:1313.6-1313.53
+                            Expr_ok: p TC |- expression : typedExpressionIR failed
+                            └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:1313.6-1313.13
+                                relation Expr_ok failed
+                                └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:1313.6-1313.13
+                                    relation did not produce results
+
 
 >>> Running interpreter test (Program_ok) on ../../../../p4c/testdata/p4_16_errors/shift_e.p4
 Error on run: ../../../../p4c/testdata/p4_16_errors/shift_e.p4
@@ -6240,4 +6286,4 @@ Group cons failed
                                     relation did not produce results
 
 
-Running interpreter test (Program_ok): [EXCLUDE] 51/310 (16.45%) [PASS] 0/310 (0.00%) [FAIL] 259/310 (83.55%)
+Running interpreter test (Program_ok): [EXCLUDE] 49/310 (15.81%) [PASS] 0/310 (0.00%) [FAIL] 261/310 (84.19%)

--- a/p4spec/test/run_sl_type_neg_p4c.expected
+++ b/p4spec/test/run_sl_type_neg_p4c.expected
@@ -944,7 +944,7 @@ Excluding file: ../../../../p4c/testdata/p4_16_errors/extract1.p4
 >>> Running interpreter test (Program_ok) on ../../../../p4c/testdata/p4_16_errors/factory-err2.p4
 Error on run: ../../../../p4c/testdata/p4_16_errors/factory-err2.p4
 relation Program_ok failed
-│ ··· omitting 42 traces ···
+│ ··· omitting 34 traces ···
 ../../../../spec-concrete/5.11-typing-declaration.watsup:1001.6-1001.14
 relation Decls_ok failed
 └── ../../../../spec-concrete/5.11-typing-declaration.watsup:995.11-995.14
@@ -1972,7 +1972,30 @@ Group statement failed
 
 
 >>> Running interpreter test (Program_ok) on ../../../../p4c/testdata/p4_16_errors/issue2260-1.p4
-Excluding file: ../../../../p4c/testdata/p4_16_errors/issue2260-1.p4
+Error on run: ../../../../p4c/testdata/p4_16_errors/issue2260-1.p4
+relation Program_ok failed
+│ ··· omitting 39 traces ···
+../../../../spec-concrete/5.10-typing-statement.watsup:729.8-729.40
+If $is_assignable_typeIR(typeIR) failed
+└── ../../../../spec-concrete/5.10-typing-statement.watsup:731.8-731.71
+    Expr_ok: (local) TC_0 |- expression_init : typedExpressionIR_init failed
+    └── ../../../../spec-concrete/5.10-typing-statement.watsup:731.8-731.15
+        relation Expr_ok failed
+        └── ../../../../spec-concrete/1-syntax.watsup:287.28-287.32
+            Case analysis on expression''' failed
+            └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:1173.18-1173.42
+                Group callExpression-callable failed
+                └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:1176.28-1176.45
+                    Case analysis on callExpression failed
+                    └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:1176.13-1176.27
+                        If (callTarget has type callableTarget) failed
+                        └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:1189.8-1190.87
+                            Call_ok: p TC |- callableTypeIR < [] # (tid_infer)*{tid_infer <- tid_infer*} >( (argumentIR)*{argumentIR <- argumentIR*} # (id_default)*{id_default <- id_default*} ): typeIR_ret < (typeArgumentIR_inferred)*{typeArgumentIR_inferred <- typeArgumentIR_inferred*} >( (argumentIR_cast)*{argumentIR_cast <- argumentIR_cast*} ) failed
+                            └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:1189.8-1189.15
+                                relation Call_ok failed
+                                └── ../../../../spec-concrete/5.06.1-typing-expression.watsup:1189.8-1189.15
+                                    relation did not produce results
+
 
 >>> Running interpreter test (Program_ok) on ../../../../p4c/testdata/p4_16_errors/issue2267.p4
 Error on run: ../../../../p4c/testdata/p4_16_errors/issue2267.p4
@@ -2691,7 +2714,30 @@ Error on run: ../../../../p4c/testdata/p4_16_errors/issue3271.p4
 ../../../../p4c/testdata/p4_16_errors/issue3271.p4:3.8-3.9: syntax error
 
 >>> Running interpreter test (Program_ok) on ../../../../p4c/testdata/p4_16_errors/issue3273.p4
-Excluding file: ../../../../p4c/testdata/p4_16_errors/issue3273.p4
+Error on run: ../../../../p4c/testdata/p4_16_errors/issue3273.p4
+relation Program_ok failed
+│ ··· omitting 9 traces ···
+../../../../spec-concrete/5.11-typing-declaration.watsup:472.13-472.37
+Group externObjectDeclaration failed
+└── ../../../../spec-concrete/5.11-typing-declaration.watsup:481.9-481.36
+    If ((externConstructorOrMethodPrototype')*{externConstructorOrMethodPrototype' <- externConstructorOrMethodPrototype'*} has type externConstructorPrototype*) failed
+    └── ../../../../spec-concrete/5.11-typing-declaration.watsup:486.9-486.31
+        If ((externConstructorOrMethodPrototype'')*{externConstructorOrMethodPrototype'' <- externConstructorOrMethodPrototype''*} has type externMethodPrototype*) failed
+        └── ../../../../spec-concrete/5.11-typing-declaration.watsup:499.6-500.68
+            ExternMethods_ok: TC_2 nameIR |- (externMethodPrototype)*{externMethodPrototype <- externMethodPrototype*} : TC_3 (externMethodPrototypeIR)*{externMethodPrototypeIR <- externMethodPrototypeIR*} failed
+            └── ../../../../spec-concrete/5.11-typing-declaration.watsup:499.6-499.22
+                relation ExternMethods_ok failed
+                └── ../../../../spec-concrete/5.12-typing-extern-method.watsup:82.20-82.23
+                    Case analysis on (externMethodPrototype)*{externMethodPrototype <- externMethodPrototype*} failed
+                    └── ../../../../spec-concrete/5.12-typing-extern-method.watsup:84.22-84.27
+                        Group cons failed
+                        └── ../../../../spec-concrete/5.12-typing-extern-method.watsup:87.6-88.72
+                            ExternMethod_ok: TC tid_extern |- externMethodPrototype_h : TC_1 externMethodPrototypeIR_h failed
+                            └── ../../../../spec-concrete/5.12-typing-extern-method.watsup:87.6-87.21
+                                relation ExternMethod_ok failed
+                                └── ../../../../spec-concrete/5.12-typing-extern-method.watsup:87.6-87.21
+                                    relation did not produce results
+
 
 >>> Running interpreter test (Program_ok) on ../../../../p4c/testdata/p4_16_errors/issue3282.p4
 Error on run: ../../../../p4c/testdata/p4_16_errors/issue3282.p4
@@ -6194,4 +6240,4 @@ Group cons failed
                                     relation did not produce results
 
 
-Running interpreter test (Program_ok): [EXCLUDE] 53/310 (17.10%) [PASS] 0/310 (0.00%) [FAIL] 257/310 (82.90%)
+Running interpreter test (Program_ok): [EXCLUDE] 51/310 (16.45%) [PASS] 0/310 (0.00%) [FAIL] 259/310 (83.55%)

--- a/p4spec/test/run_sl_type_pos_p4c.expected
+++ b/p4spec/test/run_sl_type_pos_p4c.expected
@@ -875,7 +875,7 @@ Run success: ../../../../p4c/testdata/p4_16_samples/hash-extern-bmv2.p4
 Run success: ../../../../p4c/testdata/p4_16_samples/hash_ubpf.p4
 
 >>> Running interpreter test (Program_ok) on ../../../../p4c/testdata/p4_16_samples/hashext.p4
-Run success: ../../../../p4c/testdata/p4_16_samples/hashext.p4
+Excluding file: ../../../../p4c/testdata/p4_16_samples/hashext.p4
 
 >>> Running interpreter test (Program_ok) on ../../../../p4c/testdata/p4_16_samples/hashext2.p4
 Run success: ../../../../p4c/testdata/p4_16_samples/hashext2.p4
@@ -3835,4 +3835,4 @@ Run success: ../../../../p4c/testdata/p4_16_samples/xdp_vlan_push_pop_ebpf-kerne
 >>> Running interpreter test (Program_ok) on ../../../../p4c/testdata/p4_16_samples/xor_test.p4
 Run success: ../../../../p4c/testdata/p4_16_samples/xor_test.p4
 
-Running interpreter test (Program_ok): [EXCLUDE] 96/1278 (7.51%) [PASS] 1182/1278 (92.49%) [FAIL] 0/1278 (0.00%)
+Running interpreter test (Program_ok): [EXCLUDE] 97/1278 (7.59%) [PASS] 1181/1278 (92.41%) [FAIL] 0/1278 (0.00%)

--- a/p4spec/test/struct.expected
+++ b/p4spec/test/struct.expected
@@ -12292,7 +12292,20 @@ relation ParameterTypes_wf: bound |- (parameterIR)*{parameterIR <- parameterIR*}
 
       1. The relation holds
 
-;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:25.1-28.74
+;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:25.1-28.81
+relation ReturnType_wf: bound |- typeIR_ret
+
+1. Group : bound |- typeIR_ret
+
+  1. If (Type_wf: bound |- typeIR_ret) holds, then
+
+    1. (Let typeIR_canon be $canon_typeIR(typeIR_ret))
+
+    2. If (((~$is_stringTypeIR(typeIR_canon) /\ ~$is_arbitraryIntTypeIR(typeIR_canon)) /\ ~$is_objectTypeIR(typeIR_canon))), then
+
+      1. The relation holds
+
+;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:30.1-33.74
 relation CallableType_wf: bound |- callableTypeIR
 
 1. Case analysis on callableTypeIR
@@ -12325,7 +12338,7 @@ relation CallableType_wf: bound |- callableTypeIR
 
         2. If ($nestable_definedFunction(typeIR))*{typeIR <- typeIR*}, then
 
-          1. If (Type_wf: bound |- typeIR_ret) holds, then
+          1. If (ReturnType_wf: bound |- typeIR_ret) holds, then
 
             1. The relation holds
 
@@ -12341,7 +12354,7 @@ relation CallableType_wf: bound |- callableTypeIR
 
         2. If ($nestable_externFunction(typeIR))*{typeIR <- typeIR*}, then
 
-          1. If (Type_wf: bound |- typeIR_ret) holds, then
+          1. If (ReturnType_wf: bound |- typeIR_ret) holds, then
 
             1. The relation holds
 
@@ -12353,7 +12366,7 @@ relation CallableType_wf: bound |- callableTypeIR
 
       1. If (ParameterTypes_wf: bound |- (parameterIR)*{parameterIR <- parameterIR*}) holds, then
 
-        1. If (Type_wf: bound |- typeIR_ret) holds, then
+        1. If (ReturnType_wf: bound |- typeIR_ret) holds, then
 
           1. The relation holds
 
@@ -12375,7 +12388,7 @@ relation CallableType_wf: bound |- callableTypeIR
 
             2. If ($nestable_externMethod(typeIR))*{typeIR <- typeIR*}, then
 
-              1. If (Type_wf: bound |- typeIR_ret) holds, then
+              1. If (ReturnType_wf: bound |- typeIR_ret) holds, then
 
                 1. The relation holds
 
@@ -12389,7 +12402,7 @@ relation CallableType_wf: bound |- callableTypeIR
 
             2. If ($nestable_externMethod(typeIR))*{typeIR <- typeIR*}, then
 
-              1. If (Type_wf: bound |- typeIR_ret) holds, then
+              1. If (ReturnType_wf: bound |- typeIR_ret) holds, then
 
                 1. The relation holds
 
@@ -12429,7 +12442,7 @@ relation CallableType_wf: bound |- callableTypeIR
 
       1. The relation holds
 
-;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:30.1-33.74
+;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:35.1-38.74
 relation CallableTypeDef_wf: bound |- callableTypeDefIR
 
 1. Group : bound |- callableTypeDefIR
@@ -12446,7 +12459,7 @@ relation CallableTypeDef_wf: bound |- callableTypeDefIR
 
       1. The relation holds
 
-;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:35.1-38.74
+;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:40.1-43.74
 relation ConstructorParameterType_wf: bound |- (_annotationList direction typeIR _nameIR _constantInitializerOptIR)
 
 1. If ((direction matches pattern ``EMPTY`)), then
@@ -12459,7 +12472,7 @@ relation ConstructorParameterType_wf: bound |- (_annotationList direction typeIR
 
         1. The relation holds
 
-;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:40.1-43.74
+;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:45.1-48.74
 relation ConstructorParameterTypes_wf: bound |- (parameterIR)*{parameterIR <- parameterIR*}
 
 1. Group : bound |- (parameterIR)*{parameterIR <- parameterIR*}
@@ -12472,7 +12485,7 @@ relation ConstructorParameterTypes_wf: bound |- (parameterIR)*{parameterIR <- pa
 
       1. The relation holds
 
-;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:45.1-48.74
+;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:50.1-53.74
 relation ConstructorType_wf: bound |- (constructor( (parameterIR)*{parameterIR <- parameterIR*} ): typeIR_object)
 
 1. Group externObjectTypeIR: bound |- (constructor( (parameterIR)*{parameterIR <- parameterIR*} ): typeIR_object)
@@ -12547,7 +12560,7 @@ relation ConstructorType_wf: bound |- (constructor( (parameterIR)*{parameterIR <
 
           1. The relation holds
 
-;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:50.1-53.74
+;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:55.1-58.74
 relation ConstructorTypeDef_wf: bound |- (constructor< (tid_tparam_expl)*{tid_tparam_expl <- tid_tparam_expl*} , (tid_tparam_impl)*{tid_tparam_impl <- tid_tparam_impl*} >( (parameterIR)*{parameterIR <- parameterIR*} ): typeIR_object)
 
 1. Group : bound |- (constructor< (tid_tparam_expl)*{tid_tparam_expl <- tid_tparam_expl*} , (tid_tparam_impl)*{tid_tparam_impl <- tid_tparam_impl*} >( (parameterIR)*{parameterIR <- parameterIR*} ): typeIR_object)
@@ -12562,14 +12575,14 @@ relation ConstructorTypeDef_wf: bound |- (constructor< (tid_tparam_expl)*{tid_tp
 
         1. The relation holds
 
-;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:77.1-79.53
+;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:82.1-84.53
 def $nestable_typedef(typeIR)
 
 1. (Let typeIR_canon be $canon_typeIR(typeIR))
 
 2. Return $nestable'_typedef(typeIR_canon)
 
-;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:80.1-82.53
+;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:85.1-87.53
 tbl def $nestable'_typedef(typeIR') =
 
   Row : ((bool) as typeIR) -> true:
@@ -12664,14 +12677,14 @@ tbl def $nestable'_typedef(typeIR') =
 
     1. Return false
 
-;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:105.1-107.54
+;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:110.1-112.54
 def $nestable_new(typeIR)
 
 1. (Let typeIR_canon be $canon_typeIR(typeIR))
 
 2. Return $nestable'_new(typeIR_canon)
 
-;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:108.1-110.54
+;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:113.1-115.54
 tbl def $nestable'_new(typeIR') =
 
   Row : ((bool) as typeIR) -> true:
@@ -12726,14 +12739,14 @@ tbl def $nestable'_new(typeIR') =
 
     1. Return false
 
-;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:129.1-131.57
+;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:134.1-136.57
 def $nestable_list(typeIR)
 
 1. (Let typeIR_canon be $canon_typeIR(typeIR))
 
 2. Return $nestable'_list(typeIR_canon)
 
-;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:132.1-134.57
+;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:137.1-139.57
 tbl def $nestable'_list(typeIR') =
 
   Row : ((bool) as typeIR) -> true:
@@ -12804,14 +12817,14 @@ tbl def $nestable'_list(typeIR') =
 
     1. Return false
 
-;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:154.1-156.58
+;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:159.1-161.58
 def $nestable_tuple(typeIR)
 
 1. (Let typeIR_canon be $canon_typeIR(typeIR))
 
 2. Return $nestable'_tuple(typeIR_canon)
 
-;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:157.1-159.58
+;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:162.1-164.58
 tbl def $nestable'_tuple(typeIR') =
 
   Row : ((bool) as typeIR) -> true:
@@ -12934,14 +12947,14 @@ tbl def $nestable'_tuple(typeIR') =
 
     1. Return false
 
-;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:184.1-186.65
+;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:189.1-191.65
 def $nestable_headerStack(typeIR)
 
 1. (Let typeIR_canon be $canon_typeIR(typeIR))
 
 2. Return $nestable'_headerStack(typeIR_canon)
 
-;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:187.1-189.65
+;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:192.1-194.65
 tbl def $nestable'_headerStack(typeIR') =
 
   Row : (nameTypeIR as typeIR) -> true:
@@ -12972,26 +12985,26 @@ tbl def $nestable'_headerStack(typeIR') =
 
     1. Return false
 
-;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:206.1-208.59
+;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:211.1-213.59
 def $nestable_struct(typeIR)
 
 1. (Let typeIR_canon be $canon_typeIR(typeIR))
 
 2. Return $nestable'_struct(typeIR_canon)
 
-;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:209.1-211.59
+;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:214.1-216.59
 def $nestable'_struct(typeIR)
 
 1. Return $nestable'_tuple(typeIR)
 
-;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:223.1-225.57
+;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:228.1-230.57
 def $nestable_header(typeIR)
 
 1. (Let typeIR_canon be $canon_typeIR(typeIR))
 
 2. Return $nestable'_header(typeIR_canon)
 
-;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:226.1-228.57
+;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:231.1-233.57
 tbl def $nestable'_header(typeIR') =
 
   Row : ((bool) as typeIR) -> true:
@@ -13078,14 +13091,14 @@ tbl def $nestable'_header(typeIR') =
 
     1. Return false
 
-;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:229.1-231.76
+;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:234.1-236.76
 def $nestable_struct_in_header(typeIR)
 
 1. (Let typeIR_canon be $canon_typeIR(typeIR))
 
 2. Return $nestable'_struct_in_header(typeIR_canon)
 
-;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:232.1-234.76
+;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:237.1-239.76
 tbl def $nestable'_struct_in_header(typeIR') =
 
   Row : ((bool) as typeIR) -> true:
@@ -13160,14 +13173,14 @@ tbl def $nestable'_struct_in_header(typeIR') =
 
     1. Return false
 
-;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:271.1-273.63
+;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:276.1-278.63
 def $nestable_headerUnion(typeIR)
 
 1. (Let typeIR_canon be $canon_typeIR(typeIR))
 
 2. Return $nestable'_headerUnion(typeIR_canon)
 
-;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:274.1-276.63
+;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:279.1-281.63
 tbl def $nestable'_headerUnion(typeIR') =
 
   Row : (nameTypeIR as typeIR) -> true:
@@ -13198,14 +13211,14 @@ tbl def $nestable'_headerUnion(typeIR') =
 
     1. Return false
 
-;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:293.1-295.68
+;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:298.1-300.68
 def $nestable_enum_serializable(typeIR)
 
 1. (Let typeIR_canon be $canon_typeIR(typeIR))
 
 2. Return $nestable'_enum_serializable(typeIR_canon)
 
-;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:296.1-298.68
+;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:301.1-303.68
 tbl def $nestable'_enum_serializable(typeIR'') =
 
   Row : ((int< _nat >) as typeIR) -> true:
@@ -13252,14 +13265,14 @@ tbl def $nestable'_enum_serializable(typeIR'') =
 
     1. Return false
 
-;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:299.1-301.89
+;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:304.1-306.89
 def $nestable_new_in_enum_serializable(typeIR)
 
 1. (Let typeIR_canon be $canon_typeIR(typeIR))
 
 2. Return $nestable'_new_in_enum_serializable(typeIR_canon)
 
-;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:302.1-304.89
+;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:307.1-309.89
 tbl def $nestable'_new_in_enum_serializable(typeIR') =
 
   Row : ((int< _nat >) as typeIR) -> true:
@@ -13306,14 +13319,14 @@ tbl def $nestable'_new_in_enum_serializable(typeIR') =
 
     1. Return false
 
-;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:396.1-398.54
+;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:401.1-403.54
 def $nestable_set(typeIR)
 
 1. (Let typeIR_canon be $canon_typeIR(typeIR))
 
 2. Return $nestable'_set(typeIR_canon)
 
-;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:399.1-401.54
+;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:404.1-406.54
 tbl def $nestable'_set(typeIR'') =
 
   Row : ((bool) as typeIR) -> true:
@@ -13404,14 +13417,14 @@ tbl def $nestable'_set(typeIR'') =
 
     1. Return false
 
-;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:402.1-404.72
+;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:407.1-409.72
 def $nestable_tuple_in_set(typeIR)
 
 1. (Let typeIR_canon be $canon_typeIR(typeIR))
 
 2. Return $nestable'_tuple_in_set(typeIR_canon)
 
-;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:405.1-407.72
+;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:410.1-412.72
 tbl def $nestable'_tuple_in_set(typeIR'') =
 
   Row : ((bool) as typeIR) -> true:
@@ -13482,14 +13495,14 @@ tbl def $nestable'_tuple_in_set(typeIR'') =
 
     1. Return false
 
-;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:408.1-410.75
+;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:413.1-415.75
 def $nestable_sequence_in_set(typeIR)
 
 1. (Let typeIR_canon be $canon_typeIR(typeIR))
 
 2. Return $nestable'_sequence_in_set(typeIR_canon)
 
-;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:411.1-413.75
+;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:416.1-418.75
 tbl def $nestable'_sequence_in_set(typeIR'') =
 
   Row : ((bool) as typeIR) -> true:
@@ -13572,12 +13585,12 @@ tbl def $nestable'_sequence_in_set(typeIR'') =
 
     1. Return false
 
-;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:530.1-532.85
+;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:547.1-549.85
 def $directionless_trailing((direction)*{direction <- direction*})
 
 1. Return $directionless_trailing'(true, $rev_<direction>((direction)*{direction <- direction*}))
 
-;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:533.1-533.54
+;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:550.1-550.54
 def $directionless_trailing'(_bool, (direction')*{direction' <- direction'*})
 
 1. Case analysis on (direction')*{direction' <- direction'*}
@@ -13616,14 +13629,14 @@ def $directionless_trailing'(_bool, (direction')*{direction' <- direction'*})
 
         1. Return false
 
-;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:546.1-548.58
+;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:563.1-565.58
 def $nestable_action(typeIR)
 
 1. (Let typeIR_canon be $canon_typeIR(typeIR))
 
 2. Return $nestable'_action(typeIR_canon)
 
-;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:549.1-551.58
+;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:566.1-568.58
 tbl def $nestable'_action(typeIR') =
 
   Row : ((int) as typeIR) -> false:
@@ -13656,14 +13669,14 @@ tbl def $nestable'_action(typeIR') =
 
     1. Return true
 
-;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:570.1-572.67
+;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:587.1-589.67
 def $nestable_definedFunction(typeIR)
 
 1. (Let typeIR_canon be $canon_typeIR(typeIR))
 
 2. Return $nestable'_definedFunction(typeIR_canon)
 
-;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:573.1-575.67
+;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:590.1-592.67
 tbl def $nestable'_definedFunction(typeIR') =
 
   Row : (objectTypeIR as typeIR) -> false:
@@ -13686,14 +13699,14 @@ tbl def $nestable'_definedFunction(typeIR') =
 
     1. Return true
 
-;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:592.1-594.67
+;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:609.1-611.67
 def $nestable_externFunction(typeIR)
 
 1. (Let typeIR_canon be $canon_typeIR(typeIR))
 
 2. Return $nestable'_externFunction(typeIR_canon)
 
-;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:595.1-597.67
+;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:612.1-614.67
 tbl def $nestable'_externFunction(typeIR') =
 
   Row : (parserObjectTypeIR as typeIR) -> false:
@@ -13732,14 +13745,14 @@ tbl def $nestable'_externFunction(typeIR') =
 
     1. Return true
 
-;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:623.1-625.65
+;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:640.1-642.65
 def $nestable_externMethod(typeIR)
 
 1. (Let typeIR_canon be $canon_typeIR(typeIR))
 
 2. Return $nestable'_externMethod(typeIR_canon)
 
-;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:626.1-628.65
+;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:643.1-645.65
 tbl def $nestable'_externMethod(typeIR') =
 
   Row : (parserObjectTypeIR as typeIR) -> false:
@@ -13778,14 +13791,14 @@ tbl def $nestable'_externMethod(typeIR') =
 
     1. Return true
 
-;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:658.1-660.70
+;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:675.1-677.70
 def $nestable_parserApplyMethod(typeIR)
 
 1. (Let typeIR_canon be $canon_typeIR(typeIR))
 
 2. Return $nestable'_parserApplyMethod(typeIR_canon)
 
-;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:661.1-663.70
+;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:678.1-680.70
 tbl def $nestable'_parserApplyMethod(typeIR') =
 
   Row : (parserObjectTypeIR as typeIR) -> false:
@@ -13824,14 +13837,14 @@ tbl def $nestable'_parserApplyMethod(typeIR') =
 
     1. Return true
 
-;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:681.1-683.71
+;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:698.1-700.71
 def $nestable_controlApplyMethod(typeIR)
 
 1. (Let typeIR_canon be $canon_typeIR(typeIR))
 
 2. Return $nestable'_controlApplyMethod(typeIR_canon)
 
-;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:684.1-686.71
+;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:701.1-703.71
 tbl def $nestable'_controlApplyMethod(typeIR') =
 
   Row : (parserObjectTypeIR as typeIR) -> false:
@@ -13862,12 +13875,12 @@ tbl def $nestable'_controlApplyMethod(typeIR') =
 
     1. Return true
 
-;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:740.1-740.48
+;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:757.1-757.48
 def $nestable_constructor_extern(typeIR)
 
 1. Return $nestable'_constructor_extern($canon_typeIR(typeIR))
 
-;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:741.1-741.53
+;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:758.1-758.53
 tbl def $nestable'_constructor_extern(typeIR') =
 
   Row : (parserObjectTypeIR as typeIR) -> false:
@@ -13906,12 +13919,12 @@ tbl def $nestable'_constructor_extern(typeIR') =
 
     1. Return true
 
-;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:760.1-760.48
+;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:777.1-777.48
 def $nestable_constructor_parser(typeIR)
 
 1. Return $nestable'_constructor_parser($canon_typeIR(typeIR))
 
-;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:761.1-761.53
+;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:778.1-778.53
 tbl def $nestable'_constructor_parser(typeIR') =
 
   Row : (controlObjectTypeIR as typeIR) -> false:
@@ -13942,12 +13955,12 @@ tbl def $nestable'_constructor_parser(typeIR') =
 
     1. Return true
 
-;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:779.1-779.49
+;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:796.1-796.49
 def $nestable_constructor_control(typeIR)
 
 1. Return $nestable'_constructor_control($canon_typeIR(typeIR))
 
-;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:780.1-780.54
+;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:797.1-797.54
 tbl def $nestable'_constructor_control(typeIR') =
 
   Row : (parserObjectTypeIR as typeIR) -> false:
@@ -13978,12 +13991,12 @@ tbl def $nestable'_constructor_control(typeIR') =
 
     1. Return true
 
-;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:798.1-798.49
+;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:815.1-815.49
 def $nestable_constructor_package(typeIR)
 
 1. Return $nestable'_constructor_package($canon_typeIR(typeIR))
 
-;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:799.1-799.50
+;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:816.1-816.50
 def $nestable'_constructor_package(typeIR)
 
 1. If ((typeIR has type tableObjectTypeIR)), then
@@ -13996,12 +14009,12 @@ def $nestable'_constructor_package(typeIR)
 
   1. Return true
 
-;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:819.1-819.42
+;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:836.1-836.42
 def $definable_constructor(typeIR)
 
 1. Return $definable'_constructor($canon_typeIR(typeIR))
 
-;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:820.1-820.47
+;; ../../../../spec-concrete/5.03-typing-wellformed.watsup:837.1-837.47
 tbl def $definable'_constructor(typeIR') =
 
   Row : (externObjectTypeIR as typeIR) -> true:

--- a/p4spec/test/struct.expected
+++ b/p4spec/test/struct.expected
@@ -16056,11 +16056,13 @@ relation Expr_ok: p TC |- expression''' : %
 
           6. If ($is_fixedBitTypeIR(typeIR_r_reduced)), then
 
-            1. (Let ctk_reduced be $join_ctk(ctk_l_reduced, ctk_r_reduced))
+            1. If (($is_arbitraryIntTypeIR(typeIR_l_reduced) => (ctk_r_reduced = (lctk)))), then
 
-            2. (Let expressionNoteIR be (( typeIR_l_reduced ctk_reduced )))
+              1. (Let ctk_reduced be $join_ctk(ctk_l_reduced, ctk_r_reduced))
 
-            3. Result in : % % |- % : (((typedExpressionIR_l_reduced binop typedExpressionIR_r_reduced) as expressionIR) # expressionNoteIR)
+              2. (Let expressionNoteIR be (( typeIR_l_reduced ctk_reduced )))
+
+              3. Result in : % % |- % : (((typedExpressionIR_l_reduced binop typedExpressionIR_r_reduced) as expressionIR) # expressionNoteIR)
 
           7. If ((ctk_r_reduced matches pattern `LCTK`)), then
 
@@ -22342,12 +22344,12 @@ def $compat'_shift(typeIR, typeIR')
 
   1. Return false
 
-;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:403.1-403.43
+;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:404.1-404.43
 def $compat_compare(typeIR_l, typeIR_r)
 
 1. Return $compat'_compare($canon_typeIR(typeIR_l), $canon_typeIR(typeIR_r))
 
-;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:404.1-404.44
+;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:405.1-405.44
 def $compat'_compare(typeIR, typeIR')
 
 1. If ((typeIR has type integerTypeIR)), then
@@ -22402,12 +22404,12 @@ def $compat'_compare(typeIR, typeIR')
 
   1. Return false
 
-;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:441.1-441.43
+;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:442.1-442.43
 def $compat_bitwise(typeIR_l, typeIR_r)
 
 1. Return $compat'_bitwise($canon_typeIR(typeIR_l), $canon_typeIR(typeIR_r))
 
-;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:442.1-442.44
+;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:443.1-443.44
 def $compat'_bitwise(typeIR, typeIR')
 
 1. If ((typeIR has type integerTypeIR)), then
@@ -22452,12 +22454,12 @@ def $compat'_bitwise(typeIR, typeIR')
 
   1. Return false
 
-;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:478.1-478.42
+;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:479.1-479.42
 def $compat_concat(typeIR_l, typeIR_r)
 
 1. Return $compat'_concat($canon_typeIR(typeIR_l), $canon_typeIR(typeIR_r))
 
-;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:479.1-479.43
+;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:480.1-480.43
 def $compat'_concat(typeIR, typeIR')
 
 1. Case analysis on typeIR
@@ -22526,12 +22528,12 @@ def $compat'_concat(typeIR, typeIR')
 
   1. Return false
 
-;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:491.1-491.45
+;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:492.1-492.45
 def $result_concat(typeIR_l, typeIR_r)
 
 1. Return $result'_concat($canon_typeIR(typeIR_l), $canon_typeIR(typeIR_r))
 
-;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:492.1-492.46
+;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:493.1-493.46
 def $result'_concat(typeIR, typeIR')
 
 1. Case analysis on typeIR
@@ -22600,12 +22602,12 @@ def $result'_concat(typeIR, typeIR')
 
   1. Return ?()
 
-;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:535.1-535.43
+;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:536.1-536.43
 def $compat_logical(typeIR_l, typeIR_r)
 
 1. Return $compat'_logical($canon_typeIR(typeIR_l), $canon_typeIR(typeIR_r))
 
-;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:536.1-536.44
+;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:537.1-537.44
 def $compat'_logical(typeIR, typeIR')
 
 1. If ((typeIR has type boolTypeIR)), then
@@ -22622,12 +22624,12 @@ def $compat'_logical(typeIR, typeIR')
 
   1. Return false
 
-;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:976.1-976.39
+;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:977.1-977.39
 def $compat_array_index(typeIR)
 
 1. Return $compat'_arrayindex($canon_typeIR(typeIR))
 
-;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:977.1-977.39
+;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:978.1-978.39
 def $compat'_arrayindex(typeIR)
 
 1. If ((typeIR has type integerTypeIR)), then
@@ -22656,12 +22658,12 @@ def $compat'_arrayindex(typeIR)
 
   1. Return false
 
-;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:1080.1-1080.41
+;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:1081.1-1081.41
 def $compat_bitslice_base(typeIR)
 
 1. Return $compat'_bitslice_base($canon_typeIR(typeIR))
 
-;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:1081.1-1081.42
+;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:1082.1-1082.42
 def $compat'_bitslice_base(typeIR)
 
 1. If ((typeIR has type integerTypeIR)), then
@@ -22690,12 +22692,12 @@ def $compat'_bitslice_base(typeIR)
 
   1. Return false
 
-;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:1091.1-1091.42
+;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:1092.1-1092.42
 def $compat_bitslice_index(typeIR)
 
 1. Return $compat'_bitslice_index($canon_typeIR(typeIR))
 
-;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:1092.1-1092.43
+;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:1093.1-1093.43
 def $compat'_bitslice_index(typeIR)
 
 1. If ((typeIR has type integerTypeIR)), then
@@ -22724,12 +22726,12 @@ def $compat'_bitslice_index(typeIR)
 
   1. Return false
 
-;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:1102.1-1102.48
+;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:1103.1-1103.48
 def $is_valid_bitslice(typeIR, n_lo, n_hi)
 
 1. Return ((n_lo <= n_hi) /\ $is_valid_bitslice'($canon_typeIR(typeIR), n_lo, n_hi))
 
-;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:1103.1-1103.49
+;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:1104.1-1104.49
 def $is_valid_bitslice'(typeIR, _nat, _nat')
 
 1. If ((typeIR has type integerTypeIR)), then
@@ -22770,12 +22772,12 @@ def $is_valid_bitslice'(typeIR, _nat, _nat')
 
   1. Return false
 
-;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:1235.1-1235.46
+;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:1236.1-1236.46
 def $is_concrete_extern_object(typeIR)
 
 1. Return $is_concrete_extern_object'($canon_typeIR(typeIR))
 
-;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:1236.1-1236.47
+;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:1237.1-1237.47
 def $is_concrete_extern_object'(typeIR)
 
 1. If (~$is_externObjectTypeIR(typeIR)), then
@@ -22794,7 +22796,7 @@ def $is_concrete_extern_object'(typeIR)
 
   1. Return false
 
-;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:1237.1-1237.63
+;; ../../../../spec-concrete/5.06.1-typing-expression.watsup:1238.1-1238.63
 def $is_concrete_extern_object''(externMethodTypeDefIR)
 
 1. If ((externMethodTypeDefIR matches pattern `EXTERN_METHOD<%,%>(%):%`)), then

--- a/spec-concrete/5.03-typing-wellformed.watsup
+++ b/spec-concrete/5.03-typing-wellformed.watsup
@@ -22,6 +22,11 @@ relation ParameterTypes_wf:
   hint(input %0 %1)
   hint(prose_true %1 "is a well-formed type, assuming bound type ids" %0)
 
+relation ReturnType_wf:
+  bound |- typeIR
+  hint(input %0 %1)
+  hint(prose_true %1 "is a well-formed return type, assuming bound type ids" %0)
+
 relation CallableType_wf:
   bound |- callableTypeIR
   hint(input %0 %1)
@@ -522,6 +527,18 @@ rule ParameterTypes_wf:
   -- (ParameterType_wf: bound |- parameterIR)*
 
 ;;
+;;;; Well-formedness of return types
+;;
+
+rule ReturnType_wf:
+  bound |- typeIR_ret
+  -- Type_wf: bound |- typeIR_ret
+  -- if typeIR_canon = $canon_typeIR(typeIR_ret)
+  -- if ~$is_stringTypeIR(typeIR_canon)
+        /\ ~$is_arbitraryIntTypeIR(typeIR_canon)
+        /\ ~$is_objectTypeIR(typeIR_canon)
+
+;;
 ;;;; Well-formedness of callable types
 ;;
 
@@ -587,7 +604,7 @@ rule CallableType_wf/definedFunctionTypeIR:
   -- ParameterTypes_wf: bound |- parameterIR*
   -- if (_ _ typeIR _ _ = parameterIR)* 
   -- if $nestable_definedFunction(typeIR)*
-  -- Type_wf: bound |- typeIR_ret
+  -- ReturnType_wf: bound |- typeIR_ret
 
 dec $nestable_externFunction(typeIR) : bool
   hint(prose_true %0 "can be used in an extern function type")
@@ -611,14 +628,14 @@ rule CallableType_wf/externFunctionTypeIR:
   -- ParameterTypes_wf: bound |- parameterIR*
   -- if (_ _ typeIR _ _ = parameterIR)* 
   -- if $nestable_externFunction(typeIR)*
-  -- Type_wf: bound |- typeIR_ret
+  -- ReturnType_wf: bound |- typeIR_ret
 
 ;;; Method types
 
 rule CallableType_wf/builtinMethodTypeIR:
   bound |- BUILTIN_METHOD `( parameterIR* ) `: typeIR_ret
   -- ParameterTypes_wf: bound |- parameterIR*
-  -- Type_wf: bound |- typeIR_ret
+  -- ReturnType_wf: bound |- typeIR_ret
 
 dec $nestable_externMethod(typeIR) : bool
   hint(prose_true %0 "can be used in an extern method type")
@@ -644,14 +661,14 @@ rulegroup CallableType_wf/externMethodTypeIR {
     -- ParameterTypes_wf: bound |- parameterIR*
     -- if (_ _ typeIR _ _ = parameterIR)* 
     -- if $nestable_externMethod(typeIR)*
-    -- Type_wf: bound |- typeIR_ret
+    -- ReturnType_wf: bound |- typeIR_ret
 
   rule CallableType_wf/abstract:
     bound |- EXTERN_METHOD ABSTRACT `( parameterIR* ) `: typeIR_ret
     -- ParameterTypes_wf: bound |- parameterIR*
     -- if (_ _ typeIR _ _ = parameterIR)* 
     -- if $nestable_externMethod(typeIR)*
-    -- Type_wf: bound |- typeIR_ret
+    -- ReturnType_wf: bound |- typeIR_ret
 
 }
 

--- a/spec-concrete/5.06.1-typing-expression.watsup
+++ b/spec-concrete/5.06.1-typing-expression.watsup
@@ -332,8 +332,7 @@ rulegroup Expr_ok/binaryExpression-shift {
           = $reduce_serenum_binary(
               typedExpressionIR_l,
               typedExpressionIR_r,
-              def $compat_shift
-            )
+              def $compat_shift)
     ---- ;; fetch annotations
     -- if typeIR_l_reduced = $type_of_typedExpressionIR(typedExpressionIR_l_reduced)
     -- if ctk_l_reduced = $ctk_of_typedExpressionIR(typedExpressionIR_l_reduced)
@@ -341,6 +340,9 @@ rulegroup Expr_ok/binaryExpression-shift {
     -- if ctk_r_reduced = $ctk_of_typedExpressionIR(typedExpressionIR_r_reduced)
     ---- ;; check that the right-hand side is fixed bit type
     -- if $is_fixedBitTypeIR(typeIR_r_reduced)
+    ---- ;; check that if the left-hand side is int type,
+    ---- ;; the right-hand side is local compile-time known
+    -- if $is_arbitraryIntTypeIR(typeIR_l_reduced) => (ctk_r_reduced = LCTK)
     ---- ;; create typed expression
     -- if ctk_reduced = $join_ctk(ctk_l_reduced, ctk_r_reduced)
     -- if expressionNoteIR = `( typeIR_l_reduced ctk_reduced )
@@ -358,8 +360,7 @@ rulegroup Expr_ok/binaryExpression-shift {
           = $reduce_serenum_binary(
               typedExpressionIR_l,
               typedExpressionIR_r,
-              def $compat_shift
-            )
+              def $compat_shift)
     ---- ;; fetch annotations
     -- if typeIR_l_reduced = $type_of_typedExpressionIR(typedExpressionIR_l_reduced)
     -- if ctk_l_reduced = $ctk_of_typedExpressionIR(typedExpressionIR_l_reduced)


### PR DESCRIPTION
Fixes #65, to enforce at the type-checking level that expressions of type `int` must be local compile-time known.

## Adds well-formedness check for return types

```
rule ReturnType_wf:
  bound |- typeIR_ret
  -- Type_wf: bound |- typeIR_ret
  -- if typeIR_canon = $canon_typeIR(typeIR_ret)
  -- if ~$is_stringTypeIR(typeIR_canon)
        /\ ~$is_arbitraryIntTypeIR(typeIR_canon)
        /\ ~$is_objectTypeIR(typeIR_canon)
```

## Checks that if a shift expression produces an `int` type, the rhs must be local compile-time known

```
  rule Expr_ok/rhs-fixbit:
    p TC |- expression_l binop expression_r
          : (typedExpressionIR_l_reduced binop typedExpressionIR_r_reduced) `# expressionNoteIR
    -- if binop <- [ `<< , `>> ]
    ---- ;; check both sides
    -- Expr_ok: p TC |- expression_l : typedExpressionIR_l
    -- Expr_ok: p TC |- expression_r : typedExpressionIR_r
    ---- ;; check that the types are compatible
    ---- ;; while inserting implicit casts if necessary
    -- if (typedExpressionIR_l_reduced, typedExpressionIR_r_reduced)
          = $reduce_serenum_binary(
              typedExpressionIR_l,
              typedExpressionIR_r,
              def $compat_shift)
    ---- ;; fetch annotations
    -- if typeIR_l_reduced = $type_of_typedExpressionIR(typedExpressionIR_l_reduced)
    -- if ctk_l_reduced = $ctk_of_typedExpressionIR(typedExpressionIR_l_reduced)
    -- if typeIR_r_reduced = $type_of_typedExpressionIR(typedExpressionIR_r_reduced)
    -- if ctk_r_reduced = $ctk_of_typedExpressionIR(typedExpressionIR_r_reduced)
    ---- ;; check that the right-hand side is fixed bit type
    -- if $is_fixedBitTypeIR(typeIR_r_reduced)
    ---- ;; check that if the left-hand side is int type,
    ---- ;; the right-hand side is local compile-time known
    -- if $is_arbitraryIntTypeIR(typeIR_l_reduced) => (ctk_r_reduced = LCTK)
    ---- ;; create typed expression
    -- if ctk_reduced = $join_ctk(ctk_l_reduced, ctk_r_reduced)
    -- if expressionNoteIR = `( typeIR_l_reduced ctk_reduced )
```

Yet, [issue2496.p4](https://github.com/p4lang/p4c/blob/main/testdata/p4_16_errors/issue2496.p4) remains as an excluded test.

```p4
control ingress(inout Headers h) {
    apply {
        // this expression will slow the compiler to a crawl to print a warning
        h.eth_hdr.eth_type =  1985245330 << 903012108;
    }
}
```

The mechanized spec does local compile-time evaluation only when necessary, thus the shift expression above is not evaluated during type checking. While in contrast, P4C does.