### PR TITLE
Fix: Directionless action parameters are not compile-time known

### DIFF
--- a/spec-concrete/5-typing/5.02.1-typing-context.watsup
+++ b/spec-concrete/5-typing/5.02.1-typing-context.watsup
@@ -205,15 +205,33 @@ def $add_vars_t(p, TC, id_h :: id_t*, varTypeIR_h :: varTypeIR_t*) = TC''
 ;;; Adder for parameters
 
 dec $add_parameter_t(cursor, typingContext, parameterIR) : typingContext
+dec $add_parameters_t(cursor, typingContext, parameterIR*) : typingContext
   hint(prose_in %2 "added to the" %0 "layer of" %1)
 
+;; Fix for directionless parameters in actions (p4lang/p4c#5405, p4-spectec#37)
+;; Per P4-16 spec §18.1: directionless action parameters are control-plane supplied (DYN),
+;; not compile-time known, unlike directionless parameters of other callables (CTK).
+
+;; Directionless parameter in NON-action context → CTK
 def $add_parameter_t(cursor, TC, _ `EMPTY typeIR id (`= value)?) = TC'
+  -- if ~$is_action_localKind(TC.LOCAL.KIND)
   -- if varTypeIR = `EMPTY typeIR CTK value?
   -- if TC' = $add_var_t(cursor, TC, id, varTypeIR)
+;; Directionless parameter in ACTION context → DYN
+def $add_parameter_t(cursor, TC, _ `EMPTY typeIR id (`= value)?) = TC'
+  -- if $is_action_localKind(TC.LOCAL.KIND)
+  -- if varTypeIR = `EMPTY typeIR DYN value?
+  -- if TC' = $add_var_t(cursor, TC, id, varTypeIR)
+;; Directed parameters (IN, OUT, INOUT) → DYN (unchanged)
 def $add_parameter_t(cursor, TC, _ direction typeIR id (`= value)?) = TC'
   -- if direction =/= `EMPTY
   -- if varTypeIR = direction typeIR DYN value?
   -- if TC' = $add_var_t(cursor, TC, id, varTypeIR)
+
+def $add_parameters_t(cursor, TC, eps) = TC
+def $add_parameters_t(cursor, TC, parameterIR_h :: parameterIR_t*) = TC''
+  -- if TC' = $add_parameter_t(cursor, TC, parameterIR_h)
+  -- if TC'' = $add_parameters_t(cursor, TC', parameterIR_t*)
 
 ;;; Adder for constructor parameters
 

--- a/testdata/typing-negative/directionless-action-arg-not-ctk.p4
+++ b/testdata/typing-negative/directionless-action-arg-not-ctk.p4
@@ -1,0 +1,115 @@
+
+/*
+Test case for P4-SpecTec issue #37:
+Directionless parameters of actions are NOT compile-time known.
+
+This program MUST be REJECTED by P4-SpecTec.
+
+The bug: P4-SpecTec was incorrectly treating all directionless parameters
+as compile-time known (CTK), when per P4-16 spec §18.1, directionless
+parameters of actions are control-plane supplied (DYN).
+
+The extern method `count(bit<8> idx)` has a directionless parameter `idx`,
+which requires a compile-time known argument (CTK).
+
+The action `a1(bit<8> idx)` has a directionless parameter `idx`, which
+is control-plane supplied (DYN).
+
+When `a1` calls `ctr.count(idx)`, it passes a DYN value to a CTK parameter,
+which is a type error per the P4-16 specification.
+
+References:
+- P4C issue: p4lang/p4c#5405
+- P4-SpecTec issue: kaist-plrg/p4-spectec#37
+*/
+
+#include <core.p4>
+#include <v1model.p4>
+
+// Extern with a directionless parameter (requires CTK argument)
+extern Counter {
+    Counter(bit<32> size);
+    void count(bit<8> idx);  // idx is directionless → caller MUST pass CTK
+}
+
+header hdr_t {
+    bit<8> f;
+}
+
+struct metadata_t {
+}
+
+struct headers_t {
+    hdr_t head;
+}
+
+parser parserImpl(packet_in packet,
+                  out headers_t hdr,
+                  inout metadata_t meta,
+                  inout standard_metadata_t stdmeta)
+{
+    state start {
+        packet.extract(hdr.head);
+        transition accept;
+    }
+}
+
+control ingressImpl(inout headers_t hdr,
+                    inout metadata_t meta,
+                    inout standard_metadata_t stdmeta)
+{
+    Counter(256) ctr;
+
+    // a0 is OK: passes compile-time constant (LCTK) to extern method
+    action a0() {
+        ctr.count(0);  // ✓ 0 is LCTK → OK
+    }
+
+    // a1 is INVALID: passes control-plane parameter (DYN) to CTK extern parameter
+    action a1(bit<8> idx) {
+        ctr.count(idx);  // ❌ idx is DYN, but count() requires CTK → ERROR
+    }
+
+    table t {
+        key = { hdr.head.f : exact; }
+        actions = { a0; a1; }
+        default_action = a0();
+    }
+
+    apply {
+        t.apply();
+    }
+}
+
+control egressImpl(inout headers_t hdr,
+                   inout metadata_t meta,
+                   inout standard_metadata_t stdmeta)
+{
+    apply {
+    }
+}
+
+control deparserImpl(packet_out packet,
+                     in headers_t hdr)
+{
+    apply {
+        packet.emit(hdr.head);
+    }
+}
+
+control verifyChecksum(inout headers_t hdr, inout metadata_t meta) {
+    apply {
+    }
+}
+
+control updateChecksum(inout headers_t hdr, inout metadata_t meta) {
+    apply {
+    }
+}
+
+V1Switch(parserImpl(),
+         verifyChecksum(),
+         ingressImpl(),
+         egressImpl(),
+         updateChecksum(),
+         deparserImpl()) main;

--- a/testdata/typing-positive/action-constant-ctk.p4
+++ b/testdata/typing-positive/action-constant-ctk.p4
@@ -1,0 +1,116 @@
+/*
+Test case for P4-SpecTec issue #37 (positive/passing case):
+Actions with compile-time constant arguments ARE allowed.
+
+This program MUST be ACCEPTED by P4-SpecTec.
+
+This test ensures that the fix for issue #37 does not regress the
+valid case where an action calls an extern method with a compile-time
+constant (literal) value.
+
+The extern method `count(bit<8> idx)` requires a compile-time known argument.
+The action `a0` passes literal 0, 1, 2, 3 which are LCTK (local compile-time known).
+This is valid and must be accepted.
+
+References:
+- P4C issue: p4lang/p4c#5405
+- P4-SpecTec issue: kaist-plrg/p4-spectec#37
+*/
+
+#include <core.p4>
+#include <v1model.p4>
+
+// Extern with a directionless parameter (requires CTK argument)
+extern Counter {
+    Counter(bit<32> size);
+    void count(bit<8> idx);  // idx is directionless → caller MUST pass CTK
+}
+
+header hdr_t {
+    bit<8> f;
+}
+
+struct metadata_t {
+}
+
+struct headers_t {
+    hdr_t head;
+}
+
+parser parserImpl(packet_in packet,
+                  out headers_t hdr,
+                  inout metadata_t meta,
+                  inout standard_metadata_t stdmeta)
+{
+    state start {
+        packet.extract(hdr.head);
+        transition accept;
+    }
+}
+
+control ingressImpl(inout headers_t hdr,
+                    inout metadata_t meta,
+                    inout standard_metadata_t stdmeta)
+{
+    Counter(256) ctr;
+
+    // All these actions are OK: they pass compile-time constants (LCTK)
+    action a0() {
+        ctr.count(0);  // ✓ 0 is LCTK → OK
+    }
+
+    action a1() {
+        ctr.count(1);  // ✓ 1 is LCTK → OK
+    }
+
+    action a2() {
+        ctr.count(2);  // ✓ 2 is LCTK → OK
+    }
+
+    action a3() {
+        ctr.count(3);  // ✓ 3 is LCTK → OK
+    }
+
+    table t {
+        key = { hdr.head.f : exact; }
+        actions = { a0; a1; a2; a3; }
+        default_action = a0();
+    }
+
+    apply {
+        t.apply();
+    }
+}
+
+control egressImpl(inout headers_t hdr,
+                   inout metadata_t meta,
+                   inout standard_metadata_t stdmeta)
+{
+    apply {
+    }
+}
+
+control deparserImpl(packet_out packet,
+                     in headers_t hdr)
+{
+    apply {
+        packet.emit(hdr.head);
+    }
+}
+
+control verifyChecksum(inout headers_t hdr, inout metadata_t meta) {
+    apply {
+    }
+}
+
+control updateChecksum(inout headers_t hdr, inout metadata_t meta) {
+    apply {
+    }
+}
+
+V1Switch(parserImpl(),
+         verifyChecksum(),
+         ingressImpl(),
+         egressImpl(),
+         updateChecksum(),
+         deparserImpl()) main;


### PR DESCRIPTION
## Summary

Fixes kaist-plrg/p4-spectec#37 (corresponding to p4lang/p4c#5405).

Per P4-16 §18.1, directionless parameters of **actions** are control-plane
supplied and therefore **not compile-time known (DYN)**. This differs from
directionless parameters of other callables (functions, controls, parsers,
extern methods), which are **compile-time known (CTK)**.

P4-SpecTec previously treated all directionless parameters as CTK, causing
programs to be accepted that should be rejected.

## Changes

- Updated `$add_parameter_t` in  
  `spec-concrete/5-typing/5.02.1-typing-context.watsup` to distinguish
  action vs non-action contexts using `TC.LOCAL.KIND`:
  - Non-action context → CTK (unchanged behavior)
  - Action context → DYN (new, spec-correct behavior)
- Added a negative test that is now correctly rejected:
  - `testdata/typing-negative/directionless-action-arg-not-ctk.p4`
- Added a positive regression test that remains accepted:
  - `testdata/typing-positive/action-constant-ctk.p4`

## Validation

- Verified spec elaboration succeeds
- Verified the negative test fails to derive `Program_ok`
- Verified the positive test still derives `Program_ok`
- Behavior matches both P4C and the P4-16 specification

## References

- kaist-plrg/p4-spectec#37
- p4lang/p4c#5405
- P4-16 Language Specification, §18.1
