### PR TITLE
Support ternary match on bool (#54)

### DIFF
--- a/excludes/static/bug/ternary-match-on-bool.exclude
+++ b/excludes/static/bug/ternary-match-on-bool.exclude
@@ -1,1 +1,0 @@
-p4c/testdata/p4_16_samples/psa-bool-ternary-const-entry-bmv2.p4

--- a/spec-concrete/5-typing/5.14.1-typing-control-table.watsup
+++ b/spec-concrete/5-typing/5.14.1-typing-control-table.watsup
@@ -17,6 +17,7 @@ tbl def $compat_table_exact_optional_key =
 
 tbl dec $compat_table_lpm_ternary_range_key(typeIR) : bool
 tbl def $compat_table_lpm_ternary_range_key =
+  | BOOL => true
   | INT => true
   | INT `< _ > => true
   | BIT `< _ > => true


### PR DESCRIPTION
**Summary**
Add BOOL to the set of types compatible with ternary, lpm, and range match kinds in table key declarations, and remove the corresponding test exclusion.

Closes #54.

**Problem**
The test 
psa-bool-ternary-const-entry-bmv2.p4
 (from [p4lang/p4c#5199](https://github.com/p4lang/p4c/pull/5199)) was excluded because P4-SpecTec rejected bool-typed keys with ternary match kind. The root cause was that $compat_table_lpm_ternary_range_key did not include a BOOL case, causing type-checking to fail at $compat_table_key("ternary", BOOL).

**Changes**
spec-concrete/5-typing/5.14.1-typing-control-table.watsup
Added | BOOL => true to $compat_table_lpm_ternary_range_key:


tbl def $compat_table_lpm_ternary_range_key =
+  | BOOL => true
   | INT => true
   | INT `< _ > => true
   | BIT `< _ > => true

excludes/static/bug/ternary-match-on-bool.exclude
Deleted — the test is no longer excluded.

**Note** on diff stats: GitHub may show ~1130 insertions / 1130 deletions for 
5.14.1-typing-control-table.watsup
. This is a line-ending artifact (CRLF → LF normalization on Windows/WSL), not actual content changes. The only semantic change is the single | BOOL => true line addition. You can verify with git diff --ignore-cr-at-eol which shows exactly 1 line added.

**Why this is sufficient**
For a const entry like (true) in a ternary key:


1. Typing: The entry is a plain expression (not a mask &&&), so TableEntry_keyset_simple_ok/non-lpm fires. It casts the expression to the key type via Cast_impl: BOOL -> BOOL (trivially succeeds) and lifts to SET < BOOL >, which is well-formed ($nestable_set(BOOL) = true).
2. Evaluation: The entry evaluates to SET { B true } — a singleton exact set. Matching uses $match_keyset(SET { value }, value_key) = $bin_eq(value, value_key), and $bin_eq already handles boolValue. The ternary mask path ($bin_band) is never reached.


No changes to $compat_mask, $bin_band, or any evaluation rules are needed.

**Testing**
make build passes
psa-bool-ternary-const-entry-bmv2.p4
 now passes the Program_inst interpreter test:
>>> Running interpreter test (Program_inst) on psa-bool-ternary-const-entry-bmv2.p4
success: psa-bool-ternary-const-entry-bmv2.p4
