### PR TITLE
fix: treat directionless action parameters as DYN not CTK

### DIFF
--- a/spec-concrete/5-typing/5.02.1-typing-context.watsup
+++ b/spec-concrete/5-typing/5.02.1-typing-context.watsup
@@ -174,6 +174,11 @@ dec $add_parameter_t(cursor, typingContext, parameterIR) : typingContext
   hint(prose_in %2 "added to the" %0 "layer of" %1)
 
 def $add_parameter_t(cursor, TC, _ `EMPTY typeIR id _) = TC'
+  -- if ACTION = TC.LOCAL.KIND
+  -- if varTypeIR = `EMPTY typeIR DYN eps
+  -- if TC' = $add_var_t(cursor, TC, id, varTypeIR)
+def $add_parameter_t(cursor, TC, _ `EMPTY typeIR id _) = TC'
+  -- if ACTION =/= TC.LOCAL.KIND
   -- if varTypeIR = `EMPTY typeIR CTK eps
   -- if TC' = $add_var_t(cursor, TC, id, varTypeIR)
 def $add_parameter_t(cursor, TC, _ direction typeIR id _) = TC'

--- a/testdata/typing-negative/control-directionless-ctk-required.p4
+++ b/testdata/typing-negative/control-directionless-ctk-required.p4
@@ -1,0 +1,85 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Negative test: directionless parameters of non-action callables
+(controls, parsers, functions) must be compile-time known (CTK).
+Per P4-16 spec Section 18.1, passing a runtime value to a
+directionless control parameter should be rejected.
+*/
+#include <core.p4>
+#include <v1model.p4>
+
+header ethernet_t {
+    bit<48> dstAddr;
+    bit<48> srcAddr;
+    bit<16> etherType;
+}
+
+struct metadata_t { }
+
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+parser parserImpl(packet_in packet,
+                  out headers_t hdr,
+                  inout metadata_t meta,
+                  inout standard_metadata_t stdmeta) {
+    state start {
+        packet.extract(hdr.ethernet);
+        transition accept;
+    }
+}
+
+// inner control has a directionless parameter
+// callers MUST supply a compile-time known value
+control inner(inout headers_t hdr,
+              inout metadata_t meta,
+              inout standard_metadata_t stdmeta,
+              bit<9> port) {
+    apply {
+        stdmeta.egress_spec = port;
+    }
+}
+
+control ingressImpl(inout headers_t hdr,
+                    inout metadata_t meta,
+                    inout standard_metadata_t stdmeta) {
+    inner() i;
+
+    apply {
+        // hdr.ethernet.srcAddr[8:0] is a runtime value - NOT CTK
+        // passing it to directionless control param should be REJECTED
+        i.apply(hdr, meta, stdmeta, hdr.ethernet.srcAddr[8:0]);
+    }
+}
+
+control egressImpl(inout headers_t hdr,
+                   inout metadata_t meta,
+                   inout standard_metadata_t stdmeta) {
+    apply { }
+}
+
+control deparserImpl(packet_out packet, in headers_t hdr) {
+    apply {
+        packet.emit(hdr.ethernet);
+    }
+}
+
+control verifyChecksum(inout headers_t hdr, inout metadata_t meta) {
+    apply { }
+}
+
+control updateChecksum(inout headers_t hdr, inout metadata_t meta) {
+    apply { }
+}
+
+V1Switch(parserImpl(),
+         verifyChecksum(),
+         ingressImpl(),
+         egressImpl(),
+         updateChecksum(),
+         deparserImpl()) main;

--- a/testdata/typing-positive/action-directionless-ctk-also-ok.p4
+++ b/testdata/typing-positive/action-directionless-ctk-also-ok.p4
@@ -1,0 +1,83 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Positive test: directionless parameters of actions (DYN) should
+still accept compile-time known values. DYN means "accepts anything"
+not "rejects constants". This test verifies our fix does not break
+the case where a compile-time constant is passed to an action param.
+*/
+#include <core.p4>
+#include <v1model.p4>
+
+header ethernet_t {
+    bit<48> dstAddr;
+    bit<48> srcAddr;
+    bit<16> etherType;
+}
+
+struct metadata_t { }
+
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+parser parserImpl(packet_in packet,
+                  out headers_t hdr,
+                  inout metadata_t meta,
+                  inout standard_metadata_t stdmeta) {
+    state start {
+        packet.extract(hdr.ethernet);
+        transition accept;
+    }
+}
+
+control ingressImpl(inout headers_t hdr,
+                    inout metadata_t meta,
+                    inout standard_metadata_t stdmeta) {
+    // directionless param on action
+    action set_port(bit<9> port) {
+        stdmeta.egress_spec = port;
+    }
+
+    table t {
+        key = { hdr.ethernet.etherType : exact; }
+        actions = { set_port; }
+        // compile-time constant passed to directionless action param
+        // DYN accepts both runtime AND compile-time values - should PASS
+        const default_action = set_port(9w1);
+    }
+
+    apply {
+        t.apply();
+    }
+}
+
+control egressImpl(inout headers_t hdr,
+                   inout metadata_t meta,
+                   inout standard_metadata_t stdmeta) {
+    apply { }
+}
+
+control deparserImpl(packet_out packet, in headers_t hdr) {
+    apply {
+        packet.emit(hdr.ethernet);
+    }
+}
+
+control verifyChecksum(inout headers_t hdr, inout metadata_t meta) {
+    apply { }
+}
+
+control updateChecksum(inout headers_t hdr, inout metadata_t meta) {
+    apply { }
+}
+
+V1Switch(parserImpl(),
+         verifyChecksum(),
+         ingressImpl(),
+         egressImpl(),
+         updateChecksum(),
+         deparserImpl()) main;

--- a/testdata/typing-positive/action-directionless-dyn.p4
+++ b/testdata/typing-positive/action-directionless-dyn.p4
@@ -1,0 +1,83 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Positive test: directionless parameters of actions should be treated
+as DYN (not CTK), meaning they accept runtime values.
+Per P4-16 spec Section 18.1, directionless action parameters are
+control-plane supplied and not required to be compile-time known.
+*/
+#include <core.p4>
+#include <v1model.p4>
+
+header ethernet_t {
+    bit<48> dstAddr;
+    bit<48> srcAddr;
+    bit<16> etherType;
+}
+
+struct metadata_t { }
+
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+parser parserImpl(packet_in packet,
+                  out headers_t hdr,
+                  inout metadata_t meta,
+                  inout standard_metadata_t stdmeta) {
+    state start {
+        packet.extract(hdr.ethernet);
+        transition accept;
+    }
+}
+
+control ingressImpl(inout headers_t hdr,
+                    inout metadata_t meta,
+                    inout standard_metadata_t stdmeta) {
+    // directionless param on action - should accept runtime values
+    // because action directionless params are DYN per spec Section 18.1
+    action set_port(bit<9> port) {
+        stdmeta.egress_spec = port;
+    }
+
+    table t {
+        key = { hdr.ethernet.etherType : exact; }
+        actions = { set_port; }
+    }
+
+    apply {
+        // hdr.ethernet.srcAddr[8:0] is a runtime value
+        // passing it to directionless action param should be ACCEPTED
+        set_port(hdr.ethernet.srcAddr[8:0]);
+    }
+}
+
+control egressImpl(inout headers_t hdr,
+                   inout metadata_t meta,
+                   inout standard_metadata_t stdmeta) {
+    apply { }
+}
+
+control deparserImpl(packet_out packet, in headers_t hdr) {
+    apply {
+        packet.emit(hdr.ethernet);
+    }
+}
+
+control verifyChecksum(inout headers_t hdr, inout metadata_t meta) {
+    apply { }
+}
+
+control updateChecksum(inout headers_t hdr, inout metadata_t meta) {
+    apply { }
+}
+
+V1Switch(parserImpl(),
+         verifyChecksum(),
+         ingressImpl(),
+         egressImpl(),
+         updateChecksum(),
+         deparserImpl()) main;


### PR DESCRIPTION
## Summary

Directionless parameters of actions were being marked as CTK (compile-time known) 
regardless of context. Per P4-16 spec §18.1, directionless parameters of actions 
are supplied by the control plane at runtime and should not require CTK. Only 
directionless parameters of non-action callables (controls, parsers, functions) 
require CTK.

## Fix

In `$add_parameter_t` (`5.02.1-typing-context.watsup`), check `TC.LOCAL.KIND` 
before assigning CTK/DYN:
- If inside an ACTION → mark directionless parameter as DYN
- Otherwise → keep CTK

This pattern already exists at line 462 of the same file.

## Tests

- `typing-positive/action-directionless-dyn.p4` : action directionless param 
  accepts runtime value (the bug case)
- `typing-negative/control-directionless-ctk-required.p4` :  control directionless 
  param correctly rejects runtime value
- `typing-positive/action-directionless-ctk-also-ok.p4` : action directionless 
  param still accepts compile-time constants (DYN accepts both)

## PNA Test Failures

During investigation  observed that all 31 PNA test programs in 
`p4c/testdata/p4_16_samples/pna-*.p4` fail. After thorough investigation I
confirmed these failures are pre-existing and unrelated to this fix , a minimal 
PNA program with no externs or special features fails identically on the `concrete` 
branch without this fix, with `ConstructorType_ok` failing on `PNA_NIC`. This is 
because PNA has no architecture file in `spec-concrete/9-arch/` unlike V1Model, 
eBPF, and PSA.

Related: p4lang/p4c#5405