### PR TITLE
Add table entries with qualified action names

### DIFF
--- a/p4spec/lib/backend-sim/v1model/pipe.ml
+++ b/p4spec/lib/backend-sim/v1model/pipe.ml
@@ -23,7 +23,7 @@ struct
              ~replacement:"main.eg")
     in
     let transform_matches = List.map Stf.Transform.Match.rewrite_valid in
-    let transform_action = Stf.Transform.Action.into_unqualified in
+    let transform_action (name, args) = (transform_name name, args) in
     match stmt with
     | Add (name, priority_opt, mtches, action, id_opt) ->
         let name = transform_name name in

--- a/p4spec/lib/interp/builtin/call.ml
+++ b/p4spec/lib/interp/builtin/call.ml
@@ -29,6 +29,7 @@ let funcs =
   (* Texts *)
   |> Funcs.add "text_to_int" Texts.text_to_int
   |> Funcs.add "int_to_text" Texts.int_to_text
+  |> Funcs.add "split_text" Texts.split_text
   |> Funcs.add "strip_prefix" Texts.strip_prefix
   |> Funcs.add "strip_suffix" Texts.strip_suffix
   |> Funcs.add "strip_all_whitespace" Texts.strip_all_whitespace

--- a/p4spec/lib/interp/builtin/texts.ml
+++ b/p4spec/lib/interp/builtin/texts.ml
@@ -25,6 +25,24 @@ let int_to_text (add : value -> unit) (at : region) (targs : targ list)
   add value;
   value
 
+(* dec $split_text(text, text) : text* *)
+
+let split_text (add : value -> unit) (at : region) (targs : targ list)
+    (values_input : value list) : value =
+  Extract.zero at targs;
+  let value_text, value_separator = Extract.two at values_input in
+  let text = Value.get_text value_text in
+  let separator = Value.get_text value_separator in
+  assert (String.length separator = 1);
+  let parts = String.split_on_char (String.get separator 0) text in
+  let values = List.map (fun part -> Value.make Il.TextT (TextV part)) parts in
+  let value =
+    let typ = Il.IterT (Il.TextT $ no_region, Il.List) in
+    Value.make typ (ListV values)
+  in
+  add value;
+  value
+
 (* dec $strip_prefix(text, text) : text *)
 
 let strip_prefix (add : value -> unit) (at : region) (targs : targ list)

--- a/p4spec/test/lang/elab.expected
+++ b/p4spec/test/lang/elab.expected
@@ -7379,8 +7379,10 @@ syntax tableKeyIR =
 
 syntax tableKeyListIR = tableKeyIR*
 
+syntax controlPlaneNameIR = nameIR*
+
 syntax tableActionReferenceIR = 
-   | prefixedNameIR ( argumentListIR )
+   | prefixedNameIR controlPlaneNameIR ( argumentListIR )
 
 syntax tableActionIR = 
    | annotationList tableActionReferenceIR #( parameterListIR , parameterListIR );
@@ -14475,7 +14477,7 @@ relation TableAction_ok: typingContext tableContext |- tableAction : tableContex
     -- Call_action_partial_ok: TC |- parameterIR*{parameterIR <- parameterIR*} @ [] : parameterIR_data*{parameterIR_data <- parameterIR_data*} , parameterIR_control*{parameterIR_control <- parameterIR_control*} @ argumentIR'*{argumentIR' <- argumentIR'*}
     -- if argumentIR'*{argumentIR' <- argumentIR'*} matches []
     -- let TBLC_1 = $add_action_tbl(TBLC_0, prefixedNameIR, parameterIR*{parameterIR <- parameterIR*}, [])
-    -- let tableActionIR = annotationList_update prefixedNameIR ( [] ) #( parameterIR_data*{parameterIR_data <- parameterIR_data*} , parameterIR_control*{parameterIR_control <- parameterIR_control*} );
+    -- let tableActionIR = annotationList_update prefixedNameIR [] ( [] ) #( parameterIR_data*{parameterIR_data <- parameterIR_data*} , parameterIR_control*{parameterIR_control <- parameterIR_control*} );
     -- output: % % |- % : TBLC_1 tableActionIR
 
     rulepath prefixedNonTypeName-argumentList
@@ -14493,7 +14495,7 @@ relation TableAction_ok: typingContext tableContext |- tableAction : tableContex
     -- ArgumentList_ok: local TC |- argumentList : argumentIR*{argumentIR <- argumentIR*}
     -- Call_action_partial_ok: TC |- parameterIR*{parameterIR <- parameterIR*} @ argumentIR*{argumentIR <- argumentIR*} : parameterIR_data*{parameterIR_data <- parameterIR_data*} , parameterIR_control*{parameterIR_control <- parameterIR_control*} @ argumentIR_cast*{argumentIR_cast <- argumentIR_cast*}
     -- let TBLC_1 = $add_action_tbl(TBLC_0, prefixedNameIR, parameterIR*{parameterIR <- parameterIR*}, argumentIR_cast*{argumentIR_cast <- argumentIR_cast*})
-    -- let tableActionIR = annotationList_update prefixedNameIR ( argumentIR_cast*{argumentIR_cast <- argumentIR_cast*} ) #( parameterIR_data*{parameterIR_data <- parameterIR_data*} , parameterIR_control*{parameterIR_control <- parameterIR_control*} );
+    -- let tableActionIR = annotationList_update prefixedNameIR [] ( argumentIR_cast*{argumentIR_cast <- argumentIR_cast*} ) #( parameterIR_data*{parameterIR_data <- parameterIR_data*} , parameterIR_control*{parameterIR_control <- parameterIR_control*} );
     -- output: % % |- % : TBLC_1 tableActionIR
 
 relation TableActions_ok: typingContext tableContext |- tableAction* : tableContext tableActionListIR
@@ -14556,7 +14558,7 @@ relation TableDefaultAction_ok: typingContext tableContext |- initializer : tabl
     -- let prefixedNonTypeName = expression' as prefixedNonTypeName
     -- let prefixedNameIR = $prefixedNonTypeName(prefixedNonTypeName)
     -- if (?(([], [])) = $find_action(TBLC, prefixedNameIR))
-    -- output: % % |- % : prefixedNameIR ( [] )
+    -- output: % % |- % : prefixedNameIR [] ( [] )
 
     rulepath prefixedNonTypeName-argumentList
     -- let expression' = expression
@@ -14575,7 +14577,7 @@ relation TableDefaultAction_ok: typingContext tableContext |- initializer : tabl
     -- let argumentIR_action_data*{argumentIR_action_data <- argumentIR_action_data*} = argumentIR_action*{argumentIR_action <- argumentIR_action*}[0 : |parameterIR_action_data*{parameterIR_action_data <- parameterIR_action_data*}|]
     -- let argumentIR_cast_data*{argumentIR_cast_data <- argumentIR_cast_data*} = argumentIR_cast*{argumentIR_cast <- argumentIR_cast*}[0 : |parameterIR_action_data*{parameterIR_action_data <- parameterIR_action_data*}|]
     -- (if (argumentIR_action_data = argumentIR_cast_data))*{argumentIR_action_data <- argumentIR_action_data*, argumentIR_cast_data <- argumentIR_cast_data*}
-    -- output: % % |- % : prefixedNameIR ( argumentIR_cast*{argumentIR_cast <- argumentIR_cast*} )
+    -- output: % % |- % : prefixedNameIR [] ( argumentIR_cast*{argumentIR_cast <- argumentIR_cast*} )
 
 relation TableEntry_keyset_ok: typingContext tableContext |- keysetExpression : tableEntryState keysetExpressionIR
 
@@ -14774,7 +14776,7 @@ relation TableEntry_action_ok: typingContext tableContext |- tableActionReferenc
     -- let prefixedNonTypeName = tableActionReference' as prefixedNonTypeName
     -- let prefixedNameIR = $prefixedNonTypeName(prefixedNonTypeName)
     -- if (?(([], [])) = $find_action(TBLC, prefixedNameIR))
-    -- output: % % |- % : prefixedNameIR ( [] )
+    -- output: % % |- % : prefixedNameIR [] ( [] )
 
     rulepath prefixedNonTypeName-argumentList
     -- let tableActionReference' = tableActionReference
@@ -14789,7 +14791,7 @@ relation TableEntry_action_ok: typingContext tableContext |- tableActionReferenc
     -- let argumentIR_action_data*{argumentIR_action_data <- argumentIR_action_data*} = argumentIR_action*{argumentIR_action <- argumentIR_action*}[0 : |parameterIR_action_data*{parameterIR_action_data <- parameterIR_action_data*}|]
     -- let argumentIR_cast_data*{argumentIR_cast_data <- argumentIR_cast_data*} = argumentIR_cast*{argumentIR_cast <- argumentIR_cast*}[0 : |parameterIR_action_data*{parameterIR_action_data <- parameterIR_action_data*}|]
     -- (if (argumentIR_action_data = argumentIR_cast_data))*{argumentIR_action_data <- argumentIR_action_data*, argumentIR_cast_data <- argumentIR_cast_data*}
-    -- output: % % |- % : prefixedNameIR ( argumentIR_cast*{argumentIR_cast <- argumentIR_cast*} )
+    -- output: % % |- % : prefixedNameIR [] ( argumentIR_cast*{argumentIR_cast <- argumentIR_cast*} )
 
 relation TableEntry_priority_ok: typingContext tableContext tableEntryState |- tableEntryPriority? : tableContext tableEntryPriorityOptIR
 
@@ -15169,7 +15171,7 @@ relation Table_ok: typingContext |- tableProperty* : tableContext tablePropertyL
     -- if (|$filter_<tableProperty>(tableProperty*{tableProperty <- tableProperty*}, $is_tableDefaultActionProperty(tableProperty)*{tableProperty <- tableProperty*})| = 0)
     -- let TBLC_0 = $empty_tableContext
     -- TableProperties_ok: TC TBLC_0 |- tableProperty*{tableProperty <- tableProperty*} : TBLC_1 tablePropertyIR*{tablePropertyIR <- tablePropertyIR*}
-    -- let tablePropertyIR_default_action = `empty ?() default_action= ` "NoAction" ( [] ) ; as tablePropertyIR
+    -- let tablePropertyIR_default_action = `empty ?() default_action= ` "NoAction" [] ( [] ) ; as tablePropertyIR
     -- let (TBLC_2, tablePropertyIR_updated*{tablePropertyIR_updated <- tablePropertyIR_updated*}) = $insert_NoAction_tablePropertyIR(TBLC_1, tablePropertyIR*{tablePropertyIR <- tablePropertyIR*})
     -- output: % |- % : TBLC_2 tablePropertyIR_updated*{tablePropertyIR_updated <- tablePropertyIR_updated*} ++ [tablePropertyIR_default_action]
 
@@ -19038,7 +19040,7 @@ def $insert_NoAction_tablePropertyIR(tableContext, tablePropertyIR*) : (tableCon
   -- if tablePropertyIR' <: tableActionsPropertyIR
   -- let actions={ tableActionIR*{tableActionIR <- tableActionIR*} } = tablePropertyIR' as tableActionsPropertyIR
   -- (let _annotationList tableActionReferenceIR #( _parameterListIR , _parameterListIR' ); = tableActionIR)*{tableActionIR <- tableActionIR*, _annotationList -> _annotationList*, _parameterListIR -> _parameterListIR*, _parameterListIR' -> _parameterListIR'*, tableActionReferenceIR -> tableActionReferenceIR*}
-  -- let tableActionReferenceIR_NoAction = . "NoAction" ( [] )
+  -- let tableActionReferenceIR_NoAction = . "NoAction" [] ( [] )
   -- if ~tableActionReferenceIR_NoAction <- tableActionReferenceIR*{tableActionReferenceIR <- tableActionReferenceIR*}
   -- let TBLC_1 = $add_action_tbl(TBLC_0, . "NoAction", [], [])
   -- let tableActionIR_NoAction = `empty tableActionReferenceIR_NoAction #( [] , [] );
@@ -19051,7 +19053,7 @@ def $insert_NoAction_tablePropertyIR(tableContext, tablePropertyIR*) : (tableCon
   -- if tablePropertyIR' <: tableActionsPropertyIR
   -- let actions={ tableActionIR*{tableActionIR <- tableActionIR*} } = tablePropertyIR' as tableActionsPropertyIR
   -- (let _annotationList tableActionReferenceIR #( _parameterListIR , _parameterListIR' ); = tableActionIR)*{tableActionIR <- tableActionIR*, _annotationList -> _annotationList*, _parameterListIR -> _parameterListIR*, _parameterListIR' -> _parameterListIR'*, tableActionReferenceIR -> tableActionReferenceIR*}
-  -- let tableActionReferenceIR_NoAction = . "NoAction" ( [] )
+  -- let tableActionReferenceIR_NoAction = . "NoAction" [] ( [] )
   -- if tableActionReferenceIR_NoAction <- tableActionReferenceIR*{tableActionReferenceIR <- tableActionReferenceIR*}
 
   clause 3 : (TBLC_0, tablePropertyIR*{tablePropertyIR <- tablePropertyIR*}) = (TBLC_1, tablePropertyIR_h :: tablePropertyIR_t_updated*{tablePropertyIR_t_updated <- tablePropertyIR_t_updated*})
@@ -19658,7 +19660,7 @@ syntax storageReference =
    | storageReference [ value : value ]
 
 syntax actionDef = 
-   | action nameIR ( parameterListIR ) blockStatementIR
+   | annotationList action nameIR ( parameterListIR ) blockStatementIR
 
 syntax definedFunctionDef = 
    | function nameIR < typeParameterListIR >( parameterListIR ) blockStatementIR
@@ -19691,7 +19693,7 @@ syntax methodDef =
    | table_apply{ tablePropertyListIR }
 
 syntax callableDef = 
-   | action nameIR ( parameterListIR ) blockStatementIR
+   | annotationList action nameIR ( parameterListIR ) blockStatementIR
    | function nameIR < typeParameterListIR >( parameterListIR ) blockStatementIR
    | extern_function nameIR < typeParameterListIR >( parameterListIR )
    | extern_method nameIR < typeParameterListIR >( parameterListIR ) blockStatementIR?
@@ -19716,7 +19718,7 @@ def $parameterListIR_of_callableDef(callableDef) : parameterIR* =
 
 def $parameterListIR_of_actionDef(actionDef) : parameterIR* =
 
-  clause 0 : (action _nameIR ( parameterListIR ) _blockStatementIR) = parameterListIR
+  clause 0 : (annotationList action _nameIR ( parameterListIR ) _blockStatementIR) = parameterListIR
 
 def $parameterListIR_of_functionDef(functionDef) : parameterIR* =
 
@@ -21771,7 +21773,7 @@ relation ActionDecl_inst: cursor instContext |- actionDeclarationIR : instContex
 
     rulepath 
     -- let callableId = $callableId_IR(nameIR, parameterListIR)
-    -- let actionDef = action nameIR ( parameterListIR ) blockStatementIR
+    -- let actionDef = annotationList action nameIR ( parameterListIR ) blockStatementIR
     -- let IC_1 = $add_callableDef_non_overload_i(p, IC_0, callableId, actionDef as callableDef)
     -- output: % % |- % : IC_1
 
@@ -25439,7 +25441,7 @@ relation Table_eval: evalContext arch |- typeId tableObjectProperty : evalContex
     -- TableMatches_eval: EC_1 ARCH_1 |- tableKeyValue*{tableKeyValue <- tableKeyValue*} @ tableEntryListIR : EC_2 ARCH_2 tableMatchesResult
     -- if tableMatchesResult <: continueResult<tableMatch*>
     -- let ` tableMatch*{tableMatch <- tableMatch*} = tableMatchesResult as continueResult<tableMatch*>
-    -- let prefixedNameIR ( argumentListIR ) = $select_action(TBL, tableMatch*{tableMatch <- tableMatch*})
+    -- let prefixedNameIR _controlPlaneNameIR ( argumentListIR ) = $select_action(TBL, tableMatch*{tableMatch <- tableMatch*})
     -- Stmt_eval: local EC_2 ARCH_2 |- prefixedNameIR as callableTargetIR < [] >( argumentListIR ); as statementIR : EC_3 ARCH_3 statementResult
     -- if statementResult <: exitResult
     -- let exitResult = statementResult as exitResult
@@ -25455,7 +25457,7 @@ relation Table_eval: evalContext arch |- typeId tableObjectProperty : evalContex
     -- TableMatches_eval: EC_1 ARCH_1 |- tableKeyValue*{tableKeyValue <- tableKeyValue*} @ tableEntryListIR : EC_2 ARCH_2 tableMatchesResult
     -- if tableMatchesResult <: continueResult<tableMatch*>
     -- let ` tableMatch*{tableMatch <- tableMatch*} = tableMatchesResult as continueResult<tableMatch*>
-    -- let prefixedNameIR ( argumentListIR ) = $select_action(TBL, tableMatch*{tableMatch <- tableMatch*})
+    -- let prefixedNameIR _controlPlaneNameIR ( argumentListIR ) = $select_action(TBL, tableMatch*{tableMatch <- tableMatch*})
     -- Stmt_eval: local EC_2 ARCH_2 |- prefixedNameIR as callableTargetIR < [] >( argumentListIR ); as statementIR : EC_3 ARCH_3 statementResult
     -- if statementResult <: continueEmptyResult
     -- let continueEmptyResult = statementResult as continueEmptyResult
@@ -25672,7 +25674,7 @@ relation Callee_eval: cursor evalContext arch |- callableTargetIR <_>( argumentL
     -- let ?(_callableId : (cursor, callableDef) # id_default*{id_default <- id_default*} # _nameIR*{_nameIR <- _nameIR*}) = callResolution<(cursor, callableDef)>?{callResolution<(cursor, callableDef)> <- callResolution<(cursor, callableDef)>?}
     -- if (cursor, callableDef) <: (cursor, actionDef)
     -- let (p_ref, actionDef) = (cursor, callableDef) as (cursor, actionDef)
-    -- let action nameIR ( parameterListIR ) blockStatementIR = actionDef
+    -- let _annotationList action nameIR ( parameterListIR ) blockStatementIR = actionDef
     -- let actionCallee = action p_ref . nameIR ( parameterListIR # id_default*{id_default <- id_default*} ) blockStatementIR
     -- output: % % % |- % <_>( % ): EC ARCH ` actionCallee as callee as calleeResult
 
@@ -28591,7 +28593,7 @@ def $find_tableActionIR_by_name(tableActionIR*, nameIR) : (nameIR, tableActionIR
   clause 1 : (tableActionIR*{tableActionIR <- tableActionIR*}, nameIR_target) = ?((nameIR_action, tableActionIR_h))
   -- if tableActionIR*{tableActionIR <- tableActionIR*} matches _ :: _
   -- let tableActionIR_h :: tableActionIR_t*{tableActionIR_t <- tableActionIR_t*} = tableActionIR*{tableActionIR <- tableActionIR*}
-  -- let annotationList prefixedNameIR ( argumentIR_data*{argumentIR_data <- argumentIR_data*} ) #( _parameterListIR , parameterIR_control*{parameterIR_control <- parameterIR_control*} ); = tableActionIR_h
+  -- let annotationList prefixedNameIR _controlPlaneNameIR ( argumentIR_data*{argumentIR_data <- argumentIR_data*} ) #( _parameterListIR , parameterIR_control*{parameterIR_control <- parameterIR_control*} ); = tableActionIR_h
   -- let nameIR_action = $flatten_prefixedNameIR(prefixedNameIR)
   -- if ([] = $name_annotation(annotationList))
   -- if (nameIR_action = nameIR_target)
@@ -28599,7 +28601,7 @@ def $find_tableActionIR_by_name(tableActionIR*, nameIR) : (nameIR, tableActionIR
   clause 2 : (tableActionIR*{tableActionIR <- tableActionIR*}, nameIR_target) = $find_tableActionIR_by_name(tableActionIR_t*{tableActionIR_t <- tableActionIR_t*}, nameIR_target)
   -- if tableActionIR*{tableActionIR <- tableActionIR*} matches _ :: _
   -- let tableActionIR_h :: tableActionIR_t*{tableActionIR_t <- tableActionIR_t*} = tableActionIR*{tableActionIR <- tableActionIR*}
-  -- let annotationList prefixedNameIR ( argumentIR_data*{argumentIR_data <- argumentIR_data*} ) #( _parameterListIR , parameterIR_control*{parameterIR_control <- parameterIR_control*} ); = tableActionIR_h
+  -- let annotationList prefixedNameIR _controlPlaneNameIR ( argumentIR_data*{argumentIR_data <- argumentIR_data*} ) #( _parameterListIR , parameterIR_control*{parameterIR_control <- parameterIR_control*} ); = tableActionIR_h
   -- let nameIR_action = $flatten_prefixedNameIR(prefixedNameIR)
   -- if ([] = $name_annotation(annotationList))
   -- if (nameIR_action =/= nameIR_target)
@@ -28607,7 +28609,7 @@ def $find_tableActionIR_by_name(tableActionIR*, nameIR) : (nameIR, tableActionIR
   clause 3 : (tableActionIR*{tableActionIR <- tableActionIR*}, nameIR) = ?((nameIR_action, tableActionIR_h))
   -- if tableActionIR*{tableActionIR <- tableActionIR*} matches _ :: _
   -- let tableActionIR_h :: tableActionIR_t*{tableActionIR_t <- tableActionIR_t*} = tableActionIR*{tableActionIR <- tableActionIR*}
-  -- let annotationList prefixedNameIR ( argumentIR_data*{argumentIR_data <- argumentIR_data*} ) #( _parameterListIR , parameterIR_control*{parameterIR_control <- parameterIR_control*} ); = tableActionIR_h
+  -- let annotationList prefixedNameIR _controlPlaneNameIR ( argumentIR_data*{argumentIR_data <- argumentIR_data*} ) #( _parameterListIR , parameterIR_control*{parameterIR_control <- parameterIR_control*} ); = tableActionIR_h
   -- let nameIR_action = $flatten_prefixedNameIR(prefixedNameIR)
   -- let nameIR_annotation*{nameIR_annotation <- nameIR_annotation*} = $name_annotation(annotationList)
   -- if (nameIR_annotation*{nameIR_annotation <- nameIR_annotation*} =/= [])
@@ -28617,7 +28619,7 @@ def $find_tableActionIR_by_name(tableActionIR*, nameIR) : (nameIR, tableActionIR
   clause 4 : (tableActionIR*{tableActionIR <- tableActionIR*}, nameIR) = $find_tableActionIR_by_name(tableActionIR_t*{tableActionIR_t <- tableActionIR_t*}, nameIR)
   -- if tableActionIR*{tableActionIR <- tableActionIR*} matches _ :: _
   -- let tableActionIR_h :: tableActionIR_t*{tableActionIR_t <- tableActionIR_t*} = tableActionIR*{tableActionIR <- tableActionIR*}
-  -- let annotationList prefixedNameIR ( argumentIR_data*{argumentIR_data <- argumentIR_data*} ) #( _parameterListIR , parameterIR_control*{parameterIR_control <- parameterIR_control*} ); = tableActionIR_h
+  -- let annotationList prefixedNameIR _controlPlaneNameIR ( argumentIR_data*{argumentIR_data <- argumentIR_data*} ) #( _parameterListIR , parameterIR_control*{parameterIR_control <- parameterIR_control*} ); = tableActionIR_h
   -- let nameIR_action = $flatten_prefixedNameIR(prefixedNameIR)
   -- let nameIR_annotation*{nameIR_annotation <- nameIR_annotation*} = $name_annotation(annotationList)
   -- if (nameIR_annotation*{nameIR_annotation <- nameIR_annotation*} =/= [])
@@ -28632,13 +28634,13 @@ def $find_tableActionIR_by_dotPrefix(tableActionIR*, nameIR) : (nameIR, tableAct
   clause 1 : (tableActionIR*{tableActionIR <- tableActionIR*}, nameIR_target) = $find_tableActionIR_by_dotPrefix(tableActionIR_t*{tableActionIR_t <- tableActionIR_t*}, nameIR_target)
   -- if tableActionIR*{tableActionIR <- tableActionIR*} matches _ :: _
   -- let tableActionIR_h :: tableActionIR_t*{tableActionIR_t <- tableActionIR_t*} = tableActionIR*{tableActionIR <- tableActionIR*}
-  -- let annotationList _prefixedNameIR ( _argumentListIR ) #( _parameterListIR , _parameterListIR' ); = tableActionIR_h
+  -- let annotationList _prefixedNameIR _controlPlaneNameIR ( _argumentListIR ) #( _parameterListIR , _parameterListIR' ); = tableActionIR_h
   -- if ([] = $name_annotation(annotationList))
 
   clause 2 : (tableActionIR*{tableActionIR <- tableActionIR*}, nameIR) = $find_tableActionIR_by_dotPrefix(tableActionIR_t*{tableActionIR_t <- tableActionIR_t*}, nameIR)
   -- if tableActionIR*{tableActionIR <- tableActionIR*} matches _ :: _
   -- let tableActionIR_h :: tableActionIR_t*{tableActionIR_t <- tableActionIR_t*} = tableActionIR*{tableActionIR <- tableActionIR*}
-  -- let annotationList prefixedNameIR ( argumentIR_data*{argumentIR_data <- argumentIR_data*} ) #( _parameterListIR , parameterIR_control*{parameterIR_control <- parameterIR_control*} ); = tableActionIR_h
+  -- let annotationList prefixedNameIR _controlPlaneNameIR ( argumentIR_data*{argumentIR_data <- argumentIR_data*} ) #( _parameterListIR , parameterIR_control*{parameterIR_control <- parameterIR_control*} ); = tableActionIR_h
   -- let nameIR_annotation*{nameIR_annotation <- nameIR_annotation*} = $name_annotation(annotationList)
   -- if (nameIR_annotation*{nameIR_annotation <- nameIR_annotation*} =/= [])
   -- if ([] = $filter_<nameIR>(nameIR_annotation*{nameIR_annotation <- nameIR_annotation*}, $starts_with(nameIR_annotation, ".")*{nameIR_annotation <- nameIR_annotation*}))
@@ -28646,7 +28648,7 @@ def $find_tableActionIR_by_dotPrefix(tableActionIR*, nameIR) : (nameIR, tableAct
   clause 3 : (tableActionIR*{tableActionIR <- tableActionIR*}, nameIR) = $find_tableActionIR_by_dotPrefix(tableActionIR_t*{tableActionIR_t <- tableActionIR_t*}, nameIR)
   -- if tableActionIR*{tableActionIR <- tableActionIR*} matches _ :: _
   -- let tableActionIR_h :: tableActionIR_t*{tableActionIR_t <- tableActionIR_t*} = tableActionIR*{tableActionIR <- tableActionIR*}
-  -- let annotationList prefixedNameIR ( argumentIR_data*{argumentIR_data <- argumentIR_data*} ) #( _parameterListIR , parameterIR_control*{parameterIR_control <- parameterIR_control*} ); = tableActionIR_h
+  -- let annotationList prefixedNameIR _controlPlaneNameIR ( argumentIR_data*{argumentIR_data <- argumentIR_data*} ) #( _parameterListIR , parameterIR_control*{parameterIR_control <- parameterIR_control*} ); = tableActionIR_h
   -- let nameIR_annotation*{nameIR_annotation <- nameIR_annotation*} = $name_annotation(annotationList)
   -- let nameIR_annotation_dotPrefix*{nameIR_annotation_dotPrefix <- nameIR_annotation_dotPrefix*} = $filter_<nameIR>(nameIR_annotation*{nameIR_annotation <- nameIR_annotation*}, $starts_with(nameIR_annotation, ".")*{nameIR_annotation <- nameIR_annotation*})
   -- if (nameIR_annotation_dotPrefix*{nameIR_annotation_dotPrefix <- nameIR_annotation_dotPrefix*} =/= [])
@@ -28656,7 +28658,7 @@ def $find_tableActionIR_by_dotPrefix(tableActionIR*, nameIR) : (nameIR, tableAct
   clause 4 : (tableActionIR*{tableActionIR <- tableActionIR*}, nameIR) = ?((nameIR_action, tableActionIR_h))
   -- if tableActionIR*{tableActionIR <- tableActionIR*} matches _ :: _
   -- let tableActionIR_h :: tableActionIR_t*{tableActionIR_t <- tableActionIR_t*} = tableActionIR*{tableActionIR <- tableActionIR*}
-  -- let annotationList prefixedNameIR ( argumentIR_data*{argumentIR_data <- argumentIR_data*} ) #( _parameterListIR , parameterIR_control*{parameterIR_control <- parameterIR_control*} ); = tableActionIR_h
+  -- let annotationList prefixedNameIR _controlPlaneNameIR ( argumentIR_data*{argumentIR_data <- argumentIR_data*} ) #( _parameterListIR , parameterIR_control*{parameterIR_control <- parameterIR_control*} ); = tableActionIR_h
   -- let nameIR_annotation*{nameIR_annotation <- nameIR_annotation*} = $name_annotation(annotationList)
   -- let nameIR_annotation_dotPrefix*{nameIR_annotation_dotPrefix <- nameIR_annotation_dotPrefix*} = $filter_<nameIR>(nameIR_annotation*{nameIR_annotation <- nameIR_annotation*}, $starts_with(nameIR_annotation, ".")*{nameIR_annotation <- nameIR_annotation*})
   -- let nameIR_annotation_strip*{nameIR_annotation_strip <- nameIR_annotation_strip*} = $strip_prefix(nameIR_annotation_dotPrefix, ".")*{nameIR_annotation_dotPrefix <- nameIR_annotation_dotPrefix*}
@@ -28665,11 +28667,11 @@ def $find_tableActionIR_by_dotPrefix(tableActionIR*, nameIR) : (nameIR, tableAct
 
 def $tableObject_create_entry_action(evalContext, tableActionsPropertyIR, tableActionInterface) : tableActionReferenceIR =
 
-  clause 0 : (EC, actions={ tableActionIR*{tableActionIR <- tableActionIR*} }, (nameIR_action_update, tableActionArgumentInterface_update*{tableActionArgumentInterface_update <- tableActionArgumentInterface_update*})) = ` nameIR_found ( argumentIR*{argumentIR <- argumentIR*} )
+  clause 0 : (EC, actions={ tableActionIR*{tableActionIR <- tableActionIR*} }, (nameIR_action_update, tableActionArgumentInterface_update*{tableActionArgumentInterface_update <- tableActionArgumentInterface_update*})) = ` nameIR_found controlPlaneNameIR ( argumentIR*{argumentIR <- argumentIR*} )
   -- let (nameIR, tableActionIR)?{(nameIR, tableActionIR) <- (nameIR, tableActionIR)?} = $find_tableActionIR_by_dotPrefix(tableActionIR*{tableActionIR <- tableActionIR*}, nameIR_action_update)
   -- if (nameIR, tableActionIR)?{(nameIR, tableActionIR) <- (nameIR, tableActionIR)?} matches (_)
   -- let ?((nameIR_found, tableActionIR_found)) = (nameIR, tableActionIR)?{(nameIR, tableActionIR) <- (nameIR, tableActionIR)?}
-  -- let annotationList prefixedNameIR ( argumentIR_data*{argumentIR_data <- argumentIR_data*} ) #( _parameterListIR , parameterIR_control*{parameterIR_control <- parameterIR_control*} ); = tableActionIR_found
+  -- let annotationList prefixedNameIR controlPlaneNameIR ( argumentIR_data*{argumentIR_data <- argumentIR_data*} ) #( _parameterListIR , parameterIR_control*{parameterIR_control <- parameterIR_control*} ); = tableActionIR_found
   -- let i_arg_aligned*{i_arg_aligned <- i_arg_aligned*} = $align_tableActionArgumentInterfaces(parameterIR_control*{parameterIR_control <- parameterIR_control*}, tableActionArgumentInterface_update*{tableActionArgumentInterface_update <- tableActionArgumentInterface_update*})
   -- (let _annotationList _direction typeIR_param _id _parameterInitializerOptIR = parameterIR_control)*{parameterIR_control <- parameterIR_control*, _annotationList -> _annotationList*, _direction -> _direction*, _id -> _id*, _parameterInitializerOptIR -> _parameterInitializerOptIR*, typeIR_param -> typeIR_param*}
   -- (let typedExpressionIR_arg = d i_arg_aligned as expressionIR # ( int as typeIR dyn ))*{i_arg_aligned <- i_arg_aligned*, typedExpressionIR_arg -> typedExpressionIR_arg*}
@@ -28678,12 +28680,12 @@ def $tableObject_create_entry_action(evalContext, tableActionsPropertyIR, tableA
   -- (let ?(typedExpressionIR_arg_cast) = typedExpressionIR?{typedExpressionIR <- typedExpressionIR?})*{typedExpressionIR? <- typedExpressionIR?*, typedExpressionIR_arg_cast -> typedExpressionIR_arg_cast*}
   -- let argumentIR*{argumentIR <- argumentIR*} = argumentIR_data*{argumentIR_data <- argumentIR_data*} ++ typedExpressionIR_arg_cast*{typedExpressionIR_arg_cast <- typedExpressionIR_arg_cast*} as argumentIR*
 
-  clause 1 : (EC, actions={ tableActionIR*{tableActionIR <- tableActionIR*} }, (nameIR_action_update, tableActionArgumentInterface_update*{tableActionArgumentInterface_update <- tableActionArgumentInterface_update*})) = ` nameIR_found ( argumentIR*{argumentIR <- argumentIR*} )
+  clause 1 : (EC, actions={ tableActionIR*{tableActionIR <- tableActionIR*} }, (nameIR_action_update, tableActionArgumentInterface_update*{tableActionArgumentInterface_update <- tableActionArgumentInterface_update*})) = ` nameIR_found controlPlaneNameIR ( argumentIR*{argumentIR <- argumentIR*} )
   -- if (?() = $find_tableActionIR_by_dotPrefix(tableActionIR*{tableActionIR <- tableActionIR*}, nameIR_action_update))
   -- let (nameIR, tableActionIR)?{(nameIR, tableActionIR) <- (nameIR, tableActionIR)?} = $find_tableActionIR_by_name(tableActionIR*{tableActionIR <- tableActionIR*}, nameIR_action_update)
   -- if (nameIR, tableActionIR)?{(nameIR, tableActionIR) <- (nameIR, tableActionIR)?} matches (_)
   -- let ?((nameIR_found, tableActionIR_found)) = (nameIR, tableActionIR)?{(nameIR, tableActionIR) <- (nameIR, tableActionIR)?}
-  -- let annotationList prefixedNameIR ( argumentIR_data*{argumentIR_data <- argumentIR_data*} ) #( _parameterListIR , parameterIR_control*{parameterIR_control <- parameterIR_control*} ); = tableActionIR_found
+  -- let annotationList prefixedNameIR controlPlaneNameIR ( argumentIR_data*{argumentIR_data <- argumentIR_data*} ) #( _parameterListIR , parameterIR_control*{parameterIR_control <- parameterIR_control*} ); = tableActionIR_found
   -- let i_arg_aligned*{i_arg_aligned <- i_arg_aligned*} = $align_tableActionArgumentInterfaces(parameterIR_control*{parameterIR_control <- parameterIR_control*}, tableActionArgumentInterface_update*{tableActionArgumentInterface_update <- tableActionArgumentInterface_update*})
   -- (let _annotationList _direction typeIR_param _id _parameterInitializerOptIR = parameterIR_control)*{parameterIR_control <- parameterIR_control*, _annotationList -> _annotationList*, _direction -> _direction*, _id -> _id*, _parameterInitializerOptIR -> _parameterInitializerOptIR*, typeIR_param -> typeIR_param*}
   -- (let typedExpressionIR_arg = d i_arg_aligned as expressionIR # ( int as typeIR dyn ))*{i_arg_aligned <- i_arg_aligned*, typedExpressionIR_arg -> typedExpressionIR_arg*}

--- a/p4spec/test/lang/elab.expected
+++ b/p4spec/test/lang/elab.expected
@@ -20076,6 +20076,36 @@ def $add_callableDef_non_overload_i(cursor, instContext, callableId, callableDef
   -- if ~$in_set<id>(id, { id_k*{id_k <- id_k*} })
   -- let callableDefEnv = $add_map<callableId, callableDef>(IC.block.callable, callableId, callableDef)
 
+def $find_callableDef_non_overload_i(cursor, instContext, prefixedNameIR) : (callableId, callableDef)? =
+
+  clause 0 : (p, IC, prefixedNameIR) = $find_non_overloaded<callableDef>(IC.global.callable, nameIR)
+  -- if prefixedNameIR matches `.%`
+  -- let . nameIR = prefixedNameIR
+
+  clause 1 : (cursor, IC, prefixedNameIR) = $find_non_overloaded<callableDef>(IC.global.callable, nameIR)
+  -- if cursor matches `GLOBAL`
+  -- if prefixedNameIR matches ``%`
+  -- let ` nameIR = prefixedNameIR
+
+  clause 2 : (cursor, IC, prefixedNameIR) = ?((callableId, callableDef))
+  -- if cursor matches `BLOCK`
+  -- if prefixedNameIR matches ``%`
+  -- let ` nameIR = prefixedNameIR
+  -- let (callableId, callableDef)?{(callableId, callableDef) <- (callableId, callableDef)?} = $find_non_overloaded<callableDef>(IC.block.callable, nameIR)
+  -- if (callableId, callableDef)?{(callableId, callableDef) <- (callableId, callableDef)?} matches (_)
+  -- let ?((callableId, callableDef)) = (callableId, callableDef)?{(callableId, callableDef) <- (callableId, callableDef)?}
+
+  clause 3 : (cursor, IC, prefixedNameIR) = $find_callableDef_non_overload_i(global, IC, ` nameIR)
+  -- if cursor matches `BLOCK`
+  -- if prefixedNameIR matches ``%`
+  -- let ` nameIR = prefixedNameIR
+  -- if (?() = $find_non_overloaded<callableDef>(IC.block.callable, nameIR))
+
+  clause 4 : (cursor, IC, prefixedNameIR) = $find_callableDef_non_overload_i(block, IC, ` nameIR)
+  -- if cursor matches `LOCAL`
+  -- if prefixedNameIR matches ``%`
+  -- let ` nameIR = prefixedNameIR
+
 def $add_constructorDef_i(instContext, callableId, constructorDef) : instContext =
 
   clause 0 : (IC, callableId, constructorDef) = IC[global.constructor = constructorDefEnv]
@@ -21421,6 +21451,72 @@ relation ParserLocalDecls_inst: instContext store |- parserLocalDeclarationIR* :
     -- ParserLocalDecls_inst: IC_1 STO_1 |- parserLocalDeclarationIR_t*{parserLocalDeclarationIR_t <- parserLocalDeclarationIR_t*} : IC_2 STO_2 parserLocalDeclarationIR_t_inst*{parserLocalDeclarationIR_t_inst <- parserLocalDeclarationIR_t_inst*}
     -- output: % % |- % : IC_2 STO_2 parserLocalDeclarationIR_h_inst :: parserLocalDeclarationIR_t_inst*{parserLocalDeclarationIR_t_inst <- parserLocalDeclarationIR_t_inst*}
 
+relation TableAction_inst: instContext store |- tableActionIR : store tableActionIR
+
+  rulegroup 
+
+   match
+
+    (signature) IC STO |- annotationList tableActionReferenceIR #( parameterListIR , parameterListIR_control ); : % %
+    IC STO |- annotationList tableActionReferenceIR #( parameterListIR , parameterListIR_control ); : % %
+
+   paths
+
+    rulepath name-annotation
+    -- let prefixedNameIR _controlPlaneNameIR ( argumentListIR ) = tableActionReferenceIR
+    -- let (callableId, callableDef)?{(callableId, callableDef) <- (callableId, callableDef)?} = $find_callableDef_non_overload_i(local, IC, prefixedNameIR)
+    -- if (callableId, callableDef)?{(callableId, callableDef) <- (callableId, callableDef)?} matches (_)
+    -- let ?((_callableId, callableDef)) = (callableId, callableDef)?{(callableId, callableDef) <- (callableId, callableDef)?}
+    -- if callableDef <: actionDef
+    -- let actionDef = callableDef as actionDef
+    -- let annotationList_actionDef action nameIR ( _parameterListIR ) _blockStatementIR = actionDef
+    -- let nameIR'*{nameIR' <- nameIR'*} = $name_annotation(annotationList_actionDef)
+    -- if nameIR'*{nameIR' <- nameIR'*} matches [ _/1 ]
+    -- let [nameIR_anno] = nameIR'*{nameIR' <- nameIR'*}
+    -- let controlPlaneNameIR = IC.path ++ [nameIR_anno]
+    -- let tableActionReferenceIR' = prefixedNameIR controlPlaneNameIR ( argumentListIR )
+    -- let tableActionIR = annotationList tableActionReferenceIR' #( parameterListIR , parameterListIR_control );
+    -- output: % % |- % : STO tableActionIR
+
+    rulepath no-name-annotation
+    -- let prefixedNameIR _controlPlaneNameIR ( argumentListIR ) = tableActionReferenceIR
+    -- let (callableId, callableDef)?{(callableId, callableDef) <- (callableId, callableDef)?} = $find_callableDef_non_overload_i(local, IC, prefixedNameIR)
+    -- if (callableId, callableDef)?{(callableId, callableDef) <- (callableId, callableDef)?} matches (_)
+    -- let ?((_callableId, callableDef)) = (callableId, callableDef)?{(callableId, callableDef) <- (callableId, callableDef)?}
+    -- if callableDef <: actionDef
+    -- let actionDef = callableDef as actionDef
+    -- let annotationList_actionDef action nameIR ( _parameterListIR ) _blockStatementIR = actionDef
+    -- if ([] = $name_annotation(annotationList_actionDef))
+    -- let controlPlaneNameIR = IC.path ++ [nameIR]
+    -- let tableActionReferenceIR' = prefixedNameIR controlPlaneNameIR ( argumentListIR )
+    -- let tableActionIR = annotationList tableActionReferenceIR' #( parameterListIR , parameterListIR_control );
+    -- output: % % |- % : STO tableActionIR
+
+relation TableActions_inst: instContext store |- tableActionIR* : store tableActionIR*
+
+  rulegroup 
+
+   match
+
+    (signature) IC store |- tableActionIR*{tableActionIR <- tableActionIR*} : % %
+    IC store |- tableActionIR*{tableActionIR <- tableActionIR*} : % %
+
+   paths
+
+    rulepath nil
+    -- let STO = store
+    -- if (tableActionIR*{tableActionIR <- tableActionIR*} = [])
+    -- output: % % |- % : STO []
+
+    rulepath cons
+    -- let STO_0 = store
+    -- let tableActionIR'*{tableActionIR' <- tableActionIR'*} = tableActionIR*{tableActionIR <- tableActionIR*}
+    -- if tableActionIR'*{tableActionIR' <- tableActionIR'*} matches _ :: _
+    -- let tableActionIR_h :: tableActionIR_t*{tableActionIR_t <- tableActionIR_t*} = tableActionIR'*{tableActionIR' <- tableActionIR'*}
+    -- TableAction_inst: IC STO_0 |- tableActionIR_h : STO_1 tableActionIR_h_inst
+    -- TableActions_inst: IC STO_1 |- tableActionIR_t*{tableActionIR_t <- tableActionIR_t*} : STO_2 tableActionIR_t_inst*{tableActionIR_t_inst <- tableActionIR_t_inst*}
+    -- output: % % |- % : STO_1 tableActionIR_h_inst :: tableActionIR_t_inst*{tableActionIR_t_inst <- tableActionIR_t_inst*}
+
 relation TableProperty_inst: instContext store |- tablePropertyIR : store tablePropertyIR
 
   rulegroup tableKeysPropertyIR
@@ -21441,15 +21537,17 @@ relation TableProperty_inst: instContext store |- tablePropertyIR : store tableP
 
    match
 
-    (signature) IC STO |- tableActionsPropertyIR as tablePropertyIR : % %
-    IC STO |- tablePropertyIR : % %
+    (signature) IC STO_0 |- actions={ tableActionListIR } as tablePropertyIR : % %
+    IC STO_0 |- tablePropertyIR : % %
     -- if tablePropertyIR <: tableActionsPropertyIR
-    -- let tableActionsPropertyIR = tablePropertyIR as tableActionsPropertyIR
+    -- let actions={ tableActionListIR } = tablePropertyIR as tableActionsPropertyIR
 
    paths
 
     rulepath tableActionsPropertyIR
-    -- output: % % |- % : STO tableActionsPropertyIR as tablePropertyIR
+    -- TableActions_inst: IC STO_0 |- tableActionListIR : STO_1 tableActionListIR_inst
+    -- let tableActionsPropertyIR = actions={ tableActionListIR_inst }
+    -- output: % % |- % : STO_1 tableActionsPropertyIR as tablePropertyIR
 
   rulegroup tableDefaultActionPropertyIR
 

--- a/p4spec/test/lang/elab.expected
+++ b/p4spec/test/lang/elab.expected
@@ -24,12 +24,27 @@ builtin def $text_to_int(text) : int
 
 builtin def $int_to_text(int) : text
 
+builtin def $split_text(text, text) : text*
+
 def $concat_text(text*) : text =
 
   clause 0 : (text*{text <- text*}) = ""
   -- if text*{text <- text*} matches []
 
   clause 1 : (text*{text <- text*}) = t_h ++ $concat_text(t_t*{t_t <- t_t*})
+  -- if text*{text <- text*} matches _ :: _
+  -- let t_h :: t_t*{t_t <- t_t*} = text*{text <- text*}
+
+def $join_text(text*, text) : text =
+
+  clause 0 : (text*{text <- text*}, t_sep) = ""
+  -- if text*{text <- text*} matches []
+
+  clause 1 : (text*{text <- text*}, t_sep) = t_h
+  -- if text*{text <- text*} matches [ _/1 ]
+  -- let [t_h] = text*{text <- text*}
+
+  clause 2 : (text*{text <- text*}, t_sep) = t_h ++ t_sep ++ $join_text(t_t*{t_t <- t_t*}, t_sep)
   -- if text*{text <- text*} matches _ :: _
   -- let t_h :: t_t*{t_t <- t_t*} = text*{text <- text*}
 
@@ -7379,7 +7394,7 @@ syntax tableKeyIR =
 
 syntax tableKeyListIR = tableKeyIR*
 
-syntax controlPlaneNameIR = nameIR*
+syntax controlPlaneNameIR = nameIR?
 
 syntax tableActionReferenceIR = 
    | prefixedNameIR controlPlaneNameIR ( argumentListIR )
@@ -14477,7 +14492,7 @@ relation TableAction_ok: typingContext tableContext |- tableAction : tableContex
     -- Call_action_partial_ok: TC |- parameterIR*{parameterIR <- parameterIR*} @ [] : parameterIR_data*{parameterIR_data <- parameterIR_data*} , parameterIR_control*{parameterIR_control <- parameterIR_control*} @ argumentIR'*{argumentIR' <- argumentIR'*}
     -- if argumentIR'*{argumentIR' <- argumentIR'*} matches []
     -- let TBLC_1 = $add_action_tbl(TBLC_0, prefixedNameIR, parameterIR*{parameterIR <- parameterIR*}, [])
-    -- let tableActionIR = annotationList_update prefixedNameIR [] ( [] ) #( parameterIR_data*{parameterIR_data <- parameterIR_data*} , parameterIR_control*{parameterIR_control <- parameterIR_control*} );
+    -- let tableActionIR = annotationList_update prefixedNameIR ?() ( [] ) #( parameterIR_data*{parameterIR_data <- parameterIR_data*} , parameterIR_control*{parameterIR_control <- parameterIR_control*} );
     -- output: % % |- % : TBLC_1 tableActionIR
 
     rulepath prefixedNonTypeName-argumentList
@@ -14495,7 +14510,7 @@ relation TableAction_ok: typingContext tableContext |- tableAction : tableContex
     -- ArgumentList_ok: local TC |- argumentList : argumentIR*{argumentIR <- argumentIR*}
     -- Call_action_partial_ok: TC |- parameterIR*{parameterIR <- parameterIR*} @ argumentIR*{argumentIR <- argumentIR*} : parameterIR_data*{parameterIR_data <- parameterIR_data*} , parameterIR_control*{parameterIR_control <- parameterIR_control*} @ argumentIR_cast*{argumentIR_cast <- argumentIR_cast*}
     -- let TBLC_1 = $add_action_tbl(TBLC_0, prefixedNameIR, parameterIR*{parameterIR <- parameterIR*}, argumentIR_cast*{argumentIR_cast <- argumentIR_cast*})
-    -- let tableActionIR = annotationList_update prefixedNameIR [] ( argumentIR_cast*{argumentIR_cast <- argumentIR_cast*} ) #( parameterIR_data*{parameterIR_data <- parameterIR_data*} , parameterIR_control*{parameterIR_control <- parameterIR_control*} );
+    -- let tableActionIR = annotationList_update prefixedNameIR ?() ( argumentIR_cast*{argumentIR_cast <- argumentIR_cast*} ) #( parameterIR_data*{parameterIR_data <- parameterIR_data*} , parameterIR_control*{parameterIR_control <- parameterIR_control*} );
     -- output: % % |- % : TBLC_1 tableActionIR
 
 relation TableActions_ok: typingContext tableContext |- tableAction* : tableContext tableActionListIR
@@ -14558,7 +14573,7 @@ relation TableDefaultAction_ok: typingContext tableContext |- initializer : tabl
     -- let prefixedNonTypeName = expression' as prefixedNonTypeName
     -- let prefixedNameIR = $prefixedNonTypeName(prefixedNonTypeName)
     -- if (?(([], [])) = $find_action(TBLC, prefixedNameIR))
-    -- output: % % |- % : prefixedNameIR [] ( [] )
+    -- output: % % |- % : prefixedNameIR ?() ( [] )
 
     rulepath prefixedNonTypeName-argumentList
     -- let expression' = expression
@@ -14577,7 +14592,7 @@ relation TableDefaultAction_ok: typingContext tableContext |- initializer : tabl
     -- let argumentIR_action_data*{argumentIR_action_data <- argumentIR_action_data*} = argumentIR_action*{argumentIR_action <- argumentIR_action*}[0 : |parameterIR_action_data*{parameterIR_action_data <- parameterIR_action_data*}|]
     -- let argumentIR_cast_data*{argumentIR_cast_data <- argumentIR_cast_data*} = argumentIR_cast*{argumentIR_cast <- argumentIR_cast*}[0 : |parameterIR_action_data*{parameterIR_action_data <- parameterIR_action_data*}|]
     -- (if (argumentIR_action_data = argumentIR_cast_data))*{argumentIR_action_data <- argumentIR_action_data*, argumentIR_cast_data <- argumentIR_cast_data*}
-    -- output: % % |- % : prefixedNameIR [] ( argumentIR_cast*{argumentIR_cast <- argumentIR_cast*} )
+    -- output: % % |- % : prefixedNameIR ?() ( argumentIR_cast*{argumentIR_cast <- argumentIR_cast*} )
 
 relation TableEntry_keyset_ok: typingContext tableContext |- keysetExpression : tableEntryState keysetExpressionIR
 
@@ -14776,7 +14791,7 @@ relation TableEntry_action_ok: typingContext tableContext |- tableActionReferenc
     -- let prefixedNonTypeName = tableActionReference' as prefixedNonTypeName
     -- let prefixedNameIR = $prefixedNonTypeName(prefixedNonTypeName)
     -- if (?(([], [])) = $find_action(TBLC, prefixedNameIR))
-    -- output: % % |- % : prefixedNameIR [] ( [] )
+    -- output: % % |- % : prefixedNameIR ?() ( [] )
 
     rulepath prefixedNonTypeName-argumentList
     -- let tableActionReference' = tableActionReference
@@ -14791,7 +14806,7 @@ relation TableEntry_action_ok: typingContext tableContext |- tableActionReferenc
     -- let argumentIR_action_data*{argumentIR_action_data <- argumentIR_action_data*} = argumentIR_action*{argumentIR_action <- argumentIR_action*}[0 : |parameterIR_action_data*{parameterIR_action_data <- parameterIR_action_data*}|]
     -- let argumentIR_cast_data*{argumentIR_cast_data <- argumentIR_cast_data*} = argumentIR_cast*{argumentIR_cast <- argumentIR_cast*}[0 : |parameterIR_action_data*{parameterIR_action_data <- parameterIR_action_data*}|]
     -- (if (argumentIR_action_data = argumentIR_cast_data))*{argumentIR_action_data <- argumentIR_action_data*, argumentIR_cast_data <- argumentIR_cast_data*}
-    -- output: % % |- % : prefixedNameIR [] ( argumentIR_cast*{argumentIR_cast <- argumentIR_cast*} )
+    -- output: % % |- % : prefixedNameIR ?() ( argumentIR_cast*{argumentIR_cast <- argumentIR_cast*} )
 
 relation TableEntry_priority_ok: typingContext tableContext tableEntryState |- tableEntryPriority? : tableContext tableEntryPriorityOptIR
 
@@ -15171,7 +15186,7 @@ relation Table_ok: typingContext |- tableProperty* : tableContext tablePropertyL
     -- if (|$filter_<tableProperty>(tableProperty*{tableProperty <- tableProperty*}, $is_tableDefaultActionProperty(tableProperty)*{tableProperty <- tableProperty*})| = 0)
     -- let TBLC_0 = $empty_tableContext
     -- TableProperties_ok: TC TBLC_0 |- tableProperty*{tableProperty <- tableProperty*} : TBLC_1 tablePropertyIR*{tablePropertyIR <- tablePropertyIR*}
-    -- let tablePropertyIR_default_action = `empty ?() default_action= ` "NoAction" [] ( [] ) ; as tablePropertyIR
+    -- let tablePropertyIR_default_action = `empty ?() default_action= ` "NoAction" ?() ( [] ) ; as tablePropertyIR
     -- let (TBLC_2, tablePropertyIR_updated*{tablePropertyIR_updated <- tablePropertyIR_updated*}) = $insert_NoAction_tablePropertyIR(TBLC_1, tablePropertyIR*{tablePropertyIR <- tablePropertyIR*})
     -- output: % |- % : TBLC_2 tablePropertyIR_updated*{tablePropertyIR_updated <- tablePropertyIR_updated*} ++ [tablePropertyIR_default_action]
 
@@ -19040,7 +19055,7 @@ def $insert_NoAction_tablePropertyIR(tableContext, tablePropertyIR*) : (tableCon
   -- if tablePropertyIR' <: tableActionsPropertyIR
   -- let actions={ tableActionIR*{tableActionIR <- tableActionIR*} } = tablePropertyIR' as tableActionsPropertyIR
   -- (let _annotationList tableActionReferenceIR #( _parameterListIR , _parameterListIR' ); = tableActionIR)*{tableActionIR <- tableActionIR*, _annotationList -> _annotationList*, _parameterListIR -> _parameterListIR*, _parameterListIR' -> _parameterListIR'*, tableActionReferenceIR -> tableActionReferenceIR*}
-  -- let tableActionReferenceIR_NoAction = . "NoAction" [] ( [] )
+  -- let tableActionReferenceIR_NoAction = . "NoAction" ?() ( [] )
   -- if ~tableActionReferenceIR_NoAction <- tableActionReferenceIR*{tableActionReferenceIR <- tableActionReferenceIR*}
   -- let TBLC_1 = $add_action_tbl(TBLC_0, . "NoAction", [], [])
   -- let tableActionIR_NoAction = `empty tableActionReferenceIR_NoAction #( [] , [] );
@@ -19053,7 +19068,7 @@ def $insert_NoAction_tablePropertyIR(tableContext, tablePropertyIR*) : (tableCon
   -- if tablePropertyIR' <: tableActionsPropertyIR
   -- let actions={ tableActionIR*{tableActionIR <- tableActionIR*} } = tablePropertyIR' as tableActionsPropertyIR
   -- (let _annotationList tableActionReferenceIR #( _parameterListIR , _parameterListIR' ); = tableActionIR)*{tableActionIR <- tableActionIR*, _annotationList -> _annotationList*, _parameterListIR -> _parameterListIR*, _parameterListIR' -> _parameterListIR'*, tableActionReferenceIR -> tableActionReferenceIR*}
-  -- let tableActionReferenceIR_NoAction = . "NoAction" [] ( [] )
+  -- let tableActionReferenceIR_NoAction = . "NoAction" ?() ( [] )
   -- if tableActionReferenceIR_NoAction <- tableActionReferenceIR*{tableActionReferenceIR <- tableActionReferenceIR*}
 
   clause 3 : (TBLC_0, tablePropertyIR*{tablePropertyIR <- tablePropertyIR*}) = (TBLC_1, tablePropertyIR_h :: tablePropertyIR_t_updated*{tablePropertyIR_t_updated <- tablePropertyIR_t_updated*})
@@ -20076,18 +20091,26 @@ def $add_callableDef_non_overload_i(cursor, instContext, callableId, callableDef
   -- if ~$in_set<id>(id, { id_k*{id_k <- id_k*} })
   -- let callableDefEnv = $add_map<callableId, callableDef>(IC.block.callable, callableId, callableDef)
 
-def $find_callableDef_non_overload_i(cursor, instContext, prefixedNameIR) : (callableId, callableDef)? =
+def $find_callableDef_non_overload_i(cursor, instContext, prefixedNameIR) : (cursor, callableId, callableDef)? =
 
-  clause 0 : (p, IC, prefixedNameIR) = $find_non_overloaded<callableDef>(IC.global.callable, nameIR)
+  clause 0 : (p, IC, prefixedNameIR) = ?()
   -- if prefixedNameIR matches `.%`
   -- let . nameIR = prefixedNameIR
+  -- if (?() = $find_non_overloaded<callableDef>(IC.global.callable, nameIR))
 
-  clause 1 : (cursor, IC, prefixedNameIR) = $find_non_overloaded<callableDef>(IC.global.callable, nameIR)
+  clause 1 : (p, IC, prefixedNameIR) = ?((global, callableId, callableDef))
+  -- if prefixedNameIR matches `.%`
+  -- let . nameIR = prefixedNameIR
+  -- let (callableId, callableDef)?{(callableId, callableDef) <- (callableId, callableDef)?} = $find_non_overloaded<callableDef>(IC.global.callable, nameIR)
+  -- if (callableId, callableDef)?{(callableId, callableDef) <- (callableId, callableDef)?} matches (_)
+  -- let ?((callableId, callableDef)) = (callableId, callableDef)?{(callableId, callableDef) <- (callableId, callableDef)?}
+
+  clause 2 : (cursor, IC, prefixedNameIR) = $find_callableDef_non_overload_i(global, IC, . nameIR)
   -- if cursor matches `GLOBAL`
   -- if prefixedNameIR matches ``%`
   -- let ` nameIR = prefixedNameIR
 
-  clause 2 : (cursor, IC, prefixedNameIR) = ?((callableId, callableDef))
+  clause 3 : (cursor, IC, prefixedNameIR) = ?((block, callableId, callableDef))
   -- if cursor matches `BLOCK`
   -- if prefixedNameIR matches ``%`
   -- let ` nameIR = prefixedNameIR
@@ -20095,13 +20118,13 @@ def $find_callableDef_non_overload_i(cursor, instContext, prefixedNameIR) : (cal
   -- if (callableId, callableDef)?{(callableId, callableDef) <- (callableId, callableDef)?} matches (_)
   -- let ?((callableId, callableDef)) = (callableId, callableDef)?{(callableId, callableDef) <- (callableId, callableDef)?}
 
-  clause 3 : (cursor, IC, prefixedNameIR) = $find_callableDef_non_overload_i(global, IC, ` nameIR)
+  clause 4 : (cursor, IC, prefixedNameIR) = $find_callableDef_non_overload_i(global, IC, ` nameIR)
   -- if cursor matches `BLOCK`
   -- if prefixedNameIR matches ``%`
   -- let ` nameIR = prefixedNameIR
   -- if (?() = $find_non_overloaded<callableDef>(IC.block.callable, nameIR))
 
-  clause 4 : (cursor, IC, prefixedNameIR) = $find_callableDef_non_overload_i(block, IC, ` nameIR)
+  clause 5 : (cursor, IC, prefixedNameIR) = $find_callableDef_non_overload_i(block, IC, ` nameIR)
   -- if cursor matches `LOCAL`
   -- if prefixedNameIR matches ``%`
   -- let ` nameIR = prefixedNameIR
@@ -21462,32 +21485,50 @@ relation TableAction_inst: instContext store |- tableActionIR : store tableActio
 
    paths
 
-    rulepath name-annotation
+    rulepath name-annotation-dot-prefix
     -- let prefixedNameIR _controlPlaneNameIR ( argumentListIR ) = tableActionReferenceIR
-    -- let (callableId, callableDef)?{(callableId, callableDef) <- (callableId, callableDef)?} = $find_callableDef_non_overload_i(local, IC, prefixedNameIR)
-    -- if (callableId, callableDef)?{(callableId, callableDef) <- (callableId, callableDef)?} matches (_)
-    -- let ?((_callableId, callableDef)) = (callableId, callableDef)?{(callableId, callableDef) <- (callableId, callableDef)?}
+    -- let (cursor, callableId, callableDef)?{(cursor, callableId, callableDef) <- (cursor, callableId, callableDef)?} = $find_callableDef_non_overload_i(local, IC, prefixedNameIR)
+    -- if (cursor, callableId, callableDef)?{(cursor, callableId, callableDef) <- (cursor, callableId, callableDef)?} matches (_)
+    -- let ?((cursor, _callableId, callableDef)) = (cursor, callableId, callableDef)?{(cursor, callableId, callableDef) <- (cursor, callableId, callableDef)?}
     -- if callableDef <: actionDef
     -- let actionDef = callableDef as actionDef
     -- let annotationList_actionDef action nameIR ( _parameterListIR ) _blockStatementIR = actionDef
     -- let nameIR'*{nameIR' <- nameIR'*} = $name_annotation(annotationList_actionDef)
     -- if nameIR'*{nameIR' <- nameIR'*} matches [ _/1 ]
     -- let [nameIR_anno] = nameIR'*{nameIR' <- nameIR'*}
-    -- let controlPlaneNameIR = IC.path ++ [nameIR_anno]
+    -- if $starts_with(nameIR_anno, ".")
+    -- let controlPlaneNameIR = ?($strip_prefix(nameIR_anno, "."))
+    -- let tableActionReferenceIR' = prefixedNameIR controlPlaneNameIR ( argumentListIR )
+    -- let tableActionIR = annotationList tableActionReferenceIR' #( parameterListIR , parameterListIR_control );
+    -- output: % % |- % : STO tableActionIR
+
+    rulepath name-annotation
+    -- let prefixedNameIR _controlPlaneNameIR ( argumentListIR ) = tableActionReferenceIR
+    -- let (cursor, callableId, callableDef)?{(cursor, callableId, callableDef) <- (cursor, callableId, callableDef)?} = $find_callableDef_non_overload_i(local, IC, prefixedNameIR)
+    -- if (cursor, callableId, callableDef)?{(cursor, callableId, callableDef) <- (cursor, callableId, callableDef)?} matches (_)
+    -- let ?((cursor, _callableId, callableDef)) = (cursor, callableId, callableDef)?{(cursor, callableId, callableDef) <- (cursor, callableId, callableDef)?}
+    -- if callableDef <: actionDef
+    -- let actionDef = callableDef as actionDef
+    -- let annotationList_actionDef action nameIR ( _parameterListIR ) _blockStatementIR = actionDef
+    -- let nameIR'*{nameIR' <- nameIR'*} = $name_annotation(annotationList_actionDef)
+    -- if nameIR'*{nameIR' <- nameIR'*} matches [ _/1 ]
+    -- let [nameIR_anno] = nameIR'*{nameIR' <- nameIR'*}
+    -- if ~$starts_with(nameIR_anno, ".")
+    -- let controlPlaneNameIR = $ite<controlPlaneNameIR>((cursor = global), ?(nameIR_anno), ?($join_text(IC.path ++ [nameIR_anno], ".")))
     -- let tableActionReferenceIR' = prefixedNameIR controlPlaneNameIR ( argumentListIR )
     -- let tableActionIR = annotationList tableActionReferenceIR' #( parameterListIR , parameterListIR_control );
     -- output: % % |- % : STO tableActionIR
 
     rulepath no-name-annotation
     -- let prefixedNameIR _controlPlaneNameIR ( argumentListIR ) = tableActionReferenceIR
-    -- let (callableId, callableDef)?{(callableId, callableDef) <- (callableId, callableDef)?} = $find_callableDef_non_overload_i(local, IC, prefixedNameIR)
-    -- if (callableId, callableDef)?{(callableId, callableDef) <- (callableId, callableDef)?} matches (_)
-    -- let ?((_callableId, callableDef)) = (callableId, callableDef)?{(callableId, callableDef) <- (callableId, callableDef)?}
+    -- let (cursor, callableId, callableDef)?{(cursor, callableId, callableDef) <- (cursor, callableId, callableDef)?} = $find_callableDef_non_overload_i(local, IC, prefixedNameIR)
+    -- if (cursor, callableId, callableDef)?{(cursor, callableId, callableDef) <- (cursor, callableId, callableDef)?} matches (_)
+    -- let ?((cursor, _callableId, callableDef)) = (cursor, callableId, callableDef)?{(cursor, callableId, callableDef) <- (cursor, callableId, callableDef)?}
     -- if callableDef <: actionDef
     -- let actionDef = callableDef as actionDef
     -- let annotationList_actionDef action nameIR ( _parameterListIR ) _blockStatementIR = actionDef
     -- if ([] = $name_annotation(annotationList_actionDef))
-    -- let controlPlaneNameIR = IC.path ++ [nameIR]
+    -- let controlPlaneNameIR = $ite<controlPlaneNameIR>((cursor = global), ?(nameIR), ?($join_text(IC.path ++ [nameIR], ".")))
     -- let tableActionReferenceIR' = prefixedNameIR controlPlaneNameIR ( argumentListIR )
     -- let tableActionIR = annotationList tableActionReferenceIR' #( parameterListIR , parameterListIR_control );
     -- output: % % |- % : STO tableActionIR
@@ -28683,90 +28724,72 @@ def $align_tableActionArgumentInterfaces'(map<id, int>, parameterIR) : int? =
 
   clause 0 : ({ id_arg : i_arg*{i_arg <- i_arg*, id_arg <- id_arg*} }, _annotationList _direction _typeIR nameIR_param _parameterInitializerOptIR) = $find_map<id, int>({ id_arg : i_arg*{i_arg <- i_arg*, id_arg <- id_arg*} }, nameIR_param)
 
-def $find_tableActionIR_by_name(tableActionIR*, nameIR) : (nameIR, tableActionIR)? =
+def $find_tableActionIR_qualified(tableActionIR*, nameIR) : (nameIR, tableActionIR)? =
 
-  clause 0 : (tableActionIR*{tableActionIR <- tableActionIR*}, _nameIR) = ?()
+  clause 0 : (tableActionIR*{tableActionIR <- tableActionIR*}, nameIR) = ?()
   -- if tableActionIR*{tableActionIR <- tableActionIR*} matches []
 
-  clause 1 : (tableActionIR*{tableActionIR <- tableActionIR*}, nameIR_target) = ?((nameIR_action, tableActionIR_h))
+  clause 1 : (tableActionIR*{tableActionIR <- tableActionIR*}, nameIR) = $find_tableActionIR_qualified(tableActionIR_t*{tableActionIR_t <- tableActionIR_t*}, nameIR)
   -- if tableActionIR*{tableActionIR <- tableActionIR*} matches _ :: _
   -- let tableActionIR_h :: tableActionIR_t*{tableActionIR_t <- tableActionIR_t*} = tableActionIR*{tableActionIR <- tableActionIR*}
-  -- let annotationList prefixedNameIR _controlPlaneNameIR ( argumentIR_data*{argumentIR_data <- argumentIR_data*} ) #( _parameterListIR , parameterIR_control*{parameterIR_control <- parameterIR_control*} ); = tableActionIR_h
-  -- let nameIR_action = $flatten_prefixedNameIR(prefixedNameIR)
-  -- if ([] = $name_annotation(annotationList))
-  -- if (nameIR_action = nameIR_target)
+  -- let annotationList tableActionReferenceIR #( _parameterListIR , parameterIR_control*{parameterIR_control <- parameterIR_control*} ); = tableActionIR_h
+  -- let prefixedNameIR controlPlaneNameIR ( argumentIR_data*{argumentIR_data <- argumentIR_data*} ) = tableActionReferenceIR
+  -- if (?(nameIR) =/= controlPlaneNameIR)
 
-  clause 2 : (tableActionIR*{tableActionIR <- tableActionIR*}, nameIR_target) = $find_tableActionIR_by_name(tableActionIR_t*{tableActionIR_t <- tableActionIR_t*}, nameIR_target)
+  clause 2 : (tableActionIR*{tableActionIR <- tableActionIR*}, nameIR) = ?((nameIR_action, tableActionIR_h))
   -- if tableActionIR*{tableActionIR <- tableActionIR*} matches _ :: _
   -- let tableActionIR_h :: tableActionIR_t*{tableActionIR_t <- tableActionIR_t*} = tableActionIR*{tableActionIR <- tableActionIR*}
-  -- let annotationList prefixedNameIR _controlPlaneNameIR ( argumentIR_data*{argumentIR_data <- argumentIR_data*} ) #( _parameterListIR , parameterIR_control*{parameterIR_control <- parameterIR_control*} ); = tableActionIR_h
+  -- let annotationList tableActionReferenceIR #( _parameterListIR , parameterIR_control*{parameterIR_control <- parameterIR_control*} ); = tableActionIR_h
+  -- let prefixedNameIR controlPlaneNameIR ( argumentIR_data*{argumentIR_data <- argumentIR_data*} ) = tableActionReferenceIR
+  -- if (?(nameIR) = controlPlaneNameIR)
   -- let nameIR_action = $flatten_prefixedNameIR(prefixedNameIR)
-  -- if ([] = $name_annotation(annotationList))
-  -- if (nameIR_action =/= nameIR_target)
 
-  clause 3 : (tableActionIR*{tableActionIR <- tableActionIR*}, nameIR) = ?((nameIR_action, tableActionIR_h))
-  -- if tableActionIR*{tableActionIR <- tableActionIR*} matches _ :: _
-  -- let tableActionIR_h :: tableActionIR_t*{tableActionIR_t <- tableActionIR_t*} = tableActionIR*{tableActionIR <- tableActionIR*}
-  -- let annotationList prefixedNameIR _controlPlaneNameIR ( argumentIR_data*{argumentIR_data <- argumentIR_data*} ) #( _parameterListIR , parameterIR_control*{parameterIR_control <- parameterIR_control*} ); = tableActionIR_h
-  -- let nameIR_action = $flatten_prefixedNameIR(prefixedNameIR)
-  -- let nameIR_annotation*{nameIR_annotation <- nameIR_annotation*} = $name_annotation(annotationList)
-  -- if (nameIR_annotation*{nameIR_annotation <- nameIR_annotation*} =/= [])
-  -- let b_hit = ((nameIR = nameIR_action) \/ nameIR <- nameIR_annotation*{nameIR_annotation <- nameIR_annotation*})
-  -- if b_hit
+def $find_tableActionIR_unqualified(tableActionIR*, nameIR) : (nameIR, tableActionIR)? =
 
-  clause 4 : (tableActionIR*{tableActionIR <- tableActionIR*}, nameIR) = $find_tableActionIR_by_name(tableActionIR_t*{tableActionIR_t <- tableActionIR_t*}, nameIR)
-  -- if tableActionIR*{tableActionIR <- tableActionIR*} matches _ :: _
-  -- let tableActionIR_h :: tableActionIR_t*{tableActionIR_t <- tableActionIR_t*} = tableActionIR*{tableActionIR <- tableActionIR*}
-  -- let annotationList prefixedNameIR _controlPlaneNameIR ( argumentIR_data*{argumentIR_data <- argumentIR_data*} ) #( _parameterListIR , parameterIR_control*{parameterIR_control <- parameterIR_control*} ); = tableActionIR_h
-  -- let nameIR_action = $flatten_prefixedNameIR(prefixedNameIR)
-  -- let nameIR_annotation*{nameIR_annotation <- nameIR_annotation*} = $name_annotation(annotationList)
-  -- if (nameIR_annotation*{nameIR_annotation <- nameIR_annotation*} =/= [])
-  -- let b_hit = ((nameIR = nameIR_action) \/ nameIR <- nameIR_annotation*{nameIR_annotation <- nameIR_annotation*})
-  -- if ~b_hit
+  clause 0 : (tableActionIR*{tableActionIR <- tableActionIR*}, nameIR) = ?()
+  -- let nameIR_split*{nameIR_split <- nameIR_split*} = $split_text(nameIR, ".")
+  -- if (|nameIR_split*{nameIR_split <- nameIR_split*}| > 1)
 
-def $find_tableActionIR_by_dotPrefix(tableActionIR*, nameIR) : (nameIR, tableActionIR)? =
+  clause 1 : (tableActionIR*{tableActionIR <- tableActionIR*}, nameIR) = $find_tableActionIR_unqualified'(tableActionIR*{tableActionIR <- tableActionIR*}, nameIR_split*{nameIR_split <- nameIR_split*}[0])
+  -- let nameIR_split*{nameIR_split <- nameIR_split*} = $split_text(nameIR, ".")
+  -- if (|nameIR_split*{nameIR_split <- nameIR_split*}| = 1)
 
-  clause 0 : (tableActionIR*{tableActionIR <- tableActionIR*}, _nameIR) = ?()
+def $find_tableActionIR_unqualified'(tableActionIR*, nameIR) : (nameIR, tableActionIR)? =
+
+  clause 0 : (tableActionIR*{tableActionIR <- tableActionIR*}, nameIR) = ?()
   -- if tableActionIR*{tableActionIR <- tableActionIR*} matches []
 
-  clause 1 : (tableActionIR*{tableActionIR <- tableActionIR*}, nameIR_target) = $find_tableActionIR_by_dotPrefix(tableActionIR_t*{tableActionIR_t <- tableActionIR_t*}, nameIR_target)
+  clause 1 : (tableActionIR*{tableActionIR <- tableActionIR*}, nameIR) = $find_tableActionIR_unqualified'(tableActionIR_t*{tableActionIR_t <- tableActionIR_t*}, nameIR)
   -- if tableActionIR*{tableActionIR <- tableActionIR*} matches _ :: _
   -- let tableActionIR_h :: tableActionIR_t*{tableActionIR_t <- tableActionIR_t*} = tableActionIR*{tableActionIR <- tableActionIR*}
-  -- let annotationList _prefixedNameIR _controlPlaneNameIR ( _argumentListIR ) #( _parameterListIR , _parameterListIR' ); = tableActionIR_h
-  -- if ([] = $name_annotation(annotationList))
+  -- let annotationList tableActionReferenceIR #( _parameterListIR , parameterIR_control*{parameterIR_control <- parameterIR_control*} ); = tableActionIR_h
+  -- let prefixedNameIR controlPlaneNameIR ( argumentIR_data*{argumentIR_data <- argumentIR_data*} ) = tableActionReferenceIR
+  -- if controlPlaneNameIR matches (_)
+  -- let ?(nameIR_controlPlane) = controlPlaneNameIR
+  -- let nameIR_split*{nameIR_split <- nameIR_split*} = $split_text(nameIR_controlPlane, ".")
+  -- let nameIR'*{nameIR' <- nameIR'*} = $rev_<nameIR>(nameIR_split*{nameIR_split <- nameIR_split*})
+  -- if nameIR'*{nameIR' <- nameIR'*} matches _ :: _
+  -- let nameIR_unqualified :: _nameIR*{_nameIR <- _nameIR*} = nameIR'*{nameIR' <- nameIR'*}
+  -- if (nameIR =/= nameIR_unqualified)
 
-  clause 2 : (tableActionIR*{tableActionIR <- tableActionIR*}, nameIR) = $find_tableActionIR_by_dotPrefix(tableActionIR_t*{tableActionIR_t <- tableActionIR_t*}, nameIR)
+  clause 2 : (tableActionIR*{tableActionIR <- tableActionIR*}, nameIR) = ?((nameIR_action, tableActionIR_h))
   -- if tableActionIR*{tableActionIR <- tableActionIR*} matches _ :: _
   -- let tableActionIR_h :: tableActionIR_t*{tableActionIR_t <- tableActionIR_t*} = tableActionIR*{tableActionIR <- tableActionIR*}
-  -- let annotationList prefixedNameIR _controlPlaneNameIR ( argumentIR_data*{argumentIR_data <- argumentIR_data*} ) #( _parameterListIR , parameterIR_control*{parameterIR_control <- parameterIR_control*} ); = tableActionIR_h
-  -- let nameIR_annotation*{nameIR_annotation <- nameIR_annotation*} = $name_annotation(annotationList)
-  -- if (nameIR_annotation*{nameIR_annotation <- nameIR_annotation*} =/= [])
-  -- if ([] = $filter_<nameIR>(nameIR_annotation*{nameIR_annotation <- nameIR_annotation*}, $starts_with(nameIR_annotation, ".")*{nameIR_annotation <- nameIR_annotation*}))
-
-  clause 3 : (tableActionIR*{tableActionIR <- tableActionIR*}, nameIR) = $find_tableActionIR_by_dotPrefix(tableActionIR_t*{tableActionIR_t <- tableActionIR_t*}, nameIR)
-  -- if tableActionIR*{tableActionIR <- tableActionIR*} matches _ :: _
-  -- let tableActionIR_h :: tableActionIR_t*{tableActionIR_t <- tableActionIR_t*} = tableActionIR*{tableActionIR <- tableActionIR*}
-  -- let annotationList prefixedNameIR _controlPlaneNameIR ( argumentIR_data*{argumentIR_data <- argumentIR_data*} ) #( _parameterListIR , parameterIR_control*{parameterIR_control <- parameterIR_control*} ); = tableActionIR_h
-  -- let nameIR_annotation*{nameIR_annotation <- nameIR_annotation*} = $name_annotation(annotationList)
-  -- let nameIR_annotation_dotPrefix*{nameIR_annotation_dotPrefix <- nameIR_annotation_dotPrefix*} = $filter_<nameIR>(nameIR_annotation*{nameIR_annotation <- nameIR_annotation*}, $starts_with(nameIR_annotation, ".")*{nameIR_annotation <- nameIR_annotation*})
-  -- if (nameIR_annotation_dotPrefix*{nameIR_annotation_dotPrefix <- nameIR_annotation_dotPrefix*} =/= [])
-  -- let nameIR_annotation_strip*{nameIR_annotation_strip <- nameIR_annotation_strip*} = $strip_prefix(nameIR_annotation_dotPrefix, ".")*{nameIR_annotation_dotPrefix <- nameIR_annotation_dotPrefix*}
-  -- if ~nameIR <- nameIR_annotation_strip*{nameIR_annotation_strip <- nameIR_annotation_strip*}
-
-  clause 4 : (tableActionIR*{tableActionIR <- tableActionIR*}, nameIR) = ?((nameIR_action, tableActionIR_h))
-  -- if tableActionIR*{tableActionIR <- tableActionIR*} matches _ :: _
-  -- let tableActionIR_h :: tableActionIR_t*{tableActionIR_t <- tableActionIR_t*} = tableActionIR*{tableActionIR <- tableActionIR*}
-  -- let annotationList prefixedNameIR _controlPlaneNameIR ( argumentIR_data*{argumentIR_data <- argumentIR_data*} ) #( _parameterListIR , parameterIR_control*{parameterIR_control <- parameterIR_control*} ); = tableActionIR_h
-  -- let nameIR_annotation*{nameIR_annotation <- nameIR_annotation*} = $name_annotation(annotationList)
-  -- let nameIR_annotation_dotPrefix*{nameIR_annotation_dotPrefix <- nameIR_annotation_dotPrefix*} = $filter_<nameIR>(nameIR_annotation*{nameIR_annotation <- nameIR_annotation*}, $starts_with(nameIR_annotation, ".")*{nameIR_annotation <- nameIR_annotation*})
-  -- let nameIR_annotation_strip*{nameIR_annotation_strip <- nameIR_annotation_strip*} = $strip_prefix(nameIR_annotation_dotPrefix, ".")*{nameIR_annotation_dotPrefix <- nameIR_annotation_dotPrefix*}
-  -- if nameIR <- nameIR_annotation_strip*{nameIR_annotation_strip <- nameIR_annotation_strip*}
+  -- let annotationList tableActionReferenceIR #( _parameterListIR , parameterIR_control*{parameterIR_control <- parameterIR_control*} ); = tableActionIR_h
+  -- let prefixedNameIR controlPlaneNameIR ( argumentIR_data*{argumentIR_data <- argumentIR_data*} ) = tableActionReferenceIR
+  -- if controlPlaneNameIR matches (_)
+  -- let ?(nameIR_controlPlane) = controlPlaneNameIR
+  -- let nameIR_split*{nameIR_split <- nameIR_split*} = $split_text(nameIR_controlPlane, ".")
+  -- let nameIR'*{nameIR' <- nameIR'*} = $rev_<nameIR>(nameIR_split*{nameIR_split <- nameIR_split*})
+  -- if nameIR'*{nameIR' <- nameIR'*} matches _ :: _
+  -- let nameIR_unqualified :: _nameIR*{_nameIR <- _nameIR*} = nameIR'*{nameIR' <- nameIR'*}
+  -- if (nameIR = nameIR_unqualified)
   -- let nameIR_action = $flatten_prefixedNameIR(prefixedNameIR)
 
 def $tableObject_create_entry_action(evalContext, tableActionsPropertyIR, tableActionInterface) : tableActionReferenceIR =
 
   clause 0 : (EC, actions={ tableActionIR*{tableActionIR <- tableActionIR*} }, (nameIR_action_update, tableActionArgumentInterface_update*{tableActionArgumentInterface_update <- tableActionArgumentInterface_update*})) = ` nameIR_found controlPlaneNameIR ( argumentIR*{argumentIR <- argumentIR*} )
-  -- let (nameIR, tableActionIR)?{(nameIR, tableActionIR) <- (nameIR, tableActionIR)?} = $find_tableActionIR_by_dotPrefix(tableActionIR*{tableActionIR <- tableActionIR*}, nameIR_action_update)
+  -- let (nameIR, tableActionIR)?{(nameIR, tableActionIR) <- (nameIR, tableActionIR)?} = $find_tableActionIR_qualified(tableActionIR*{tableActionIR <- tableActionIR*}, nameIR_action_update)
   -- if (nameIR, tableActionIR)?{(nameIR, tableActionIR) <- (nameIR, tableActionIR)?} matches (_)
   -- let ?((nameIR_found, tableActionIR_found)) = (nameIR, tableActionIR)?{(nameIR, tableActionIR) <- (nameIR, tableActionIR)?}
   -- let annotationList prefixedNameIR controlPlaneNameIR ( argumentIR_data*{argumentIR_data <- argumentIR_data*} ) #( _parameterListIR , parameterIR_control*{parameterIR_control <- parameterIR_control*} ); = tableActionIR_found
@@ -28779,8 +28802,8 @@ def $tableObject_create_entry_action(evalContext, tableActionsPropertyIR, tableA
   -- let argumentIR*{argumentIR <- argumentIR*} = argumentIR_data*{argumentIR_data <- argumentIR_data*} ++ typedExpressionIR_arg_cast*{typedExpressionIR_arg_cast <- typedExpressionIR_arg_cast*} as argumentIR*
 
   clause 1 : (EC, actions={ tableActionIR*{tableActionIR <- tableActionIR*} }, (nameIR_action_update, tableActionArgumentInterface_update*{tableActionArgumentInterface_update <- tableActionArgumentInterface_update*})) = ` nameIR_found controlPlaneNameIR ( argumentIR*{argumentIR <- argumentIR*} )
-  -- if (?() = $find_tableActionIR_by_dotPrefix(tableActionIR*{tableActionIR <- tableActionIR*}, nameIR_action_update))
-  -- let (nameIR, tableActionIR)?{(nameIR, tableActionIR) <- (nameIR, tableActionIR)?} = $find_tableActionIR_by_name(tableActionIR*{tableActionIR <- tableActionIR*}, nameIR_action_update)
+  -- if (?() = $find_tableActionIR_qualified(tableActionIR*{tableActionIR <- tableActionIR*}, nameIR_action_update))
+  -- let (nameIR, tableActionIR)?{(nameIR, tableActionIR) <- (nameIR, tableActionIR)?} = $find_tableActionIR_unqualified(tableActionIR*{tableActionIR <- tableActionIR*}, nameIR_action_update)
   -- if (nameIR, tableActionIR)?{(nameIR, tableActionIR) <- (nameIR, tableActionIR)?} matches (_)
   -- let ?((nameIR_found, tableActionIR_found)) = (nameIR, tableActionIR)?{(nameIR, tableActionIR) <- (nameIR, tableActionIR)?}
   -- let annotationList prefixedNameIR controlPlaneNameIR ( argumentIR_data*{argumentIR_data <- argumentIR_data*} ) #( _parameterListIR , parameterIR_control*{parameterIR_control <- parameterIR_control*} ); = tableActionIR_found

--- a/p4spec/test/lang/elab.expected
+++ b/p4spec/test/lang/elab.expected
@@ -44,9 +44,11 @@ def $join_text(text*, text) : text =
   -- if text*{text <- text*} matches [ _/1 ]
   -- let [t_h] = text*{text <- text*}
 
-  clause 2 : (text*{text <- text*}, t_sep) = t_h ++ t_sep ++ $join_text(t_t*{t_t <- t_t*}, t_sep)
+  clause 2 : (text'*{text' <- text'*}, t_sep) = t_h1 ++ t_sep ++ $join_text(t_h2 :: t_t*{t_t <- t_t*}, t_sep)
+  -- if text'*{text' <- text'*} matches _ :: _
+  -- let t_h1 :: text*{text <- text*} = text'*{text' <- text'*}
   -- if text*{text <- text*} matches _ :: _
-  -- let t_h :: t_t*{t_t <- t_t*} = text*{text <- text*}
+  -- let t_h2 :: t_t*{t_t <- t_t*} = text*{text <- text*}
 
 def $replace_text(text, text, text) : text =
 

--- a/p4spec/test/lang/prose.expected
+++ b/p4spec/test/lang/prose.expected
@@ -8596,7 +8596,7 @@ xref:TableAction_ok[Typing ``annotationList`` ``tableActionReference`` ``+;+``, 
 * the result of xref:Call_action_partial_ok[typing partial action call on ``parameterIR^{asterisk}^`` with ``·``, under context ``TC``].
  .. Check that ``argumentIR^{asterisk}^`` is an empty list.
  .. Let ``TBLC~1~`` be xref:add_action_tbl[``TBLC~0~`` with match action ``prefixedNameIR`` ``+(+`` ``parameterIR^{asterisk}^`` ``+)+`` applied using ``·`` added].
- .. Let ``tableActionIR`` be ``annotationList~update~`` ``prefixedNameIR`` ``+(+`` ``·`` ``+)+`` ``+#+`` ``+(+`` ``parameterIR~data~^{asterisk}^`` ``+,+`` ``parameterIR~control~^{asterisk}^`` ``+)+`` ``+;+``.
+ .. Let ``tableActionIR`` be ``annotationList~update~`` ``prefixedNameIR`` ``·`` ``+(+`` ``·`` ``+)+`` ``+#+`` ``+(+`` ``parameterIR~data~^{asterisk}^`` ``+,+`` ``parameterIR~control~^{asterisk}^`` ``+)+`` ``+;+``.
  .. Result in table context ``TBLC~1~`` and ``tableActionIR``.
 . Else:
  .. Let ``prefixedNonTypeName`` ``+(+`` ``argumentList`` ``+)+`` be ``tableActionReference``.
@@ -8611,7 +8611,7 @@ xref:TableAction_ok[Typing ``annotationList`` ``tableActionReference`` ``+;+``, 
  .. Let parameters ``parameterIR~data~^{asterisk}^`` for data-plane, ``parameterIR~control~^{asterisk}^`` for control-plane, and casted ``argumentIR~cast~^{asterisk}^`` be
 * the result of xref:Call_action_partial_ok[typing partial action call on ``parameterIR^{asterisk}^`` with ``argumentIR^{asterisk}^``, under context ``TC``].
  .. Let ``TBLC~1~`` be xref:add_action_tbl[``TBLC~0~`` with match action ``prefixedNameIR`` ``+(+`` ``parameterIR^{asterisk}^`` ``+)+`` applied using ``argumentIR~cast~^{asterisk}^`` added].
- .. Let ``tableActionIR`` be ``annotationList~update~`` ``prefixedNameIR`` ``+(+`` ``argumentIR~cast~^{asterisk}^`` ``+)+`` ``+#+`` ``+(+`` ``parameterIR~data~^{asterisk}^`` ``+,+`` ``parameterIR~control~^{asterisk}^`` ``+)+`` ``+;+``.
+ .. Let ``tableActionIR`` be ``annotationList~update~`` ``prefixedNameIR`` ``·`` ``+(+`` ``argumentIR~cast~^{asterisk}^`` ``+)+`` ``+#+`` ``+(+`` ``parameterIR~data~^{asterisk}^`` ``+,+`` ``parameterIR~control~^{asterisk}^`` ``+)+`` ``+;+``.
  .. Result in table context ``TBLC~1~`` and ``tableActionIR``.
 
 xref:TableActions_ok[TableActions_ok]:
@@ -8654,7 +8654,7 @@ xref:TableDefaultAction_ok[Typing ``+=+`` ``expression``, under context ``TC`` a
 . If let ``prefixedNonTypeName`` be ``expression``:
  .. Let ``prefixedNameIR`` be xref:prefixedNonTypeName[the prefixed name of  ``prefixedNonTypeName``].
  .. Check that ( ``·``, ``·`` ) is equal to ``xref:find_action[$find_action(TBLC,`` ``prefixedNameIR)]``.
- .. Result in ``prefixedNameIR`` ``+(+`` ``·`` ``+)+``.
+ .. Result in ``prefixedNameIR`` ``·`` ``+(+`` ``·`` ``+)+``.
 . Else if let ``callExpression`` be ``expression``:
  .. Check that ``callExpression`` matches pattern ``%`` ``(`` ``%`` ``)``.
  .. Let ``callTarget`` ``+(+`` ``argumentList`` ``+)+`` be ``callExpression``.
@@ -8669,7 +8669,7 @@ xref:TableDefaultAction_ok[Typing ``+=+`` ``expression``, under context ``TC`` a
  .. Let ``argumentIR~action_data~^{asterisk}^`` be ``argumentIR~action~^{asterisk}^[0`` ``:`` ``the`` ``length`` ``of`` ``parameterIR~action_data~^{asterisk}^]``.
  .. Let ``argumentIR~cast_data~^{asterisk}^`` be ``argumentIR~cast~^{asterisk}^[0`` ``:`` ``the`` ``length`` ``of`` ``parameterIR~action_data~^{asterisk}^]``.
  .. Check that ``argumentIR~action_data~`` is equal to ``argumentIR~cast_data~``, for all ``argumentIR~action_data~`` in ``argumentIR~action_data~^{asterisk}^`` and ``argumentIR~cast_data~`` in ``argumentIR~cast_data~^{asterisk}^``.
- .. Result in ``prefixedNameIR`` ``+(+`` ``argumentIR~cast~^{asterisk}^`` ``+)+``.
+ .. Result in ``prefixedNameIR`` ``·`` ``+(+`` ``argumentIR~cast~^{asterisk}^`` ``+)+``.
 
 xref:TableEntry_keyset_ok[TableEntry_keyset_ok]:
 
@@ -8780,7 +8780,7 @@ xref:TableEntry_action_ok[Typing ``tableActionReference``, under context ``TC`` 
 . If let ``prefixedNonTypeName`` be ``tableActionReference``:
  .. Let ``prefixedNameIR`` be xref:prefixedNonTypeName[the prefixed name of  ``prefixedNonTypeName``].
  .. Check that ( ``·``, ``·`` ) is equal to ``xref:find_action[$find_action(TBLC,`` ``prefixedNameIR)]``.
- .. Result in ``prefixedNameIR`` ``+(+`` ``·`` ``+)+``.
+ .. Result in ``prefixedNameIR`` ``·`` ``+(+`` ``·`` ``+)+``.
 . Else:
  .. Let ``prefixedNonTypeName`` ``+(+`` ``argumentList`` ``+)+`` be ``tableActionReference``.
  .. Let ``prefixedNameIR`` be xref:prefixedNonTypeName[the prefixed name of  ``prefixedNonTypeName``].
@@ -8792,7 +8792,7 @@ xref:TableEntry_action_ok[Typing ``tableActionReference``, under context ``TC`` 
  .. Let ``argumentIR~action_data~^{asterisk}^`` be ``argumentIR~action~^{asterisk}^[0`` ``:`` ``the`` ``length`` ``of`` ``parameterIR~action_data~^{asterisk}^]``.
  .. Let ``argumentIR~cast_data~^{asterisk}^`` be ``argumentIR~cast~^{asterisk}^[0`` ``:`` ``the`` ``length`` ``of`` ``parameterIR~action_data~^{asterisk}^]``.
  .. Check that ``argumentIR~action_data~`` is equal to ``argumentIR~cast_data~``, for all ``argumentIR~action_data~`` in ``argumentIR~action_data~^{asterisk}^`` and ``argumentIR~cast_data~`` in ``argumentIR~cast_data~^{asterisk}^``.
- .. Result in ``prefixedNameIR`` ``+(+`` ``argumentIR~cast~^{asterisk}^`` ``+)+``.
+ .. Result in ``prefixedNameIR`` ``·`` ``+(+`` ``argumentIR~cast~^{asterisk}^`` ``+)+``.
 
 xref:TableEntry_priority_ok[TableEntry_priority_ok]:
 
@@ -9038,7 +9038,7 @@ xref:Table_ok[Typing ``tableProperty^{asterisk}^``, under context ``TC``]:
  .. Let ``TBLC~0~`` be ``xref:empty_tableContext[$empty_tableContext]``.
  .. Let table context ``TBLC~1~`` and ``tablePropertyIR^{asterisk}^`` be
 * the result of xref:TableProperties_ok[typing ``tableProperty^{asterisk}^``, under context ``TC`` and table context ``TBLC~0~``].
- .. Let ``tablePropertyIR~default_action~`` be ``+`EMPTY+`` ``·`` ``+DEFAULT_ACTION+`` ``+=+`` ``"NoAction"`` ``+(+`` ``·`` ``+)+`` ``+;+``.
+ .. Let ``tablePropertyIR~default_action~`` be ``+`EMPTY+`` ``·`` ``+DEFAULT_ACTION+`` ``+=+`` ``"NoAction"`` ``·`` ``+(+`` ``·`` ``+)+`` ``+;+``.
  .. Let ``(`` ``TBLC~2~,`` ``tablePropertyIR~updated~^{asterisk}^`` ``)`` be ``xref:insert_NoAction_tablePropertyIR[$insert_NoAction_tablePropertyIR(TBLC~1~,`` ``tablePropertyIR^{asterisk}^)]``.
  .. Result in context ``TBLC~2~`` and ``tablePropertyIR~updated~^{asterisk}^`` concatenated with ``tablePropertyIR~default_action~``.
 . Else if the length of xref:filter_[``tableProperty^{asterisk}^`` filtered by ``$is_tableDefaultActionProperty(tableProperty)^{asterisk}^``] is equal to ``1``:
@@ -11712,7 +11712,7 @@ xref:insert_NoAction_tablePropertyIR[$insert_NoAction_tablePropertyIR(TBLC, tabl
 --
 +
 for each ``tableActionIR`` in ``tableActionIR^{asterisk}^``
-  ... Let ``tableActionReferenceIR~NoAction~`` be ``+.+`` ``"NoAction"`` ``+(+`` ``·`` ``+)+``.
+  ... Let ``tableActionReferenceIR~NoAction~`` be ``+.+`` ``"NoAction"`` ``·`` ``+(+`` ``·`` ``+)+``.
   ... If ``tableActionReferenceIR~NoAction~`` is not in ``tableActionReferenceIR^{asterisk}^``:
    .... Let ``TBLC~1~`` be xref:add_action_tbl[``TBLC`` with match action ``+.+`` ``"NoAction"`` ``+(+`` ``·`` ``+)+`` applied using ``·`` added].
    .... Let ``tableActionIR~NoAction~`` be ``+`EMPTY+`` ``tableActionReferenceIR~NoAction~`` ``+#+`` ``+(+`` ``·`` ``+,+`` ``·`` ``+)+`` ``+;+``.
@@ -12199,7 +12199,7 @@ xref:parameterListIR_of_callableDef[$parameterListIR_of_callableDef(callableDef)
  .. Let ``methodDef`` be ``callableDef``.
  .. Return ``xref:parameterListIR_of_methodDef[$parameterListIR_of_methodDef(methodDef)]``.
 
-xref:parameterListIR_of_actionDef[$parameterListIR_of_actionDef(+ACTION+ ++_++ +(+ parameterListIR +)+ ++_++)]
+xref:parameterListIR_of_actionDef[$parameterListIR_of_actionDef(annotationList +ACTION+ ++_++ +(+ parameterListIR +)+ ++_++)]
 
 
 . Return ``parameterListIR``.
@@ -13322,7 +13322,7 @@ xref:ActionDecl_inst[ActionDecl_inst]:
 xref:ActionDecl_inst[Loading ``annotationList`` ``+ACTION+`` ``nameIR`` ``+(+`` ``parameterListIR`` ``+)+`` ``blockStatementIR``, under context ``IC~0~`` at ``p``]:
 
 . Let ``callableId`` be xref:callableId_IR[the callable identifier for ``nameIR`` ``+(+`` ``parameterListIR`` ``+)+``].
-. Let ``actionDef`` be ``+ACTION+`` ``nameIR`` ``+(+`` ``parameterListIR`` ``+)+`` ``blockStatementIR``.
+. Let ``actionDef`` be ``annotationList`` ``+ACTION+`` ``nameIR`` ``+(+`` ``parameterListIR`` ``+)+`` ``blockStatementIR``.
 . Let ``IC~1~`` be xref:add_callableDef_non_overload_i[``IC~0~`` where ``callableId`` to ``actionDef`` is added as a non-overloaded callable to the ``p`` layer].
 . Result in context ``IC~1~``.
 
@@ -15414,7 +15414,7 @@ xref:Table_eval[``EC~0~`` ``ARCH~0~`` ``+|-+`` ``typeId`` ``TBL`` ``+:+`` ``%`` 
   ... Result in ``EC~2~``, ``ARCH~2~``, and ``+EXIT+``.
  .. Else:
   ... Let ``tableMatch^{asterisk}^`` be ``tableMatchesResult``.
-  ... Let ``prefixedNameIR`` ``+(+`` ``argumentListIR`` ``+)+`` be xref:select_action[tie-breaking among matches ``tableMatch^{asterisk}^`` for table object ``TBL``].
+  ... Let ``prefixedNameIR`` ``++_++`` ``+(+`` ``argumentListIR`` ``+)+`` be xref:select_action[tie-breaking among matches ``tableMatch^{asterisk}^`` for table object ``TBL``].
   ... Let context ``EC~3~``, state ``ARCH~3~``, and ``statementResult`` be
 * the result of xref:Stmt_eval[runtime evaluation of ``prefixedNameIR`` ``+<+`` ``·`` ``+>+`` ``+(+`` ``argumentListIR`` ``+)+`` ``+;+``, under context ``EC~2~`` and state ``ARCH~2~`` at ``+LOCAL+``].
   ... If let ``exitResult`` be ``statementResult``:
@@ -15526,7 +15526,7 @@ xref:Callee_eval[Finding callee ``referenceExpressionIR`` ``+(+`` ``argumentList
 . Let ``++_++`` ``+:+`` ``(cursor,`` ``callableDef)`` ``+#+`` ``id~default~^{asterisk}^`` ``+#+`` ``++_++^{asterisk}^`` be xref:option_get[*!*] xref:find_callableDef_overloaded_e[the overloaded callable definition of ``referenceExpressionIR``( ``argumentListIR`` ) in the ``p`` layer of ``EC``].
 . Check that ``(cursor,`` ``callableDef)`` has type ``(cursor,`` ``actionDef)``.
 . Let ``(`` ``p~ref~,`` ``actionDef`` ``)`` be ``(cursor,`` ``callableDef)``.
-. Let ``+ACTION+`` ``nameIR`` ``+(+`` ``parameterListIR`` ``+)+`` ``blockStatementIR`` be ``actionDef``.
+. Let ``++_++`` ``+ACTION+`` ``nameIR`` ``+(+`` ``parameterListIR`` ``+)+`` ``blockStatementIR`` be ``actionDef``.
 . Let ``actionCallee`` be ``+ACTION+`` ``p~ref~`` ``+.+`` ``nameIR`` ``+(+`` ``parameterListIR`` ``+#+`` ``id~default~^{asterisk}^`` ``+)+`` ``blockStatementIR``.
 . Result in context ``EC``, state ``ARCH``, and callee ``actionCallee``.
 
@@ -17345,7 +17345,7 @@ xref:find_tableActionIR_by_name[$find_tableActionIR_by_name(tableActionIR^{aster
  .. Return ``·``.
 . Else:
  .. Let ``tableActionIR~h~`` ``{two-colons}`` ``tableActionIR~t~^{asterisk}^`` be ``tableActionIR^{asterisk}^``.
- .. Let ``annotationList`` ``prefixedNameIR`` ``+(+`` ``argumentIR~data~^{asterisk}^`` ``+)+`` ``+#+`` ``+(+`` ``++_++`` ``+,+`` ``parameterIR~control~^{asterisk}^`` ``+)+`` ``+;+`` be ``tableActionIR~h~``.
+ .. Let ``annotationList`` ``prefixedNameIR`` ``++_++`` ``+(+`` ``argumentIR~data~^{asterisk}^`` ``+)+`` ``+#+`` ``+(+`` ``++_++`` ``+,+`` ``parameterIR~control~^{asterisk}^`` ``+)+`` ``+;+`` be ``tableActionIR~h~``.
  .. Let ``nameIR~action~`` be xref:flatten_prefixedNameIR[the string form of  ``prefixedNameIR``].
  .. If ``·`` is equal to ``xref:name_annotation[$name_annotation(annotationList)]``:
   ... If ``nameIR~action~`` is equal to ``nameIR``:
@@ -17367,10 +17367,10 @@ xref:find_tableActionIR_by_dotPrefix[$find_tableActionIR_by_dotPrefix(tableActio
  .. Return ``·``.
 . Else:
  .. Let ``tableActionIR~h~`` ``{two-colons}`` ``tableActionIR~t~^{asterisk}^`` be ``tableActionIR^{asterisk}^``.
- .. Let ``annotationList`` ``++_++`` ``+(+`` ``++_++`` ``+)+`` ``+#+`` ``+(+`` ``++_++`` ``+,+`` ``++_++`` ``+)+`` ``+;+`` be ``tableActionIR~h~``.
+ .. Let ``annotationList`` ``++_++`` ``++_++`` ``+(+`` ``++_++`` ``+)+`` ``+#+`` ``+(+`` ``++_++`` ``+,+`` ``++_++`` ``+)+`` ``+;+`` be ``tableActionIR~h~``.
  .. If ``·`` is equal to ``xref:name_annotation[$name_annotation(annotationList)]``:
   ... Return ``xref:find_tableActionIR_by_dotPrefix[$find_tableActionIR_by_dotPrefix(tableActionIR~t~^{asterisk}^,`` ``nameIR)]``.
- .. Let ``annotationList`` ``prefixedNameIR`` ``+(+`` ``argumentIR~data~^{asterisk}^`` ``+)+`` ``+#+`` ``+(+`` ``++_++`` ``+,+`` ``parameterIR~control~^{asterisk}^`` ``+)+`` ``+;+`` be ``tableActionIR~h~``.
+ .. Let ``annotationList`` ``prefixedNameIR`` ``++_++`` ``+(+`` ``argumentIR~data~^{asterisk}^`` ``+)+`` ``+#+`` ``+(+`` ``++_++`` ``+,+`` ``parameterIR~control~^{asterisk}^`` ``+)+`` ``+;+`` be ``tableActionIR~h~``.
  .. Let ``nameIR~annotation~^{asterisk}^`` be ``xref:name_annotation[$name_annotation(annotationList)]``.
  .. If ``nameIR~annotation~^{asterisk}^`` is not equal to ``·``:
   ... Check that ``·`` is equal to xref:filter_[``nameIR~annotation~^{asterisk}^`` filtered by ``(`` ``$starts_with(nameIR~annotation~,`` ``".")`` ``)^{asterisk}^``].
@@ -17397,7 +17397,7 @@ xref:tableObject_create_entry_action[$tableObject_create_entry_action(EC, +ACTIO
 
 . Let ``(nameIR,`` ``tableActionIR)^?^`` be ``xref:find_tableActionIR_by_dotPrefix[$find_tableActionIR_by_dotPrefix(tableActionIR^{asterisk}^,`` ``nameIR~action_update~)]``.
 . If let ``(`` ``nameIR~found~,`` ``tableActionIR~found~`` ``)`` be ``(nameIR,`` ``tableActionIR)^?^``:
- .. Let ``annotationList`` ``prefixedNameIR`` ``+(+`` ``argumentIR~data~^{asterisk}^`` ``+)+`` ``+#+`` ``+(+`` ``++_++`` ``+,+`` ``parameterIR~control~^{asterisk}^`` ``+)+`` ``+;+`` be ``tableActionIR~found~``.
+ .. Let ``annotationList`` ``prefixedNameIR`` ``controlPlaneNameIR`` ``+(+`` ``argumentIR~data~^{asterisk}^`` ``+)+`` ``+#+`` ``+(+`` ``++_++`` ``+,+`` ``parameterIR~control~^{asterisk}^`` ``+)+`` ``+;+`` be ``tableActionIR~found~``.
  .. Let ``i~arg_aligned~^{asterisk}^`` be ``xref:align_tableActionArgumentInterfaces[$align_tableActionArgumentInterfaces(parameterIR~control~^{asterisk}^,`` ``tableActionArgumentInterface~update~^{asterisk}^)]``.
  .. Let ``typeIR~param~^{asterisk}^`` be the list obtained by repeating:
 +
@@ -17429,10 +17429,10 @@ for each ``typeIR~param~`` in ``typeIR~param~^{asterisk}^`` and ``typedExpressio
 +
 for each ``typedExpressionIR^?^`` in ``typedExpressionIR^?^^{asterisk}^``
  .. Let ``argumentIR^{asterisk}^`` be ``argumentIR~data~^{asterisk}^`` concatenated with ``typedExpressionIR~arg_cast~^{asterisk}^``.
- .. Return ``nameIR~found~`` ``+(+`` ``argumentIR^{asterisk}^`` ``+)+``.
+ .. Return ``nameIR~found~`` ``controlPlaneNameIR`` ``+(+`` ``argumentIR^{asterisk}^`` ``+)+``.
 . If ``·`` is equal to ``xref:find_tableActionIR_by_dotPrefix[$find_tableActionIR_by_dotPrefix(tableActionIR^{asterisk}^,`` ``nameIR~action_update~)]``:
  .. Let ``(`` ``nameIR~found~,`` ``tableActionIR~found~`` ``)`` be xref:option_get[*!*] ``xref:find_tableActionIR_by_name[$find_tableActionIR_by_name(tableActionIR^{asterisk}^,`` ``nameIR~action_update~)]``.
- .. Let ``annotationList`` ``prefixedNameIR`` ``+(+`` ``argumentIR~data~^{asterisk}^`` ``+)+`` ``+#+`` ``+(+`` ``++_++`` ``+,+`` ``parameterIR~control~^{asterisk}^`` ``+)+`` ``+;+`` be ``tableActionIR~found~``.
+ .. Let ``annotationList`` ``prefixedNameIR`` ``controlPlaneNameIR`` ``+(+`` ``argumentIR~data~^{asterisk}^`` ``+)+`` ``+#+`` ``+(+`` ``++_++`` ``+,+`` ``parameterIR~control~^{asterisk}^`` ``+)+`` ``+;+`` be ``tableActionIR~found~``.
  .. Let ``i~arg_aligned~^{asterisk}^`` be ``xref:align_tableActionArgumentInterfaces[$align_tableActionArgumentInterfaces(parameterIR~control~^{asterisk}^,`` ``tableActionArgumentInterface~update~^{asterisk}^)]``.
  .. Let ``typeIR~param~^{asterisk}^`` be the list obtained by repeating:
 +
@@ -17464,7 +17464,7 @@ for each ``typeIR~param~`` in ``typeIR~param~^{asterisk}^`` and ``typedExpressio
 +
 for each ``typedExpressionIR^?^`` in ``typedExpressionIR^?^^{asterisk}^``
  .. Let ``argumentIR^{asterisk}^`` be ``argumentIR~data~^{asterisk}^`` concatenated with ``typedExpressionIR~arg_cast~^{asterisk}^``.
- .. Return ``nameIR~found~`` ``+(+`` ``argumentIR^{asterisk}^`` ``+)+``.
+ .. Return ``nameIR~found~`` ``controlPlaneNameIR`` ``+(+`` ``argumentIR^{asterisk}^`` ``+)+``.
 
 xref:tableObject_add_entry[$tableObject_add_entry(EC, +TABLE+ typeId +{+ frame TBL +}+, tableEntryPriorityInterface, tableKeysetInterface, tableActionInterface)]
 

--- a/p4spec/test/lang/prose.expected
+++ b/p4spec/test/lang/prose.expected
@@ -43,9 +43,11 @@ xref:join_text[The result of joining ``text^{asterisk}^`` with separator ``t~sep
  .. Return ``""``.
 . Else if let ``t~h~`` be ``text^{asterisk}^``:
  .. Return ``t~h~``.
-. Else if let ``t~h~`` ``{two-colons}`` ``t~t~^{asterisk}^`` be ``text^{asterisk}^``:
- .. Let ``text'`` be xref:join_text[the result of joining ``t~t~^{asterisk}^`` with separator ``t~sep~``].
- .. Return ``t~h~`` concatenated with ``t~sep~`` concatenated with ``text'``.
+. Else if let ``t~h1~`` ``{two-colons}`` ``text'^{asterisk}^`` be ``text^{asterisk}^``:
+ .. Check that ``text'^{asterisk}^`` is a non-empty list.
+ .. Let ``t~h2~`` ``{two-colons}`` ``t~t~^{asterisk}^`` be ``text'^{asterisk}^``.
+ .. Let ``text''`` be xref:join_text[the result of joining ``t~h2~`` ``{two-colons}`` ``t~t~^{asterisk}^`` with separator ``t~sep~``].
+ .. Return ``t~h1~`` concatenated with ``t~sep~`` concatenated with ``text''``.
 
 xref:replace_text[The text ``t`` with all occurrences of ``t~old~`` replaced by ``t~new~``]
 

--- a/p4spec/test/lang/prose.expected
+++ b/p4spec/test/lang/prose.expected
@@ -12449,6 +12449,28 @@ xref:add_callableDef_non_overload_i[``IC`` where ``callableId`` to ``callableDef
  .. Let ``callableDefEnv`` be xref:add_map[``IC.+BLOCK+.+CALLABLE+`` where ``callableId`` to ``callableDef`` is added].
  .. Return ``IC`` with ``+BLOCK+.+CALLABLE+`` set to ``callableDefEnv``.
 
+xref:find_callableDef_non_overload_i[The non-overloaded callable definition of ``prefixedNameIR`` from the ``p`` layer of ``IC``]
+
+
+. If let ``+.+`` ``nameIR`` be ``prefixedNameIR``:
+ .. Return ``xref:find_non_overloaded[$find_non_overloaded<callableDef>(IC.+GLOBAL+.+CALLABLE+,`` ``nameIR)]``.
+. If ``p`` is ``GLOBAL``:
+ .. Check that ``prefixedNameIR`` matches pattern ````` ``%``.
+ .. Let ``nameIR`` be ``prefixedNameIR``.
+ .. Return ``xref:find_non_overloaded[$find_non_overloaded<callableDef>(IC.+GLOBAL+.+CALLABLE+,`` ``nameIR)]``.
+. Else if ``p`` is ``BLOCK``:
+ .. Check that ``prefixedNameIR`` matches pattern ````` ``%``.
+ .. Let ``nameIR`` be ``prefixedNameIR``.
+ .. Let ``(callableId,`` ``callableDef)^?^`` be ``xref:find_non_overloaded[$find_non_overloaded<callableDef>(IC.+BLOCK+.+CALLABLE+,`` ``nameIR)]``.
+ .. If let ``(`` ``callableId,`` ``callableDef`` ``)`` be ``(callableId,`` ``callableDef)^?^``:
+  ... Return ( ``callableId``, ``callableDef`` ).
+ .. If ``·`` is equal to ``xref:find_non_overloaded[$find_non_overloaded<callableDef>(IC.+BLOCK+.+CALLABLE+,`` ``nameIR)]``:
+  ... Return xref:find_callableDef_non_overload_i[the non-overloaded callable definition of ``nameIR`` from the ``+GLOBAL+`` layer of ``IC``].
+. Else:
+ .. Check that ``prefixedNameIR`` matches pattern ````` ``%``.
+ .. Let ``nameIR`` be ``prefixedNameIR``.
+ .. Return xref:find_callableDef_non_overload_i[the non-overloaded callable definition of ``nameIR`` from the ``+BLOCK+`` layer of ``IC``].
+
 xref:add_constructorDef_i[Where ``callableId`` to ``constructorDef`` is added to ``IC``]
 
 
@@ -13129,6 +13151,46 @@ xref:ParserLocalDecls_inst[Compile-time evaluation of ``parserLocalDeclarationIR
 * the result of xref:ParserLocalDecls_inst[compile-time evaluation of ``parserLocalDeclarationIR~t~^{asterisk}^``, under context ``IC~1~`` and store ``STO~1~``].
  .. Result in context ``IC~2~``, store ``STO~2~``, and ``parserLocalDeclarationIR~h_inst~`` ``{two-colons}`` ``parserLocalDeclarationIR~t_inst~^{asterisk}^``.
 
+xref:TableAction_inst[TableAction_inst]:
+
+* Compile-time evaluation of ``tableActionIR``, under context ``instContext``and store ``store``:
+* Result in store ``store`` and ``tableActionIR``.
+
+xref:TableAction_inst[Compile-time evaluation of ``annotationList`` ``tableActionReferenceIR`` ``+#+`` ``+(+`` ``parameterListIR`` ``+,+`` ``parameterListIR~control~`` ``+)+`` ``+;+``, under context ``IC``and store ``STO``]:
+
+. Let ``prefixedNameIR`` ``++_++`` ``+(+`` ``argumentListIR`` ``+)+`` be ``tableActionReferenceIR``.
+. Let ``(`` ``++_++,`` ``callableDef`` ``)`` be xref:option_get[*!*] xref:find_callableDef_non_overload_i[the non-overloaded callable definition of ``prefixedNameIR`` from the ``+LOCAL+`` layer of ``IC``].
+. Check that ``callableDef`` has type ``actionDef``.
+. Let ``actionDef`` be ``callableDef``.
+. Let ``annotationList~actionDef~`` ``+ACTION+`` ``nameIR`` ``+(+`` ``++_++`` ``+)+`` ``++_++`` be ``actionDef``.
+. Let ``nameIR'^{asterisk}^`` be ``xref:name_annotation[$name_annotation(annotationList~actionDef~)]``.
+. If let ``nameIR~anno~`` be ``nameIR'^{asterisk}^``:
+ .. Let ``controlPlaneNameIR`` be ``IC.+PATH+`` concatenated with ``nameIR~anno~``.
+ .. Let ``tableActionReferenceIR'`` be ``prefixedNameIR`` ``controlPlaneNameIR`` ``+(+`` ``argumentListIR`` ``+)+``.
+ .. Let ``tableActionIR`` be ``annotationList`` ``tableActionReferenceIR'`` ``+#+`` ``+(+`` ``parameterListIR`` ``+,+`` ``parameterListIR~control~`` ``+)+`` ``+;+``.
+ .. Result in store ``STO`` and ``tableActionIR``.
+. If ``·`` is equal to ``xref:name_annotation[$name_annotation(annotationList~actionDef~)]``:
+ .. Let ``controlPlaneNameIR`` be ``IC.+PATH+`` concatenated with ``nameIR``.
+ .. Let ``tableActionReferenceIR'`` be ``prefixedNameIR`` ``controlPlaneNameIR`` ``+(+`` ``argumentListIR`` ``+)+``.
+ .. Let ``tableActionIR`` be ``annotationList`` ``tableActionReferenceIR'`` ``+#+`` ``+(+`` ``parameterListIR`` ``+,+`` ``parameterListIR~control~`` ``+)+`` ``+;+``.
+ .. Result in store ``STO`` and ``tableActionIR``.
+
+xref:TableActions_inst[TableActions_inst]:
+
+* Compile-time evaluation of ``tableActionIR^{asterisk}^``, under context ``instContext``and store ``store``:
+* Result in store ``store`` and ``tableActionIR^{asterisk}^``.
+
+xref:TableActions_inst[Compile-time evaluation of ``tableActionIR^{asterisk}^``, under context ``IC``and store ``store``]:
+
+. If ``tableActionIR^{asterisk}^`` is equal to ``·``:
+ .. Result in store ``store`` and ``·``.
+. If let ``tableActionIR~h~`` ``{two-colons}`` ``tableActionIR~t~^{asterisk}^`` be ``tableActionIR^{asterisk}^``:
+ .. Let store ``STO~1~`` and ``tableActionIR~h_inst~`` be
+* the result of xref:TableAction_inst[compile-time evaluation of ``tableActionIR~h~``, under context ``IC``and store ``store``].
+ .. Let store ``STO~2~`` and ``tableActionIR~t_inst~^{asterisk}^`` be
+* the result of xref:TableActions_inst[compile-time evaluation of ``tableActionIR~t~^{asterisk}^``, under context ``IC``and store ``STO~1~``].
+ .. Result in store ``STO~1~`` and ``tableActionIR~h_inst~`` ``{two-colons}`` ``tableActionIR~t_inst~^{asterisk}^``.
+
 xref:TableProperty_inst[TableProperty_inst]:
 
 * Compile-time evaluation of ``tablePropertyIR``, under context ``instContext``and store ``store``:
@@ -13138,9 +13200,12 @@ xref:TableProperty_inst[Compile-time evaluation of ``tableKeysPropertyIR``, unde
 
 . Result in store ``STO`` and ``tableKeysPropertyIR``.
 
-xref:TableProperty_inst[Compile-time evaluation of ``tableActionsPropertyIR``, under context ``IC``and store ``STO``]:
+xref:TableProperty_inst[Compile-time evaluation of ``+ACTIONS+`` ``+=+`` ``+{+`` ``tableActionListIR`` ``+}+``, under context ``IC``and store ``STO``]:
 
-. Result in store ``STO`` and ``tableActionsPropertyIR``.
+. Let store ``STO~1~`` and ``tableActionListIR~inst~`` be
+* the result of xref:TableActions_inst[compile-time evaluation of ``tableActionListIR``, under context ``IC``and store ``STO``].
+. Let ``tableActionsPropertyIR`` be ``+ACTIONS+`` ``+=+`` ``+{+`` ``tableActionListIR~inst~`` ``+}+``.
+. Result in store ``STO~1~`` and ``tableActionsPropertyIR``.
 
 xref:TableProperty_inst[Compile-time evaluation of ``tableDefaultActionPropertyIR``, under context ``IC``and store ``STO``]:
 

--- a/p4spec/test/lang/prose.expected
+++ b/p4spec/test/lang/prose.expected
@@ -24,6 +24,8 @@ xref:text_to_int[$text_to_int(text)]
 
 xref:int_to_text[$int_to_text(int)]
 
+xref:split_text[$split_text(text, text')]
+
 xref:concat_text[The concatenation of ``text^{asterisk}^``]
 
 
@@ -33,6 +35,17 @@ xref:concat_text[The concatenation of ``text^{asterisk}^``]
  .. Let ``t~h~`` ``{two-colons}`` ``t~t~^{asterisk}^`` be ``text^{asterisk}^``.
  .. Let ``text'`` be xref:concat_text[the concatenation of ``t~t~^{asterisk}^``].
  .. Return ``t~h~`` concatenated with ``text'``.
+
+xref:join_text[The result of joining ``text^{asterisk}^`` with separator ``t~sep~``]
+
+
+. If ``text^{asterisk}^`` is an empty list:
+ .. Return ``""``.
+. Else if let ``t~h~`` be ``text^{asterisk}^``:
+ .. Return ``t~h~``.
+. Else if let ``t~h~`` ``{two-colons}`` ``t~t~^{asterisk}^`` be ``text^{asterisk}^``:
+ .. Let ``text'`` be xref:join_text[the result of joining ``t~t~^{asterisk}^`` with separator ``t~sep~``].
+ .. Return ``t~h~`` concatenated with ``t~sep~`` concatenated with ``text'``.
 
 xref:replace_text[The text ``t`` with all occurrences of ``t~old~`` replaced by ``t~new~``]
 
@@ -12453,17 +12466,21 @@ xref:find_callableDef_non_overload_i[The non-overloaded callable definition of `
 
 
 . If let ``+.+`` ``nameIR`` be ``prefixedNameIR``:
- .. Return ``xref:find_non_overloaded[$find_non_overloaded<callableDef>(IC.+GLOBAL+.+CALLABLE+,`` ``nameIR)]``.
+ .. If ``·`` is equal to ``xref:find_non_overloaded[$find_non_overloaded<callableDef>(IC.+GLOBAL+.+CALLABLE+,`` ``nameIR)]``:
+  ... Return ``·``.
+ .. Let ``(callableId,`` ``callableDef)^?^`` be ``xref:find_non_overloaded[$find_non_overloaded<callableDef>(IC.+GLOBAL+.+CALLABLE+,`` ``nameIR)]``.
+ .. If let ``(`` ``callableId,`` ``callableDef`` ``)`` be ``(callableId,`` ``callableDef)^?^``:
+  ... Return ( ``+GLOBAL+``, ``callableId``, ``callableDef`` ).
 . If ``p`` is ``GLOBAL``:
  .. Check that ``prefixedNameIR`` matches pattern ````` ``%``.
  .. Let ``nameIR`` be ``prefixedNameIR``.
- .. Return ``xref:find_non_overloaded[$find_non_overloaded<callableDef>(IC.+GLOBAL+.+CALLABLE+,`` ``nameIR)]``.
+ .. Return xref:find_callableDef_non_overload_i[the non-overloaded callable definition of ``+.+`` ``nameIR`` from the ``+GLOBAL+`` layer of ``IC``].
 . Else if ``p`` is ``BLOCK``:
  .. Check that ``prefixedNameIR`` matches pattern ````` ``%``.
  .. Let ``nameIR`` be ``prefixedNameIR``.
  .. Let ``(callableId,`` ``callableDef)^?^`` be ``xref:find_non_overloaded[$find_non_overloaded<callableDef>(IC.+BLOCK+.+CALLABLE+,`` ``nameIR)]``.
  .. If let ``(`` ``callableId,`` ``callableDef`` ``)`` be ``(callableId,`` ``callableDef)^?^``:
-  ... Return ( ``callableId``, ``callableDef`` ).
+  ... Return ( ``+BLOCK+``, ``callableId``, ``callableDef`` ).
  .. If ``·`` is equal to ``xref:find_non_overloaded[$find_non_overloaded<callableDef>(IC.+BLOCK+.+CALLABLE+,`` ``nameIR)]``:
   ... Return xref:find_callableDef_non_overload_i[the non-overloaded callable definition of ``nameIR`` from the ``+GLOBAL+`` layer of ``IC``].
 . Else:
@@ -13159,18 +13176,27 @@ xref:TableAction_inst[TableAction_inst]:
 xref:TableAction_inst[Compile-time evaluation of ``annotationList`` ``tableActionReferenceIR`` ``+#+`` ``+(+`` ``parameterListIR`` ``+,+`` ``parameterListIR~control~`` ``+)+`` ``+;+``, under context ``IC``and store ``STO``]:
 
 . Let ``prefixedNameIR`` ``++_++`` ``+(+`` ``argumentListIR`` ``+)+`` be ``tableActionReferenceIR``.
-. Let ``(`` ``++_++,`` ``callableDef`` ``)`` be xref:option_get[*!*] xref:find_callableDef_non_overload_i[the non-overloaded callable definition of ``prefixedNameIR`` from the ``+LOCAL+`` layer of ``IC``].
+. Let ``(`` ``cursor,`` ``++_++,`` ``callableDef`` ``)`` be xref:option_get[*!*] xref:find_callableDef_non_overload_i[the non-overloaded callable definition of ``prefixedNameIR`` from the ``+LOCAL+`` layer of ``IC``].
 . Check that ``callableDef`` has type ``actionDef``.
 . Let ``actionDef`` be ``callableDef``.
 . Let ``annotationList~actionDef~`` ``+ACTION+`` ``nameIR`` ``+(+`` ``++_++`` ``+)+`` ``++_++`` be ``actionDef``.
 . Let ``nameIR'^{asterisk}^`` be ``xref:name_annotation[$name_annotation(annotationList~actionDef~)]``.
 . If let ``nameIR~anno~`` be ``nameIR'^{asterisk}^``:
- .. Let ``controlPlaneNameIR`` be ``IC.+PATH+`` concatenated with ``nameIR~anno~``.
- .. Let ``tableActionReferenceIR'`` be ``prefixedNameIR`` ``controlPlaneNameIR`` ``+(+`` ``argumentListIR`` ``+)+``.
- .. Let ``tableActionIR`` be ``annotationList`` ``tableActionReferenceIR'`` ``+#+`` ``+(+`` ``parameterListIR`` ``+,+`` ``parameterListIR~control~`` ``+)+`` ``+;+``.
- .. Result in store ``STO`` and ``tableActionIR``.
+ .. If ``xref:starts_with[$starts_with(nameIR~anno~,`` ``".")]``:
+  ... Let ``text`` be xref:strip_prefix[the text ``nameIR~anno~`` with the prefix ``"."`` removed].
+  ... Let ``controlPlaneNameIR`` be ``text``.
+  ... Let ``tableActionReferenceIR'`` be ``prefixedNameIR`` ``controlPlaneNameIR`` ``+(+`` ``argumentListIR`` ``+)+``.
+  ... Let ``tableActionIR`` be ``annotationList`` ``tableActionReferenceIR'`` ``+#+`` ``+(+`` ``parameterListIR`` ``+,+`` ``parameterListIR~control~`` ``+)+`` ``+;+``.
+  ... Result in store ``STO`` and ``tableActionIR``.
+ .. Else:
+  ... Let ``text`` be xref:join_text[the result of joining ``IC.+PATH+`` concatenated with ``nameIR~anno~`` with separator ``"."``].
+  ... Let ``controlPlaneNameIR`` be xref:ite[``nameIR~anno~`` if ``cursor`` is equal to ``+GLOBAL+`` otherwise ``text``].
+  ... Let ``tableActionReferenceIR'`` be ``prefixedNameIR`` ``controlPlaneNameIR`` ``+(+`` ``argumentListIR`` ``+)+``.
+  ... Let ``tableActionIR`` be ``annotationList`` ``tableActionReferenceIR'`` ``+#+`` ``+(+`` ``parameterListIR`` ``+,+`` ``parameterListIR~control~`` ``+)+`` ``+;+``.
+  ... Result in store ``STO`` and ``tableActionIR``.
 . If ``·`` is equal to ``xref:name_annotation[$name_annotation(annotationList~actionDef~)]``:
- .. Let ``controlPlaneNameIR`` be ``IC.+PATH+`` concatenated with ``nameIR``.
+ .. Let ``text`` be xref:join_text[the result of joining ``IC.+PATH+`` concatenated with ``nameIR`` with separator ``"."``].
+ .. Let ``controlPlaneNameIR`` be xref:ite[``nameIR`` if ``cursor`` is equal to ``+GLOBAL+`` otherwise ``text``].
  .. Let ``tableActionReferenceIR'`` be ``prefixedNameIR`` ``controlPlaneNameIR`` ``+(+`` ``argumentListIR`` ``+)+``.
  .. Let ``tableActionIR`` be ``annotationList`` ``tableActionReferenceIR'`` ``+#+`` ``+(+`` ``parameterListIR`` ``+,+`` ``parameterListIR~control~`` ``+)+`` ``+;+``.
  .. Result in store ``STO`` and ``tableActionIR``.
@@ -17403,64 +17429,55 @@ xref:align_tableActionArgumentInterfaces'[$align_tableActionArgumentInterfaces'(
 
 . Return xref:find_map[the value of ``nameIR~param~`` in map ``+{+`` ``(`` ``id~arg~`` ``+:+`` ``i~arg~`` ``)^{asterisk}^`` ``+}+``].
 
-xref:find_tableActionIR_by_name[$find_tableActionIR_by_name(tableActionIR^{asterisk}^, nameIR)]
+xref:find_tableActionIR_qualified[$find_tableActionIR_qualified(tableActionIR^{asterisk}^, nameIR)]
 
 
 . If ``tableActionIR^{asterisk}^`` is an empty list:
  .. Return ``·``.
 . Else:
  .. Let ``tableActionIR~h~`` ``{two-colons}`` ``tableActionIR~t~^{asterisk}^`` be ``tableActionIR^{asterisk}^``.
- .. Let ``annotationList`` ``prefixedNameIR`` ``++_++`` ``+(+`` ``argumentIR~data~^{asterisk}^`` ``+)+`` ``+#+`` ``+(+`` ``++_++`` ``+,+`` ``parameterIR~control~^{asterisk}^`` ``+)+`` ``+;+`` be ``tableActionIR~h~``.
- .. Let ``nameIR~action~`` be xref:flatten_prefixedNameIR[the string form of  ``prefixedNameIR``].
- .. If ``·`` is equal to ``xref:name_annotation[$name_annotation(annotationList)]``:
-  ... If ``nameIR~action~`` is equal to ``nameIR``:
-   .... Return ( ``nameIR~action~``, ``tableActionIR~h~`` ).
-  ... Else:
-   .... Return ``xref:find_tableActionIR_by_name[$find_tableActionIR_by_name(tableActionIR~t~^{asterisk}^,`` ``nameIR)]``.
- .. Let ``nameIR~annotation~^{asterisk}^`` be ``xref:name_annotation[$name_annotation(annotationList)]``.
- .. If ``nameIR~annotation~^{asterisk}^`` is not equal to ``·``:
-  ... Let ``b~hit~`` be ``nameIR`` is equal to ``nameIR~action~`` or ``nameIR`` is in ``nameIR~annotation~^{asterisk}^``.
-  ... If ``b~hit~``:
-   .... Return ( ``nameIR~action~``, ``tableActionIR~h~`` ).
-  ... Else:
-   .... Return ``xref:find_tableActionIR_by_name[$find_tableActionIR_by_name(tableActionIR~t~^{asterisk}^,`` ``nameIR)]``.
+ .. Let ``annotationList`` ``tableActionReferenceIR`` ``+#+`` ``+(+`` ``++_++`` ``+,+`` ``parameterIR~control~^{asterisk}^`` ``+)+`` ``+;+`` be ``tableActionIR~h~``.
+ .. Let ``prefixedNameIR`` ``controlPlaneNameIR`` ``+(+`` ``argumentIR~data~^{asterisk}^`` ``+)+`` be ``tableActionReferenceIR``.
+ .. If ``nameIR`` is not equal to ``controlPlaneNameIR``:
+  ... Return ``xref:find_tableActionIR_qualified[$find_tableActionIR_qualified(tableActionIR~t~^{asterisk}^,`` ``nameIR)]``.
+ .. If ``nameIR`` is equal to ``controlPlaneNameIR``:
+  ... Let ``nameIR~action~`` be xref:flatten_prefixedNameIR[the string form of  ``prefixedNameIR``].
+  ... Return ( ``nameIR~action~``, ``tableActionIR~h~`` ).
 
-xref:find_tableActionIR_by_dotPrefix[$find_tableActionIR_by_dotPrefix(tableActionIR^{asterisk}^, nameIR)]
+xref:find_tableActionIR_unqualified[$find_tableActionIR_unqualified(tableActionIR^{asterisk}^, nameIR)]
+
+
+. Let ``nameIR~split~^{asterisk}^`` be ``xref:split_text[$split_text(nameIR,`` ``".")]``.
+. If the length of ``nameIR~split~^{asterisk}^`` is greater than ``1``:
+ .. Return ``·``.
+. If the length of ``nameIR~split~^{asterisk}^`` is equal to ``1``:
+ .. Return ``<<find_tableActionIR_unqualified',$find_tableActionIR_unqualified'(tableActionIR^{asterisk}^,`` ``nameIR~split~^{asterisk}^[0])>>``.
+
+xref:find_tableActionIR_unqualified'[$find_tableActionIR_unqualified'(tableActionIR^{asterisk}^, nameIR)]
 
 
 . If ``tableActionIR^{asterisk}^`` is an empty list:
  .. Return ``·``.
 . Else:
  .. Let ``tableActionIR~h~`` ``{two-colons}`` ``tableActionIR~t~^{asterisk}^`` be ``tableActionIR^{asterisk}^``.
- .. Let ``annotationList`` ``++_++`` ``++_++`` ``+(+`` ``++_++`` ``+)+`` ``+#+`` ``+(+`` ``++_++`` ``+,+`` ``++_++`` ``+)+`` ``+;+`` be ``tableActionIR~h~``.
- .. If ``·`` is equal to ``xref:name_annotation[$name_annotation(annotationList)]``:
-  ... Return ``xref:find_tableActionIR_by_dotPrefix[$find_tableActionIR_by_dotPrefix(tableActionIR~t~^{asterisk}^,`` ``nameIR)]``.
- .. Let ``annotationList`` ``prefixedNameIR`` ``++_++`` ``+(+`` ``argumentIR~data~^{asterisk}^`` ``+)+`` ``+#+`` ``+(+`` ``++_++`` ``+,+`` ``parameterIR~control~^{asterisk}^`` ``+)+`` ``+;+`` be ``tableActionIR~h~``.
- .. Let ``nameIR~annotation~^{asterisk}^`` be ``xref:name_annotation[$name_annotation(annotationList)]``.
- .. If ``nameIR~annotation~^{asterisk}^`` is not equal to ``·``:
-  ... Check that ``·`` is equal to xref:filter_[``nameIR~annotation~^{asterisk}^`` filtered by ``(`` ``$starts_with(nameIR~annotation~,`` ``".")`` ``)^{asterisk}^``].
-  ... Return ``xref:find_tableActionIR_by_dotPrefix[$find_tableActionIR_by_dotPrefix(tableActionIR~t~^{asterisk}^,`` ``nameIR)]``.
- .. Let ``bool^{asterisk}^`` be the list obtained by repeating:
-+
---
-  *** Let ``bool`` be ``xref:starts_with[$starts_with(nameIR~annotation~,`` ``".")]``.
---
-+
-for each ``nameIR~annotation~`` in ``nameIR~annotation~^{asterisk}^``
- .. Let ``nameIR~annotation_dotPrefix~^{asterisk}^`` be xref:filter_[``nameIR~annotation~^{asterisk}^`` filtered by ``bool^{asterisk}^``].
- .. If ``nameIR~annotation_dotPrefix~^{asterisk}^`` is not equal to ``·``:
-  ... Let ``nameIR~annotation_strip~^{asterisk}^`` be ``(`` ``xref:strip_prefix[$strip_prefix(nameIR~annotation_dotPrefix~,`` ``".")]`` ``)^{asterisk}^``.
-  ... Check that ``nameIR`` is not in ``nameIR~annotation_strip~^{asterisk}^``.
-  ... Return ``xref:find_tableActionIR_by_dotPrefix[$find_tableActionIR_by_dotPrefix(tableActionIR~t~^{asterisk}^,`` ``nameIR)]``.
- .. Let ``nameIR~annotation_strip~^{asterisk}^`` be ``(`` ``xref:strip_prefix[$strip_prefix(nameIR~annotation_dotPrefix~,`` ``".")]`` ``)^{asterisk}^``.
- .. If ``nameIR`` is in ``nameIR~annotation_strip~^{asterisk}^``:
+ .. Let ``annotationList`` ``tableActionReferenceIR`` ``+#+`` ``+(+`` ``++_++`` ``+,+`` ``parameterIR~control~^{asterisk}^`` ``+)+`` ``+;+`` be ``tableActionIR~h~``.
+ .. Let ``prefixedNameIR`` ``controlPlaneNameIR`` ``+(+`` ``argumentIR~data~^{asterisk}^`` ``+)+`` be ``tableActionReferenceIR``.
+ .. Check that ``controlPlaneNameIR`` is defined.
+ .. Let ``nameIR~controlPlane~`` be ``controlPlaneNameIR``.
+ .. Let ``nameIR~split~^{asterisk}^`` be ``xref:split_text[$split_text(nameIR~controlPlane~,`` ``".")]``.
+ .. Let ``nameIR'^{asterisk}^`` be xref:rev_[the reversal of ``nameIR~split~^{asterisk}^``].
+ .. Check that ``nameIR'^{asterisk}^`` is a non-empty list.
+ .. Let ``nameIR~unqualified~`` ``{two-colons}`` ``++_++^{asterisk}^`` be ``nameIR'^{asterisk}^``.
+ .. If ``nameIR`` is not equal to ``nameIR~unqualified~``:
+  ... Return ``xref:find_tableActionIR_unqualified'[$find_tableActionIR_unqualified'(tableActionIR~t~^{asterisk}^,`` ``nameIR)]``.
+ .. If ``nameIR`` is equal to ``nameIR~unqualified~``:
   ... Let ``nameIR~action~`` be xref:flatten_prefixedNameIR[the string form of  ``prefixedNameIR``].
   ... Return ( ``nameIR~action~``, ``tableActionIR~h~`` ).
 
 xref:tableObject_create_entry_action[$tableObject_create_entry_action(EC, +ACTIONS+ +=+ +{+ tableActionIR^{asterisk}^ +}+, ( nameIR~action_update~, tableActionArgumentInterface~update~^{asterisk}^ ))]
 
 
-. Let ``(nameIR,`` ``tableActionIR)^?^`` be ``xref:find_tableActionIR_by_dotPrefix[$find_tableActionIR_by_dotPrefix(tableActionIR^{asterisk}^,`` ``nameIR~action_update~)]``.
+. Let ``(nameIR,`` ``tableActionIR)^?^`` be ``xref:find_tableActionIR_qualified[$find_tableActionIR_qualified(tableActionIR^{asterisk}^,`` ``nameIR~action_update~)]``.
 . If let ``(`` ``nameIR~found~,`` ``tableActionIR~found~`` ``)`` be ``(nameIR,`` ``tableActionIR)^?^``:
  .. Let ``annotationList`` ``prefixedNameIR`` ``controlPlaneNameIR`` ``+(+`` ``argumentIR~data~^{asterisk}^`` ``+)+`` ``+#+`` ``+(+`` ``++_++`` ``+,+`` ``parameterIR~control~^{asterisk}^`` ``+)+`` ``+;+`` be ``tableActionIR~found~``.
  .. Let ``i~arg_aligned~^{asterisk}^`` be ``xref:align_tableActionArgumentInterfaces[$align_tableActionArgumentInterfaces(parameterIR~control~^{asterisk}^,`` ``tableActionArgumentInterface~update~^{asterisk}^)]``.
@@ -17495,8 +17512,8 @@ for each ``typeIR~param~`` in ``typeIR~param~^{asterisk}^`` and ``typedExpressio
 for each ``typedExpressionIR^?^`` in ``typedExpressionIR^?^^{asterisk}^``
  .. Let ``argumentIR^{asterisk}^`` be ``argumentIR~data~^{asterisk}^`` concatenated with ``typedExpressionIR~arg_cast~^{asterisk}^``.
  .. Return ``nameIR~found~`` ``controlPlaneNameIR`` ``+(+`` ``argumentIR^{asterisk}^`` ``+)+``.
-. If ``·`` is equal to ``xref:find_tableActionIR_by_dotPrefix[$find_tableActionIR_by_dotPrefix(tableActionIR^{asterisk}^,`` ``nameIR~action_update~)]``:
- .. Let ``(`` ``nameIR~found~,`` ``tableActionIR~found~`` ``)`` be xref:option_get[*!*] ``xref:find_tableActionIR_by_name[$find_tableActionIR_by_name(tableActionIR^{asterisk}^,`` ``nameIR~action_update~)]``.
+. If ``·`` is equal to ``xref:find_tableActionIR_qualified[$find_tableActionIR_qualified(tableActionIR^{asterisk}^,`` ``nameIR~action_update~)]``:
+ .. Let ``(`` ``nameIR~found~,`` ``tableActionIR~found~`` ``)`` be xref:option_get[*!*] ``xref:find_tableActionIR_unqualified[$find_tableActionIR_unqualified(tableActionIR^{asterisk}^,`` ``nameIR~action_update~)]``.
  .. Let ``annotationList`` ``prefixedNameIR`` ``controlPlaneNameIR`` ``+(+`` ``argumentIR~data~^{asterisk}^`` ``+)+`` ``+#+`` ``+(+`` ``++_++`` ``+,+`` ``parameterIR~control~^{asterisk}^`` ``+)+`` ``+;+`` be ``tableActionIR~found~``.
  .. Let ``i~arg_aligned~^{asterisk}^`` be ``xref:align_tableActionArgumentInterfaces[$align_tableActionArgumentInterfaces(parameterIR~control~^{asterisk}^,`` ``tableActionArgumentInterface~update~^{asterisk}^)]``.
  .. Let ``typeIR~param~^{asterisk}^`` be the list obtained by repeating:

--- a/p4spec/test/lang/struct.expected
+++ b/p4spec/test/lang/struct.expected
@@ -10150,8 +10150,10 @@ syntax tableKeyIR =
 
 syntax tableKeyListIR = tableKeyIR*
 
+syntax controlPlaneNameIR = nameIR*
+
 syntax tableActionReferenceIR = 
-   | prefixedNameIR ( argumentListIR )
+   | prefixedNameIR controlPlaneNameIR ( argumentListIR )
 
 syntax tableActionIR = 
    | annotationList tableActionReferenceIR #( parameterListIR , parameterListIR );
@@ -19217,7 +19219,7 @@ relation TableAction_ok: TC TBLC_0 |- (annotationList tableActionReference ;) : 
 
                             1. (Let TBLC_1 be $add_action_tbl(TBLC_0, prefixedNameIR, (parameterIR)*, []))
 
-                              1. (Let tableActionIR be (annotationList_update (prefixedNameIR ( [] )) #( (parameterIR_data)* , (parameterIR_control)* );))
+                              1. (Let tableActionIR be (annotationList_update (prefixedNameIR [] ( [] )) #( (parameterIR_data)* , (parameterIR_control)* );))
 
                                 1. Result in: % % |- % : TBLC_1 tableActionIR
 
@@ -19253,7 +19255,7 @@ relation TableAction_ok: TC TBLC_0 |- (annotationList tableActionReference ;) : 
 
                             1. (Let TBLC_1 be $add_action_tbl(TBLC_0, prefixedNameIR, (parameterIR)*, (argumentIR_cast)*))
 
-                              1. (Let tableActionIR be (annotationList_update (prefixedNameIR ( (argumentIR_cast)* )) #( (parameterIR_data)* , (parameterIR_control)* );))
+                              1. (Let tableActionIR be (annotationList_update (prefixedNameIR [] ( (argumentIR_cast)* )) #( (parameterIR_data)* , (parameterIR_control)* );))
 
                                 1. Result in: % % |- % : TBLC_1 tableActionIR
 
@@ -19313,7 +19315,7 @@ relation TableDefaultAction_ok: TC TBLC |- (= expression) : %
 
           1. If ((?(([], [])) = $find_action(TBLC, prefixedNameIR))), then
 
-            1. Result in: % % |- % : (prefixedNameIR ( [] ))
+            1. Result in: % % |- % : (prefixedNameIR [] ( [] ))
 
           1. Else Phantom#1026
 
@@ -19347,7 +19349,7 @@ relation TableDefaultAction_ok: TC TBLC |- (= expression) : %
 
                                 1. If ((argumentIR_action_data = argumentIR_cast_data))*, then
 
-                                  1. Result in: % % |- % : (prefixedNameIR ( (argumentIR_cast)* ))
+                                  1. Result in: % % |- % : (prefixedNameIR [] ( (argumentIR_cast)* ))
 
                                 1. Else Phantom#1027
 
@@ -19623,7 +19625,7 @@ relation TableEntry_action_ok: TC TBLC |- tableActionReference : %
 
           1. If ((?(([], [])) = $find_action(TBLC, prefixedNameIR))), then
 
-            1. Result in: % % |- % : (prefixedNameIR ( [] ))
+            1. Result in: % % |- % : (prefixedNameIR [] ( [] ))
 
           1. Else Phantom#1060
 
@@ -19649,7 +19651,7 @@ relation TableEntry_action_ok: TC TBLC |- tableActionReference : %
 
                         1. If ((argumentIR_action_data = argumentIR_cast_data))*, then
 
-                          1. Result in: % % |- % : (prefixedNameIR ( (argumentIR_cast)* ))
+                          1. Result in: % % |- % : (prefixedNameIR [] ( (argumentIR_cast)* ))
 
                         1. Else Phantom#1061
 
@@ -20147,7 +20149,7 @@ relation Table_ok: TC |- (tableProperty)* : % %
 
             1. (TableProperties_ok: TC TBLC_0 |- (tableProperty)* : TBLC_1 (tablePropertyIR)*)
 
-              1. (Let tablePropertyIR_default_action be (((`empty) ?() default_action= ((` "NoAction") ( [] )) ;) as tablePropertyIR))
+              1. (Let tablePropertyIR_default_action be (((`empty) ?() default_action= ((` "NoAction") [] ( [] )) ;) as tablePropertyIR))
 
                 1. (Let (TBLC_2, (tablePropertyIR_updated)*) be $insert_NoAction_tablePropertyIR(TBLC_1, (tablePropertyIR)*))
 
@@ -25172,7 +25174,7 @@ def $insert_NoAction_tablePropertyIR(TBLC, (tablePropertyIR)*)
 
             1. (Let (_annotationList tableActionReferenceIR #( _parameterListIR , _parameterListIR' );) be tableActionIR)*
 
-              1. (Let tableActionReferenceIR_NoAction be ((. "NoAction") ( [] )))
+              1. (Let tableActionReferenceIR_NoAction be ((. "NoAction") [] ( [] )))
 
                 1. Case analysis on tableActionReferenceIR_NoAction is in (tableActionReferenceIR)*
 
@@ -26058,7 +26060,7 @@ syntax storageReference =
    | storageReference [ value : value ]
 
 syntax actionDef = 
-   | action nameIR ( parameterListIR ) blockStatementIR
+   | annotationList action nameIR ( parameterListIR ) blockStatementIR
 
 syntax definedFunctionDef = 
    | function nameIR < typeParameterListIR >( parameterListIR ) blockStatementIR
@@ -26091,7 +26093,7 @@ syntax methodDef =
    | table_apply{ tablePropertyListIR }
 
 syntax callableDef = 
-   | action nameIR ( parameterListIR ) blockStatementIR
+   | annotationList action nameIR ( parameterListIR ) blockStatementIR
    | function nameIR < typeParameterListIR >( parameterListIR ) blockStatementIR
    | extern_function nameIR < typeParameterListIR >( parameterListIR )
    | extern_method nameIR < typeParameterListIR >( parameterListIR ) blockStatementIR?
@@ -26122,7 +26124,7 @@ def $parameterListIR_of_callableDef(callableDef)
 
       1. Return $parameterListIR_of_methodDef(methodDef)
 
-def $parameterListIR_of_actionDef((action _nameIR ( parameterListIR ) _blockStatementIR))
+def $parameterListIR_of_actionDef((annotationList action _nameIR ( parameterListIR ) _blockStatementIR))
 
 1. Return parameterListIR
 
@@ -28271,7 +28273,7 @@ relation ActionDecl_inst: p IC_0 |- (annotationList action nameIR ( parameterLis
 
   1. (Let callableId be $callableId_IR(nameIR, parameterListIR))
 
-    1. (Let actionDef be (action nameIR ( parameterListIR ) blockStatementIR))
+    1. (Let actionDef be (annotationList action nameIR ( parameterListIR ) blockStatementIR))
 
       1. (Let IC_1 be $add_callableDef_non_overload_i(p, IC_0, callableId, (actionDef as callableDef)))
 
@@ -32328,7 +32330,7 @@ relation Table_eval: EC_0 ARCH_0 |- typeId TBL : % % %
 
                     1. (Let (` (tableMatch)*) be (tableMatchesResult as continueResult<tableMatch*>))
 
-                      1. (Let (prefixedNameIR ( argumentListIR )) be $select_action(TBL, (tableMatch)*))
+                      1. (Let (prefixedNameIR _controlPlaneNameIR ( argumentListIR )) be $select_action(TBL, (tableMatch)*))
 
                         1. (Stmt_eval: (local) EC_2 ARCH_2 |- (((prefixedNameIR as callableTargetIR) < [] >( argumentListIR );) as statementIR) : EC_3 ARCH_3 statementResult)
 
@@ -32542,7 +32544,7 @@ relation Callee_eval: p EC ARCH |- callableTargetIR <_>( argumentListIR ): % % %
 
                 1. (Let (p_ref, actionDef) be ((cursor, callableDef) as (cursor, actionDef)))
 
-                  1. (Let (action nameIR ( parameterListIR ) blockStatementIR) be actionDef)
+                  1. (Let (_annotationList action nameIR ( parameterListIR ) blockStatementIR) be actionDef)
 
                     1. (Let actionCallee be (action p_ref . nameIR ( parameterListIR # (id_default)* ) blockStatementIR))
 
@@ -36103,7 +36105,7 @@ def $find_tableActionIR_by_name((tableActionIR)*, nameIR)
 
     1. (Let tableActionIR_h :: (tableActionIR_t)* be (tableActionIR)*)
 
-      1. (Let (annotationList (prefixedNameIR ( (argumentIR_data)* )) #( _parameterListIR , (parameterIR_control)* );) be tableActionIR_h)
+      1. (Let (annotationList (prefixedNameIR _controlPlaneNameIR ( (argumentIR_data)* )) #( _parameterListIR , (parameterIR_control)* );) be tableActionIR_h)
 
         1. (Let nameIR_action be $flatten_prefixedNameIR(prefixedNameIR))
 
@@ -36151,7 +36153,7 @@ def $find_tableActionIR_by_dotPrefix((tableActionIR)*, nameIR)
 
     1. (Let tableActionIR_h :: (tableActionIR_t)* be (tableActionIR)*)
 
-      1. (Let (annotationList (_prefixedNameIR ( _argumentListIR )) #( _parameterListIR , _parameterListIR' );) be tableActionIR_h)
+      1. (Let (annotationList (_prefixedNameIR _controlPlaneNameIR ( _argumentListIR )) #( _parameterListIR , _parameterListIR' );) be tableActionIR_h)
 
         1. If (([] = $name_annotation(annotationList))), then
 
@@ -36159,7 +36161,7 @@ def $find_tableActionIR_by_dotPrefix((tableActionIR)*, nameIR)
 
         1. Else Phantom#1931
 
-      2. (Let (annotationList (prefixedNameIR ( (argumentIR_data)* )) #( _parameterListIR , (parameterIR_control)* );) be tableActionIR_h)
+      2. (Let (annotationList (prefixedNameIR _controlPlaneNameIR ( (argumentIR_data)* )) #( _parameterListIR , (parameterIR_control)* );) be tableActionIR_h)
 
         1. (Let (nameIR_annotation)* be $name_annotation(annotationList))
 
@@ -36205,7 +36207,7 @@ def $tableObject_create_entry_action(EC, (actions={ (tableActionIR)* }), (nameIR
 
     1. (Let ?((nameIR_found, tableActionIR_found)) be ((nameIR, tableActionIR))?)
 
-      1. (Let (annotationList (prefixedNameIR ( (argumentIR_data)* )) #( _parameterListIR , (parameterIR_control)* );) be tableActionIR_found)
+      1. (Let (annotationList (prefixedNameIR controlPlaneNameIR ( (argumentIR_data)* )) #( _parameterListIR , (parameterIR_control)* );) be tableActionIR_found)
 
         1. (Let (i_arg_aligned)* be $align_tableActionArgumentInterfaces((parameterIR_control)*, (tableActionArgumentInterface_update)*))
 
@@ -36221,7 +36223,7 @@ def $tableObject_create_entry_action(EC, (actions={ (tableActionIR)* }), (nameIR
 
                     1. (Let (argumentIR)* be (argumentIR_data)* ++ ((typedExpressionIR_arg_cast)* as argumentIR*))
 
-                      1. Return ((` nameIR_found) ( (argumentIR)* ))
+                      1. Return ((` nameIR_found) controlPlaneNameIR ( (argumentIR)* ))
 
                 1. Else Phantom#1937
 
@@ -36235,7 +36237,7 @@ def $tableObject_create_entry_action(EC, (actions={ (tableActionIR)* }), (nameIR
 
       1. (Let ?((nameIR_found, tableActionIR_found)) be ((nameIR, tableActionIR))?)
 
-        1. (Let (annotationList (prefixedNameIR ( (argumentIR_data)* )) #( _parameterListIR , (parameterIR_control)* );) be tableActionIR_found)
+        1. (Let (annotationList (prefixedNameIR controlPlaneNameIR ( (argumentIR_data)* )) #( _parameterListIR , (parameterIR_control)* );) be tableActionIR_found)
 
           1. (Let (i_arg_aligned)* be $align_tableActionArgumentInterfaces((parameterIR_control)*, (tableActionArgumentInterface_update)*))
 
@@ -36251,7 +36253,7 @@ def $tableObject_create_entry_action(EC, (actions={ (tableActionIR)* }), (nameIR
 
                       1. (Let (argumentIR)* be (argumentIR_data)* ++ ((typedExpressionIR_arg_cast)* as argumentIR*))
 
-                        1. Return ((` nameIR_found) ( (argumentIR)* ))
+                        1. Return ((` nameIR_found) controlPlaneNameIR ( (argumentIR)* ))
 
                   1. Else Phantom#1939
 

--- a/p4spec/test/lang/struct.expected
+++ b/p4spec/test/lang/struct.expected
@@ -28,6 +28,8 @@ builtin def $text_to_int(text)
 
 builtin def $int_to_text(int)
 
+builtin def $split_text(text, text')
+
 def $concat_text((text)*)
 
 1. Case analysis on (text)*
@@ -42,6 +44,28 @@ def $concat_text((text)*)
 
       1. Return t_h ++ $concat_text((t_t)*)
 
+def $join_text((text)*, t_sep)
+
+1. Case analysis on (text)*
+
+  1. Case (% matches pattern [])
+
+    1. Return ""
+
+  2. Case (% matches pattern [ _/1 ])
+
+    1. (Let [t_h] be (text)*)
+
+      1. Return t_h
+
+  3. Case (% matches pattern _ :: _)
+
+    1. (Let t_h :: (t_t)* be (text)*)
+
+      1. Return t_h ++ t_sep ++ $join_text((t_t)*, t_sep)
+
+1. Else Phantom#0
+
 def $replace_text(t, t_old, t_new)
 
 1. Return $replace_text'(0, |t|, t, t_old, t_new)
@@ -52,7 +76,7 @@ def $replace_text'(n_len, n_len', t, t_old, t_new)
 
   1. Return t
 
-1. Else Phantom#0
+1. Else Phantom#1
 
 2. If ((n_len < n_len')), then
 
@@ -60,7 +84,7 @@ def $replace_text'(n_len, n_len', t, t_old, t_new)
 
     1. Return $replace_text'((n_len + 1), n_len', t_replaced, t_old, t_new)
 
-2. Else Phantom#1
+2. Else Phantom#2
 
 def $replace_text_except(t, t_old, t_new)
 
@@ -72,7 +96,7 @@ def $replace_text_except'(n_len, n_len', t, t_old, t_new)
 
   1. Return t
 
-1. Else Phantom#2
+1. Else Phantom#3
 
 2. If ((n_len < n_len')), then
 
@@ -80,7 +104,7 @@ def $replace_text_except'(n_len, n_len', t, t_old, t_new)
 
     1. Return $replace_text_except'((n_len + 1), n_len', t_replaced, t_old, t_new)
 
-2. Else Phantom#3
+2. Else Phantom#4
 
 builtin def $strip_prefix(text, text')
 
@@ -156,7 +180,7 @@ def $contains'(n_len, n_len', t, t_c)
 
   1. Return false
 
-1. Else Phantom#4
+1. Else Phantom#5
 
 2. If ((n_len < n_len')), then
 
@@ -170,7 +194,7 @@ def $contains'(n_len, n_len', t, t_c)
 
       1. Return $contains'((n_len + 1), n_len', t, t_c)
 
-2. Else Phantom#5
+2. Else Phantom#6
 
 def $is_some_<X>((X)?)
 
@@ -244,7 +268,7 @@ def $init_(nat)
 
           1. Return n :: $init_(n)
 
-      1. Else Phantom#6
+      1. Else Phantom#7
 
 def $repeat_<X>(X, nat)
 
@@ -264,7 +288,7 @@ def $repeat_<X>(X, nat)
 
           1. Return [X] ++ $repeat_<X>(X, n)
 
-      1. Else Phantom#7
+      1. Else Phantom#8
 
 builtin def $rev_<X>((X)*)
 
@@ -282,7 +306,7 @@ def $filter_<X>((X)*, (bool)*)
 
       1. Return []
 
-    1. Else Phantom#8
+    1. Else Phantom#9
 
   2. Case (% matches pattern _ :: _)
 
@@ -302,7 +326,7 @@ def $filter_<X>((X)*, (bool)*)
 
               1. Return $filter_<X>((X_t)*, (b_t)*)
 
-      1. Else Phantom#9
+      1. Else Phantom#10
 
 builtin def $assoc_<X, Y>(X, ((X, Y))*)
 
@@ -372,13 +396,13 @@ def $modulo(n_a, n_b)
 
   1. Return ?((n_a \ n_b))
 
-1. Else Phantom#10
+1. Else Phantom#11
 
 2. If ((n_b = 0)), then
 
   1. Return ?()
 
-2. Else Phantom#11
+2. Else Phantom#12
 
 def $modulo_42(n)
 
@@ -390,7 +414,7 @@ def $modulo_42(n)
 
       1. Return n_result
 
-  1. Else Phantom#12
+  1. Else Phantom#13
 
 syntax trailingCommaOpt = 
    | `empty
@@ -646,7 +670,7 @@ def $flatten_parameterList(parameterList)
 
       1. Return [parameter]
 
-1. Else Phantom#13
+1. Else Phantom#14
 
 2. If ((parameterList has type nonEmptyParameterList)), then
 
@@ -658,9 +682,9 @@ def $flatten_parameterList(parameterList)
 
         1. Return $flatten_parameterList((nonEmptyParameterList' as parameterList)) ++ [parameter]
 
-    1. Else Phantom#14
+    1. Else Phantom#15
 
-2. Else Phantom#15
+2. Else Phantom#16
 
 syntax constructorParameter = parameter
 
@@ -1658,7 +1682,7 @@ def $flatten_argumentList(argumentList)
 
       1. Return [argument]
 
-1. Else Phantom#16
+1. Else Phantom#17
 
 2. If ((argumentList has type argumentListNonEmpty)), then
 
@@ -1670,9 +1694,9 @@ def $flatten_argumentList(argumentList)
 
         1. Return $flatten_argumentList((argumentListNonEmpty' as argumentList)) ++ [argument]
 
-    1. Else Phantom#17
+    1. Else Phantom#18
 
-2. Else Phantom#18
+2. Else Phantom#19
 
 syntax lvalue = 
    | `id text
@@ -1758,9 +1782,9 @@ def $expression_as_lvalue(expression)
 
                 1. Return ?((lvalue' . member))
 
-            1. Else Phantom#19
+            1. Else Phantom#20
 
-      1. Else Phantom#20
+      1. Else Phantom#21
 
   3. Case (% has type indexAccessExpression)
 
@@ -1774,7 +1798,7 @@ def $expression_as_lvalue(expression)
 
             1. Return ?((lvalue_base [ expression_index ]))
 
-        1. Else Phantom#21
+        1. Else Phantom#22
 
   4. Case (% has type sliceAccessExpression)
 
@@ -1788,7 +1812,7 @@ def $expression_as_lvalue(expression)
 
             1. Return ?((lvalue_base [ expression_hi : expression_lo ]))
 
-        1. Else Phantom#22
+        1. Else Phantom#23
 
   5. Case (% has type parenthesizedExpression)
 
@@ -1802,9 +1826,9 @@ def $expression_as_lvalue(expression)
 
             1. Return ?((( lvalue' )))
 
-        1. Else Phantom#23
+        1. Else Phantom#24
 
-1. Else Phantom#24
+1. Else Phantom#25
 
 syntax emptyStatement = 
    | ;
@@ -1868,7 +1892,7 @@ def $flatten_forUpdateStatementList(forUpdateStatementList)
 
       1. Return [forUpdateStatement]
 
-1. Else Phantom#25
+1. Else Phantom#26
 
 2. If ((forUpdateStatementList has type forUpdateStatementListNonEmpty)), then
 
@@ -1880,9 +1904,9 @@ def $flatten_forUpdateStatementList(forUpdateStatementList)
 
         1. Return $flatten_forUpdateStatementList((forUpdateStatementListNonEmpty' as forUpdateStatementList)) ++ [forUpdateStatement]
 
-    1. Else Phantom#26
+    1. Else Phantom#27
 
-2. Else Phantom#27
+2. Else Phantom#28
 
 syntax forInitStatement = 
    | annotationList type name initializerOpt
@@ -1919,7 +1943,7 @@ def $flatten_forInitStatementList(forInitStatementList)
 
       1. Return [forInitStatement]
 
-1. Else Phantom#28
+1. Else Phantom#29
 
 2. If ((forInitStatementList has type forInitStatementListNonEmpty)), then
 
@@ -1931,9 +1955,9 @@ def $flatten_forInitStatementList(forInitStatementList)
 
         1. Return $flatten_forInitStatementList((forInitStatementListNonEmpty' as forInitStatementList)) ++ [forInitStatement]
 
-    1. Else Phantom#29
+    1. Else Phantom#30
 
-2. Else Phantom#30
+2. Else Phantom#31
 
 syntax forCollectionExpression = 
    | true
@@ -2753,7 +2777,7 @@ def $flatten_annotationList(annotationList)
 
       1. Return [annotation]
 
-1. Else Phantom#31
+1. Else Phantom#32
 
 2. If ((annotationList has type annotationListNonEmpty)), then
 
@@ -2765,9 +2789,9 @@ def $flatten_annotationList(annotationList)
 
         1. Return $flatten_annotationList((annotationListNonEmpty' as annotationList)) ++ [annotation]
 
-    1. Else Phantom#32
+    1. Else Phantom#33
 
-2. Else Phantom#33
+2. Else Phantom#34
 
 syntax p4program = 
    | `empty
@@ -2833,7 +2857,7 @@ def $fresh_typeIds(nat)
 
           1. Return $fresh_typeId :: $fresh_typeIds(n)
 
-      1. Else Phantom#34
+      1. Else Phantom#35
 
 syntax callTargetId = 
    | nameIR ( id* )
@@ -2860,7 +2884,7 @@ def $callableId'(parameterList)
 
       1. Return [$name(name)]
 
-1. Else Phantom#35
+1. Else Phantom#36
 
 2. If ((parameterList has type nonEmptyParameterList)), then
 
@@ -2872,9 +2896,9 @@ def $callableId'(parameterList)
 
         1. Return $callableId'((nonEmptyParameterList' as parameterList)) ++ [$name(name)]
 
-    1. Else Phantom#36
+    1. Else Phantom#37
 
-2. Else Phantom#37
+2. Else Phantom#38
 
 def $constructorId(name, constructorParameterListOpt)
 
@@ -3163,7 +3187,7 @@ def $update_headerUnion((fieldValue)*, nameIR)
 
                 1. Return (value_field_h_update nameIR_field_h ;) :: $update_headerUnion((fieldValue_t)*, nameIR)
 
-          1. Else Phantom#38
+          1. Else Phantom#39
 
 def $isValid_header(value)
 
@@ -3175,7 +3199,7 @@ def $isValid_header(value)
 
       1. Return b_valid
 
-1. Else Phantom#39
+1. Else Phantom#40
 
 def $invalidate_value(value)
 
@@ -3193,7 +3217,7 @@ def $invalidate_value(value)
 
       1. Return ($invalidate_headerUnion(headerUnionValue) as value)
 
-1. Else Phantom#40
+1. Else Phantom#41
 
 def $invalidate_header((header typeId { _bool ; (fieldValue)* }))
 
@@ -3213,7 +3237,7 @@ def $write_value_from_bits(value, n_var, (b)*)
 
     1. Return value_updated
 
-  1. Else Phantom#41
+  1. Else Phantom#42
 
 def $write_value_from_bits'(value, n_var, (bool)*)
 
@@ -3227,7 +3251,7 @@ def $write_value_from_bits'(value, n_var, (bool)*)
 
         1. Return (((`b b_h) as value), (b_t)*)
 
-    1. Else Phantom#42
+    1. Else Phantom#43
 
   2. Case (% has type integerLiteral)
 
@@ -3255,9 +3279,9 @@ def $write_value_from_bits'(value, n_var, (bool)*)
 
                           1. Return (((w w i) as value), (b_t)*)
 
-                  1. Else Phantom#43
+                  1. Else Phantom#44
 
-            1. Else Phantom#44
+            1. Else Phantom#45
 
         2. Case (% matches pattern `%S%`)
 
@@ -3279,11 +3303,11 @@ def $write_value_from_bits'(value, n_var, (bool)*)
 
                           1. Return (((w s i) as value), (b_t)*)
 
-                  1. Else Phantom#45
+                  1. Else Phantom#46
 
-            1. Else Phantom#46
+            1. Else Phantom#47
 
-      1. Else Phantom#47
+      1. Else Phantom#48
 
   3. Case (% has type structValue)
 
@@ -3313,7 +3337,7 @@ def $write_value_from_bits'(value, n_var, (bool)*)
 
             1. Return (((typeId . "__UNSPECIFIED" . value_updated) as value), (b_rest)*)
 
-      1. Else Phantom#48
+      1. Else Phantom#49
 
   6. Case (% has type headerStackValue)
 
@@ -3323,7 +3347,7 @@ def $write_value_from_bits'(value, n_var, (bool)*)
 
         1. Return (((header_stack[ (value_updated)* ( n_idx ; n_size )]) as value), (b_rest)*)
 
-1. Else Phantom#49
+1. Else Phantom#50
 
 2. If ((value has type integerValue)), then
 
@@ -3337,7 +3361,7 @@ def $write_value_from_bits'(value, n_var, (bool)*)
 
           1. Return (((n_max . 0 v i) as value), (bool)*)
 
-        1. Else Phantom#50
+        1. Else Phantom#51
 
         2. If ((|(bool)*| >= n_var)), then
 
@@ -3355,13 +3379,13 @@ def $write_value_from_bits'(value, n_var, (bool)*)
 
                       1. Return (((n_max . n_var v i') as value), (b_t)*)
 
-              1. Else Phantom#51
+              1. Else Phantom#52
 
-        2. Else Phantom#52
+        2. Else Phantom#53
 
-    1. Else Phantom#53
+    1. Else Phantom#54
 
-2. Else Phantom#54
+2. Else Phantom#55
 
 def $write_values_from_bits'((value)*, n_var, (b)*)
 
@@ -3433,7 +3457,7 @@ def $write_bits_from_value(value)
 
             1. Return $int_to_bits_unsigned(w, i)
 
-      1. Else Phantom#55
+      1. Else Phantom#56
 
   3. Case (% has type headerStackValue)
 
@@ -3455,7 +3479,7 @@ def $write_bits_from_value(value)
 
         1. Return $concat_<bool>(($write_bits_from_value(value_field))*)
 
-      1. Else Phantom#56
+      1. Else Phantom#57
 
     2. (Let (header _typeId { bool ; (_fieldValue)* }) be (value as headerValue))
 
@@ -3463,7 +3487,7 @@ def $write_bits_from_value(value)
 
         1. Return []
 
-      1. Else Phantom#57
+      1. Else Phantom#58
 
   6. Case (% has type headerUnionValue)
 
@@ -3481,9 +3505,9 @@ def $write_bits_from_value(value)
 
           1. Return $write_bits_from_value(value')
 
-      1. Else Phantom#58
+      1. Else Phantom#59
 
-1. Else Phantom#59
+1. Else Phantom#60
 
 2. If ((value has type integerValue)), then
 
@@ -3495,9 +3519,9 @@ def $write_bits_from_value(value)
 
         1. Return $int_to_bits_unsigned(w, i)
 
-    1. Else Phantom#60
+    1. Else Phantom#61
 
-2. Else Phantom#61
+2. Else Phantom#62
 
 syntax voidTypeIR = 
    | void
@@ -4505,7 +4529,7 @@ def $callableTypeIR_of_callableTypeDefIR(callableTypeDefIR)
 
       1. Return (controlApplyMethodTypeDefIR as callableTypeIR)
 
-1. Else Phantom#62
+1. Else Phantom#63
 
 def $typeParameterListIR_of_callableTypeDefIR(callableTypeDefIR)
 
@@ -4553,7 +4577,7 @@ def $typeParameterListIR_of_callableTypeDefIR(callableTypeDefIR)
 
     1. Return ([], [])
 
-1. Else Phantom#63
+1. Else Phantom#64
 
 def $parameterListIR_of_callableTypeDefIR(callableTypeDefIR)
 
@@ -4975,9 +4999,9 @@ def $capture_avoiding_(theta, (typeParameterIR)*, B)
 
                 1. Return (theta_fresh, (typeParameterIR_fresh)*)
 
-            1. Else Phantom#64
+            1. Else Phantom#65
 
-    1. Else Phantom#65
+    1. Else Phantom#66
 
 def $capture_avoiding(theta, (typeParameterIR_expl)*, (typeParameterIR_impl)*, B)
 
@@ -5003,9 +5027,9 @@ def $capture_avoiding(theta, (typeParameterIR_expl)*, (typeParameterIR_impl)*, B
 
                     1. Return (theta_fresh, (typeParameterIR_expl_fresh)*, (typeParameterIR_impl_fresh)*)
 
-            1. Else Phantom#66
+            1. Else Phantom#67
 
-    1. Else Phantom#67
+    1. Else Phantom#68
 
 def $subst_typeIR(set<pair<typeId, typeIR>>, typeIR)
 
@@ -5039,13 +5063,13 @@ def $subst_typeIR'(theta, typeIR)
 
             1. Return typeIR''
 
-        1. Else Phantom#68
+        1. Else Phantom#69
 
       2. If ((?() = $find_map<typeId, typeIR>(theta, typeId))), then
 
         1. Return ((` typeId) as typeIR)
 
-      2. Else Phantom#69
+      2. Else Phantom#70
 
   3. Case (% has type typedefTypeIR)
 
@@ -5161,7 +5185,7 @@ def $subst_typeIR'(theta, typeIR)
 
                   1. Return (externObjectTypeIR_subst as typeIR)
 
-            1. Else Phantom#70
+            1. Else Phantom#71
 
   14. Case (% has type parserObjectTypeIR)
 
@@ -5423,7 +5447,7 @@ def $subst_callableTypeDefIR'(theta, callableTypeDefIR)
 
             1. Return (actionTypeDefIR_subst as callableTypeDefIR)
 
-        1. Else Phantom#71
+        1. Else Phantom#72
 
   2. Case (% has type definedFunctionTypeDefIR)
 
@@ -5499,7 +5523,7 @@ def $subst_callableTypeDefIR'(theta, callableTypeDefIR)
 
             1. Return (parserApplyMethodTypeDefIR_subst as callableTypeDefIR)
 
-        1. Else Phantom#72
+        1. Else Phantom#73
 
   6. Case (% has type controlApplyMethodTypeDefIR)
 
@@ -5513,9 +5537,9 @@ def $subst_callableTypeDefIR'(theta, callableTypeDefIR)
 
             1. Return (controlApplyMethodTypeDefIR_subst as callableTypeDefIR)
 
-        1. Else Phantom#73
+        1. Else Phantom#74
 
-1. Else Phantom#74
+1. Else Phantom#75
 
 def $subst_constructorTypeIR(set<pair<typeId, typeIR>>, constructorTypeIR)
 
@@ -5551,7 +5575,7 @@ def $specialize_typeDefIR(typeDefIR_base, (typeArgumentIR)*)
 
             1. Return typeIR_spec
 
-    1. Else Phantom#75
+    1. Else Phantom#76
 
 def $specialize_callableTypeDefIR(callableTypeDefIR_base, (typeArgumentIR)*)
 
@@ -5573,7 +5597,7 @@ def $specialize_callableTypeDefIR(callableTypeDefIR_base, (typeArgumentIR)*)
 
                 1. Return (callableTypeIR_spec, (typeId_fresh)*)
 
-    1. Else Phantom#76
+    1. Else Phantom#77
 
     2. If (((|(typeParameterIR_expl)*| > 0) /\ (|(typeArgumentIR)*| = 0))), then
 
@@ -5589,7 +5613,7 @@ def $specialize_callableTypeDefIR(callableTypeDefIR_base, (typeArgumentIR)*)
 
                 1. Return (callableTypeIR_spec, (typeId_fresh)*)
 
-    2. Else Phantom#77
+    2. Else Phantom#78
 
 def $specialize_constructorTypeDefIR((constructor< (typeParameterIR_expl)* , (typeParameterIR_impl)* >( (constructorParameterIR)* ): typeIR), (typeArgumentIR)*)
 
@@ -5607,7 +5631,7 @@ def $specialize_constructorTypeDefIR((constructor< (typeParameterIR_expl)* , (ty
 
             1. Return (constructorTypeIR_spec, (typeId_fresh)*)
 
-  1. Else Phantom#78
+  1. Else Phantom#79
 
   2. If (((|(typeParameterIR_expl)*| > 0) /\ (|(typeArgumentIR)*| = 0))), then
 
@@ -5621,7 +5645,7 @@ def $specialize_constructorTypeDefIR((constructor< (typeParameterIR_expl)* , (ty
 
             1. Return (constructorTypeIR_spec, (typeId_fresh)*)
 
-  2. Else Phantom#79
+  2. Else Phantom#80
 
 relation Type_alpha: typeIR ~~ typeIR'
 
@@ -5641,9 +5665,9 @@ relation Type_alpha: typeIR ~~ typeIR'
 
               1. The relation holds
 
-          1. Else Phantom#80
+          1. Else Phantom#81
 
-      1. Else Phantom#81
+      1. Else Phantom#82
 
   2. Case (% has type nameTypeIR)
 
@@ -5659,11 +5683,11 @@ relation Type_alpha: typeIR ~~ typeIR'
 
               1. The relation holds
 
-          1. Else Phantom#82
+          1. Else Phantom#83
 
-      1. Else Phantom#83
+      1. Else Phantom#84
 
-1. Else Phantom#84
+1. Else Phantom#85
 
 2. Group typedefTypeIR: typeIR ~~ typeIR'
 
@@ -5675,9 +5699,9 @@ relation Type_alpha: typeIR ~~ typeIR'
 
         1. The relation holds
 
-      1. Else Phantom#85
+      1. Else Phantom#86
 
-  1. Else Phantom#86
+  1. Else Phantom#87
 
   2. If ((typeIR' has type typedefTypeIR)), then
 
@@ -5689,11 +5713,11 @@ relation Type_alpha: typeIR ~~ typeIR'
 
           1. The relation holds
 
-        1. Else Phantom#87
+        1. Else Phantom#88
 
-      1. Else Phantom#88
+      1. Else Phantom#89
 
-  2. Else Phantom#89
+  2. Else Phantom#90
 
 3. Case analysis on typeIR
 
@@ -5713,11 +5737,11 @@ relation Type_alpha: typeIR ~~ typeIR'
 
                 1. The relation holds
 
-              1. Else Phantom#90
+              1. Else Phantom#91
 
-          1. Else Phantom#91
+          1. Else Phantom#92
 
-      1. Else Phantom#92
+      1. Else Phantom#93
 
   2. Case (% has type listTypeIR)
 
@@ -5733,9 +5757,9 @@ relation Type_alpha: typeIR ~~ typeIR'
 
               1. The relation holds
 
-            1. Else Phantom#93
+            1. Else Phantom#94
 
-      1. Else Phantom#94
+      1. Else Phantom#95
 
   3. Case (% has type tupleTypeIR)
 
@@ -5751,9 +5775,9 @@ relation Type_alpha: typeIR ~~ typeIR'
 
               1. The relation holds
 
-            1. Else Phantom#95
+            1. Else Phantom#96
 
-      1. Else Phantom#96
+      1. Else Phantom#97
 
   4. Case (% has type headerStackTypeIR)
 
@@ -5771,11 +5795,11 @@ relation Type_alpha: typeIR ~~ typeIR'
 
                 1. The relation holds
 
-              1. Else Phantom#97
+              1. Else Phantom#98
 
-          1. Else Phantom#98
+          1. Else Phantom#99
 
-      1. Else Phantom#99
+      1. Else Phantom#100
 
   5. Case (% has type structTypeIR)
 
@@ -5793,11 +5817,11 @@ relation Type_alpha: typeIR ~~ typeIR'
 
                 1. The relation holds
 
-              1. Else Phantom#100
+              1. Else Phantom#101
 
-          1. Else Phantom#101
+          1. Else Phantom#102
 
-      1. Else Phantom#102
+      1. Else Phantom#103
 
   6. Case (% has type headerTypeIR)
 
@@ -5815,11 +5839,11 @@ relation Type_alpha: typeIR ~~ typeIR'
 
                 1. The relation holds
 
-              1. Else Phantom#103
+              1. Else Phantom#104
 
-          1. Else Phantom#104
+          1. Else Phantom#105
 
-      1. Else Phantom#105
+      1. Else Phantom#106
 
   7. Case (% has type headerUnionTypeIR)
 
@@ -5837,13 +5861,13 @@ relation Type_alpha: typeIR ~~ typeIR'
 
                 1. The relation holds
 
-              1. Else Phantom#106
+              1. Else Phantom#107
 
-          1. Else Phantom#107
+          1. Else Phantom#108
 
-      1. Else Phantom#108
+      1. Else Phantom#109
 
-3. Else Phantom#109
+3. Else Phantom#110
 
 4. Group enumTypeIR: typeIR ~~ typeIR'
 
@@ -5857,7 +5881,7 @@ relation Type_alpha: typeIR ~~ typeIR'
 
           1. The relation holds
 
-        1. Else Phantom#110
+        1. Else Phantom#111
 
     2. Case (% has type serializableEnumTypeIR)
 
@@ -5875,15 +5899,15 @@ relation Type_alpha: typeIR ~~ typeIR'
 
                   1. The relation holds
 
-                1. Else Phantom#111
+                1. Else Phantom#112
 
-              1. Else Phantom#112
+              1. Else Phantom#113
 
-            1. Else Phantom#113
+            1. Else Phantom#114
 
-        1. Else Phantom#114
+        1. Else Phantom#115
 
-  1. Else Phantom#115
+  1. Else Phantom#116
 
 5. Case analysis on typeIR
 
@@ -5903,11 +5927,11 @@ relation Type_alpha: typeIR ~~ typeIR'
 
                 1. The relation holds
 
-              1. Else Phantom#116
+              1. Else Phantom#117
 
-          1. Else Phantom#117
+          1. Else Phantom#118
 
-      1. Else Phantom#118
+      1. Else Phantom#119
 
   2. Case (% has type parserObjectTypeIR)
 
@@ -5923,9 +5947,9 @@ relation Type_alpha: typeIR ~~ typeIR'
 
               1. The relation holds
 
-            1. Else Phantom#119
+            1. Else Phantom#120
 
-      1. Else Phantom#120
+      1. Else Phantom#121
 
   3. Case (% has type controlObjectTypeIR)
 
@@ -5941,9 +5965,9 @@ relation Type_alpha: typeIR ~~ typeIR'
 
               1. The relation holds
 
-            1. Else Phantom#121
+            1. Else Phantom#122
 
-      1. Else Phantom#122
+      1. Else Phantom#123
 
   4. Case (% has type packageObjectTypeIR)
 
@@ -5959,9 +5983,9 @@ relation Type_alpha: typeIR ~~ typeIR'
 
               1. The relation holds
 
-            1. Else Phantom#123
+            1. Else Phantom#124
 
-      1. Else Phantom#124
+      1. Else Phantom#125
 
   5. Case (% has type tableObjectTypeIR)
 
@@ -5977,9 +6001,9 @@ relation Type_alpha: typeIR ~~ typeIR'
 
               1. The relation holds
 
-          1. Else Phantom#125
+          1. Else Phantom#126
 
-      1. Else Phantom#126
+      1. Else Phantom#127
 
   6. Case (% has type defaultTypeIR)
 
@@ -5993,7 +6017,7 @@ relation Type_alpha: typeIR ~~ typeIR'
 
             1. The relation holds
 
-      1. Else Phantom#127
+      1. Else Phantom#128
 
   7. Case (% has type invalidHeaderTypeIR)
 
@@ -6007,7 +6031,7 @@ relation Type_alpha: typeIR ~~ typeIR'
 
             1. The relation holds
 
-      1. Else Phantom#128
+      1. Else Phantom#129
 
   8. Case (% has type sequenceTypeIR)
 
@@ -6033,9 +6057,9 @@ relation Type_alpha: typeIR ~~ typeIR'
 
                         1. The relation holds
 
-                      1. Else Phantom#129
+                      1. Else Phantom#130
 
-                  1. Else Phantom#130
+                  1. Else Phantom#131
 
               2. Case (% matches pattern `SEQ<%,...>`)
 
@@ -6049,11 +6073,11 @@ relation Type_alpha: typeIR ~~ typeIR'
 
                         1. The relation holds
 
-                      1. Else Phantom#131
+                      1. Else Phantom#132
 
-                  1. Else Phantom#132
+                  1. Else Phantom#133
 
-      1. Else Phantom#133
+      1. Else Phantom#134
 
   9. Case (% has type recordTypeIR)
 
@@ -6083,13 +6107,13 @@ relation Type_alpha: typeIR ~~ typeIR'
 
                             1. The relation holds
 
-                          1. Else Phantom#134
+                          1. Else Phantom#135
 
-                        1. Else Phantom#135
+                        1. Else Phantom#136
 
-                      1. Else Phantom#136
+                      1. Else Phantom#137
 
-                  1. Else Phantom#137
+                  1. Else Phantom#138
 
               2. Case (% matches pattern `RECORD{%,...}`)
 
@@ -6107,15 +6131,15 @@ relation Type_alpha: typeIR ~~ typeIR'
 
                             1. The relation holds
 
-                          1. Else Phantom#138
+                          1. Else Phantom#139
 
-                        1. Else Phantom#139
+                        1. Else Phantom#140
 
-                      1. Else Phantom#140
+                      1. Else Phantom#141
 
-                  1. Else Phantom#141
+                  1. Else Phantom#142
 
-      1. Else Phantom#142
+      1. Else Phantom#143
 
   10. Case (% has type setTypeIR)
 
@@ -6131,9 +6155,9 @@ relation Type_alpha: typeIR ~~ typeIR'
 
               1. The relation holds
 
-            1. Else Phantom#143
+            1. Else Phantom#144
 
-      1. Else Phantom#144
+      1. Else Phantom#145
 
   11. Case (% has type tableMetadataTypeIR)
 
@@ -6149,11 +6173,11 @@ relation Type_alpha: typeIR ~~ typeIR'
 
               1. The relation holds
 
-          1. Else Phantom#145
+          1. Else Phantom#146
 
-      1. Else Phantom#146
+      1. Else Phantom#147
 
-5. Else Phantom#147
+5. Else Phantom#148
 
 relation ParameterType_alpha: (annotationList direction typeIR_a id parameterInitializerOptIR) ~~ (annotationList' direction' typeIR_b id' parameterInitializerOptIR')
 
@@ -6165,9 +6189,9 @@ relation ParameterType_alpha: (annotationList direction typeIR_a id parameterIni
 
       1. The relation holds
 
-    1. Else Phantom#148
+    1. Else Phantom#149
 
-1. Else Phantom#149
+1. Else Phantom#150
 
 relation ExternMethodType_alpha: externMethodTypeIR ~~ externMethodTypeIR'
 
@@ -6191,13 +6215,13 @@ relation ExternMethodType_alpha: externMethodTypeIR ~~ externMethodTypeIR'
 
                   1. The relation holds
 
-                1. Else Phantom#150
+                1. Else Phantom#151
 
-              1. Else Phantom#151
+              1. Else Phantom#152
 
-            1. Else Phantom#152
+            1. Else Phantom#153
 
-        1. Else Phantom#153
+        1. Else Phantom#154
 
     2. Case (% matches pattern `EXTERN_METHODABSTRACT%(%):%`)
 
@@ -6215,13 +6239,13 @@ relation ExternMethodType_alpha: externMethodTypeIR ~~ externMethodTypeIR'
 
                   1. The relation holds
 
-                1. Else Phantom#154
+                1. Else Phantom#155
 
-              1. Else Phantom#155
+              1. Else Phantom#156
 
-            1. Else Phantom#156
+            1. Else Phantom#157
 
-        1. Else Phantom#157
+        1. Else Phantom#158
 
 relation ExternMethodTypeDef_alpha: externMethodTypeDefIR_a ~~ externMethodTypeDefIR_b
 
@@ -6273,19 +6297,19 @@ relation ExternMethodTypeDef_alpha: externMethodTypeDefIR_a ~~ externMethodTypeD
 
                                               1. The relation holds
 
-                                            1. Else Phantom#158
+                                            1. Else Phantom#159
 
-                                        1. Else Phantom#159
+                                        1. Else Phantom#160
 
-                                  1. Else Phantom#160
+                                  1. Else Phantom#161
 
-                        1. Else Phantom#161
+                        1. Else Phantom#162
 
-                  1. Else Phantom#162
+                  1. Else Phantom#163
 
-        1. Else Phantom#163
+        1. Else Phantom#164
 
-      1. Else Phantom#164
+      1. Else Phantom#165
 
 syntax ctk = 
    | lctk
@@ -6360,11 +6384,11 @@ def $joins_ctk((ctk)*)
 
                 1. Return $joins_ctk(ctk_d :: (ctk_c)*)
 
-            1. Else Phantom#165
+            1. Else Phantom#166
 
-      1. Else Phantom#166
+      1. Else Phantom#167
 
-1. Else Phantom#167
+1. Else Phantom#168
 
 builtin def $pow2(nat)
 
@@ -6422,9 +6446,9 @@ def $un_bnot(value)
 
             1. Return ((w w i'') as value)
 
-    1. Else Phantom#168
+    1. Else Phantom#169
 
-1. Else Phantom#169
+1. Else Phantom#170
 
 def $un_lnot(value)
 
@@ -6434,7 +6458,7 @@ def $un_lnot(value)
 
     1. Return ((`b ~b) as value)
 
-1. Else Phantom#170
+1. Else Phantom#171
 
 def $un_plus(value)
 
@@ -6462,7 +6486,7 @@ def $un_plus(value)
 
           1. Return ((w s i) as value)
 
-1. Else Phantom#171
+1. Else Phantom#172
 
 def $un_minus(value)
 
@@ -6494,7 +6518,7 @@ def $un_minus(value)
 
             1. Return ((w s i') as value)
 
-1. Else Phantom#172
+1. Else Phantom#173
 
 def $bin_op(binop, value_l, value_r)
 
@@ -6576,7 +6600,7 @@ def $bin_op(binop, value_l, value_r)
 
     1. Return $bin_concat(value_l, value_r)
 
-1. Else Phantom#173
+1. Else Phantom#174
 
 def $bin_plus(value, value')
 
@@ -6600,9 +6624,9 @@ def $bin_plus(value, value')
 
                   1. Return ((d (i_l + i_r)) as value)
 
-              1. Else Phantom#174
+              1. Else Phantom#175
 
-          1. Else Phantom#175
+          1. Else Phantom#176
 
       2. Case (% matches pattern `%W%`)
 
@@ -6626,11 +6650,11 @@ def $bin_plus(value, value')
 
                           1. Return ((w w i) as value)
 
-                  1. Else Phantom#176
+                  1. Else Phantom#177
 
-              1. Else Phantom#177
+              1. Else Phantom#178
 
-          1. Else Phantom#178
+          1. Else Phantom#179
 
       3. Case (% matches pattern `%S%`)
 
@@ -6654,13 +6678,13 @@ def $bin_plus(value, value')
 
                           1. Return ((w s i) as value)
 
-                  1. Else Phantom#179
+                  1. Else Phantom#180
 
-              1. Else Phantom#180
+              1. Else Phantom#181
 
-          1. Else Phantom#181
+          1. Else Phantom#182
 
-1. Else Phantom#182
+1. Else Phantom#183
 
 def $bin_satplus(value, value')
 
@@ -6692,11 +6716,11 @@ def $bin_satplus(value, value')
 
                           1. Return ((w w i') as value)
 
-                  1. Else Phantom#183
+                  1. Else Phantom#184
 
-              1. Else Phantom#184
+              1. Else Phantom#185
 
-          1. Else Phantom#185
+          1. Else Phantom#186
 
       2. Case (% matches pattern `%S%`)
 
@@ -6734,9 +6758,9 @@ def $bin_satplus(value, value')
 
                                         1. Return ((w s i'') as value)
 
-                              1. Else Phantom#186
+                              1. Else Phantom#187
 
-                          1. Else Phantom#187
+                          1. Else Phantom#188
 
                           2. If ((i <= (0 as int))), then
 
@@ -6754,19 +6778,19 @@ def $bin_satplus(value, value')
 
                                         1. Return ((w s i'') as value)
 
-                              1. Else Phantom#188
+                              1. Else Phantom#189
 
-                          2. Else Phantom#189
+                          2. Else Phantom#190
 
-                  1. Else Phantom#190
+                  1. Else Phantom#191
 
-              1. Else Phantom#191
+              1. Else Phantom#192
 
-          1. Else Phantom#192
+          1. Else Phantom#193
 
-    1. Else Phantom#193
+    1. Else Phantom#194
 
-1. Else Phantom#194
+1. Else Phantom#195
 
 def $bin_minus(value, value')
 
@@ -6790,9 +6814,9 @@ def $bin_minus(value, value')
 
                   1. Return ((d (i_l - i_r)) as value)
 
-              1. Else Phantom#195
+              1. Else Phantom#196
 
-          1. Else Phantom#196
+          1. Else Phantom#197
 
       2. Case (% matches pattern `%W%`)
 
@@ -6816,11 +6840,11 @@ def $bin_minus(value, value')
 
                           1. Return ((w w i) as value)
 
-                  1. Else Phantom#197
+                  1. Else Phantom#198
 
-              1. Else Phantom#198
+              1. Else Phantom#199
 
-          1. Else Phantom#199
+          1. Else Phantom#200
 
       3. Case (% matches pattern `%S%`)
 
@@ -6844,13 +6868,13 @@ def $bin_minus(value, value')
 
                           1. Return ((w s i) as value)
 
-                  1. Else Phantom#200
+                  1. Else Phantom#201
 
-              1. Else Phantom#201
+              1. Else Phantom#202
 
-          1. Else Phantom#202
+          1. Else Phantom#203
 
-1. Else Phantom#203
+1. Else Phantom#204
 
 def $bin_satminus(value, value')
 
@@ -6880,11 +6904,11 @@ def $bin_satminus(value, value')
 
                         1. Return ((w w i') as value)
 
-                  1. Else Phantom#204
+                  1. Else Phantom#205
 
-              1. Else Phantom#205
+              1. Else Phantom#206
 
-          1. Else Phantom#206
+          1. Else Phantom#207
 
       2. Case (% matches pattern `%S%`)
 
@@ -6922,9 +6946,9 @@ def $bin_satminus(value, value')
 
                                         1. Return ((w s i'') as value)
 
-                              1. Else Phantom#207
+                              1. Else Phantom#208
 
-                          1. Else Phantom#208
+                          1. Else Phantom#209
 
                           2. If ((i <= (0 as int))), then
 
@@ -6942,19 +6966,19 @@ def $bin_satminus(value, value')
 
                                         1. Return ((w s i'') as value)
 
-                              1. Else Phantom#209
+                              1. Else Phantom#210
 
-                          2. Else Phantom#210
+                          2. Else Phantom#211
 
-                  1. Else Phantom#211
+                  1. Else Phantom#212
 
-              1. Else Phantom#212
+              1. Else Phantom#213
 
-          1. Else Phantom#213
+          1. Else Phantom#214
 
-    1. Else Phantom#214
+    1. Else Phantom#215
 
-1. Else Phantom#215
+1. Else Phantom#216
 
 def $bin_mul(value, value')
 
@@ -6978,9 +7002,9 @@ def $bin_mul(value, value')
 
                   1. Return ((d (i_l * i_r)) as value)
 
-              1. Else Phantom#216
+              1. Else Phantom#217
 
-          1. Else Phantom#217
+          1. Else Phantom#218
 
       2. Case (% matches pattern `%W%`)
 
@@ -7004,11 +7028,11 @@ def $bin_mul(value, value')
 
                           1. Return ((w w i) as value)
 
-                  1. Else Phantom#218
+                  1. Else Phantom#219
 
-              1. Else Phantom#219
+              1. Else Phantom#220
 
-          1. Else Phantom#220
+          1. Else Phantom#221
 
       3. Case (% matches pattern `%S%`)
 
@@ -7032,13 +7056,13 @@ def $bin_mul(value, value')
 
                           1. Return ((w s i) as value)
 
-                  1. Else Phantom#221
+                  1. Else Phantom#222
 
-              1. Else Phantom#222
+              1. Else Phantom#223
 
-          1. Else Phantom#223
+          1. Else Phantom#224
 
-1. Else Phantom#224
+1. Else Phantom#225
 
 def $bin_div(value, value')
 
@@ -7060,13 +7084,13 @@ def $bin_div(value, value')
 
                 1. Return ((d (i_l / i_r)) as value)
 
-            1. Else Phantom#225
+            1. Else Phantom#226
 
-        1. Else Phantom#226
+        1. Else Phantom#227
 
-    1. Else Phantom#227
+    1. Else Phantom#228
 
-1. Else Phantom#228
+1. Else Phantom#229
 
 def $bin_mod(value, value')
 
@@ -7088,13 +7112,13 @@ def $bin_mod(value, value')
 
                 1. Return ((d (i_l \ i_r)) as value)
 
-            1. Else Phantom#229
+            1. Else Phantom#230
 
-        1. Else Phantom#230
+        1. Else Phantom#231
 
-    1. Else Phantom#231
+    1. Else Phantom#232
 
-1. Else Phantom#232
+1. Else Phantom#233
 
 def $bin_shl(value, value')
 
@@ -7134,7 +7158,7 @@ def $bin_shl(value, value')
 
                       1. Return ((d $shl(i_l, i_r')) as value)
 
-          1. Else Phantom#233
+          1. Else Phantom#234
 
       2. Case (% matches pattern `%W%`)
 
@@ -7170,7 +7194,7 @@ def $bin_shl(value, value')
 
                         1. Return ((w_l w i) as value)
 
-          1. Else Phantom#234
+          1. Else Phantom#235
 
       3. Case (% matches pattern `%S%`)
 
@@ -7210,9 +7234,9 @@ def $bin_shl(value, value')
 
                           1. Return ((w_l s i) as value)
 
-          1. Else Phantom#235
+          1. Else Phantom#236
 
-1. Else Phantom#236
+1. Else Phantom#237
 
 def $bin_shr(value, value')
 
@@ -7252,7 +7276,7 @@ def $bin_shr(value, value')
 
                       1. Return ((d $shr(i_l, i_r')) as value)
 
-          1. Else Phantom#237
+          1. Else Phantom#238
 
       2. Case (% matches pattern `%W%`)
 
@@ -7288,7 +7312,7 @@ def $bin_shr(value, value')
 
                         1. Return ((w_l w i) as value)
 
-          1. Else Phantom#238
+          1. Else Phantom#239
 
       3. Case (% matches pattern `%S%`)
 
@@ -7320,9 +7344,9 @@ def $bin_shr(value, value')
 
                                   1. Return ((w_l s i') as value)
 
-                          1. Else Phantom#239
+                          1. Else Phantom#240
 
-                      1. Else Phantom#240
+                      1. Else Phantom#241
 
                       2. If ((i_l' >= (0 as int))), then
 
@@ -7332,7 +7356,7 @@ def $bin_shr(value, value')
 
                             1. Return ((w_l s i') as value)
 
-                      2. Else Phantom#241
+                      2. Else Phantom#242
 
                 2. Case (% matches pattern `%W%`)
 
@@ -7354,9 +7378,9 @@ def $bin_shr(value, value')
 
                                   1. Return ((w_l s i') as value)
 
-                          1. Else Phantom#242
+                          1. Else Phantom#243
 
-                      1. Else Phantom#243
+                      1. Else Phantom#244
 
                       2. If ((i_l' >= (0 as int))), then
 
@@ -7366,7 +7390,7 @@ def $bin_shr(value, value')
 
                             1. Return ((w_l s i') as value)
 
-                      2. Else Phantom#244
+                      2. Else Phantom#245
 
                 3. Case (% matches pattern `%S%`)
 
@@ -7390,9 +7414,9 @@ def $bin_shr(value, value')
 
                                     1. Return ((w_l s i') as value)
 
-                            1. Else Phantom#245
+                            1. Else Phantom#246
 
-                        1. Else Phantom#246
+                        1. Else Phantom#247
 
                         2. If ((i_l' >= (0 as int))), then
 
@@ -7402,11 +7426,11 @@ def $bin_shr(value, value')
 
                               1. Return ((w_l s i') as value)
 
-                        2. Else Phantom#247
+                        2. Else Phantom#248
 
-          1. Else Phantom#248
+          1. Else Phantom#249
 
-1. Else Phantom#249
+1. Else Phantom#250
 
 def $bin_le(value, value')
 
@@ -7430,9 +7454,9 @@ def $bin_le(value, value')
 
                   1. Return (i_l <= i_r)
 
-              1. Else Phantom#250
+              1. Else Phantom#251
 
-          1. Else Phantom#251
+          1. Else Phantom#252
 
       2. Case (% matches pattern `%W%`)
 
@@ -7450,11 +7474,11 @@ def $bin_le(value, value')
 
                     1. Return (i_l <= i_r)
 
-                  1. Else Phantom#252
+                  1. Else Phantom#253
 
-              1. Else Phantom#253
+              1. Else Phantom#254
 
-          1. Else Phantom#254
+          1. Else Phantom#255
 
       3. Case (% matches pattern `%S%`)
 
@@ -7476,13 +7500,13 @@ def $bin_le(value, value')
 
                         1. Return (i_l' <= i_r')
 
-                  1. Else Phantom#255
+                  1. Else Phantom#256
 
-              1. Else Phantom#256
+              1. Else Phantom#257
 
-          1. Else Phantom#257
+          1. Else Phantom#258
 
-1. Else Phantom#258
+1. Else Phantom#259
 
 def $bin_ge(value, value')
 
@@ -7506,9 +7530,9 @@ def $bin_ge(value, value')
 
                   1. Return (i_l >= i_r)
 
-              1. Else Phantom#259
+              1. Else Phantom#260
 
-          1. Else Phantom#260
+          1. Else Phantom#261
 
       2. Case (% matches pattern `%W%`)
 
@@ -7526,11 +7550,11 @@ def $bin_ge(value, value')
 
                     1. Return (i_l >= i_r)
 
-                  1. Else Phantom#261
+                  1. Else Phantom#262
 
-              1. Else Phantom#262
+              1. Else Phantom#263
 
-          1. Else Phantom#263
+          1. Else Phantom#264
 
       3. Case (% matches pattern `%S%`)
 
@@ -7552,13 +7576,13 @@ def $bin_ge(value, value')
 
                         1. Return (i_l' >= i_r')
 
-                  1. Else Phantom#264
+                  1. Else Phantom#265
 
-              1. Else Phantom#265
+              1. Else Phantom#266
 
-          1. Else Phantom#266
+          1. Else Phantom#267
 
-1. Else Phantom#267
+1. Else Phantom#268
 
 def $bin_lt(value, value')
 
@@ -7582,9 +7606,9 @@ def $bin_lt(value, value')
 
                   1. Return (i_l < i_r)
 
-              1. Else Phantom#268
+              1. Else Phantom#269
 
-          1. Else Phantom#269
+          1. Else Phantom#270
 
       2. Case (% matches pattern `%W%`)
 
@@ -7602,11 +7626,11 @@ def $bin_lt(value, value')
 
                     1. Return (i_l < i_r)
 
-                  1. Else Phantom#270
+                  1. Else Phantom#271
 
-              1. Else Phantom#271
+              1. Else Phantom#272
 
-          1. Else Phantom#272
+          1. Else Phantom#273
 
       3. Case (% matches pattern `%S%`)
 
@@ -7628,13 +7652,13 @@ def $bin_lt(value, value')
 
                         1. Return (i_l' < i_r')
 
-                  1. Else Phantom#273
+                  1. Else Phantom#274
 
-              1. Else Phantom#274
+              1. Else Phantom#275
 
-          1. Else Phantom#275
+          1. Else Phantom#276
 
-1. Else Phantom#276
+1. Else Phantom#277
 
 def $bin_gt(value, value')
 
@@ -7658,9 +7682,9 @@ def $bin_gt(value, value')
 
                   1. Return (i_l > i_r)
 
-              1. Else Phantom#277
+              1. Else Phantom#278
 
-          1. Else Phantom#278
+          1. Else Phantom#279
 
       2. Case (% matches pattern `%W%`)
 
@@ -7678,11 +7702,11 @@ def $bin_gt(value, value')
 
                     1. Return (i_l > i_r)
 
-                  1. Else Phantom#279
+                  1. Else Phantom#280
 
-              1. Else Phantom#280
+              1. Else Phantom#281
 
-          1. Else Phantom#281
+          1. Else Phantom#282
 
       3. Case (% matches pattern `%S%`)
 
@@ -7704,13 +7728,13 @@ def $bin_gt(value, value')
 
                         1. Return (i_l' > i_r')
 
-                  1. Else Phantom#282
+                  1. Else Phantom#283
 
-              1. Else Phantom#283
+              1. Else Phantom#284
 
-          1. Else Phantom#284
+          1. Else Phantom#285
 
-1. Else Phantom#285
+1. Else Phantom#286
 
 def $bin_eq(value, value')
 
@@ -7726,7 +7750,7 @@ def $bin_eq(value, value')
 
           1. Return (b_a = b_b)
 
-      1. Else Phantom#286
+      1. Else Phantom#287
 
   2. Case (% has type errorValue)
 
@@ -7738,7 +7762,7 @@ def $bin_eq(value, value')
 
           1. Return (id_a = id_b)
 
-      1. Else Phantom#287
+      1. Else Phantom#288
 
   3. Case (% has type matchKindValue)
 
@@ -7750,7 +7774,7 @@ def $bin_eq(value, value')
 
           1. Return (id_a = id_b)
 
-      1. Else Phantom#288
+      1. Else Phantom#289
 
   4. Case (% has type stringValue)
 
@@ -7762,7 +7786,7 @@ def $bin_eq(value, value')
 
           1. Return (stringValue_a = stringValue_b)
 
-      1. Else Phantom#289
+      1. Else Phantom#290
 
   5. Case (% has type integerLiteral)
 
@@ -7784,9 +7808,9 @@ def $bin_eq(value, value')
 
                     1. Return (i_a = i_b)
 
-                1. Else Phantom#290
+                1. Else Phantom#291
 
-            1. Else Phantom#291
+            1. Else Phantom#292
 
         2. Case (% matches pattern `%W%`)
 
@@ -7802,9 +7826,9 @@ def $bin_eq(value, value')
 
                     1. Return ((w_a = w_b) /\ (i_a = i_b))
 
-                1. Else Phantom#292
+                1. Else Phantom#293
 
-            1. Else Phantom#293
+            1. Else Phantom#294
 
         3. Case (% matches pattern `%S%`)
 
@@ -7820,9 +7844,9 @@ def $bin_eq(value, value')
 
                     1. Return ((w_a = w_b) /\ (i_a = i_b))
 
-                1. Else Phantom#294
+                1. Else Phantom#295
 
-            1. Else Phantom#295
+            1. Else Phantom#296
 
   6. Case (% has type listValue)
 
@@ -7834,7 +7858,7 @@ def $bin_eq(value, value')
 
           1. Return ((|(value_a)*| = |(value_b)*|) /\ $forall_(($bin_eq(value_a, value_b))*))
 
-      1. Else Phantom#296
+      1. Else Phantom#297
 
   7. Case (% has type tupleValue)
 
@@ -7846,7 +7870,7 @@ def $bin_eq(value, value')
 
           1. Return ((|(value_a)*| = |(value_b)*|) /\ $forall_(($bin_eq(value_a, value_b))*))
 
-      1. Else Phantom#297
+      1. Else Phantom#298
 
   8. Case (% has type headerStackValue)
 
@@ -7858,7 +7882,7 @@ def $bin_eq(value, value')
 
           1. Return (((|(value_a)*| = |(value_b)*|) /\ $forall_(($bin_eq(value_a, value_b))*)) /\ (n_size_a = n_size_b))
 
-      1. Else Phantom#298
+      1. Else Phantom#299
 
   9. Case (% has type structValue)
 
@@ -7874,7 +7898,7 @@ def $bin_eq(value, value')
 
               1. Return ((((typeId_a = typeId_b) /\ (|(fieldValue_a)*| = |(fieldValue_b)*|)) /\ $forall_(($bin_eq(value_field_a, value_field_b))*)) /\ $forall_(((nameIR_field_a = nameIR_field_b))*))
 
-      1. Else Phantom#299
+      1. Else Phantom#300
 
   10. Case (% has type headerValue)
 
@@ -7890,7 +7914,7 @@ def $bin_eq(value, value')
 
               1. Return ((((typeId_a = typeId_b) /\ (|(fieldValue_a)*| = |(fieldValue_b)*|)) /\ $forall_(($bin_eq(value_field_a, value_field_b))*)) /\ $forall_(((nameIR_field_a = nameIR_field_b))*))
 
-      1. Else Phantom#300
+      1. Else Phantom#301
 
   11. Case (% has type headerUnionValue)
 
@@ -7906,7 +7930,7 @@ def $bin_eq(value, value')
 
               1. Return ((((typeId_a = typeId_b) /\ (|(fieldValue_a)*| = |(fieldValue_b)*|)) /\ $forall_(($bin_eq(value_field_a, value_field_b))*)) /\ $forall_(((nameIR_field_a = nameIR_field_b))*))
 
-      1. Else Phantom#301
+      1. Else Phantom#302
 
   12. Case (% has type enumValue)
 
@@ -7928,9 +7952,9 @@ def $bin_eq(value, value')
 
                     1. Return ((typeId_a = typeId_b) /\ (nameIR_field_a = nameIR_field_b))
 
-                1. Else Phantom#302
+                1. Else Phantom#303
 
-            1. Else Phantom#303
+            1. Else Phantom#304
 
         2. Case (% matches pattern `%.%.%`)
 
@@ -7946,9 +7970,9 @@ def $bin_eq(value, value')
 
                     1. Return ((typeId_a = typeId_b) /\ $bin_eq(value_field_a, value_field_b))
 
-                1. Else Phantom#304
+                1. Else Phantom#305
 
-            1. Else Phantom#305
+            1. Else Phantom#306
 
   13. Case (% has type invalidHeaderValue)
 
@@ -7960,9 +7984,9 @@ def $bin_eq(value, value')
 
           1. Return true
 
-      1. Else Phantom#306
+      1. Else Phantom#307
 
-1. Else Phantom#307
+1. Else Phantom#308
 
 2. If ((value has type integerValue)), then
 
@@ -7982,13 +8006,13 @@ def $bin_eq(value, value')
 
                 1. Return ((w_max_a = w_max_b) /\ (i_a = i_b))
 
-            1. Else Phantom#308
+            1. Else Phantom#309
 
-        1. Else Phantom#309
+        1. Else Phantom#310
 
-    1. Else Phantom#310
+    1. Else Phantom#311
 
-2. Else Phantom#311
+2. Else Phantom#312
 
 def $bin_ne(value_l, value_r)
 
@@ -8020,11 +8044,11 @@ def $bin_band(value, value')
 
                       1. Return ((w w i) as value)
 
-                  1. Else Phantom#312
+                  1. Else Phantom#313
 
-              1. Else Phantom#313
+              1. Else Phantom#314
 
-          1. Else Phantom#314
+          1. Else Phantom#315
 
       2. Case (% matches pattern `%S%`)
 
@@ -8048,15 +8072,15 @@ def $bin_band(value, value')
 
                           1. Return ((w s i) as value)
 
-                  1. Else Phantom#315
+                  1. Else Phantom#316
 
-              1. Else Phantom#316
+              1. Else Phantom#317
 
-          1. Else Phantom#317
+          1. Else Phantom#318
 
-    1. Else Phantom#318
+    1. Else Phantom#319
 
-1. Else Phantom#319
+1. Else Phantom#320
 
 def $bin_bxor(value, value')
 
@@ -8084,11 +8108,11 @@ def $bin_bxor(value, value')
 
                       1. Return ((w w i) as value)
 
-                  1. Else Phantom#320
+                  1. Else Phantom#321
 
-              1. Else Phantom#321
+              1. Else Phantom#322
 
-          1. Else Phantom#322
+          1. Else Phantom#323
 
       2. Case (% matches pattern `%S%`)
 
@@ -8112,15 +8136,15 @@ def $bin_bxor(value, value')
 
                           1. Return ((w s i) as value)
 
-                  1. Else Phantom#323
+                  1. Else Phantom#324
 
-              1. Else Phantom#324
+              1. Else Phantom#325
 
-          1. Else Phantom#325
+          1. Else Phantom#326
 
-    1. Else Phantom#326
+    1. Else Phantom#327
 
-1. Else Phantom#327
+1. Else Phantom#328
 
 def $bin_bor(value, value')
 
@@ -8148,11 +8172,11 @@ def $bin_bor(value, value')
 
                       1. Return ((w w i) as value)
 
-                  1. Else Phantom#328
+                  1. Else Phantom#329
 
-              1. Else Phantom#329
+              1. Else Phantom#330
 
-          1. Else Phantom#330
+          1. Else Phantom#331
 
       2. Case (% matches pattern `%S%`)
 
@@ -8176,15 +8200,15 @@ def $bin_bor(value, value')
 
                           1. Return ((w s i) as value)
 
-                  1. Else Phantom#331
+                  1. Else Phantom#332
 
-              1. Else Phantom#332
+              1. Else Phantom#333
 
-          1. Else Phantom#333
+          1. Else Phantom#334
 
-    1. Else Phantom#334
+    1. Else Phantom#335
 
-1. Else Phantom#335
+1. Else Phantom#336
 
 def $bin_concat(value, value')
 
@@ -8232,9 +8256,9 @@ def $bin_concat(value, value')
 
                             1. Return ((w w i) as value)
 
-              1. Else Phantom#336
+              1. Else Phantom#337
 
-          1. Else Phantom#337
+          1. Else Phantom#338
 
       2. Case (% matches pattern `%S%`)
 
@@ -8278,13 +8302,13 @@ def $bin_concat(value, value')
 
                               1. Return ((w s i) as value)
 
-              1. Else Phantom#338
+              1. Else Phantom#339
 
-          1. Else Phantom#339
+          1. Else Phantom#340
 
-    1. Else Phantom#340
+    1. Else Phantom#341
 
-1. Else Phantom#341
+1. Else Phantom#342
 
 def $cast_op(typeIR, value)
 
@@ -8392,7 +8416,7 @@ def $cast_op(typeIR, value)
 
         1. Return $cast_set(typeIR_unroll, setValue)
 
-1. Else Phantom#342
+1. Else Phantom#343
 
 def $default(typeIR)
 
@@ -8496,7 +8520,7 @@ def $default(typeIR)
 
           1. Return ((typeId . id_f_h) as value)
 
-      1. Else Phantom#343
+      1. Else Phantom#344
 
   16. Case (% has type serializableEnumTypeIR)
 
@@ -8512,7 +8536,7 @@ def $default(typeIR)
 
               1. Return ((typeId . id_zero . value_zero) as value)
 
-          1. Else Phantom#344
+          1. Else Phantom#345
 
         2. If ((?() = $assoc_<value, id>(value_zero, ((value_field, nameIR_field))*))), then
 
@@ -8520,9 +8544,9 @@ def $default(typeIR)
 
             1. Return ((typeId . id_zero . value_zero) as value)
 
-        2. Else Phantom#345
+        2. Else Phantom#346
 
-1. Else Phantom#346
+1. Else Phantom#347
 
 def $cast_to_enum(enumTypeIR, value)
 
@@ -8532,7 +8556,7 @@ def $cast_to_enum(enumTypeIR, value)
 
     1. Return $cast_to_enum'(typeId, typeIR, (valueFieldIR)*, value)
 
-1. Else Phantom#347
+1. Else Phantom#348
 
 def $cast_to_enum'(typeId, typeIR, (valueFieldIR)*, value_target)
 
@@ -8572,7 +8596,7 @@ def $cast_bool(typeIR, boolValue)
 
       1. Return ((`b b) as value)
 
-  1. Else Phantom#348
+  1. Else Phantom#349
 
 2. Case analysis on typeIR
 
@@ -8590,7 +8614,7 @@ def $cast_bool(typeIR, boolValue)
 
           1. Return ((w w (0 as int)) as value)
 
-      1. Else Phantom#349
+      1. Else Phantom#350
 
   2. Case (% has type newTypeIR)
 
@@ -8604,7 +8628,7 @@ def $cast_bool(typeIR, boolValue)
 
       1. Return ((set{ $cast_bool(typeIR', boolValue) }) as value)
 
-2. Else Phantom#350
+2. Else Phantom#351
 
 def $cast_int(typeIR, integerValue)
 
@@ -8632,9 +8656,9 @@ def $cast_int(typeIR, integerValue)
 
                 1. Return ((`b (i =/= (0 as int))) as value)
 
-          1. Else Phantom#351
+          1. Else Phantom#352
 
-      1. Else Phantom#352
+      1. Else Phantom#353
 
   2. Case (% has type intTypeIR)
 
@@ -8664,7 +8688,7 @@ def $cast_int(typeIR, integerValue)
 
                 1. Return ((d $bitstr_to_int((w as int), i)) as value)
 
-      1. Else Phantom#353
+      1. Else Phantom#354
 
   3. Case (% has type fixedBitTypeIR)
 
@@ -8702,7 +8726,7 @@ def $cast_int(typeIR, integerValue)
 
                     1. Return ((w_to w i_cast) as value)
 
-      1. Else Phantom#354
+      1. Else Phantom#355
 
   4. Case (% has type fixedIntTypeIR)
 
@@ -8740,7 +8764,7 @@ def $cast_int(typeIR, integerValue)
 
                     1. Return ((w_to s i_cast) as value)
 
-      1. Else Phantom#355
+      1. Else Phantom#356
 
   5. Case (% has type varBitTypeIR)
 
@@ -8754,9 +8778,9 @@ def $cast_int(typeIR, integerValue)
 
             1. Return ((w_max . w v i) as value)
 
-          1. Else Phantom#356
+          1. Else Phantom#357
 
-      1. Else Phantom#357
+      1. Else Phantom#358
 
   6. Case (% has type newTypeIR)
 
@@ -8786,7 +8810,7 @@ def $cast_int(typeIR, integerValue)
 
                 1. Return $cast_op(typeIR', ((w s i) as value))
 
-      1. Else Phantom#358
+      1. Else Phantom#359
 
   7. Case (% has type enumTypeIR)
 
@@ -8810,9 +8834,9 @@ def $cast_int(typeIR, integerValue)
 
                 1. Return $cast_to_enum(enumTypeIR, ((w s i) as value))
 
-          1. Else Phantom#359
+          1. Else Phantom#360
 
-      1. Else Phantom#360
+      1. Else Phantom#361
 
   8. Case (% has type setTypeIR)
 
@@ -8842,9 +8866,9 @@ def $cast_int(typeIR, integerValue)
 
                 1. Return ((set{ $cast_op(typeIR', ((w s i) as value)) }) as value)
 
-      1. Else Phantom#361
+      1. Else Phantom#362
 
-1. Else Phantom#362
+1. Else Phantom#363
 
 def $cast_error(typeIR, errorValue)
 
@@ -8856,7 +8880,7 @@ def $cast_error(typeIR, errorValue)
 
       1. Return ((error. nameIR) as value)
 
-  1. Else Phantom#363
+  1. Else Phantom#364
 
 2. If ((typeIR has type setTypeIR)), then
 
@@ -8864,7 +8888,7 @@ def $cast_error(typeIR, errorValue)
 
     1. Return ((set{ $cast_op(typeIR', (errorValue as value)) }) as value)
 
-2. Else Phantom#364
+2. Else Phantom#365
 
 def $cast_list(typeIR, (list[ (value)* ]))
 
@@ -8874,7 +8898,7 @@ def $cast_list(typeIR, (list[ (value)* ]))
 
     1. Return ((list[ ($cast_op(typeIR', value))* ]) as value)
 
-1. Else Phantom#365
+1. Else Phantom#366
 
 def $cast_header_stack(typeIR, (header_stack[ (value)* ( n_idx ; n_size )]))
 
@@ -8886,9 +8910,9 @@ def $cast_header_stack(typeIR, (header_stack[ (value)* ( n_idx ; n_size )]))
 
       1. Return ((header_stack[ (value)* ( n_idx ; n_size' )]) as value)
 
-    1. Else Phantom#366
+    1. Else Phantom#367
 
-1. Else Phantom#367
+1. Else Phantom#368
 
 def $cast_struct(typeIR, (struct typeId { ((value_field nameIR_field ;))* }))
 
@@ -8900,9 +8924,9 @@ def $cast_struct(typeIR, (struct typeId { ((value_field nameIR_field ;))* }))
 
       1. Return ((struct typeId' { ((value_field nameIR_field ;))* }) as value)
 
-    1. Else Phantom#368
+    1. Else Phantom#369
 
-1. Else Phantom#369
+1. Else Phantom#370
 
 def $cast_header(typeIR, (header typeId { b ; ((value_field nameIR_field ;))* }))
 
@@ -8914,9 +8938,9 @@ def $cast_header(typeIR, (header typeId { b ; ((value_field nameIR_field ;))* })
 
       1. Return ((header typeId' { b ; ((value_field nameIR_field ;))* }) as value)
 
-    1. Else Phantom#370
+    1. Else Phantom#371
 
-1. Else Phantom#371
+1. Else Phantom#372
 
 def $cast_enum(typeIR, enumValue)
 
@@ -8934,9 +8958,9 @@ def $cast_enum(typeIR, enumValue)
 
             1. Return ((typeId . nameIR) as value)
 
-          1. Else Phantom#372
+          1. Else Phantom#373
 
-      1. Else Phantom#373
+      1. Else Phantom#374
 
   2. Case (% has type serializableEnumTypeIR)
 
@@ -8950,9 +8974,9 @@ def $cast_enum(typeIR, enumValue)
 
             1. Return ((typeId . nameIR . value) as value)
 
-          1. Else Phantom#374
+          1. Else Phantom#375
 
-      1. Else Phantom#375
+      1. Else Phantom#376
 
   3. Case (% has type setTypeIR)
 
@@ -8960,7 +8984,7 @@ def $cast_enum(typeIR, enumValue)
 
       1. Return ((set{ $cast_op(typeIR', (enumValue as value)) }) as value)
 
-1. Else Phantom#376
+1. Else Phantom#377
 
 2. If ((enumValue matches pattern `%.%.%`)), then
 
@@ -8970,9 +8994,9 @@ def $cast_enum(typeIR, enumValue)
 
       1. Return $cast_op(typeIR, value)
 
-    1. Else Phantom#377
+    1. Else Phantom#378
 
-2. Else Phantom#378
+2. Else Phantom#379
 
 def $cast_sequence(typeIR, sequenceValue)
 
@@ -8988,7 +9012,7 @@ def $cast_sequence(typeIR, sequenceValue)
 
           1. Return ((list[ ($cast_op(typeIR', value))* ]) as value)
 
-      1. Else Phantom#379
+      1. Else Phantom#380
 
   2. Case (% has type tupleTypeIR)
 
@@ -9000,7 +9024,7 @@ def $cast_sequence(typeIR, sequenceValue)
 
           1. Return ((tuple( ($cast_op(typeIR', value))* )) as value)
 
-      1. Else Phantom#380
+      1. Else Phantom#381
 
   3. Case (% has type headerStackTypeIR)
 
@@ -9016,7 +9040,7 @@ def $cast_sequence(typeIR, sequenceValue)
 
               1. Return ((header_stack[ (value_cast)* ( n_idx ; n_size )]) as value)
 
-      1. Else Phantom#381
+      1. Else Phantom#382
 
   4. Case (% has type structTypeIR)
 
@@ -9030,7 +9054,7 @@ def $cast_sequence(typeIR, sequenceValue)
 
             1. Return ((struct typeId { ((value_cast nameIR_field ;))* }) as value)
 
-      1. Else Phantom#382
+      1. Else Phantom#383
 
   5. Case (% has type headerTypeIR)
 
@@ -9044,9 +9068,9 @@ def $cast_sequence(typeIR, sequenceValue)
 
             1. Return ((header typeId { true ; ((value_cast nameIR_field ;))* }) as value)
 
-      1. Else Phantom#383
+      1. Else Phantom#384
 
-1. Else Phantom#384
+1. Else Phantom#385
 
 def $cast_record(typeIR, recordValue)
 
@@ -9070,9 +9094,9 @@ def $cast_record(typeIR, recordValue)
 
                   1. Return ((struct typeId { ((value_field_cast nameIR_field ;))* }) as value)
 
-            1. Else Phantom#385
+            1. Else Phantom#386
 
-      1. Else Phantom#386
+      1. Else Phantom#387
 
   2. Case (% has type headerTypeIR)
 
@@ -9092,11 +9116,11 @@ def $cast_record(typeIR, recordValue)
 
                   1. Return ((header typeId { true ; ((value_field_cast nameIR_field ;))* }) as value)
 
-            1. Else Phantom#387
+            1. Else Phantom#388
 
-      1. Else Phantom#388
+      1. Else Phantom#389
 
-1. Else Phantom#389
+1. Else Phantom#390
 
 def $cast_default(typeIR, defaultValue)
 
@@ -9118,7 +9142,7 @@ def $cast_invalid_header(typeIR)
 
       1. Return $default((headerUnionTypeIR as typeIR))
 
-1. Else Phantom#390
+1. Else Phantom#391
 
 def $cast_set(typeIR, setValue)
 
@@ -9154,9 +9178,9 @@ def $cast_set(typeIR, setValue)
 
               1. Return ((set{ value_l_cast .. value_u_cast }) as value)
 
-    1. Else Phantom#391
+    1. Else Phantom#392
 
-1. Else Phantom#392
+1. Else Phantom#393
 
 def $bitacc_op(value, value', value'')
 
@@ -9188,13 +9212,13 @@ def $bitacc_op(value, value', value'')
 
                           1. Return ((w w i) as value)
 
-                    1. Else Phantom#393
+                    1. Else Phantom#394
 
-        1. Else Phantom#394
+        1. Else Phantom#395
 
-    1. Else Phantom#395
+    1. Else Phantom#396
 
-1. Else Phantom#396
+1. Else Phantom#397
 
 def $bitacc_replace_op(value, value', value'', value''')
 
@@ -9238,21 +9262,21 @@ def $bitacc_replace_op(value, value', value'', value''')
 
                                       1. Return ((w w i) as value)
 
-                                1. Else Phantom#397
+                                1. Else Phantom#398
 
-                            1. Else Phantom#398
+                            1. Else Phantom#399
 
-                    1. Else Phantom#399
+                    1. Else Phantom#400
 
-                1. Else Phantom#400
+                1. Else Phantom#401
 
-            1. Else Phantom#401
+            1. Else Phantom#402
 
-        1. Else Phantom#402
+        1. Else Phantom#403
 
-    1. Else Phantom#403
+    1. Else Phantom#404
 
-1. Else Phantom#404
+1. Else Phantom#405
 
 def $sizeof(typeIR, text)
 
@@ -9274,7 +9298,7 @@ def $sizeof(typeIR, text)
 
     1. Return $sizeof_maxSizeInBytes(typeIR)
 
-1. Else Phantom#405
+1. Else Phantom#406
 
 def $sizeof_minSizeInBits(typeIR)
 
@@ -9354,7 +9378,7 @@ def $sizeof_minSizeInBits'(typeIR)
 
       1. Return $min_nat(($sizeof_minSizeInBits'(typeIR'))*)
 
-1. Else Phantom#406
+1. Else Phantom#407
 
 def $sizeof_minSizeInBytes(typeIR)
 
@@ -9442,7 +9466,7 @@ def $sizeof_maxSizeInBits'(typeIR)
 
       1. Return $max_nat(($sizeof_maxSizeInBits'(typeIR'))*)
 
-1. Else Phantom#407
+1. Else Phantom#408
 
 def $sizeof_maxSizeInBytes(typeIR)
 
@@ -9729,7 +9753,7 @@ def $typedLvalueIR_as_typedExpressionIR((lvalueIR # (( typeIR ))))
 
             1. Return ?(((((typedExpressionIR' as memberAccessBaseIR) . nameIR) as expressionIR) # (( typeIR (dyn) ))))
 
-        1. Else Phantom#408
+        1. Else Phantom#409
 
   3. Case (% matches pattern `%[%]`)
 
@@ -9743,7 +9767,7 @@ def $typedLvalueIR_as_typedExpressionIR((lvalueIR # (( typeIR ))))
 
             1. Return ?((((typedExpressionIR_base [ typedExpressionIR_index ]) as expressionIR) # (( typeIR (dyn) ))))
 
-        1. Else Phantom#409
+        1. Else Phantom#410
 
   4. Case (% matches pattern `%[%:%]`)
 
@@ -9757,9 +9781,9 @@ def $typedLvalueIR_as_typedExpressionIR((lvalueIR # (( typeIR ))))
 
             1. Return ?((((typedExpressionIR_base [ typedExpressionIR_hi : typedExpressionIR_lo ]) as expressionIR) # (( typeIR (dyn) ))))
 
-        1. Else Phantom#410
+        1. Else Phantom#411
 
-1. Else Phantom#411
+1. Else Phantom#412
 
 def $typedExpressionIR_as_typedLvalueIR((expressionIR # (( typeIR _ctk ))))
 
@@ -9787,9 +9811,9 @@ def $typedExpressionIR_as_typedLvalueIR((expressionIR # (( typeIR _ctk ))))
 
                 1. Return ?(((typedLvalueIR' . nameIR) # (( typeIR ))))
 
-            1. Else Phantom#412
+            1. Else Phantom#413
 
-      1. Else Phantom#413
+      1. Else Phantom#414
 
   3. Case (% has type indexAccessExpressionIR)
 
@@ -9803,7 +9827,7 @@ def $typedExpressionIR_as_typedLvalueIR((expressionIR # (( typeIR _ctk ))))
 
             1. Return ?(((typedLvalueIR_base [ typedExpressionIR_index ]) # (( typeIR ))))
 
-        1. Else Phantom#414
+        1. Else Phantom#415
 
   4. Case (% has type sliceAccessExpressionIR)
 
@@ -9817,7 +9841,7 @@ def $typedExpressionIR_as_typedLvalueIR((expressionIR # (( typeIR _ctk ))))
 
             1. Return ?(((typedLvalueIR_base [ typedExpressionIR_hi : typedExpressionIR_lo ]) # (( typeIR ))))
 
-        1. Else Phantom#415
+        1. Else Phantom#416
 
   5. Case (% has type parenthesizedExpressionIR)
 
@@ -9831,9 +9855,9 @@ def $typedExpressionIR_as_typedLvalueIR((expressionIR # (( typeIR _ctk ))))
 
             1. Return ?(((( typedLvalueIR' )) # (( typeIR ))))
 
-        1. Else Phantom#416
+        1. Else Phantom#417
 
-1. Else Phantom#417
+1. Else Phantom#418
 
 syntax emptyStatementIR = emptyStatement
 
@@ -9977,7 +10001,7 @@ def $flatten_objectInitializerOptIR(objectInitializerOptIR)
 
     1. Return []
 
-  1. Else Phantom#418
+  1. Else Phantom#419
 
 2. If ((objectInitializerOptIR matches pattern (_))), then
 
@@ -9985,7 +10009,7 @@ def $flatten_objectInitializerOptIR(objectInitializerOptIR)
 
     1. Return objectDeclarationListIR
 
-2. Else Phantom#419
+2. Else Phantom#420
 
 syntax errorDeclarationIR = 
    | error{ nameListIR }
@@ -10150,7 +10174,7 @@ syntax tableKeyIR =
 
 syntax tableKeyListIR = tableKeyIR*
 
-syntax controlPlaneNameIR = nameIR*
+syntax controlPlaneNameIR = nameIR?
 
 syntax tableActionReferenceIR = 
    | prefixedNameIR controlPlaneNameIR ( argumentListIR )
@@ -10284,13 +10308,13 @@ def $partition_parameterListIR((parameterIR)*, (nameIR)*, (nameIR')*)
 
                 1. Return (parameterIR_h :: (parameterIR_given)*, (parameterIR_default)*, (parameterIR_optional)*)
 
-              1. Else Phantom#420
+              1. Else Phantom#421
 
           2. If (nameIR_h is in (nameIR')*), then
 
             1. Return ((parameterIR_given)*, (parameterIR_default)*, parameterIR_h :: (parameterIR_optional)*)
 
-          2. Else Phantom#421
+          2. Else Phantom#422
 
 syntax callAlign = 
    | given parameterIR* default parameterIR*
@@ -10315,7 +10339,7 @@ def $align_parameterListIR_given(({ ((id : parameterIR))* }), (parameterIR')*, (
 
       1. Return []
 
-    1. Else Phantom#422
+    1. Else Phantom#423
 
   2. Case (% matches pattern _ :: _)
 
@@ -10353,7 +10377,7 @@ def $align_parameterListIR_given(({ ((id : parameterIR))* }), (parameterIR')*, (
 
                         1. Return parameterIR_match :: (parameterIR_aligned)*
 
-                  1. Else Phantom#423
+                  1. Else Phantom#424
 
             4. Case (% matches pattern `%=_`)
 
@@ -10369,9 +10393,9 @@ def $align_parameterListIR_given(({ ((id : parameterIR))* }), (parameterIR')*, (
 
                         1. Return parameterIR_match :: (parameterIR_aligned)*
 
-                  1. Else Phantom#424
+                  1. Else Phantom#425
 
-      1. Else Phantom#425
+      1. Else Phantom#426
 
 syntax callTargetKey = 
    | nameIR ( id?* )
@@ -10510,7 +10534,7 @@ def $find_overloadeds_named<V>(set<pair<callableId, V>>, (nameIR_f ( (id_arg)* )
 
   1. Return []
 
-1. Else Phantom#426
+1. Else Phantom#427
 
 2. (Let ({ (pair<callableId, V>)* }) be set<pair<callableId, V>>)
 
@@ -10522,7 +10546,7 @@ def $find_overloadeds_named<V>(set<pair<callableId, V>>, (nameIR_f ( (id_arg)* )
 
         1. Return $find_overloadeds_named<V>(({ ((callTargetId_t : V_t))* }), (nameIR_f ( (id_arg)* )), $get_parameterListIR)
 
-      1. Else Phantom#427
+      1. Else Phantom#428
 
       2. (Let callTargetMatch be $match_overloaded_named<V>((callTargetId_h : V_h), (nameIR_f ( (id_arg)* )), $get_parameterListIR))
 
@@ -10532,9 +10556,9 @@ def $find_overloadeds_named<V>(set<pair<callableId, V>>, (nameIR_f ( (id_arg)* )
 
             1. Return (callTargetId_h : V_h # (id_default)* # (id_optional)*) :: $find_overloadeds_named<V>(({ ((callTargetId_t : V_t))* }), (nameIR_f ( (id_arg)* )), $get_parameterListIR)
 
-        1. Else Phantom#428
+        1. Else Phantom#429
 
-  1. Else Phantom#429
+  1. Else Phantom#430
 
 def $find_overloadeds_unnamed<V>(set<pair<callableId, V>>, (nameIR_f ( nat )), $get_parameterListIR)
 
@@ -10542,7 +10566,7 @@ def $find_overloadeds_unnamed<V>(set<pair<callableId, V>>, (nameIR_f ( nat )), $
 
   1. Return []
 
-1. Else Phantom#430
+1. Else Phantom#431
 
 2. (Let ({ (pair<callableId, V>)* }) be set<pair<callableId, V>>)
 
@@ -10554,7 +10578,7 @@ def $find_overloadeds_unnamed<V>(set<pair<callableId, V>>, (nameIR_f ( nat )), $
 
         1. Return $find_overloadeds_unnamed<V>(({ ((callTargetId_t : V_t))* }), (nameIR_f ( nat )), $get_parameterListIR)
 
-      1. Else Phantom#431
+      1. Else Phantom#432
 
       2. (Let callTargetMatch be $match_overloaded_unnamed<V>((callTargetId_h : V_h), (nameIR_f ( nat )), $get_parameterListIR))
 
@@ -10564,9 +10588,9 @@ def $find_overloadeds_unnamed<V>(set<pair<callableId, V>>, (nameIR_f ( nat )), $
 
             1. Return (callTargetId_h : V_h # (id_default)* # (id_optional)*) :: $find_overloadeds_unnamed<V>(({ ((callTargetId_t : V_t))* }), (nameIR_f ( nat )), $get_parameterListIR)
 
-        1. Else Phantom#432
+        1. Else Phantom#433
 
-  1. Else Phantom#433
+  1. Else Phantom#434
 
 def $find_overloaded<V>(({ ((callableId : V))* }), (nameIR_f ( ((id_arg)?)* )), $get_parameterListIR)
 
@@ -10580,7 +10604,7 @@ def $find_overloaded<V>(({ ((callableId : V))* }), (nameIR_f ( ((id_arg)?)* )), 
 
         1. Return ?()
 
-      1. Else Phantom#434
+      1. Else Phantom#435
 
       2. (Let (callResolution<V>)* be $find_overloadeds_named<V>(({ ((callableId : V))* }), (nameIR_f ( (id_arg_inner)* )), $get_parameterListIR))
 
@@ -10590,11 +10614,11 @@ def $find_overloaded<V>(({ ((callableId : V))* }), (nameIR_f ( ((id_arg)?)* )), 
 
             1. Return ?((callableId_found : V_found # (id_default)* # (id_optional)*))
 
-        1. Else Phantom#435
+        1. Else Phantom#436
 
-  1. Else Phantom#436
+  1. Else Phantom#437
 
-1. Else Phantom#437
+1. Else Phantom#438
 
 2. If (((id_arg)? matches pattern ()))*, then
 
@@ -10602,7 +10626,7 @@ def $find_overloaded<V>(({ ((callableId : V))* }), (nameIR_f ( ((id_arg)?)* )), 
 
     1. Return ?()
 
-  1. Else Phantom#438
+  1. Else Phantom#439
 
   2. (Let (callResolution<V>)* be $find_overloadeds_unnamed<V>(({ ((callableId : V))* }), (nameIR_f ( |((id_arg)?)*| )), $get_parameterListIR))
 
@@ -10612,9 +10636,9 @@ def $find_overloaded<V>(({ ((callableId : V))* }), (nameIR_f ( ((id_arg)?)* )), 
 
         1. Return ?((callableId_found : V_found # (id_omitted)* # (id_optional)*))
 
-    1. Else Phantom#439
+    1. Else Phantom#440
 
-2. Else Phantom#440
+2. Else Phantom#441
 
 def $find_non_overloaded<V>(({ ((callableId : V))* }), nameIR_f)
 
@@ -10636,7 +10660,7 @@ def $find_non_overloadeds<V>(set<pair<callableId, V>>, nameIR_f)
 
   1. Return []
 
-1. Else Phantom#441
+1. Else Phantom#442
 
 2. (Let ({ (pair<callableId, V>)* }) be set<pair<callableId, V>>)
 
@@ -10660,7 +10684,7 @@ def $find_non_overloadeds<V>(set<pair<callableId, V>>, nameIR_f)
 
               1. Return ((callableId_t_found, V_t_found))*
 
-  1. Else Phantom#442
+  1. Else Phantom#443
 
 def $name_annotation(annotationList)
 
@@ -10704,13 +10728,13 @@ def $name_annotation_default(annotationList, nameIR)
 
       1. Return nameIR_found
 
-  1. Else Phantom#443
+  1. Else Phantom#444
 
 2. If (([] = $name_annotation(annotationList))), then
 
   1. Return nameIR
 
-2. Else Phantom#444
+2. Else Phantom#445
 
 def $find_name_annotation_opt(annotationList)
 
@@ -10768,7 +10792,7 @@ def $add_annotationList(annotationList, (annotation)?)
 
   1. Return annotationList
 
-1. Else Phantom#445
+1. Else Phantom#446
 
 2. Case analysis on annotationList
 
@@ -10780,7 +10804,7 @@ def $add_annotationList(annotationList, (annotation)?)
 
         1. Return (annotation' as annotationList)
 
-    1. Else Phantom#446
+    1. Else Phantom#447
 
   2. Case (% has type annotationListNonEmpty)
 
@@ -10792,7 +10816,7 @@ def $add_annotationList(annotationList, (annotation)?)
 
           1. Return ((annotationListNonEmpty annotation') as annotationList)
 
-      1. Else Phantom#447
+      1. Else Phantom#448
 
 def $subexpressions_of_typedExpressionIR(typedExpressionIR)
 
@@ -11081,7 +11105,7 @@ def $exit_t(TC)
 
       1. Return TC[local.frames = (typeFrame_t)*]
 
-  1. Else Phantom#448
+  1. Else Phantom#449
 
 def $add_var_t(cursor, TC, id, varTypeIR)
 
@@ -11105,9 +11129,9 @@ def $add_var_t(cursor, TC, id, varTypeIR)
 
                   1. Return TC'
 
-            1. Else Phantom#449
+            1. Else Phantom#450
 
-      1. Else Phantom#450
+      1. Else Phantom#451
 
   2. Case (% matches pattern `BLOCK`)
 
@@ -11123,9 +11147,9 @@ def $add_var_t(cursor, TC, id, varTypeIR)
 
               1. Return TC'
 
-        1. Else Phantom#451
+        1. Else Phantom#452
 
-      1. Else Phantom#452
+      1. Else Phantom#453
 
   3. Case (% matches pattern `LOCAL`)
 
@@ -11147,11 +11171,11 @@ def $add_var_t(cursor, TC, id, varTypeIR)
 
                     1. Return TC'
 
-            1. Else Phantom#453
+            1. Else Phantom#454
 
-          1. Else Phantom#454
+          1. Else Phantom#455
 
-      1. Else Phantom#455
+      1. Else Phantom#456
 
 def $add_vars_t(p, TC, (id)*, (varTypeIR)*)
 
@@ -11163,7 +11187,7 @@ def $add_vars_t(p, TC, (id)*, (varTypeIR)*)
 
       1. Return TC
 
-    1. Else Phantom#456
+    1. Else Phantom#457
 
   2. Case (% matches pattern _ :: _)
 
@@ -11179,7 +11203,7 @@ def $add_vars_t(p, TC, (id)*, (varTypeIR)*)
 
               1. Return TC''
 
-      1. Else Phantom#457
+      1. Else Phantom#458
 
 def $add_parameter_t(cursor, TC, (_annotationList direction typeIR id _parameterInitializerOptIR))
 
@@ -11243,7 +11267,7 @@ def $add_typeDef_t(cursor, TC, typeId, typeDefIR)
 
             1. Return TC'
 
-      1. Else Phantom#458
+      1. Else Phantom#459
 
   2. Case (% matches pattern `BLOCK`)
 
@@ -11257,7 +11281,7 @@ def $add_typeDef_t(cursor, TC, typeId, typeDefIR)
 
             1. Return TC'
 
-      1. Else Phantom#459
+      1. Else Phantom#460
 
   3. Case (% matches pattern `LOCAL`)
 
@@ -11271,7 +11295,7 @@ def $add_typeDef_t(cursor, TC, typeId, typeDefIR)
 
             1. Return TC'
 
-      1. Else Phantom#460
+      1. Else Phantom#461
 
 def $add_typeDefs_t(p, TC, (typeId)*, (typeDefIR)*)
 
@@ -11283,7 +11307,7 @@ def $add_typeDefs_t(p, TC, (typeId)*, (typeDefIR)*)
 
       1. Return TC
 
-    1. Else Phantom#461
+    1. Else Phantom#462
 
   2. Case (% matches pattern _ :: _)
 
@@ -11299,7 +11323,7 @@ def $add_typeDefs_t(p, TC, (typeId)*, (typeDefIR)*)
 
               1. Return TC''
 
-      1. Else Phantom#462
+      1. Else Phantom#463
 
 def $add_typeParameters_t(p, TC, (typeId)*)
 
@@ -11321,7 +11345,7 @@ def $add_callableDef_overload_t(cursor, TC, callableId, callableTypeDefIR)
 
             1. Return TC'
 
-      1. Else Phantom#463
+      1. Else Phantom#464
 
   2. Case (% matches pattern `BLOCK`)
 
@@ -11335,9 +11359,9 @@ def $add_callableDef_overload_t(cursor, TC, callableId, callableTypeDefIR)
 
             1. Return TC'
 
-      1. Else Phantom#464
+      1. Else Phantom#465
 
-1. Else Phantom#465
+1. Else Phantom#466
 
 def $add_callableDef_non_overload_t(cursor, TC, callableId, callableTypeDefIR)
 
@@ -11359,7 +11383,7 @@ def $add_callableDef_non_overload_t(cursor, TC, callableId, callableTypeDefIR)
 
                 1. Return TC'
 
-          1. Else Phantom#466
+          1. Else Phantom#467
 
   2. Case (% matches pattern `BLOCK`)
 
@@ -11377,9 +11401,9 @@ def $add_callableDef_non_overload_t(cursor, TC, callableId, callableTypeDefIR)
 
                 1. Return TC'
 
-          1. Else Phantom#467
+          1. Else Phantom#468
 
-1. Else Phantom#468
+1. Else Phantom#469
 
 def $add_constructorDef_t(TC, callableId, constructorTypeDefIR)
 
@@ -11393,7 +11417,7 @@ def $add_constructorDef_t(TC, callableId, constructorTypeDefIR)
 
         1. Return TC'
 
-  1. Else Phantom#469
+  1. Else Phantom#470
 
 def $add_constructorDef_non_overload_t(TC, callableId, constructorTypeDefIR)
 
@@ -11411,7 +11435,7 @@ def $add_constructorDef_non_overload_t(TC, callableId, constructorTypeDefIR)
 
             1. Return TC'
 
-      1. Else Phantom#470
+      1. Else Phantom#471
 
 def $add_constructorDefs_t(TC, (callableId)*, (constructorTypeDefIR)*)
 
@@ -11423,7 +11447,7 @@ def $add_constructorDefs_t(TC, (callableId)*, (constructorTypeDefIR)*)
 
       1. Return TC
 
-    1. Else Phantom#471
+    1. Else Phantom#472
 
   2. Case (% matches pattern _ :: _)
 
@@ -11439,7 +11463,7 @@ def $add_constructorDefs_t(TC, (callableId)*, (constructorTypeDefIR)*)
 
               1. Return TC''
 
-      1. Else Phantom#472
+      1. Else Phantom#473
 
 def $find_var_t(prefixedNameIR, p, TC)
 
@@ -11477,13 +11501,13 @@ def $find_var_t(prefixedNameIR, p, TC)
 
                   1. Return ?(varTypeIR')
 
-              1. Else Phantom#473
+              1. Else Phantom#474
 
             2. If ((?() = $find_map<id, varTypeIR>(typeFrame, id))), then
 
               1. Return $find_var_t((` id), (global), TC)
 
-            2. Else Phantom#474
+            2. Else Phantom#475
 
         3. Case (% matches pattern `LOCAL`)
 
@@ -11497,13 +11521,13 @@ def $find_var_t(prefixedNameIR, p, TC)
 
                   1. Return ?(varTypeIR')
 
-              1. Else Phantom#475
+              1. Else Phantom#476
 
             2. If ((?() = $find_maps<id, varTypeIR>((typeFrame)*, id))), then
 
               1. Return $find_var_t((` id), (block), TC)
 
-            2. Else Phantom#476
+            2. Else Phantom#477
 
 def $find_var_value_t(prefixedNameIR, p, TC)
 
@@ -11519,9 +11543,9 @@ def $find_var_value_t(prefixedNameIR, p, TC)
 
           1. Return value'
 
-      1. Else Phantom#477
+      1. Else Phantom#478
 
-  1. Else Phantom#478
+  1. Else Phantom#479
 
 def $find_typeDef_t(p, TC, prefixedNameIR)
 
@@ -11533,7 +11557,7 @@ def $find_typeDef_t(p, TC, prefixedNameIR)
 
       1. Return $find_map<typeId, typeDefIR>(typeDefEnv, typeId)
 
-1. Else Phantom#479
+1. Else Phantom#480
 
 2. Case analysis on p
 
@@ -11547,7 +11571,7 @@ def $find_typeDef_t(p, TC, prefixedNameIR)
 
           1. Return $find_map<typeId, typeDefIR>(typeDefEnv, typeId)
 
-    1. Else Phantom#480
+    1. Else Phantom#481
 
   2. Case (% matches pattern `BLOCK`)
 
@@ -11565,15 +11589,15 @@ def $find_typeDef_t(p, TC, prefixedNameIR)
 
                 1. Return ?(typeDefIR')
 
-            1. Else Phantom#481
+            1. Else Phantom#482
 
           2. If ((?() = $find_map<typeId, typeDefIR>(typeDefEnv, typeId))), then
 
             1. Return $find_typeDef_t((global), TC, (` typeId))
 
-          2. Else Phantom#482
+          2. Else Phantom#483
 
-    1. Else Phantom#483
+    1. Else Phantom#484
 
   3. Case (% matches pattern `LOCAL`)
 
@@ -11591,15 +11615,15 @@ def $find_typeDef_t(p, TC, prefixedNameIR)
 
                 1. Return ?(typeDefIR')
 
-            1. Else Phantom#484
+            1. Else Phantom#485
 
           2. If ((?() = $find_maps<typeId, typeDefIR>((typeDefEnv)*, typeId))), then
 
             1. Return $find_typeDef_t((block), TC, (` typeId))
 
-          2. Else Phantom#485
+          2. Else Phantom#486
 
-    1. Else Phantom#486
+    1. Else Phantom#487
 
 def $find_callableDef_overloaded_t(cursor, TC, prefixedNameIR, (argumentIR)*)
 
@@ -11647,15 +11671,15 @@ def $find_callableDef_overloaded_t(cursor, TC, prefixedNameIR, (argumentIR)*)
 
                   1. Return ?((callableId : callableTypeDefIR # (id_default)* # (id_optional)*))
 
-              1. Else Phantom#487
+              1. Else Phantom#488
 
             2. If ((?() = $find_overloaded<callableTypeDefIR>(callableTypeDefEnv, callTargetKey, $parameterListIR_of_callableTypeDefIR))), then
 
               1. Return $find_callableDef_overloaded_t((global), TC, (` nameIR), (argumentIR)*)
 
-            2. Else Phantom#488
+            2. Else Phantom#489
 
-    1. Else Phantom#489
+    1. Else Phantom#490
 
   3. Case (% matches pattern `LOCAL`)
 
@@ -11665,7 +11689,7 @@ def $find_callableDef_overloaded_t(cursor, TC, prefixedNameIR, (argumentIR)*)
 
         1. Return $find_callableDef_overloaded_t((block), TC, (` nameIR), (argumentIR)*)
 
-    1. Else Phantom#490
+    1. Else Phantom#491
 
 def $find_callableDef_non_overloaded_t(p, TC, prefixedNameIR)
 
@@ -11675,7 +11699,7 @@ def $find_callableDef_non_overloaded_t(p, TC, prefixedNameIR)
 
     1. Return $find_non_overloaded<callableTypeDefIR>(TC.global.callable, nameIR)
 
-1. Else Phantom#491
+1. Else Phantom#492
 
 2. Case analysis on p
 
@@ -11687,7 +11711,7 @@ def $find_callableDef_non_overloaded_t(p, TC, prefixedNameIR)
 
         1. Return $find_non_overloaded<callableTypeDefIR>(TC.global.callable, nameIR)
 
-    1. Else Phantom#492
+    1. Else Phantom#493
 
   2. Case (% matches pattern `BLOCK`)
 
@@ -11703,15 +11727,15 @@ def $find_callableDef_non_overloaded_t(p, TC, prefixedNameIR)
 
               1. Return ?((callableId, callableTypeDefIR))
 
-          1. Else Phantom#493
+          1. Else Phantom#494
 
         2. If ((?() = $find_non_overloaded<callableTypeDefIR>(TC.block.callable, nameIR))), then
 
           1. Return $find_callableDef_non_overloaded_t((global), TC, (` nameIR))
 
-        2. Else Phantom#494
+        2. Else Phantom#495
 
-    1. Else Phantom#495
+    1. Else Phantom#496
 
   3. Case (% matches pattern `LOCAL`)
 
@@ -11721,7 +11745,7 @@ def $find_callableDef_non_overloaded_t(p, TC, prefixedNameIR)
 
         1. Return $find_callableDef_non_overloaded_t((block), TC, (` nameIR))
 
-    1. Else Phantom#496
+    1. Else Phantom#497
 
 def $find_constructorDef_overloaded_t(TC, prefixedNameIR, (argumentIR)*)
 
@@ -11969,7 +11993,7 @@ def $find_table_priority_last(TBLC)
 
         1. Return (n)*[n_last]
 
-    1. Else Phantom#497
+    1. Else Phantom#498
 
 def $join_tableEntryState(tableEntryState, tableEntryState')
 
@@ -11997,7 +12021,7 @@ def $join_tableEntryState(tableEntryState, tableEntryState')
 
         1. Return (lpm n)
 
-      1. Else Phantom#498
+      1. Else Phantom#499
 
 def $tableEntry_lpm_prefix(value)
 
@@ -12017,7 +12041,7 @@ def $tableEntry_lpm_prefix'(value, n_prefix)
 
           1. Return n_prefix
 
-        1. Else Phantom#499
+        1. Else Phantom#500
 
         2. If ((_int has type nat)), then
 
@@ -12043,13 +12067,13 @@ def $tableEntry_lpm_prefix'(value, n_prefix)
 
                               1. Return $tableEntry_lpm_prefix'(value', (n_prefix + 1))
 
-                        1. Else Phantom#500
+                        1. Else Phantom#501
 
-                    1. Else Phantom#501
+                    1. Else Phantom#502
 
-                1. Else Phantom#502
+                1. Else Phantom#503
 
-            1. Else Phantom#503
+            1. Else Phantom#504
 
             2. If ((n_prefix = 0)), then
 
@@ -12067,19 +12091,19 @@ def $tableEntry_lpm_prefix'(value, n_prefix)
 
                           1. Return $tableEntry_lpm_prefix'(value', 0)
 
-                      1. Else Phantom#504
+                      1. Else Phantom#505
 
-                  1. Else Phantom#505
+                  1. Else Phantom#506
 
-              1. Else Phantom#506
+              1. Else Phantom#507
 
-            2. Else Phantom#507
+            2. Else Phantom#508
 
-        2. Else Phantom#508
+        2. Else Phantom#509
 
-    1. Else Phantom#509
+    1. Else Phantom#510
 
-1. Else Phantom#510
+1. Else Phantom#511
 
 relation Type_wf: B |- typeIR
 
@@ -12103,7 +12127,7 @@ relation Type_wf: B |- typeIR
 
           1. The relation holds
 
-        1. Else Phantom#511
+        1. Else Phantom#512
 
   3. Case (% has type typedefTypeIR)
 
@@ -12117,9 +12141,9 @@ relation Type_wf: B |- typeIR
 
             1. The relation holds
 
-          1. Else Phantom#512
+          1. Else Phantom#513
 
-        1. Else Phantom#513
+        1. Else Phantom#514
 
   4. Case (% has type newTypeIR)
 
@@ -12133,9 +12157,9 @@ relation Type_wf: B |- typeIR
 
             1. The relation holds
 
-          1. Else Phantom#514
+          1. Else Phantom#515
 
-        1. Else Phantom#515
+        1. Else Phantom#516
 
   5. Case (% has type listTypeIR)
 
@@ -12149,9 +12173,9 @@ relation Type_wf: B |- typeIR
 
             1. The relation holds
 
-          1. Else Phantom#516
+          1. Else Phantom#517
 
-        1. Else Phantom#517
+        1. Else Phantom#518
 
   6. Case (% has type tupleTypeIR)
 
@@ -12165,9 +12189,9 @@ relation Type_wf: B |- typeIR
 
             1. The relation holds
 
-          1. Else Phantom#518
+          1. Else Phantom#519
 
-        1. Else Phantom#519
+        1. Else Phantom#520
 
   7. Case (% has type headerStackTypeIR)
 
@@ -12181,9 +12205,9 @@ relation Type_wf: B |- typeIR
 
             1. The relation holds
 
-          1. Else Phantom#520
+          1. Else Phantom#521
 
-        1. Else Phantom#521
+        1. Else Phantom#522
 
   8. Case (% has type structTypeIR)
 
@@ -12199,11 +12223,11 @@ relation Type_wf: B |- typeIR
 
               1. The relation holds
 
-            1. Else Phantom#522
+            1. Else Phantom#523
 
-          1. Else Phantom#523
+          1. Else Phantom#524
 
-        1. Else Phantom#524
+        1. Else Phantom#525
 
   9. Case (% has type headerTypeIR)
 
@@ -12219,11 +12243,11 @@ relation Type_wf: B |- typeIR
 
               1. The relation holds
 
-            1. Else Phantom#525
+            1. Else Phantom#526
 
-          1. Else Phantom#526
+          1. Else Phantom#527
 
-        1. Else Phantom#527
+        1. Else Phantom#528
 
   10. Case (% has type headerUnionTypeIR)
 
@@ -12239,13 +12263,13 @@ relation Type_wf: B |- typeIR
 
               1. The relation holds
 
-            1. Else Phantom#528
+            1. Else Phantom#529
 
-          1. Else Phantom#529
+          1. Else Phantom#530
 
-        1. Else Phantom#530
+        1. Else Phantom#531
 
-1. Else Phantom#531
+1. Else Phantom#532
 
 2. Group enumTypeIR: B |- typeIR
 
@@ -12259,7 +12283,7 @@ relation Type_wf: B |- typeIR
 
           1. The relation holds
 
-        1. Else Phantom#532
+        1. Else Phantom#533
 
     2. Case (% has type serializableEnumTypeIR)
 
@@ -12273,13 +12297,13 @@ relation Type_wf: B |- typeIR
 
               1. The relation holds
 
-            1. Else Phantom#533
+            1. Else Phantom#534
 
-          1. Else Phantom#534
+          1. Else Phantom#535
 
-        1. Else Phantom#535
+        1. Else Phantom#536
 
-  1. Else Phantom#536
+  1. Else Phantom#537
 
 3. Case analysis on typeIR
 
@@ -12293,7 +12317,7 @@ relation Type_wf: B |- typeIR
 
           1. The relation holds
 
-        1. Else Phantom#537
+        1. Else Phantom#538
 
   2. Case (% has type parserObjectTypeIR)
 
@@ -12305,7 +12329,7 @@ relation Type_wf: B |- typeIR
 
           1. The relation holds
 
-        1. Else Phantom#538
+        1. Else Phantom#539
 
   3. Case (% has type controlObjectTypeIR)
 
@@ -12317,7 +12341,7 @@ relation Type_wf: B |- typeIR
 
           1. The relation holds
 
-        1. Else Phantom#539
+        1. Else Phantom#540
 
   4. Case (% has type packageObjectTypeIR)
 
@@ -12329,7 +12353,7 @@ relation Type_wf: B |- typeIR
 
           1. The relation holds
 
-        1. Else Phantom#540
+        1. Else Phantom#541
 
   5. Case (% has type tableObjectTypeIR)
 
@@ -12341,7 +12365,7 @@ relation Type_wf: B |- typeIR
 
           1. The relation holds
 
-        1. Else Phantom#541
+        1. Else Phantom#542
 
   6. Case (% has type defaultTypeIR)
 
@@ -12375,7 +12399,7 @@ relation Type_wf: B |- typeIR
 
                 1. The relation holds
 
-              1. Else Phantom#542
+              1. Else Phantom#543
 
           2. Case (% matches pattern `SEQ<%,...>`)
 
@@ -12385,7 +12409,7 @@ relation Type_wf: B |- typeIR
 
                 1. The relation holds
 
-              1. Else Phantom#543
+              1. Else Phantom#544
 
   9. Case (% has type recordTypeIR)
 
@@ -12405,9 +12429,9 @@ relation Type_wf: B |- typeIR
 
                   1. The relation holds
 
-                1. Else Phantom#544
+                1. Else Phantom#545
 
-              1. Else Phantom#545
+              1. Else Phantom#546
 
           2. Case (% matches pattern `RECORD{%,...}`)
 
@@ -12419,9 +12443,9 @@ relation Type_wf: B |- typeIR
 
                   1. The relation holds
 
-                1. Else Phantom#546
+                1. Else Phantom#547
 
-              1. Else Phantom#547
+              1. Else Phantom#548
 
   10. Case (% has type setTypeIR)
 
@@ -12435,11 +12459,11 @@ relation Type_wf: B |- typeIR
 
             1. The relation holds
 
-          1. Else Phantom#548
+          1. Else Phantom#549
 
-        1. Else Phantom#549
+        1. Else Phantom#550
 
-3. Else Phantom#550
+3. Else Phantom#551
 
 4. Group tableMetadataTypeIR: B |- typeIR
 
@@ -12453,7 +12477,7 @@ relation Type_wf: B |- typeIR
 
           1. The relation holds
 
-        1. Else Phantom#551
+        1. Else Phantom#552
 
     2. Case (% has type tableMetadataStructTypeIR)
 
@@ -12463,9 +12487,9 @@ relation Type_wf: B |- typeIR
 
           1. The relation holds
 
-        1. Else Phantom#552
+        1. Else Phantom#553
 
-  1. Else Phantom#553
+  1. Else Phantom#554
 
 relation TypeDef_wf: B |- typeDefIR
 
@@ -12485,9 +12509,9 @@ relation TypeDef_wf: B |- typeDefIR
 
               1. The relation holds
 
-            1. Else Phantom#554
+            1. Else Phantom#555
 
-      1. Else Phantom#555
+      1. Else Phantom#556
 
 relation ParameterType_wf: B |- (annotationList direction typeIR id (parameterInitializerIR)?)
 
@@ -12507,11 +12531,11 @@ relation ParameterType_wf: B |- (annotationList direction typeIR id (parameterIn
 
               1. The relation holds
 
-            1. Else Phantom#556
+            1. Else Phantom#557
 
-          1. Else Phantom#557
+          1. Else Phantom#558
 
-      1. Else Phantom#558
+      1. Else Phantom#559
 
     2. Case (% matches pattern (_))
 
@@ -12529,15 +12553,15 @@ relation ParameterType_wf: B |- (annotationList direction typeIR id (parameterIn
 
                   1. The relation holds
 
-                1. Else Phantom#559
+                1. Else Phantom#560
 
-              1. Else Phantom#560
+              1. Else Phantom#561
 
-            1. Else Phantom#561
+            1. Else Phantom#562
 
-          1. Else Phantom#562
+          1. Else Phantom#563
 
-      1. Else Phantom#563
+      1. Else Phantom#564
 
 relation ReturnType_wf: B |- typeIR_ret
 
@@ -12551,9 +12575,9 @@ relation ReturnType_wf: B |- typeIR_ret
 
         1. The relation holds
 
-      1. Else Phantom#564
+      1. Else Phantom#565
 
-  1. Else Phantom#565
+  1. Else Phantom#566
 
 relation CallableType_wf: B |- callableTypeIR
 
@@ -12577,13 +12601,13 @@ relation CallableType_wf: B |- callableTypeIR
 
                   1. The relation holds
 
-                1. Else Phantom#566
+                1. Else Phantom#567
 
-              1. Else Phantom#567
+              1. Else Phantom#568
 
-          1. Else Phantom#568
+          1. Else Phantom#569
 
-        1. Else Phantom#569
+        1. Else Phantom#570
 
   2. Case (% has type definedFunctionTypeIR)
 
@@ -12603,13 +12627,13 @@ relation CallableType_wf: B |- callableTypeIR
 
                   1. The relation holds
 
-                1. Else Phantom#570
+                1. Else Phantom#571
 
-              1. Else Phantom#571
+              1. Else Phantom#572
 
-          1. Else Phantom#572
+          1. Else Phantom#573
 
-        1. Else Phantom#573
+        1. Else Phantom#574
 
   3. Case (% has type externFunctionTypeIR)
 
@@ -12627,11 +12651,11 @@ relation CallableType_wf: B |- callableTypeIR
 
                 1. The relation holds
 
-              1. Else Phantom#574
+              1. Else Phantom#575
 
-            1. Else Phantom#575
+            1. Else Phantom#576
 
-        1. Else Phantom#576
+        1. Else Phantom#577
 
   4. Case (% has type builtinMethodTypeIR)
 
@@ -12647,11 +12671,11 @@ relation CallableType_wf: B |- callableTypeIR
 
               1. The relation holds
 
-            1. Else Phantom#577
+            1. Else Phantom#578
 
-          1. Else Phantom#578
+          1. Else Phantom#579
 
-        1. Else Phantom#579
+        1. Else Phantom#580
 
   5. Case (% has type externMethodTypeIR)
 
@@ -12675,11 +12699,11 @@ relation CallableType_wf: B |- callableTypeIR
 
                       1. The relation holds
 
-                    1. Else Phantom#580
+                    1. Else Phantom#581
 
-                  1. Else Phantom#581
+                  1. Else Phantom#582
 
-              1. Else Phantom#582
+              1. Else Phantom#583
 
           2. Case (% matches pattern `EXTERN_METHODABSTRACT%(%):%`)
 
@@ -12697,13 +12721,13 @@ relation CallableType_wf: B |- callableTypeIR
 
                         1. The relation holds
 
-                      1. Else Phantom#583
+                      1. Else Phantom#584
 
-                    1. Else Phantom#584
+                    1. Else Phantom#585
 
-                1. Else Phantom#585
+                1. Else Phantom#586
 
-              1. Else Phantom#586
+              1. Else Phantom#587
 
   6. Case (% has type parserApplyMethodTypeIR)
 
@@ -12721,11 +12745,11 @@ relation CallableType_wf: B |- callableTypeIR
 
                 1. The relation holds
 
-              1. Else Phantom#587
+              1. Else Phantom#588
 
-          1. Else Phantom#588
+          1. Else Phantom#589
 
-        1. Else Phantom#589
+        1. Else Phantom#590
 
   7. Case (% has type controlApplyMethodTypeIR)
 
@@ -12743,11 +12767,11 @@ relation CallableType_wf: B |- callableTypeIR
 
                 1. The relation holds
 
-              1. Else Phantom#590
+              1. Else Phantom#591
 
-          1. Else Phantom#591
+          1. Else Phantom#592
 
-        1. Else Phantom#592
+        1. Else Phantom#593
 
   8. Case (% has type tableApplyMethodTypeIR)
 
@@ -12775,9 +12799,9 @@ relation CallableTypeDef_wf: B |- callableTypeDefIR
 
               1. The relation holds
 
-            1. Else Phantom#593
+            1. Else Phantom#594
 
-      1. Else Phantom#594
+      1. Else Phantom#595
 
 relation ConstructorParameterType_wf: B |- constructorParameterIR
 
@@ -12791,9 +12815,9 @@ relation ConstructorParameterType_wf: B |- constructorParameterIR
 
         1. The relation holds
 
-      1. Else Phantom#595
+      1. Else Phantom#596
 
-    1. Else Phantom#596
+    1. Else Phantom#597
 
 relation ConstructorType_wf: B |- (constructor( (parameterIR)* ): typeIR_object)
 
@@ -12813,13 +12837,13 @@ relation ConstructorType_wf: B |- (constructor( (parameterIR)* ): typeIR_object)
 
               1. The relation holds
 
-            1. Else Phantom#597
+            1. Else Phantom#598
 
-        1. Else Phantom#598
+        1. Else Phantom#599
 
-    1. Else Phantom#599
+    1. Else Phantom#600
 
-  1. Else Phantom#600
+  1. Else Phantom#601
 
 2. Group parserObjectTypeIR: B |- (constructor( (parameterIR)* ): typeIR_object)
 
@@ -12839,15 +12863,15 @@ relation ConstructorType_wf: B |- (constructor( (parameterIR)* ): typeIR_object)
 
                 1. The relation holds
 
-              1. Else Phantom#601
+              1. Else Phantom#602
 
-          1. Else Phantom#602
+          1. Else Phantom#603
 
-      1. Else Phantom#603
+      1. Else Phantom#604
 
-    1. Else Phantom#604
+    1. Else Phantom#605
 
-  1. Else Phantom#605
+  1. Else Phantom#606
 
 3. Group controlObjectTypeIR: B |- (constructor( (parameterIR)* ): typeIR_object)
 
@@ -12867,15 +12891,15 @@ relation ConstructorType_wf: B |- (constructor( (parameterIR)* ): typeIR_object)
 
                 1. The relation holds
 
-              1. Else Phantom#606
+              1. Else Phantom#607
 
-          1. Else Phantom#607
+          1. Else Phantom#608
 
-      1. Else Phantom#608
+      1. Else Phantom#609
 
-    1. Else Phantom#609
+    1. Else Phantom#610
 
-  1. Else Phantom#610
+  1. Else Phantom#611
 
 4. If (((parameterIR)* matches pattern [])), then
 
@@ -12889,11 +12913,11 @@ relation ConstructorType_wf: B |- (constructor( (parameterIR)* ): typeIR_object)
 
           1. The relation holds
 
-        1. Else Phantom#611
+        1. Else Phantom#612
 
-    1. Else Phantom#612
+    1. Else Phantom#613
 
-4. Else Phantom#613
+4. Else Phantom#614
 
 5. Group packageObjectTypeIR: B |- (constructor( (parameterIR)* ): typeIR_object)
 
@@ -12911,13 +12935,13 @@ relation ConstructorType_wf: B |- (constructor( (parameterIR)* ): typeIR_object)
 
               1. The relation holds
 
-            1. Else Phantom#614
+            1. Else Phantom#615
 
-        1. Else Phantom#615
+        1. Else Phantom#616
 
-    1. Else Phantom#616
+    1. Else Phantom#617
 
-  1. Else Phantom#617
+  1. Else Phantom#618
 
 relation ConstructorTypeDef_wf: B |- constructorTypeDefIR
 
@@ -12937,11 +12961,11 @@ relation ConstructorTypeDef_wf: B |- constructorTypeDefIR
 
               1. The relation holds
 
-            1. Else Phantom#618
+            1. Else Phantom#619
 
-        1. Else Phantom#619
+        1. Else Phantom#620
 
-    1. Else Phantom#620
+    1. Else Phantom#621
 
 tbl def $nestable_typedef(typeIR'')
 =
@@ -13758,7 +13782,7 @@ def $directionless_trailing'(bool, (direction)*)
 
         1. Return $directionless_trailing'(false, (direction_t)*)
 
-      1. Else Phantom#621
+      1. Else Phantom#622
 
 2. Case analysis on bool
 
@@ -13772,9 +13796,9 @@ def $directionless_trailing'(bool, (direction)*)
 
           1. Return $directionless_trailing'(true, (direction_t)*)
 
-        1. Else Phantom#622
+        1. Else Phantom#623
 
-    1. Else Phantom#623
+    1. Else Phantom#624
 
   2. Case (% = false)
 
@@ -13786,9 +13810,9 @@ def $directionless_trailing'(bool, (direction)*)
 
           1. Return false
 
-        1. Else Phantom#624
+        1. Else Phantom#625
 
-    1. Else Phantom#625
+    1. Else Phantom#626
 
 tbl def $nestable_action(typeIR'')
 =
@@ -14195,7 +14219,7 @@ relation Expr_eval_lctk: p TC |- (expressionIR # expressionNoteIR) ~> %
 
         1. Result in: % % |- % ~> (stringLiteral as value)
 
-  1. Else Phantom#626
+  1. Else Phantom#627
 
 2. Case analysis on expressionIR
 
@@ -14241,7 +14265,7 @@ relation Expr_eval_lctk: p TC |- (expressionIR # expressionNoteIR) ~> %
 
               1. Result in: % % |- % ~> $bin_op(binop, value_l, value_r)
 
-        1. Else Phantom#627
+        1. Else Phantom#628
 
         2. Case analysis on binop
 
@@ -14261,7 +14285,7 @@ relation Expr_eval_lctk: p TC |- (expressionIR # expressionNoteIR) ~> %
 
                     1. Result in: % % |- % ~> value_r
 
-              1. Else Phantom#628
+              1. Else Phantom#629
 
           2. Case (% matches pattern `||`)
 
@@ -14279,9 +14303,9 @@ relation Expr_eval_lctk: p TC |- (expressionIR # expressionNoteIR) ~> %
 
                     1. Result in: % % |- % ~> value_r
 
-              1. Else Phantom#629
+              1. Else Phantom#630
 
-        2. Else Phantom#630
+        2. Else Phantom#631
 
   5. Case (% has type ternaryExpressionIR)
 
@@ -14305,7 +14329,7 @@ relation Expr_eval_lctk: p TC |- (expressionIR # expressionNoteIR) ~> %
 
                 1. Result in: % % |- % ~> value_false
 
-          1. Else Phantom#631
+          1. Else Phantom#632
 
   6. Case (% has type castExpressionIR)
 
@@ -14375,7 +14399,7 @@ relation Expr_eval_lctk: p TC |- (expressionIR # expressionNoteIR) ~> %
 
                 1. Result in: % % |- % ~> ((record{ ((value nameIR ;))* ,...}) as value)
 
-2. Else Phantom#632
+2. Else Phantom#633
 
 3. (Let (( typeIR ctk )) be expressionNoteIR)
 
@@ -14391,7 +14415,7 @@ relation Expr_eval_lctk: p TC |- (expressionIR # expressionNoteIR) ~> %
 
             1. Result in: % % |- % ~> value_error
 
-  1. Else Phantom#633
+  1. Else Phantom#634
 
 4. Case analysis on expressionIR
 
@@ -14429,7 +14453,7 @@ relation Expr_eval_lctk: p TC |- (expressionIR # expressionNoteIR) ~> %
 
                                   1. Result in: % % |- % ~> ((typeId . nameIR) as value)
 
-                                1. Else Phantom#634
+                                1. Else Phantom#635
 
                             2. Case (% has type serializableEnumTypeIR)
 
@@ -14443,13 +14467,13 @@ relation Expr_eval_lctk: p TC |- (expressionIR # expressionNoteIR) ~> %
 
                                       1. Result in: % % |- % ~> ((typeId . nameIR . value') as value)
 
-                                  1. Else Phantom#635
+                                  1. Else Phantom#636
 
-                          1. Else Phantom#636
+                          1. Else Phantom#637
 
-                    1. Else Phantom#637
+                    1. Else Phantom#638
 
-                1. Else Phantom#638
+                1. Else Phantom#639
 
         2. Case (% has type typedExpressionIR)
 
@@ -14469,9 +14493,9 @@ relation Expr_eval_lctk: p TC |- (expressionIR # expressionNoteIR) ~> %
 
                         1. Result in: % % |- % ~> ((d (n_size as int)) as value)
 
-                      1. Else Phantom#639
+                      1. Else Phantom#640
 
-                  1. Else Phantom#640
+                  1. Else Phantom#641
 
               2. (Expr_eval_lctk: p TC |- typedExpressionIR_base ~> value)
 
@@ -14491,7 +14515,7 @@ relation Expr_eval_lctk: p TC |- (expressionIR # expressionNoteIR) ~> %
 
                               1. Result in: % % |- % ~> value''
 
-                          1. Else Phantom#641
+                          1. Else Phantom#642
 
                   2. Case (% has type headerValue)
 
@@ -14507,7 +14531,7 @@ relation Expr_eval_lctk: p TC |- (expressionIR # expressionNoteIR) ~> %
 
                               1. Result in: % % |- % ~> value''
 
-                          1. Else Phantom#642
+                          1. Else Phantom#643
 
                   3. Case (% has type headerUnionValue)
 
@@ -14523,9 +14547,9 @@ relation Expr_eval_lctk: p TC |- (expressionIR # expressionNoteIR) ~> %
 
                               1. Result in: % % |- % ~> value''
 
-                          1. Else Phantom#643
+                          1. Else Phantom#644
 
-                1. Else Phantom#644
+                1. Else Phantom#645
 
   2. Case (% has type indexAccessExpressionIR)
 
@@ -14559,9 +14583,9 @@ relation Expr_eval_lctk: p TC |- (expressionIR # expressionNoteIR) ~> %
 
                                 1. Result in: % % |- % ~> value'
 
-                            1. Else Phantom#645
+                            1. Else Phantom#646
 
-                        1. Else Phantom#646
+                        1. Else Phantom#647
 
                   2. Case (% has type headerStackValue)
 
@@ -14579,13 +14603,13 @@ relation Expr_eval_lctk: p TC |- (expressionIR # expressionNoteIR) ~> %
 
                                 1. Result in: % % |- % ~> value'
 
-                            1. Else Phantom#647
+                            1. Else Phantom#648
 
-                        1. Else Phantom#648
+                        1. Else Phantom#649
 
-                1. Else Phantom#649
+                1. Else Phantom#650
 
-            1. Else Phantom#650
+            1. Else Phantom#651
 
   3. Case (% has type sliceAccessExpressionIR)
 
@@ -14657,17 +14681,17 @@ relation Expr_eval_lctk: p TC |- (expressionIR # expressionNoteIR) ~> %
 
                                                         1. Result in: % % |- % ~> (boolValue as value)
 
-                                                      1. Else Phantom#651
+                                                      1. Else Phantom#652
 
-                                                  1. Else Phantom#652
+                                                  1. Else Phantom#653
 
-                                      1. Else Phantom#653
+                                      1. Else Phantom#654
 
-                            1. Else Phantom#654
+                            1. Else Phantom#655
 
-                          1. Else Phantom#655
+                          1. Else Phantom#656
 
-                    1. Else Phantom#656
+                    1. Else Phantom#657
 
               2. Case (% matches pattern `%.%`)
 
@@ -14679,7 +14703,7 @@ relation Expr_eval_lctk: p TC |- (expressionIR # expressionNoteIR) ~> %
 
                       1. Result in: % % |- % ~> $sizeof(typeIR_base, nameIR)
 
-                    1. Else Phantom#657
+                    1. Else Phantom#658
 
               3. Case (% matches pattern `TYPE%.%`)
 
@@ -14701,7 +14725,7 @@ relation Expr_eval_lctk: p TC |- (expressionIR # expressionNoteIR) ~> %
 
                                 1. Result in: % % |- % ~> $sizeof(typeIR_base, nameIR)
 
-                              1. Else Phantom#658
+                              1. Else Phantom#659
 
                           2. Case false
 
@@ -14713,11 +14737,11 @@ relation Expr_eval_lctk: p TC |- (expressionIR # expressionNoteIR) ~> %
 
                                   1. Result in: % % |- % ~> $sizeof(typeIR_base, nameIR)
 
-                                1. Else Phantom#659
+                                1. Else Phantom#660
 
-                            1. Else Phantom#660
+                            1. Else Phantom#661
 
-                    1. Else Phantom#661
+                    1. Else Phantom#662
 
               4. Case (% matches pattern `(%)`)
 
@@ -14729,7 +14753,7 @@ relation Expr_eval_lctk: p TC |- (expressionIR # expressionNoteIR) ~> %
 
                       1. Result in: % % |- % ~> value
 
-      1. Else Phantom#662
+      1. Else Phantom#663
 
   5. Case (% has type parenthesizedExpressionIR)
 
@@ -14741,7 +14765,7 @@ relation Expr_eval_lctk: p TC |- (expressionIR # expressionNoteIR) ~> %
 
           1. Result in: % % |- % ~> value
 
-4. Else Phantom#663
+4. Else Phantom#664
 
 relation Argument_eval_lctk: p TC |- argumentIR ~> %
 
@@ -14767,7 +14791,7 @@ relation Argument_eval_lctk: p TC |- argumentIR ~> %
 
           1. Result in: % % |- % ~> value
 
-1. Else Phantom#664
+1. Else Phantom#665
 
 relation Type_ok: p TC |- typeOrVoid : % # %
 
@@ -14815,7 +14839,7 @@ relation Type_ok: p TC |- typeOrVoid : % # %
 
             1. Result in: % % |- % : ((int) as typeIR) # []
 
-      1. Else Phantom#665
+      1. Else Phantom#666
 
       2. Group fixedInt: p TC |- (baseType as typeOrVoid) : % # %
 
@@ -14833,9 +14857,9 @@ relation Type_ok: p TC |- typeOrVoid : % # %
 
                     1. Result in: % % |- % : ((int< n >) as typeIR) # []
 
-                  1. Else Phantom#666
+                  1. Else Phantom#667
 
-              1. Else Phantom#667
+              1. Else Phantom#668
 
           2. Case (% matches pattern `INT<(%)>`)
 
@@ -14861,15 +14885,15 @@ relation Type_ok: p TC |- typeOrVoid : % # %
 
                                 1. Result in: % % |- % : ((int< n >) as typeIR) # []
 
-                              1. Else Phantom#668
+                              1. Else Phantom#669
 
-                          1. Else Phantom#669
+                          1. Else Phantom#670
 
-                    1. Else Phantom#670
+                    1. Else Phantom#671
 
-                1. Else Phantom#671
+                1. Else Phantom#672
 
-        1. Else Phantom#672
+        1. Else Phantom#673
 
       3. Group fixedBit: p TC |- (baseType as typeOrVoid) : % # %
 
@@ -14889,7 +14913,7 @@ relation Type_ok: p TC |- typeOrVoid : % # %
 
                   1. Result in: % % |- % : ((bit< n >) as typeIR) # []
 
-              1. Else Phantom#673
+              1. Else Phantom#674
 
           3. Case (% matches pattern `BIT<(%)>`)
 
@@ -14913,13 +14937,13 @@ relation Type_ok: p TC |- typeOrVoid : % # %
 
                               1. Result in: % % |- % : ((bit< n >) as typeIR) # []
 
-                          1. Else Phantom#674
+                          1. Else Phantom#675
 
-                    1. Else Phantom#675
+                    1. Else Phantom#676
 
-                1. Else Phantom#676
+                1. Else Phantom#677
 
-        1. Else Phantom#677
+        1. Else Phantom#678
 
       4. Group variableBit: p TC |- (baseType as typeOrVoid) : % # %
 
@@ -14935,7 +14959,7 @@ relation Type_ok: p TC |- typeOrVoid : % # %
 
                   1. Result in: % % |- % : ((varbit< n >) as typeIR) # []
 
-              1. Else Phantom#678
+              1. Else Phantom#679
 
           2. Case (% matches pattern `VARBIT<(%)>`)
 
@@ -14959,15 +14983,15 @@ relation Type_ok: p TC |- typeOrVoid : % # %
 
                               1. Result in: % % |- % : ((varbit< n >) as typeIR) # []
 
-                          1. Else Phantom#679
+                          1. Else Phantom#680
 
-                    1. Else Phantom#680
+                    1. Else Phantom#681
 
-                1. Else Phantom#681
+                1. Else Phantom#682
 
-        1. Else Phantom#682
+        1. Else Phantom#683
 
-1. Else Phantom#683
+1. Else Phantom#684
 
 2. Group prefixedTypeName-identifier: p TC |- typeOrVoid : % # %
 
@@ -15007,9 +15031,9 @@ relation Type_ok: p TC |- typeOrVoid : % # %
 
                       1. Result in: % % |- % : typeIR # []
 
-            1. Else Phantom#684
+            1. Else Phantom#685
 
-  1. Else Phantom#685
+  1. Else Phantom#686
 
 3. Case analysis on typeOrVoid
 
@@ -15035,9 +15059,9 @@ relation Type_ok: p TC |- typeOrVoid : % # %
 
                       1. Result in: % % |- % : typeIR # (typeId_fresh)*
 
-                1. Else Phantom#686
+                1. Else Phantom#687
 
-            1. Else Phantom#687
+            1. Else Phantom#688
 
   2. Case (% has type headerStackType)
 
@@ -15067,13 +15091,13 @@ relation Type_ok: p TC |- typeOrVoid : % # %
 
                             1. Result in: % % |- % : ((typeIR_base [ n_size ]) as typeIR) # (typeId_fresh)*
 
-                          1. Else Phantom#688
+                          1. Else Phantom#689
 
-                      1. Else Phantom#689
+                      1. Else Phantom#690
 
-                1. Else Phantom#690
+                1. Else Phantom#691
 
-            1. Else Phantom#691
+            1. Else Phantom#692
 
   3. Case (% has type listType)
 
@@ -15095,7 +15119,7 @@ relation Type_ok: p TC |- typeOrVoid : % # %
 
           1. Result in: % % |- % : ((tuple< (typeIR_arg)* >) as typeIR) # (typeId_fresh)*
 
-3. Else Phantom#692
+3. Else Phantom#693
 
 relation TypeParameterListOpt_ok: p TC_0 |- typeParameterListOpt : % %
 
@@ -15133,7 +15157,7 @@ relation TypeArgument_ok: p TC |- typeArgument : % # %
 
           1. Result in: % % |- % : ((` typeId) as typeArgumentIR) # []
 
-1. Else Phantom#693
+1. Else Phantom#694
 
 2. If ((typeArgument has type realTypeArgument)), then
 
@@ -15155,9 +15179,9 @@ relation TypeArgument_ok: p TC |- typeArgument : % # %
 
             1. Result in: % % |- % : ((` typeId_impl) as typeArgumentIR) # [typeId_impl]
 
-    1. Else Phantom#694
+    1. Else Phantom#695
 
-2. Else Phantom#695
+2. Else Phantom#696
 
 relation TypeArguments_ok: p TC |- (typeArgument)* : % # %
 
@@ -15167,7 +15191,7 @@ relation TypeArguments_ok: p TC |- (typeArgument)* : % # %
 
     1. Result in: % % |- % : [] # []
 
-  1. Else Phantom#696
+  1. Else Phantom#697
 
   2. If (((typeArgument)* matches pattern _ :: _)), then
 
@@ -15181,7 +15205,7 @@ relation TypeArguments_ok: p TC |- (typeArgument)* : % # %
 
             1. Result in: % % |- % : typeArgumentIR_h :: (typeArgumentIR_t)* # (typeId_impl)*
 
-  2. Else Phantom#697
+  2. Else Phantom#698
 
 relation TypeArgumentList_ok: p TC |- typeArgumentList : % # %
 
@@ -15211,7 +15235,7 @@ relation Cast_expl: typeIR_a -> typeIR_b
 
           1. The relation holds
 
-        1. Else Phantom#698
+        1. Else Phantom#699
 
 relation Cast_expl_neq: typeIR -> typeIR'
 
@@ -15227,7 +15251,7 @@ relation Cast_expl_neq: typeIR -> typeIR'
 
           1. The relation holds
 
-      1. Else Phantom#699
+      1. Else Phantom#700
 
   2. Case (% has type intTypeIR)
 
@@ -15239,7 +15263,7 @@ relation Cast_expl_neq: typeIR -> typeIR'
 
           1. The relation holds
 
-        1. Else Phantom#700
+        1. Else Phantom#701
 
         2. Case analysis on typeIR'
 
@@ -15251,7 +15275,7 @@ relation Cast_expl_neq: typeIR -> typeIR'
 
             1. The relation holds
 
-        2. Else Phantom#701
+        2. Else Phantom#702
 
   3. Case (% has type fixedIntTypeIR)
 
@@ -15269,13 +15293,13 @@ relation Cast_expl_neq: typeIR -> typeIR'
 
             1. The relation holds
 
-        1. Else Phantom#702
+        1. Else Phantom#703
 
         2. If ((typeIR' has type fixedIntTypeIR)), then
 
           1. The relation holds
 
-        2. Else Phantom#703
+        2. Else Phantom#704
 
   4. Case (% has type fixedBitTypeIR)
 
@@ -15289,9 +15313,9 @@ relation Cast_expl_neq: typeIR -> typeIR'
 
             1. The relation holds
 
-          1. Else Phantom#704
+          1. Else Phantom#705
 
-        1. Else Phantom#705
+        1. Else Phantom#706
 
         2. Case analysis on typeIR'
 
@@ -15303,15 +15327,15 @@ relation Cast_expl_neq: typeIR -> typeIR'
 
             1. The relation holds
 
-        2. Else Phantom#706
+        2. Else Phantom#707
 
         3. If ((typeIR' has type fixedBitTypeIR)), then
 
           1. The relation holds
 
-        3. Else Phantom#707
+        3. Else Phantom#708
 
-1. Else Phantom#708
+1. Else Phantom#709
 
 2. Group newTypeIR: typeIR -> typeIR'
 
@@ -15323,9 +15347,9 @@ relation Cast_expl_neq: typeIR -> typeIR'
 
         1. The relation holds
 
-      1. Else Phantom#709
+      1. Else Phantom#710
 
-  1. Else Phantom#710
+  1. Else Phantom#711
 
   2. If ((typeIR' has type newTypeIR)), then
 
@@ -15335,9 +15359,9 @@ relation Cast_expl_neq: typeIR -> typeIR'
 
         1. The relation holds
 
-      1. Else Phantom#711
+      1. Else Phantom#712
 
-  2. Else Phantom#712
+  2. Else Phantom#713
 
 3. Group enumTypeIR-serializable: typeIR -> typeIR'
 
@@ -15349,9 +15373,9 @@ relation Cast_expl_neq: typeIR -> typeIR'
 
         1. The relation holds
 
-      1. Else Phantom#713
+      1. Else Phantom#714
 
-  1. Else Phantom#714
+  1. Else Phantom#715
 
   2. If ((typeIR' has type serializableEnumTypeIR)), then
 
@@ -15361,9 +15385,9 @@ relation Cast_expl_neq: typeIR -> typeIR'
 
         1. The relation holds
 
-      1. Else Phantom#715
+      1. Else Phantom#716
 
-  2. Else Phantom#716
+  2. Else Phantom#717
 
 4. Case analysis on typeIR
 
@@ -15377,7 +15401,7 @@ relation Cast_expl_neq: typeIR -> typeIR'
 
           1. The relation holds
 
-        1. Else Phantom#717
+        1. Else Phantom#718
 
   2. Case (% has type invalidHeaderTypeIR)
 
@@ -15395,7 +15419,7 @@ relation Cast_expl_neq: typeIR -> typeIR'
 
             1. The relation holds
 
-        1. Else Phantom#718
+        1. Else Phantom#719
 
   3. Case (% has type sequenceTypeIR)
 
@@ -15419,7 +15443,7 @@ relation Cast_expl_neq: typeIR -> typeIR'
 
                       1. The relation holds
 
-                    1. Else Phantom#719
+                    1. Else Phantom#720
 
                 2. Case (% has type tupleTypeIR)
 
@@ -15429,7 +15453,7 @@ relation Cast_expl_neq: typeIR -> typeIR'
 
                       1. The relation holds
 
-                    1. Else Phantom#720
+                    1. Else Phantom#721
 
                 3. Case (% has type headerStackTypeIR)
 
@@ -15441,9 +15465,9 @@ relation Cast_expl_neq: typeIR -> typeIR'
 
                         1. The relation holds
 
-                      1. Else Phantom#721
+                      1. Else Phantom#722
 
-                    1. Else Phantom#722
+                    1. Else Phantom#723
 
                 4. Case (% has type structTypeIR)
 
@@ -15453,7 +15477,7 @@ relation Cast_expl_neq: typeIR -> typeIR'
 
                       1. The relation holds
 
-                    1. Else Phantom#723
+                    1. Else Phantom#724
 
                 5. Case (% has type headerTypeIR)
 
@@ -15463,9 +15487,9 @@ relation Cast_expl_neq: typeIR -> typeIR'
 
                       1. The relation holds
 
-                    1. Else Phantom#724
+                    1. Else Phantom#725
 
-              1. Else Phantom#725
+              1. Else Phantom#726
 
         2. Case (% matches pattern `SEQ<%,...>`)
 
@@ -15489,11 +15513,11 @@ relation Cast_expl_neq: typeIR -> typeIR'
 
                             1. The relation holds
 
-                          1. Else Phantom#726
+                          1. Else Phantom#727
 
-                        1. Else Phantom#727
+                        1. Else Phantom#728
 
-                    1. Else Phantom#728
+                    1. Else Phantom#729
 
                 2. Case (% has type headerStackTypeIR)
 
@@ -15507,11 +15531,11 @@ relation Cast_expl_neq: typeIR -> typeIR'
 
                           1. The relation holds
 
-                        1. Else Phantom#729
+                        1. Else Phantom#730
 
-                      1. Else Phantom#730
+                      1. Else Phantom#731
 
-                    1. Else Phantom#731
+                    1. Else Phantom#732
 
                 3. Case (% has type structTypeIR)
 
@@ -15527,11 +15551,11 @@ relation Cast_expl_neq: typeIR -> typeIR'
 
                             1. The relation holds
 
-                          1. Else Phantom#732
+                          1. Else Phantom#733
 
-                        1. Else Phantom#733
+                        1. Else Phantom#734
 
-                    1. Else Phantom#734
+                    1. Else Phantom#735
 
                 4. Case (% has type headerTypeIR)
 
@@ -15547,13 +15571,13 @@ relation Cast_expl_neq: typeIR -> typeIR'
 
                             1. The relation holds
 
-                          1. Else Phantom#735
+                          1. Else Phantom#736
 
-                        1. Else Phantom#736
+                        1. Else Phantom#737
 
-                    1. Else Phantom#737
+                    1. Else Phantom#738
 
-              1. Else Phantom#738
+              1. Else Phantom#739
 
   4. Case (% has type recordTypeIR)
 
@@ -15591,13 +15615,13 @@ relation Cast_expl_neq: typeIR -> typeIR'
 
                                     1. The relation holds
 
-                                  1. Else Phantom#739
+                                  1. Else Phantom#740
 
-                              1. Else Phantom#740
+                              1. Else Phantom#741
 
-                        1. Else Phantom#741
+                        1. Else Phantom#742
 
-                    1. Else Phantom#742
+                    1. Else Phantom#743
 
                 2. Case (% has type headerTypeIR)
 
@@ -15621,15 +15645,15 @@ relation Cast_expl_neq: typeIR -> typeIR'
 
                                     1. The relation holds
 
-                                  1. Else Phantom#743
+                                  1. Else Phantom#744
 
-                              1. Else Phantom#744
+                              1. Else Phantom#745
 
-                        1. Else Phantom#745
+                        1. Else Phantom#746
 
-                    1. Else Phantom#746
+                    1. Else Phantom#747
 
-              1. Else Phantom#747
+              1. Else Phantom#748
 
         2. Case (% matches pattern `RECORD{%,...}`)
 
@@ -15671,17 +15695,17 @@ relation Cast_expl_neq: typeIR -> typeIR'
 
                                               1. The relation holds
 
-                                            1. Else Phantom#748
+                                            1. Else Phantom#749
 
-                                        1. Else Phantom#749
+                                        1. Else Phantom#750
 
-                                  1. Else Phantom#750
+                                  1. Else Phantom#751
 
-                              1. Else Phantom#751
+                              1. Else Phantom#752
 
-                        1. Else Phantom#752
+                        1. Else Phantom#753
 
-                    1. Else Phantom#753
+                    1. Else Phantom#754
 
                 2. Case (% has type headerTypeIR)
 
@@ -15715,21 +15739,21 @@ relation Cast_expl_neq: typeIR -> typeIR'
 
                                               1. The relation holds
 
-                                            1. Else Phantom#754
+                                            1. Else Phantom#755
 
-                                        1. Else Phantom#755
+                                        1. Else Phantom#756
 
-                                  1. Else Phantom#756
+                                  1. Else Phantom#757
 
-                              1. Else Phantom#757
+                              1. Else Phantom#758
 
-                        1. Else Phantom#758
+                        1. Else Phantom#759
 
-                    1. Else Phantom#759
+                    1. Else Phantom#760
 
-              1. Else Phantom#760
+              1. Else Phantom#761
 
-4. Else Phantom#761
+4. Else Phantom#762
 
 relation Cast_impl: typeIR_a -> typeIR_b
 
@@ -15749,7 +15773,7 @@ relation Cast_impl: typeIR_a -> typeIR_b
 
           1. The relation holds
 
-        1. Else Phantom#762
+        1. Else Phantom#763
 
 relation Cast_impl_neq: typeIR -> typeIR'
 
@@ -15771,7 +15795,7 @@ relation Cast_impl_neq: typeIR -> typeIR'
 
             1. The relation holds
 
-        1. Else Phantom#763
+        1. Else Phantom#764
 
   2. Case (% has type serializableEnumTypeIR)
 
@@ -15783,7 +15807,7 @@ relation Cast_impl_neq: typeIR -> typeIR'
 
           1. The relation holds
 
-        1. Else Phantom#764
+        1. Else Phantom#765
 
   3. Case (% has type defaultTypeIR)
 
@@ -15795,7 +15819,7 @@ relation Cast_impl_neq: typeIR -> typeIR'
 
           1. The relation holds
 
-        1. Else Phantom#765
+        1. Else Phantom#766
 
   4. Case (% has type invalidHeaderTypeIR)
 
@@ -15813,7 +15837,7 @@ relation Cast_impl_neq: typeIR -> typeIR'
 
             1. The relation holds
 
-        1. Else Phantom#766
+        1. Else Phantom#767
 
   5. Case (% has type sequenceTypeIR)
 
@@ -15837,7 +15861,7 @@ relation Cast_impl_neq: typeIR -> typeIR'
 
                       1. The relation holds
 
-                    1. Else Phantom#767
+                    1. Else Phantom#768
 
                 2. Case (% has type tupleTypeIR)
 
@@ -15847,7 +15871,7 @@ relation Cast_impl_neq: typeIR -> typeIR'
 
                       1. The relation holds
 
-                    1. Else Phantom#768
+                    1. Else Phantom#769
 
                 3. Case (% has type headerStackTypeIR)
 
@@ -15859,9 +15883,9 @@ relation Cast_impl_neq: typeIR -> typeIR'
 
                         1. The relation holds
 
-                      1. Else Phantom#769
+                      1. Else Phantom#770
 
-                    1. Else Phantom#770
+                    1. Else Phantom#771
 
                 4. Case (% has type structTypeIR)
 
@@ -15871,7 +15895,7 @@ relation Cast_impl_neq: typeIR -> typeIR'
 
                       1. The relation holds
 
-                    1. Else Phantom#771
+                    1. Else Phantom#772
 
                 5. Case (% has type headerTypeIR)
 
@@ -15881,7 +15905,7 @@ relation Cast_impl_neq: typeIR -> typeIR'
 
                       1. The relation holds
 
-                    1. Else Phantom#772
+                    1. Else Phantom#773
 
                 6. Case (% has type sequenceTypeIR)
 
@@ -15895,11 +15919,11 @@ relation Cast_impl_neq: typeIR -> typeIR'
 
                           1. The relation holds
 
-                        1. Else Phantom#773
+                        1. Else Phantom#774
 
-                    1. Else Phantom#774
+                    1. Else Phantom#775
 
-              1. Else Phantom#775
+              1. Else Phantom#776
 
         2. Case (% matches pattern `SEQ<%,...>`)
 
@@ -15923,11 +15947,11 @@ relation Cast_impl_neq: typeIR -> typeIR'
 
                             1. The relation holds
 
-                          1. Else Phantom#776
+                          1. Else Phantom#777
 
-                        1. Else Phantom#777
+                        1. Else Phantom#778
 
-                    1. Else Phantom#778
+                    1. Else Phantom#779
 
                 2. Case (% has type headerStackTypeIR)
 
@@ -15941,11 +15965,11 @@ relation Cast_impl_neq: typeIR -> typeIR'
 
                           1. The relation holds
 
-                        1. Else Phantom#779
+                        1. Else Phantom#780
 
-                      1. Else Phantom#780
+                      1. Else Phantom#781
 
-                    1. Else Phantom#781
+                    1. Else Phantom#782
 
                 3. Case (% has type structTypeIR)
 
@@ -15961,11 +15985,11 @@ relation Cast_impl_neq: typeIR -> typeIR'
 
                             1. The relation holds
 
-                          1. Else Phantom#782
+                          1. Else Phantom#783
 
-                        1. Else Phantom#783
+                        1. Else Phantom#784
 
-                    1. Else Phantom#784
+                    1. Else Phantom#785
 
                 4. Case (% has type headerTypeIR)
 
@@ -15981,13 +16005,13 @@ relation Cast_impl_neq: typeIR -> typeIR'
 
                             1. The relation holds
 
-                          1. Else Phantom#785
+                          1. Else Phantom#786
 
-                        1. Else Phantom#786
+                        1. Else Phantom#787
 
-                    1. Else Phantom#787
+                    1. Else Phantom#788
 
-              1. Else Phantom#788
+              1. Else Phantom#789
 
   6. Case (% has type recordTypeIR)
 
@@ -16025,13 +16049,13 @@ relation Cast_impl_neq: typeIR -> typeIR'
 
                                     1. The relation holds
 
-                                  1. Else Phantom#789
+                                  1. Else Phantom#790
 
-                              1. Else Phantom#790
+                              1. Else Phantom#791
 
-                        1. Else Phantom#791
+                        1. Else Phantom#792
 
-                    1. Else Phantom#792
+                    1. Else Phantom#793
 
                 2. Case (% has type headerTypeIR)
 
@@ -16055,15 +16079,15 @@ relation Cast_impl_neq: typeIR -> typeIR'
 
                                     1. The relation holds
 
-                                  1. Else Phantom#793
+                                  1. Else Phantom#794
 
-                              1. Else Phantom#794
+                              1. Else Phantom#795
 
-                        1. Else Phantom#795
+                        1. Else Phantom#796
 
-                    1. Else Phantom#796
+                    1. Else Phantom#797
 
-              1. Else Phantom#797
+              1. Else Phantom#798
 
         2. Case (% matches pattern `RECORD{%,...}`)
 
@@ -16105,17 +16129,17 @@ relation Cast_impl_neq: typeIR -> typeIR'
 
                                               1. The relation holds
 
-                                            1. Else Phantom#798
+                                            1. Else Phantom#799
 
-                                        1. Else Phantom#799
+                                        1. Else Phantom#800
 
-                                  1. Else Phantom#800
+                                  1. Else Phantom#801
 
-                              1. Else Phantom#801
+                              1. Else Phantom#802
 
-                        1. Else Phantom#802
+                        1. Else Phantom#803
 
-                    1. Else Phantom#803
+                    1. Else Phantom#804
 
                 2. Case (% has type headerTypeIR)
 
@@ -16149,21 +16173,21 @@ relation Cast_impl_neq: typeIR -> typeIR'
 
                                               1. The relation holds
 
-                                            1. Else Phantom#804
+                                            1. Else Phantom#805
 
-                                        1. Else Phantom#805
+                                        1. Else Phantom#806
 
-                                  1. Else Phantom#806
+                                  1. Else Phantom#807
 
-                              1. Else Phantom#807
+                              1. Else Phantom#808
 
-                        1. Else Phantom#808
+                        1. Else Phantom#809
 
-                    1. Else Phantom#809
+                    1. Else Phantom#810
 
-              1. Else Phantom#810
+              1. Else Phantom#811
 
-1. Else Phantom#811
+1. Else Phantom#812
 
 relation Expr_ok: p TC |- expression : %
 
@@ -16217,7 +16241,7 @@ relation Expr_ok: p TC |- expression : %
 
           1. Result in: % % |- % : ((stringLiteral as expressionIR) # expressionNoteIR)
 
-  1. Else Phantom#812
+  1. Else Phantom#813
 
 2. Group referenceExpression: p TC |- expression : %
 
@@ -16237,9 +16261,9 @@ relation Expr_ok: p TC |- expression : %
 
                 1. Result in: % % |- % : ((prefixedNameIR as expressionIR) # expressionNoteIR)
 
-          1. Else Phantom#813
+          1. Else Phantom#814
 
-  1. Else Phantom#814
+  1. Else Phantom#815
 
   2. If ((expression = ((this) as expression))), then
 
@@ -16255,9 +16279,9 @@ relation Expr_ok: p TC |- expression : %
 
               1. Result in: % % |- % : ((prefixedNameIR as expressionIR) # expressionNoteIR)
 
-        1. Else Phantom#815
+        1. Else Phantom#816
 
-  2. Else Phantom#816
+  2. Else Phantom#817
 
 3. Case analysis on expression
 
@@ -16297,7 +16321,7 @@ relation Expr_ok: p TC |- expression : %
 
                           1. Result in: % % |- % : ((((!) typedExpressionIR_reduced) as expressionIR) # expressionNoteIR)
 
-                1. Else Phantom#817
+                1. Else Phantom#818
 
         2. Case (% matches pattern `~`)
 
@@ -16319,9 +16343,9 @@ relation Expr_ok: p TC |- expression : %
 
                           1. Result in: % % |- % : ((((~) typedExpressionIR_reduced) as expressionIR) # expressionNoteIR)
 
-                1. Else Phantom#818
+                1. Else Phantom#819
 
-      1. Else Phantom#819
+      1. Else Phantom#820
 
       2. Group unaryExpression-uplusminus: p TC |- ((unop expression') as expression) : %
 
@@ -16343,9 +16367,9 @@ relation Expr_ok: p TC |- expression : %
 
                         1. Result in: % % |- % : (((unop typedExpressionIR_reduced) as expressionIR) # expressionNoteIR)
 
-              1. Else Phantom#820
+              1. Else Phantom#821
 
-        1. Else Phantom#821
+        1. Else Phantom#822
 
   3. Case (% has type binaryExpression)
 
@@ -16383,11 +16407,11 @@ relation Expr_ok: p TC |- expression : %
 
                                     1. Result in: % % |- % : (((typedExpressionIR_l_reduced binop typedExpressionIR_r_reduced) as expressionIR) # expressionNoteIR)
 
-                      1. Else Phantom#822
+                      1. Else Phantom#823
 
-                1. Else Phantom#823
+                1. Else Phantom#824
 
-        1. Else Phantom#824
+        1. Else Phantom#825
 
       2. Group binaryExpression-satplusminus: p TC |- ((expression_l binop expression_r) as expression) : %
 
@@ -16421,11 +16445,11 @@ relation Expr_ok: p TC |- expression : %
 
                                     1. Result in: % % |- % : (((typedExpressionIR_l_reduced binop typedExpressionIR_r_reduced) as expressionIR) # expressionNoteIR)
 
-                      1. Else Phantom#825
+                      1. Else Phantom#826
 
-                1. Else Phantom#826
+                1. Else Phantom#827
 
-        1. Else Phantom#827
+        1. Else Phantom#828
 
       3. Group binaryExpression-divmod: p TC |- ((expression_l binop expression_r) as expression) : %
 
@@ -16477,11 +16501,11 @@ relation Expr_ok: p TC |- expression : %
 
                                                       1. Result in: % % |- % : (((typedExpressionIR_l_reduced binop typedExpressionIR_r_reduced) as expressionIR) # expressionNoteIR)
 
-                                                1. Else Phantom#828
+                                                1. Else Phantom#829
 
-                                            1. Else Phantom#829
+                                            1. Else Phantom#830
 
-                                      1. Else Phantom#830
+                                      1. Else Phantom#831
 
                                   2. Case false
 
@@ -16491,11 +16515,11 @@ relation Expr_ok: p TC |- expression : %
 
                                         1. Result in: % % |- % : (((typedExpressionIR_l_reduced binop typedExpressionIR_r_reduced) as expressionIR) # expressionNoteIR)
 
-                      1. Else Phantom#831
+                      1. Else Phantom#832
 
-                1. Else Phantom#832
+                1. Else Phantom#833
 
-        1. Else Phantom#833
+        1. Else Phantom#834
 
       4. Group binaryExpression-shift: p TC |- ((expression_l binop expression_r) as expression) : %
 
@@ -16531,7 +16555,7 @@ relation Expr_ok: p TC |- expression : %
 
                                       1. Result in: % % |- % : (((typedExpressionIR_l_reduced binop typedExpressionIR_r_reduced) as expressionIR) # expressionNoteIR)
 
-                                1. Else Phantom#834
+                                1. Else Phantom#835
 
                               2. Case false
 
@@ -16553,15 +16577,15 @@ relation Expr_ok: p TC |- expression : %
 
                                                 1. Result in: % % |- % : (((typedExpressionIR_l_reduced binop typedExpressionIR_r_reduced) as expressionIR) # expressionNoteIR)
 
-                                          1. Else Phantom#835
+                                          1. Else Phantom#836
 
-                                    1. Else Phantom#836
+                                    1. Else Phantom#837
 
-                                1. Else Phantom#837
+                                1. Else Phantom#838
 
-                1. Else Phantom#838
+                1. Else Phantom#839
 
-        1. Else Phantom#839
+        1. Else Phantom#840
 
       5. Group binaryExpression-equality: p TC |- ((expression_l binop expression_r) as expression) : %
 
@@ -16591,11 +16615,11 @@ relation Expr_ok: p TC |- expression : %
 
                                 1. Result in: % % |- % : (((typedExpressionIR_l_cast binop typedExpressionIR_r_cast) as expressionIR) # expressionNoteIR)
 
-                          1. Else Phantom#840
+                          1. Else Phantom#841
 
-                1. Else Phantom#841
+                1. Else Phantom#842
 
-        1. Else Phantom#842
+        1. Else Phantom#843
 
       6. Group binaryExpression-comparison: p TC |- ((expression_l binop expression_r) as expression) : %
 
@@ -16629,11 +16653,11 @@ relation Expr_ok: p TC |- expression : %
 
                                     1. Result in: % % |- % : (((typedExpressionIR_l_reduced binop typedExpressionIR_r_reduced) as expressionIR) # expressionNoteIR)
 
-                      1. Else Phantom#843
+                      1. Else Phantom#844
 
-                1. Else Phantom#844
+                1. Else Phantom#845
 
-        1. Else Phantom#845
+        1. Else Phantom#846
 
       7. Group binaryExpression-bitwise: p TC |- ((expression_l binop expression_r) as expression) : %
 
@@ -16667,11 +16691,11 @@ relation Expr_ok: p TC |- expression : %
 
                                     1. Result in: % % |- % : (((typedExpressionIR_l_reduced binop typedExpressionIR_r_reduced) as expressionIR) # expressionNoteIR)
 
-                      1. Else Phantom#846
+                      1. Else Phantom#847
 
-                1. Else Phantom#847
+                1. Else Phantom#848
 
-        1. Else Phantom#848
+        1. Else Phantom#849
 
       8. If ((binop matches pattern `++`)), then
 
@@ -16703,9 +16727,9 @@ relation Expr_ok: p TC |- expression : %
 
                                   1. Result in: % % |- % : (((typedExpressionIR_l_reduced (++) typedExpressionIR_r_reduced) as expressionIR) # expressionNoteIR)
 
-                1. Else Phantom#849
+                1. Else Phantom#850
 
-      8. Else Phantom#850
+      8. Else Phantom#851
 
       9. Group binaryExpression-logical: p TC |- ((expression_l binop expression_r) as expression) : %
 
@@ -16739,11 +16763,11 @@ relation Expr_ok: p TC |- expression : %
 
                                     1. Result in: % % |- % : (((typedExpressionIR_l_reduced binop typedExpressionIR_r_reduced) as expressionIR) # expressionNoteIR)
 
-                      1. Else Phantom#851
+                      1. Else Phantom#852
 
-                1. Else Phantom#852
+                1. Else Phantom#853
 
-        1. Else Phantom#853
+        1. Else Phantom#854
 
   4. Case (% has type ternaryExpression)
 
@@ -16783,11 +16807,11 @@ relation Expr_ok: p TC |- expression : %
 
                                       1. Result in: % % |- % : (((typedExpressionIR_cond ? typedExpressionIR_true_cast : typedExpressionIR_false_cast) as expressionIR) # expressionNoteIR)
 
-                                1. Else Phantom#854
+                                1. Else Phantom#855
 
-                      1. Else Phantom#855
+                      1. Else Phantom#856
 
-              1. Else Phantom#856
+              1. Else Phantom#857
 
   5. Case (% has type castExpression)
 
@@ -16813,11 +16837,11 @@ relation Expr_ok: p TC |- expression : %
 
                         1. Result in: % % |- % : (((( typeIR_t ) typedExpressionIR) as expressionIR) # expressionNoteIR)
 
-                    1. Else Phantom#857
+                    1. Else Phantom#858
 
-            1. Else Phantom#858
+            1. Else Phantom#859
 
-          1. Else Phantom#859
+          1. Else Phantom#860
 
   6. Case (% has type invalidHeaderExpression)
 
@@ -16891,11 +16915,11 @@ relation Expr_ok: p TC |- expression : %
 
                                               1. Result in: % % |- % : (((seq{ (typedExpressionIR_e_h)* ,...}) as expressionIR) # expressionNoteIR)
 
-                                1. Else Phantom#860
+                                1. Else Phantom#861
 
-                          1. Else Phantom#861
+                          1. Else Phantom#862
 
-                      1. Else Phantom#862
+                      1. Else Phantom#863
 
         2. Case (% has type recordElementExpression)
 
@@ -17009,7 +17033,7 @@ relation Expr_ok: p TC |- expression : %
 
                 1. Result in: % % |- % : (((error. nameIR) as expressionIR) # expressionNoteIR)
 
-            1. Else Phantom#863
+            1. Else Phantom#864
 
   9. Case (% has type memberAccessExpression)
 
@@ -17051,7 +17075,7 @@ relation Expr_ok: p TC |- expression : %
 
                                         1. Result in: % % |- % : ((((type prefixedNameIR_base) . nameIR) as expressionIR) # expressionNoteIR)
 
-                                    1. Else Phantom#864
+                                    1. Else Phantom#865
 
                               2. Case (% has type serializableEnumTypeIR)
 
@@ -17065,13 +17089,13 @@ relation Expr_ok: p TC |- expression : %
 
                                         1. Result in: % % |- % : ((((type prefixedNameIR_base) . nameIR) as expressionIR) # expressionNoteIR)
 
-                                    1. Else Phantom#865
+                                    1. Else Phantom#866
 
-                            1. Else Phantom#866
+                            1. Else Phantom#867
 
-                      1. Else Phantom#867
+                      1. Else Phantom#868
 
-                  1. Else Phantom#868
+                  1. Else Phantom#869
 
         2. Case (% has type expression)
 
@@ -17095,7 +17119,7 @@ relation Expr_ok: p TC |- expression : %
 
                             1. Result in: % % |- % : ((((typedExpressionIR_base as memberAccessBaseIR) . "size") as expressionIR) # expressionNoteIR)
 
-                        1. Else Phantom#869
+                        1. Else Phantom#870
 
                         2. If (("lastIndex" = $name(member))), then
 
@@ -17105,9 +17129,9 @@ relation Expr_ok: p TC |- expression : %
 
                               1. Result in: % % |- % : ((((typedExpressionIR_base as memberAccessBaseIR) . "lastIndex") as expressionIR) # expressionNoteIR)
 
-                          1. Else Phantom#870
+                          1. Else Phantom#871
 
-                        2. Else Phantom#871
+                        2. Else Phantom#872
 
                         3. If (("last" = $name(member))), then
 
@@ -17117,9 +17141,9 @@ relation Expr_ok: p TC |- expression : %
 
                               1. Result in: % % |- % : ((((typedExpressionIR_base as memberAccessBaseIR) . "last") as expressionIR) # expressionNoteIR)
 
-                          1. Else Phantom#872
+                          1. Else Phantom#873
 
-                        3. Else Phantom#873
+                        3. Else Phantom#874
 
                         4. If (("next" = $name(member))), then
 
@@ -17129,11 +17153,11 @@ relation Expr_ok: p TC |- expression : %
 
                               1. Result in: % % |- % : ((((typedExpressionIR_base as memberAccessBaseIR) . "next") as expressionIR) # expressionNoteIR)
 
-                          1. Else Phantom#874
+                          1. Else Phantom#875
 
-                        4. Else Phantom#875
+                        4. Else Phantom#876
 
-                    1. Else Phantom#876
+                    1. Else Phantom#877
 
                   2. (Let ctk_base be $ctk_of_typedExpressionIR(typedExpressionIR_base))
 
@@ -17157,7 +17181,7 @@ relation Expr_ok: p TC |- expression : %
 
                                       1. Result in: % % |- % : ((((typedExpressionIR_base as memberAccessBaseIR) . nameIR) as expressionIR) # expressionNoteIR)
 
-                                1. Else Phantom#877
+                                1. Else Phantom#878
 
                         2. Case (% has type headerTypeIR)
 
@@ -17175,7 +17199,7 @@ relation Expr_ok: p TC |- expression : %
 
                                       1. Result in: % % |- % : ((((typedExpressionIR_base as memberAccessBaseIR) . nameIR) as expressionIR) # expressionNoteIR)
 
-                                1. Else Phantom#878
+                                1. Else Phantom#879
 
                         3. Case (% has type headerUnionTypeIR)
 
@@ -17193,9 +17217,9 @@ relation Expr_ok: p TC |- expression : %
 
                                       1. Result in: % % |- % : ((((typedExpressionIR_base as memberAccessBaseIR) . nameIR) as expressionIR) # expressionNoteIR)
 
-                                1. Else Phantom#879
+                                1. Else Phantom#880
 
-                      1. Else Phantom#880
+                      1. Else Phantom#881
 
                   3. (Let typeIR be $unroll_typeIR(typeIR_base))
 
@@ -17225,9 +17249,9 @@ relation Expr_ok: p TC |- expression : %
 
                                 1. Result in: % % |- % : ((((typedExpressionIR_base as memberAccessBaseIR) . nameIR) as expressionIR) # expressionNoteIR)
 
-                          1. Else Phantom#881
+                          1. Else Phantom#882
 
-                    1. Else Phantom#882
+                    1. Else Phantom#883
 
   10. Case (% has type indexAccessExpression)
 
@@ -17281,13 +17305,13 @@ relation Expr_ok: p TC |- expression : %
 
                                                     1. Result in: % % |- % : (((typedExpressionIR_base [ typedExpressionIR_index_reduced ]) as expressionIR) # expressionNoteIR)
 
-                                                1. Else Phantom#883
+                                                1. Else Phantom#884
 
-                                            1. Else Phantom#884
+                                            1. Else Phantom#885
 
-                                      1. Else Phantom#885
+                                      1. Else Phantom#886
 
-                                  1. Else Phantom#886
+                                  1. Else Phantom#887
 
                               2. Case (% has type headerStackTypeIR)
 
@@ -17315,11 +17339,11 @@ relation Expr_ok: p TC |- expression : %
 
                                                       1. Result in: % % |- % : (((typedExpressionIR_base [ typedExpressionIR_index_reduced ]) as expressionIR) # expressionNoteIR)
 
-                                                  1. Else Phantom#887
+                                                  1. Else Phantom#888
 
-                                              1. Else Phantom#888
+                                              1. Else Phantom#889
 
-                                        1. Else Phantom#889
+                                        1. Else Phantom#890
 
                                     2. Case false
 
@@ -17329,9 +17353,9 @@ relation Expr_ok: p TC |- expression : %
 
                                           1. Result in: % % |- % : (((typedExpressionIR_base [ typedExpressionIR_index_reduced ]) as expressionIR) # expressionNoteIR)
 
-                            1. Else Phantom#890
+                            1. Else Phantom#891
 
-                      1. Else Phantom#891
+                      1. Else Phantom#892
 
   11. Case (% has type sliceAccessExpression)
 
@@ -17417,27 +17441,27 @@ relation Expr_ok: p TC |- expression : %
 
                                                                                     1. Result in: % % |- % : (((typedExpressionIR_base [ typedExpressionIR_hi_reduced : typedExpressionIR_lo_reduced ]) as expressionIR) # expressionNoteIR)
 
-                                                                            1. Else Phantom#892
+                                                                            1. Else Phantom#893
 
-                                                                        1. Else Phantom#893
+                                                                        1. Else Phantom#894
 
-                                                                    1. Else Phantom#894
+                                                                    1. Else Phantom#895
 
-                                                              1. Else Phantom#895
+                                                              1. Else Phantom#896
 
-                                                          1. Else Phantom#896
+                                                          1. Else Phantom#897
 
-                                                      1. Else Phantom#897
+                                                      1. Else Phantom#898
 
-                                                1. Else Phantom#898
+                                                1. Else Phantom#899
 
-                                            1. Else Phantom#899
+                                            1. Else Phantom#900
 
-                                1. Else Phantom#900
+                                1. Else Phantom#901
 
-                          1. Else Phantom#901
+                          1. Else Phantom#902
 
-                1. Else Phantom#902
+                1. Else Phantom#903
 
   12. Case (% has type callExpression)
 
@@ -17483,7 +17507,7 @@ relation Expr_ok: p TC |- expression : %
 
                                             1. Result in: % % |- % : ((literalExpressionIR as expressionIR) # expressionNoteIR)
 
-                                        1. Else Phantom#903
+                                        1. Else Phantom#904
 
                                 2. Case false
 
@@ -17493,9 +17517,9 @@ relation Expr_ok: p TC |- expression : %
 
                                       1. Result in: % % |- % : ((callExpressionIR as expressionIR) # expressionNoteIR)
 
-                          1. Else Phantom#904
+                          1. Else Phantom#905
 
-              1. Else Phantom#905
+              1. Else Phantom#906
 
           2. Case (% matches pattern `%<%>(%)`)
 
@@ -17525,7 +17549,7 @@ relation Expr_ok: p TC |- expression : %
 
                                     1. Result in: % % |- % : ((callExpressionIR as expressionIR) # expressionNoteIR)
 
-                            1. Else Phantom#906
+                            1. Else Phantom#907
 
       2. If ((callExpression matches pattern `%(%)`)), then
 
@@ -17557,7 +17581,7 @@ relation Expr_ok: p TC |- expression : %
 
                                   1. Result in: % % |- % : ((callExpressionIR as expressionIR) # expressionNoteIR)
 
-                            1. Else Phantom#907
+                            1. Else Phantom#908
 
               2. Case (% has type specializedType)
 
@@ -17585,11 +17609,11 @@ relation Expr_ok: p TC |- expression : %
 
                                       1. Result in: % % |- % : ((callExpressionIR as expressionIR) # expressionNoteIR)
 
-                                1. Else Phantom#908
+                                1. Else Phantom#909
 
-            1. Else Phantom#909
+            1. Else Phantom#910
 
-      2. Else Phantom#910
+      2. Else Phantom#911
 
   13. Case (% has type parenthesizedExpression)
 
@@ -17607,7 +17631,7 @@ relation Expr_ok: p TC |- expression : %
 
                 1. Result in: % % |- % : (((( typedExpressionIR )) as expressionIR) # expressionNoteIR)
 
-3. Else Phantom#911
+3. Else Phantom#912
 
 relation Argument_ok: p TC |- argument : %
 
@@ -17687,13 +17711,13 @@ relation Lvalue_ok: p TC |- lvalue : %
 
                       1. Result in: % % |- % : ((prefixedNameIR as lvalueIR) # (( typeIR )))
 
-                    1. Else Phantom#912
+                    1. Else Phantom#913
 
-                  1. Else Phantom#913
+                  1. Else Phantom#914
 
-                1. Else Phantom#914
+                1. Else Phantom#915
 
-            1. Else Phantom#915
+            1. Else Phantom#916
 
   2. Case (% matches pattern `%.%`)
 
@@ -17723,9 +17747,9 @@ relation Lvalue_ok: p TC |- lvalue : %
 
                             1. Result in: % % |- % : typedLvalueIR
 
-                        1. Else Phantom#916
+                        1. Else Phantom#917
 
-                      1. Else Phantom#917
+                      1. Else Phantom#918
 
                 2. Case (% has type structTypeIR)
 
@@ -17743,7 +17767,7 @@ relation Lvalue_ok: p TC |- lvalue : %
 
                               1. Result in: % % |- % : typedLvalueIR
 
-                        1. Else Phantom#918
+                        1. Else Phantom#919
 
                 3. Case (% has type headerTypeIR)
 
@@ -17761,7 +17785,7 @@ relation Lvalue_ok: p TC |- lvalue : %
 
                               1. Result in: % % |- % : typedLvalueIR
 
-                        1. Else Phantom#919
+                        1. Else Phantom#920
 
                 4. Case (% has type headerUnionTypeIR)
 
@@ -17779,9 +17803,9 @@ relation Lvalue_ok: p TC |- lvalue : %
 
                               1. Result in: % % |- % : typedLvalueIR
 
-                        1. Else Phantom#920
+                        1. Else Phantom#921
 
-              1. Else Phantom#921
+              1. Else Phantom#922
 
   3. Case (% matches pattern `%[%]`)
 
@@ -17831,11 +17855,11 @@ relation Lvalue_ok: p TC |- lvalue : %
 
                                                 1. Result in: % % |- % : typedLvalueIR
 
-                                            1. Else Phantom#922
+                                            1. Else Phantom#923
 
-                                        1. Else Phantom#923
+                                        1. Else Phantom#924
 
-                                  1. Else Phantom#924
+                                  1. Else Phantom#925
 
                               2. Case false
 
@@ -17843,9 +17867,9 @@ relation Lvalue_ok: p TC |- lvalue : %
 
                                   1. Result in: % % |- % : typedLvalueIR
 
-                        1. Else Phantom#925
+                        1. Else Phantom#926
 
-              1. Else Phantom#926
+              1. Else Phantom#927
 
   4. Case (% matches pattern `%[%:%]`)
 
@@ -17921,27 +17945,27 @@ relation Lvalue_ok: p TC |- lvalue : %
 
                                                                           1. Result in: % % |- % : typedLvalueIR
 
-                                                                  1. Else Phantom#927
+                                                                  1. Else Phantom#928
 
-                                                              1. Else Phantom#928
+                                                              1. Else Phantom#929
 
-                                                          1. Else Phantom#929
+                                                          1. Else Phantom#930
 
-                                                    1. Else Phantom#930
+                                                    1. Else Phantom#931
 
-                                                1. Else Phantom#931
+                                                1. Else Phantom#932
 
-                                            1. Else Phantom#932
+                                            1. Else Phantom#933
 
-                                      1. Else Phantom#933
+                                      1. Else Phantom#934
 
-                                  1. Else Phantom#934
+                                  1. Else Phantom#935
 
-                          1. Else Phantom#935
+                          1. Else Phantom#936
 
-                    1. Else Phantom#936
+                    1. Else Phantom#937
 
-            1. Else Phantom#937
+            1. Else Phantom#938
 
   5. Case (% matches pattern `(%)`)
 
@@ -17957,7 +17981,7 @@ relation Lvalue_ok: p TC |- lvalue : %
 
               1. Result in: % % |- % : typedLvalueIR
 
-1. Else Phantom#938
+1. Else Phantom#939
 
 syntax loopctxt = 
    | loop
@@ -17997,7 +18021,7 @@ relation Stmt_ok: p TC f l |- statement : % % %
 
                       1. Result in: % % % % |- % : TC f ((typedLvalueIR (=) typedExpressionIR_cast ;) as statementIR)
 
-                  1. Else Phantom#939
+                  1. Else Phantom#940
 
   3. Case (% has type callStatement)
 
@@ -18035,7 +18059,7 @@ relation Stmt_ok: p TC f l |- statement : % % %
 
                                     1. Result in: % % % % |- % : TC f (emptyStatementIR as statementIR)
 
-                                1. Else Phantom#940
+                                1. Else Phantom#941
 
                         2. Case false
 
@@ -18117,25 +18141,25 @@ relation Stmt_ok: p TC f l |- statement : % % %
 
                                                       1. Result in: % % % % |- % : TC f (directApplicationStatementIR as statementIR)
 
-                                                  1. Else Phantom#941
+                                                  1. Else Phantom#942
 
-                                                1. Else Phantom#942
+                                                1. Else Phantom#943
 
-                                              1. Else Phantom#943
+                                              1. Else Phantom#944
 
-                                            1. Else Phantom#944
+                                            1. Else Phantom#945
 
-                                        1. Else Phantom#945
+                                        1. Else Phantom#946
 
-                                  1. Else Phantom#946
+                                  1. Else Phantom#947
 
-                        1. Else Phantom#947
+                        1. Else Phantom#948
 
-                  1. Else Phantom#948
+                  1. Else Phantom#949
 
-              1. Else Phantom#949
+              1. Else Phantom#950
 
-          1. Else Phantom#950
+          1. Else Phantom#951
 
   5. Case (% has type exitStatement)
 
@@ -18167,7 +18191,7 @@ relation Stmt_ok: p TC f l |- statement : % % %
 
                       1. Result in: % % % % |- % : TC f ((if( typedExpressionIR_cond ) statementIR_then) as statementIR)
 
-                  1. Else Phantom#951
+                  1. Else Phantom#952
 
           2. Case (% matches pattern `IF(%)%ELSE%`)
 
@@ -18187,9 +18211,9 @@ relation Stmt_ok: p TC f l |- statement : % % %
 
                           1. Result in: % % % % |- % : TC f_post ((if( typedExpressionIR_cond ) statementIR_then else statementIR_else) as statementIR)
 
-                  1. Else Phantom#952
+                  1. Else Phantom#953
 
-1. Else Phantom#953
+1. Else Phantom#954
 
 2. If ((p matches pattern `LOCAL`)), then
 
@@ -18209,7 +18233,7 @@ relation Stmt_ok: p TC f l |- statement : % % %
 
                 1. Result in: % % % % |- % : TC (ret) ((return;) as statementIR)
 
-              1. Else Phantom#954
+              1. Else Phantom#955
 
             2. Case (% matches pattern `RETURN%;`)
 
@@ -18233,9 +18257,9 @@ relation Stmt_ok: p TC f l |- statement : % % %
 
                                 1. Result in: % % % % |- % : TC (ret) ((return typedExpressionIR_cast ;) as statementIR)
 
-                            1. Else Phantom#955
+                            1. Else Phantom#956
 
-                      1. Else Phantom#956
+                      1. Else Phantom#957
 
     2. Case (% has type blockStatement)
 
@@ -18281,9 +18305,9 @@ relation Stmt_ok: p TC f l |- statement : % % %
 
                                 1. Result in: % % % % |- % : TC f_post (forStatementIR as statementIR)
 
-                      1. Else Phantom#957
+                      1. Else Phantom#958
 
-        1. Else Phantom#958
+        1. Else Phantom#959
 
         2. Group forStatement-in: (local) TC f l |- (forStatement as statement) : % % %
 
@@ -18317,11 +18341,11 @@ relation Stmt_ok: p TC f l |- statement : % % %
 
                                       1. Result in: % % % % |- % : TC f_post (forStatementIR as statementIR)
 
-                      1. Else Phantom#959
+                      1. Else Phantom#960
 
-                    1. Else Phantom#960
+                    1. Else Phantom#961
 
-                  1. Else Phantom#961
+                  1. Else Phantom#962
 
             2. Case (% matches pattern `%FOR(%%%IN%)%`)
 
@@ -18335,9 +18359,9 @@ relation Stmt_ok: p TC f l |- statement : % % %
 
                       1. Result in: % % % % |- % : TC f_post (forStatementIR as statementIR)
 
-                  1. Else Phantom#962
+                  1. Else Phantom#963
 
-          1. Else Phantom#963
+          1. Else Phantom#964
 
     4. Case (% has type switchStatement)
 
@@ -18369,13 +18393,13 @@ relation Stmt_ok: p TC f l |- statement : % % %
 
                                 1. Result in: % % % % |- % : TC f_post (switchStatementIR as statementIR)
 
-                            1. Else Phantom#964
+                            1. Else Phantom#965
 
-                          1. Else Phantom#965
+                          1. Else Phantom#966
 
-                  1. Else Phantom#966
+                  1. Else Phantom#967
 
-          1. Else Phantom#967
+          1. Else Phantom#968
 
         2. Group switchStatement-general: (local) TC f l |- ((switch( expression_switch ){ switchCaseList }) as statement) : % % %
 
@@ -18397,15 +18421,15 @@ relation Stmt_ok: p TC f l |- statement : % % %
 
                           1. Result in: % % % % |- % : TC f_post (switchStatementIR as statementIR)
 
-                      1. Else Phantom#968
+                      1. Else Phantom#969
 
-                    1. Else Phantom#969
+                    1. Else Phantom#970
 
-                1. Else Phantom#970
+                1. Else Phantom#971
 
-          1. Else Phantom#971
+          1. Else Phantom#972
 
-  1. Else Phantom#972
+  1. Else Phantom#973
 
   2. If ((l matches pattern `LOOP`)), then
 
@@ -18427,11 +18451,11 @@ relation Stmt_ok: p TC f l |- statement : % % %
 
             1. Result in: % % % % |- % : TC f (continueStatement as statementIR)
 
-    1. Else Phantom#973
+    1. Else Phantom#974
 
-  2. Else Phantom#974
+  2. Else Phantom#975
 
-2. Else Phantom#975
+2. Else Phantom#976
 
 relation BlockElementStmt_ok: TC_0 f l |- blockElementStatement : % % %
 
@@ -18505,7 +18529,7 @@ relation Parameter_ok: p TC_0 |- (annotationList direction type name initializer
 
                   1. Result in: % % |- % : TC_1 parameterIR # (typeId_fresh)*
 
-          1. Else Phantom#976
+          1. Else Phantom#977
 
     2. Case (% has type initializer)
 
@@ -18541,7 +18565,7 @@ relation Parameter_ok: p TC_0 |- (annotationList direction type name initializer
 
                                     1. Result in: % % |- % : TC_1 parameterIR # (typeId_fresh)*
 
-                        1. Else Phantom#977
+                        1. Else Phantom#978
 
                     2. Case (% matches pattern `LCTK`)
 
@@ -18563,11 +18587,11 @@ relation Parameter_ok: p TC_0 |- (annotationList direction type name initializer
 
                                       1. Result in: % % |- % : TC_1 parameterIR # (typeId_fresh)*
 
-                        1. Else Phantom#978
+                        1. Else Phantom#979
 
-                  1. Else Phantom#979
+                  1. Else Phantom#980
 
-            1. Else Phantom#980
+            1. Else Phantom#981
 
 relation ParameterList_ok: p TC_0 |- parameterList : % % # %
 
@@ -18663,11 +18687,11 @@ relation ExternMethod_ok: TC_0 typeId_extern |- externMethodPrototype : %
 
                               1. Result in: % % |- % : externMethodPrototypeIR
 
-                          1. Else Phantom#981
+                          1. Else Phantom#982
 
-                  1. Else Phantom#982
+                  1. Else Phantom#983
 
-            1. Else Phantom#983
+            1. Else Phantom#984
 
     2. Case (% matches pattern `%ABSTRACT%;`)
 
@@ -18697,11 +18721,11 @@ relation ExternMethod_ok: TC_0 typeId_extern |- externMethodPrototype : %
 
                               1. Result in: % % |- % : externMethodPrototypeIR
 
-                          1. Else Phantom#984
+                          1. Else Phantom#985
 
-                  1. Else Phantom#985
+                  1. Else Phantom#986
 
-            1. Else Phantom#986
+            1. Else Phantom#987
 
 relation ExternConstructor_ok: TC_0 typeId_extern |- (annotationList typeIdentifier ( parameterList );) : %
 
@@ -18737,15 +18761,15 @@ relation ExternConstructor_ok: TC_0 typeId_extern |- (annotationList typeIdentif
 
                               1. Result in: % % |- % : externConstructorPrototypeIR
 
-                          1. Else Phantom#987
+                          1. Else Phantom#988
 
-                    1. Else Phantom#988
+                    1. Else Phantom#989
 
-              1. Else Phantom#989
+              1. Else Phantom#990
 
-          1. Else Phantom#990
+          1. Else Phantom#991
 
-    1. Else Phantom#991
+    1. Else Phantom#992
 
 relation ParserSelect_ok: TC_0 (nameIR_state)* |- (select( expressionList_key ){ selectCaseList }) : %
 
@@ -18769,7 +18793,7 @@ relation ParserSelect_ok: TC_0 (nameIR_state)* |- (select( expressionList_key ){
 
                   1. Result in: % % |- % : selectExpressionIR
 
-          1. Else Phantom#992
+          1. Else Phantom#993
 
 relation ParserTransition_ok: TC_0 (nameIR_state)* |- transitionStatement : %
 
@@ -18799,7 +18823,7 @@ relation ParserTransition_ok: TC_0 (nameIR_state)* |- transitionStatement : %
 
                     1. Result in: % % |- % : transitionStatementIR
 
-                1. Else Phantom#993
+                1. Else Phantom#994
 
           2. Case (% has type selectExpression)
 
@@ -18851,11 +18875,11 @@ relation ParserStmt_ok: TC_0 |- parserStatement : % %
 
                   1. Result in: % |- % : TC_0 (emptyStatementIR as parserStatementIR)
 
-              1. Else Phantom#994
+              1. Else Phantom#995
 
-            1. Else Phantom#995
+            1. Else Phantom#996
 
-          1. Else Phantom#996
+          1. Else Phantom#997
 
   4. Case (% has type assignmentStatement)
 
@@ -18873,9 +18897,9 @@ relation ParserStmt_ok: TC_0 |- parserStatement : % %
 
                 1. Result in: % |- % : TC_1 (assignmentStatementIR as parserStatementIR)
 
-            1. Else Phantom#997
+            1. Else Phantom#998
 
-          1. Else Phantom#998
+          1. Else Phantom#999
 
   5. Case (% has type callStatement)
 
@@ -18893,9 +18917,9 @@ relation ParserStmt_ok: TC_0 |- parserStatement : % %
 
                 1. Result in: % |- % : TC_1 (callStatementIR as parserStatementIR)
 
-            1. Else Phantom#999
+            1. Else Phantom#1000
 
-          1. Else Phantom#1000
+          1. Else Phantom#1001
 
   6. Case (% has type directApplicationStatement)
 
@@ -18913,9 +18937,9 @@ relation ParserStmt_ok: TC_0 |- parserStatement : % %
 
                 1. Result in: % |- % : TC_1 (directApplicationStatementIR as parserStatementIR)
 
-            1. Else Phantom#1001
+            1. Else Phantom#1002
 
-          1. Else Phantom#1002
+          1. Else Phantom#1003
 
   7. Case (% has type parserBlockStatement)
 
@@ -18955,7 +18979,7 @@ relation ParserStmt_ok: TC_0 |- parserStatement : % %
 
                       1. Result in: % |- % : TC_0 ((if( typedExpressionIR_cond ) parserStatementIR_then) as parserStatementIR)
 
-                  1. Else Phantom#1003
+                  1. Else Phantom#1004
 
           2. Case (% matches pattern `IF(%)%ELSE%`)
 
@@ -18973,7 +18997,7 @@ relation ParserStmt_ok: TC_0 |- parserStatement : % %
 
                         1. Result in: % |- % : TC_0 ((if( typedExpressionIR_cond ) parserStatementIR_then else parserStatementIR_else) as parserStatementIR)
 
-                  1. Else Phantom#1004
+                  1. Else Phantom#1005
 
 relation ParserStmtList_ok: TC_0 |- parserStatementList : % %
 
@@ -19029,11 +19053,11 @@ relation ParserStateList_ok: TC |- parserStateList : %
 
                   1. Result in: % |- % : (parserStateIR)*
 
-            1. Else Phantom#1005
+            1. Else Phantom#1006
 
-          1. Else Phantom#1006
+          1. Else Phantom#1007
 
-        1. Else Phantom#1007
+        1. Else Phantom#1008
 
 relation ParserLocalDecl_ok: TC_0 |- parserLocalDeclaration : % %
 
@@ -19095,11 +19119,11 @@ relation ParserLocalDecl_ok: TC_0 |- parserLocalDeclaration : % %
 
                           1. Result in: % |- % : TC_1 (valueSetDeclarationIR as parserLocalDeclarationIR)
 
-                1. Else Phantom#1008
+                1. Else Phantom#1009
 
-            1. Else Phantom#1009
+            1. Else Phantom#1010
 
-          1. Else Phantom#1010
+          1. Else Phantom#1011
 
 relation ParserLocalDeclList_ok: TC_0 |- parserLocalDeclarationList : % %
 
@@ -19139,11 +19163,11 @@ relation TableKey_ok: TC TBLC_0 |- (expression : name_matchkind annotationList ;
 
                         1. Result in: % % |- % : TBLC_2 tableKeyIR
 
-                1. Else Phantom#1011
+                1. Else Phantom#1012
 
-              1. Else Phantom#1012
+              1. Else Phantom#1013
 
-      1. Else Phantom#1013
+      1. Else Phantom#1014
 
 relation TableKeys_ok: TC tableContext |- (tableKey)* : % %
 
@@ -19153,7 +19177,7 @@ relation TableKeys_ok: TC tableContext |- (tableKey)* : % %
 
     1. Result in: % % |- % : tableContext []
 
-  1. Else Phantom#1014
+  1. Else Phantom#1015
 
   2. If (((tableKey)* matches pattern _ :: _)), then
 
@@ -19165,7 +19189,7 @@ relation TableKeys_ok: TC tableContext |- (tableKey)* : % %
 
           1. Result in: % % |- % : TBLC_2 tableKeyIR_h :: (tableKeyIR_t)*
 
-  2. Else Phantom#1015
+  2. Else Phantom#1016
 
 relation Call_action_partial_ok: TC |- (parameterIR)* @ (argumentIR)* : % , % @ %
 
@@ -19183,9 +19207,9 @@ relation Call_action_partial_ok: TC |- (parameterIR)* @ (argumentIR)* : % , % @ 
 
             1. Result in: % |- % @ % : (parameterIR_data)* , (parameterIR_control)* @ (argumentIR_cast)*
 
-        1. Else Phantom#1016
+        1. Else Phantom#1017
 
-    1. Else Phantom#1017
+    1. Else Phantom#1018
 
 relation TableAction_ok: TC TBLC_0 |- (annotationList tableActionReference ;) : % %
 
@@ -19219,15 +19243,15 @@ relation TableAction_ok: TC TBLC_0 |- (annotationList tableActionReference ;) : 
 
                             1. (Let TBLC_1 be $add_action_tbl(TBLC_0, prefixedNameIR, (parameterIR)*, []))
 
-                              1. (Let tableActionIR be (annotationList_update (prefixedNameIR [] ( [] )) #( (parameterIR_data)* , (parameterIR_control)* );))
+                              1. (Let tableActionIR be (annotationList_update (prefixedNameIR ?() ( [] )) #( (parameterIR_data)* , (parameterIR_control)* );))
 
                                 1. Result in: % % |- % : TBLC_1 tableActionIR
 
-                          1. Else Phantom#1018
+                          1. Else Phantom#1019
 
-                1. Else Phantom#1019
+                1. Else Phantom#1020
 
-            1. Else Phantom#1020
+            1. Else Phantom#1021
 
     2. Case (% matches pattern `%(%)`)
 
@@ -19255,13 +19279,13 @@ relation TableAction_ok: TC TBLC_0 |- (annotationList tableActionReference ;) : 
 
                             1. (Let TBLC_1 be $add_action_tbl(TBLC_0, prefixedNameIR, (parameterIR)*, (argumentIR_cast)*))
 
-                              1. (Let tableActionIR be (annotationList_update (prefixedNameIR [] ( (argumentIR_cast)* )) #( (parameterIR_data)* , (parameterIR_control)* );))
+                              1. (Let tableActionIR be (annotationList_update (prefixedNameIR ?() ( (argumentIR_cast)* )) #( (parameterIR_data)* , (parameterIR_control)* );))
 
                                 1. Result in: % % |- % : TBLC_1 tableActionIR
 
-                1. Else Phantom#1021
+                1. Else Phantom#1022
 
-            1. Else Phantom#1022
+            1. Else Phantom#1023
 
 relation TableActions_ok: TC tableContext |- (tableAction)* : % %
 
@@ -19271,7 +19295,7 @@ relation TableActions_ok: TC tableContext |- (tableAction)* : % %
 
     1. Result in: % % |- % : tableContext []
 
-  1. Else Phantom#1023
+  1. Else Phantom#1024
 
   2. If (((tableAction)* matches pattern _ :: _)), then
 
@@ -19283,7 +19307,7 @@ relation TableActions_ok: TC tableContext |- (tableAction)* : % %
 
           1. Result in: % % |- % : TBLC_2 tableActionIR_h :: (tableActionIR_t)*
 
-  2. Else Phantom#1024
+  2. Else Phantom#1025
 
 relation Call_action_default_ok: TC |- (parameterIR)* @ (argumentIR)* : % , % @ %
 
@@ -19299,7 +19323,7 @@ relation Call_action_default_ok: TC |- (parameterIR)* @ (argumentIR)* : % , % @ 
 
           1. Result in: % |- % @ % : (parameterIR_data)* , (parameterIR_control)* @ (argumentIR_cast)*
 
-      1. Else Phantom#1025
+      1. Else Phantom#1026
 
 relation TableDefaultAction_ok: TC TBLC |- (= expression) : %
 
@@ -19315,9 +19339,9 @@ relation TableDefaultAction_ok: TC TBLC |- (= expression) : %
 
           1. If ((?(([], [])) = $find_action(TBLC, prefixedNameIR))), then
 
-            1. Result in: % % |- % : (prefixedNameIR [] ( [] ))
+            1. Result in: % % |- % : (prefixedNameIR ?() ( [] ))
 
-          1. Else Phantom#1026
+          1. Else Phantom#1027
 
     2. Case (% has type callExpression)
 
@@ -19349,17 +19373,17 @@ relation TableDefaultAction_ok: TC TBLC |- (= expression) : %
 
                                 1. If ((argumentIR_action_data = argumentIR_cast_data))*, then
 
-                                  1. Result in: % % |- % : (prefixedNameIR [] ( (argumentIR_cast)* ))
+                                  1. Result in: % % |- % : (prefixedNameIR ?() ( (argumentIR_cast)* ))
 
-                                1. Else Phantom#1027
+                                1. Else Phantom#1028
 
-                    1. Else Phantom#1028
+                    1. Else Phantom#1029
 
-            1. Else Phantom#1029
+            1. Else Phantom#1030
 
-        1. Else Phantom#1030
+        1. Else Phantom#1031
 
-  1. Else Phantom#1031
+  1. Else Phantom#1032
 
 relation TableEntry_keyset_ok: TC TBLC |- keysetExpression : % %
 
@@ -19379,11 +19403,11 @@ relation TableEntry_keyset_ok: TC TBLC |- keysetExpression : % %
 
               1. Result in: % % |- % : TBLS (simpleKeysetExpressionIR' as keysetExpressionIR)
 
-          1. Else Phantom#1032
+          1. Else Phantom#1033
 
-      1. Else Phantom#1033
+      1. Else Phantom#1034
 
-1. Else Phantom#1034
+1. Else Phantom#1035
 
 2. Group mask: TC TBLC |- keysetExpression : % %
 
@@ -19407,11 +19431,11 @@ relation TableEntry_keyset_ok: TC TBLC |- keysetExpression : % %
 
                     1. Result in: % % |- % : TBLS (simpleKeysetExpressionIR' as keysetExpressionIR)
 
-                1. Else Phantom#1035
+                1. Else Phantom#1036
 
-            1. Else Phantom#1036
+            1. Else Phantom#1037
 
-        1. Else Phantom#1037
+        1. Else Phantom#1038
 
     2. Case (% has type tupleKeysetExpression)
 
@@ -19431,11 +19455,11 @@ relation TableEntry_keyset_ok: TC TBLC |- keysetExpression : % %
 
                     1. Result in: % % |- % : TBLS ((( [simpleKeysetExpressionIR'] )) as keysetExpressionIR)
 
-                1. Else Phantom#1038
+                1. Else Phantom#1039
 
-            1. Else Phantom#1039
+            1. Else Phantom#1040
 
-        1. Else Phantom#1040
+        1. Else Phantom#1041
 
 3. Group range: TC TBLC |- keysetExpression : % %
 
@@ -19459,11 +19483,11 @@ relation TableEntry_keyset_ok: TC TBLC |- keysetExpression : % %
 
                     1. Result in: % % |- % : TBLS (simpleKeysetExpressionIR' as keysetExpressionIR)
 
-                1. Else Phantom#1041
+                1. Else Phantom#1042
 
-            1. Else Phantom#1042
+            1. Else Phantom#1043
 
-        1. Else Phantom#1043
+        1. Else Phantom#1044
 
     2. Case (% has type tupleKeysetExpression)
 
@@ -19483,11 +19507,11 @@ relation TableEntry_keyset_ok: TC TBLC |- keysetExpression : % %
 
                     1. Result in: % % |- % : TBLS ((( [simpleKeysetExpressionIR'] )) as keysetExpressionIR)
 
-                1. Else Phantom#1044
+                1. Else Phantom#1045
 
-            1. Else Phantom#1045
+            1. Else Phantom#1046
 
-        1. Else Phantom#1046
+        1. Else Phantom#1047
 
 4. Group default: TC TBLC |- keysetExpression : % %
 
@@ -19505,7 +19529,7 @@ relation TableEntry_keyset_ok: TC TBLC |- keysetExpression : % %
 
               1. Result in: % % |- % : TBLS ((default) as keysetExpressionIR)
 
-        1. Else Phantom#1047
+        1. Else Phantom#1048
 
       2. If ((((TBLC.mode = (nopri)) \/ (TBLC.mode = (pri))) \/ (TBLC.mode = (prilpm)))), then
 
@@ -19513,7 +19537,7 @@ relation TableEntry_keyset_ok: TC TBLC |- keysetExpression : % %
 
           1. Result in: % % |- % : TBLS ((default) as keysetExpressionIR)
 
-      2. Else Phantom#1048
+      2. Else Phantom#1049
 
     2. Case (% = (((default)) as keysetExpression))
 
@@ -19527,7 +19551,7 @@ relation TableEntry_keyset_ok: TC TBLC |- keysetExpression : % %
 
               1. Result in: % % |- % : TBLS ((( [(default)] )) as keysetExpressionIR)
 
-        1. Else Phantom#1049
+        1. Else Phantom#1050
 
       2. If ((((TBLC.mode = (nopri)) \/ (TBLC.mode = (pri))) \/ (TBLC.mode = (prilpm)))), then
 
@@ -19535,9 +19559,9 @@ relation TableEntry_keyset_ok: TC TBLC |- keysetExpression : % %
 
           1. Result in: % % |- % : TBLS ((( [(default)] )) as keysetExpressionIR)
 
-      2. Else Phantom#1050
+      2. Else Phantom#1051
 
-  1. Else Phantom#1051
+  1. Else Phantom#1052
 
 5. Group dontcare: TC TBLC |- keysetExpression : % %
 
@@ -19553,7 +19577,7 @@ relation TableEntry_keyset_ok: TC TBLC |- keysetExpression : % %
 
             1. Result in: % % |- % : TBLS ((_) as keysetExpressionIR)
 
-        1. Else Phantom#1052
+        1. Else Phantom#1053
 
       2. If ((((TBLC.mode = (nopri)) \/ (TBLC.mode = (pri))) \/ (TBLC.mode = (prilpm)))), then
 
@@ -19561,7 +19585,7 @@ relation TableEntry_keyset_ok: TC TBLC |- keysetExpression : % %
 
           1. Result in: % % |- % : TBLS ((_) as keysetExpressionIR)
 
-      2. Else Phantom#1053
+      2. Else Phantom#1054
 
     2. Case (% = (((_)) as keysetExpression))
 
@@ -19573,7 +19597,7 @@ relation TableEntry_keyset_ok: TC TBLC |- keysetExpression : % %
 
             1. Result in: % % |- % : TBLS ((( [(_)] )) as keysetExpressionIR)
 
-        1. Else Phantom#1054
+        1. Else Phantom#1055
 
       2. If ((((TBLC.mode = (nopri)) \/ (TBLC.mode = (pri))) \/ (TBLC.mode = (prilpm)))), then
 
@@ -19581,9 +19605,9 @@ relation TableEntry_keyset_ok: TC TBLC |- keysetExpression : % %
 
           1. Result in: % % |- % : TBLS ((( [(_)] )) as keysetExpressionIR)
 
-      2. Else Phantom#1055
+      2. Else Phantom#1056
 
-  1. Else Phantom#1056
+  1. Else Phantom#1057
 
 6. If ((keysetExpression has type tupleKeysetExpression)), then
 
@@ -19605,11 +19629,11 @@ relation TableEntry_keyset_ok: TC TBLC |- keysetExpression : % %
 
                   1. Result in: % % |- % : TBLS ((( (simpleKeysetExpressionIR)* )) as keysetExpressionIR)
 
-              1. Else Phantom#1057
+              1. Else Phantom#1058
 
-    1. Else Phantom#1058
+    1. Else Phantom#1059
 
-6. Else Phantom#1059
+6. Else Phantom#1060
 
 relation TableEntry_action_ok: TC TBLC |- tableActionReference : %
 
@@ -19625,9 +19649,9 @@ relation TableEntry_action_ok: TC TBLC |- tableActionReference : %
 
           1. If ((?(([], [])) = $find_action(TBLC, prefixedNameIR))), then
 
-            1. Result in: % % |- % : (prefixedNameIR [] ( [] ))
+            1. Result in: % % |- % : (prefixedNameIR ?() ( [] ))
 
-          1. Else Phantom#1060
+          1. Else Phantom#1061
 
     2. Case (% matches pattern `%(%)`)
 
@@ -19651,11 +19675,11 @@ relation TableEntry_action_ok: TC TBLC |- tableActionReference : %
 
                         1. If ((argumentIR_action_data = argumentIR_cast_data))*, then
 
-                          1. Result in: % % |- % : (prefixedNameIR [] ( (argumentIR_cast)* ))
+                          1. Result in: % % |- % : (prefixedNameIR ?() ( (argumentIR_cast)* ))
 
-                        1. Else Phantom#1061
+                        1. Else Phantom#1062
 
-            1. Else Phantom#1062
+            1. Else Phantom#1063
 
 relation TableEntry_priority_ok: TC tableContext TBLS |- (tableEntryPriority)? : % %
 
@@ -19669,7 +19693,7 @@ relation TableEntry_priority_ok: TC tableContext TBLS |- (tableEntryPriority)? :
 
         1. Result in: % % % |- % : tableContext ?()
 
-      1. Else Phantom#1063
+      1. Else Phantom#1064
 
       2. (Let matchMode be tableContext.mode)
 
@@ -19681,9 +19705,9 @@ relation TableEntry_priority_ok: TC tableContext TBLS |- (tableEntryPriority)? :
 
               1. Result in: % % % |- % : tableContext ?((priority= (d (n_prefix as int)) :))
 
-          1. Else Phantom#1064
+          1. Else Phantom#1065
 
-        1. Else Phantom#1065
+        1. Else Phantom#1066
 
       3. If (((tableContext.mode = (pri)) \/ (tableContext.mode = (prilpm)))), then
 
@@ -19707,7 +19731,7 @@ relation TableEntry_priority_ok: TC tableContext TBLS |- (tableEntryPriority)? :
 
                           1. Result in: % % % |- % : TBLC_1 ?((priority= (d (n as int)) :))
 
-                    1. Else Phantom#1066
+                    1. Else Phantom#1067
 
           2. Case (% =/= [])
 
@@ -19727,9 +19751,9 @@ relation TableEntry_priority_ok: TC tableContext TBLS |- (tableEntryPriority)? :
 
                           1. Result in: % % % |- % : TBLC_1 ?((priority= (d (n as int)) :))
 
-                    1. Else Phantom#1067
+                    1. Else Phantom#1068
 
-      3. Else Phantom#1068
+      3. Else Phantom#1069
 
   2. Case (% matches pattern (_))
 
@@ -19763,7 +19787,7 @@ relation TableEntry_priority_ok: TC tableContext TBLS |- (tableEntryPriority)? :
 
                                 1. Result in: % % % |- % : TBLC_2 ?((priority= integerLiteral :))
 
-                        1. Else Phantom#1069
+                        1. Else Phantom#1070
 
                     2. Case (% =/= [])
 
@@ -19779,13 +19803,13 @@ relation TableEntry_priority_ok: TC tableContext TBLS |- (tableEntryPriority)? :
 
                                 1. Result in: % % % |- % : TBLC_1 ?((priority= integerLiteral :))
 
-                          1. Else Phantom#1070
+                          1. Else Phantom#1071
 
-                      1. Else Phantom#1071
+                      1. Else Phantom#1072
 
-                1. Else Phantom#1072
+                1. Else Phantom#1073
 
-              1. Else Phantom#1073
+              1. Else Phantom#1074
 
         2. Case (% matches pattern `PRIORITY=(%):`)
 
@@ -19823,11 +19847,11 @@ relation TableEntry_priority_ok: TC tableContext TBLS |- (tableEntryPriority)? :
 
                                           1. Result in: % % % |- % : TBLC_2 ?((priority= (d (n as int)) :))
 
-                                  1. Else Phantom#1074
+                                  1. Else Phantom#1075
 
-                            1. Else Phantom#1075
+                            1. Else Phantom#1076
 
-                        1. Else Phantom#1076
+                        1. Else Phantom#1077
 
                     2. Case (% =/= [])
 
@@ -19853,17 +19877,17 @@ relation TableEntry_priority_ok: TC tableContext TBLS |- (tableEntryPriority)? :
 
                                           1. Result in: % % % |- % : TBLC_1 ?((priority= (d (n as int)) :))
 
-                                    1. Else Phantom#1077
+                                    1. Else Phantom#1078
 
-                              1. Else Phantom#1078
+                              1. Else Phantom#1079
 
-                          1. Else Phantom#1079
+                          1. Else Phantom#1080
 
-                      1. Else Phantom#1080
+                      1. Else Phantom#1081
 
-                1. Else Phantom#1081
+                1. Else Phantom#1082
 
-              1. Else Phantom#1082
+              1. Else Phantom#1083
 
 relation TableEntry_ok: TC TBLC_0 |- tableEntry : % %
 
@@ -19911,7 +19935,7 @@ relation TableEntries_ok: TC tableContext |- (tableEntry)* : % %
 
     1. Result in: % % |- % : tableContext []
 
-  1. Else Phantom#1083
+  1. Else Phantom#1084
 
   2. If (((tableEntry)* matches pattern _ :: _)), then
 
@@ -19923,7 +19947,7 @@ relation TableEntries_ok: TC tableContext |- (tableEntry)* : % %
 
           1. Result in: % % |- % : TBLC_2 tableEntryIR_h :: (tableEntryIR_t)*
 
-  2. Else Phantom#1084
+  2. Else Phantom#1085
 
 relation TableProperty_ok: TC TBLC_0 |- tableProperty : % %
 
@@ -19973,7 +19997,7 @@ relation TableProperty_ok: TC TBLC_0 |- tableProperty : % %
 
                     1. Result in: % % |- % : TBLC_3 ((annotationList constOptIR entries={ (tableEntryIR)* }) as tablePropertyIR)
 
-          1. Else Phantom#1085
+          1. Else Phantom#1086
 
   4. Case (% matches pattern `%%%%;`)
 
@@ -19991,7 +20015,7 @@ relation TableProperty_ok: TC TBLC_0 |- tableProperty : % %
 
                 1. Result in: % % |- % : TBLC_0 tablePropertyIR
 
-        1. Else Phantom#1086
+        1. Else Phantom#1087
 
     2. (Let (annotationList constOpt tableCustomName (= expression) ;) be tableProperty)
 
@@ -20021,13 +20045,13 @@ relation TableProperty_ok: TC TBLC_0 |- tableProperty : % %
 
                               1. Result in: % % |- % : TBLC_1 tablePropertyIR
 
-                    1. Else Phantom#1087
+                    1. Else Phantom#1088
 
-                1. Else Phantom#1088
+                1. Else Phantom#1089
 
-              1. Else Phantom#1089
+              1. Else Phantom#1090
 
-        1. Else Phantom#1090
+        1. Else Phantom#1091
 
         2. If (("priority_delta" = $tableCustomName(tableCustomName))), then
 
@@ -20063,17 +20087,17 @@ relation TableProperty_ok: TC TBLC_0 |- tableProperty : % %
 
                                         1. Result in: % % |- % : TBLC_1 tablePropertyIR
 
-                                1. Else Phantom#1091
+                                1. Else Phantom#1092
 
-                            1. Else Phantom#1092
+                            1. Else Phantom#1093
 
-                      1. Else Phantom#1093
+                      1. Else Phantom#1094
 
-                  1. Else Phantom#1094
+                  1. Else Phantom#1095
 
-              1. Else Phantom#1095
+              1. Else Phantom#1096
 
-        2. Else Phantom#1096
+        2. Else Phantom#1097
 
       2. Group size-and-others: TC TBLC_0 |- (annotationList constOpt tableCustomName (= expression) ;) : % %
 
@@ -20093,9 +20117,9 @@ relation TableProperty_ok: TC TBLC_0 |- tableProperty : % %
 
                       1. Result in: % % |- % : TBLC_0 tablePropertyIR
 
-                1. Else Phantom#1097
+                1. Else Phantom#1098
 
-        1. Else Phantom#1098
+        1. Else Phantom#1099
 
         2. (Let nameIR be $tableCustomName(tableCustomName))
 
@@ -20109,7 +20133,7 @@ relation TableProperty_ok: TC TBLC_0 |- tableProperty : % %
 
                   1. Result in: % % |- % : TBLC_0 tablePropertyIR
 
-          1. Else Phantom#1099
+          1. Else Phantom#1100
 
 relation TableProperties_ok: TC tableContext |- (tableProperty)* : % %
 
@@ -20119,7 +20143,7 @@ relation TableProperties_ok: TC tableContext |- (tableProperty)* : % %
 
     1. Result in: % % |- % : tableContext []
 
-  1. Else Phantom#1100
+  1. Else Phantom#1101
 
   2. If (((tableProperty)* matches pattern _ :: _)), then
 
@@ -20131,7 +20155,7 @@ relation TableProperties_ok: TC tableContext |- (tableProperty)* : % %
 
           1. Result in: % % |- % : TBLC_2 tablePropertyIR_h :: (tablePropertyIR_t)*
 
-  2. Else Phantom#1101
+  2. Else Phantom#1102
 
 relation Table_ok: TC |- (tableProperty)* : % %
 
@@ -20149,7 +20173,7 @@ relation Table_ok: TC |- (tableProperty)* : % %
 
             1. (TableProperties_ok: TC TBLC_0 |- (tableProperty)* : TBLC_1 (tablePropertyIR)*)
 
-              1. (Let tablePropertyIR_default_action be (((`empty) ?() default_action= ((` "NoAction") [] ( [] )) ;) as tablePropertyIR))
+              1. (Let tablePropertyIR_default_action be (((`empty) ?() default_action= ((` "NoAction") ?() ( [] )) ;) as tablePropertyIR))
 
                 1. (Let (TBLC_2, (tablePropertyIR_updated)*) be $insert_NoAction_tablePropertyIR(TBLC_1, (tablePropertyIR)*))
 
@@ -20163,11 +20187,11 @@ relation Table_ok: TC |- (tableProperty)* : % %
 
               1. Result in: % |- % : TBLC_1 (tablePropertyIR)*
 
-      1. Else Phantom#1102
+      1. Else Phantom#1103
 
-    1. Else Phantom#1103
+    1. Else Phantom#1104
 
-  1. Else Phantom#1104
+  1. Else Phantom#1105
 
 relation TableType_ok: TC_0 TBLC |- name : % %
 
@@ -20299,11 +20323,11 @@ relation VarDecl_ok: p TC_0 |- (annotationList type name initializerOpt ;) : % %
 
                     1. Result in: % % |- % : TC_1 variableDeclarationIR
 
-            1. Else Phantom#1105
+            1. Else Phantom#1106
 
-          1. Else Phantom#1106
+          1. Else Phantom#1107
 
-        1. Else Phantom#1107
+        1. Else Phantom#1108
 
     2. Case (% has type initializer)
 
@@ -20333,13 +20357,13 @@ relation VarDecl_ok: p TC_0 |- (annotationList type name initializerOpt ;) : % %
 
                               1. Result in: % % |- % : TC_1 variableDeclarationIR
 
-                    1. Else Phantom#1108
+                    1. Else Phantom#1109
 
-              1. Else Phantom#1109
+              1. Else Phantom#1110
 
-            1. Else Phantom#1110
+            1. Else Phantom#1111
 
-          1. Else Phantom#1111
+          1. Else Phantom#1112
 
 relation ConstDecl_ok: p TC_0 |- (annotationList const type name (= expression_value) ;) : % %
 
@@ -20371,13 +20395,13 @@ relation ConstDecl_ok: p TC_0 |- (annotationList const type name (= expression_v
 
                           1. Result in: % % |- % : TC_1 constantDeclarationIR
 
-              1. Else Phantom#1112
+              1. Else Phantom#1113
 
-          1. Else Phantom#1113
+          1. Else Phantom#1114
 
-      1. Else Phantom#1114
+      1. Else Phantom#1115
 
-    1. Else Phantom#1115
+    1. Else Phantom#1116
 
 relation InstDecl_ok: p TC_0 |- instantiation : % %
 
@@ -20407,7 +20431,7 @@ relation InstDecl_ok: p TC_0 |- instantiation : % %
 
                 1. Result in: % % |- % : TC_1 instantiationIR
 
-        1. Else Phantom#1116
+        1. Else Phantom#1117
 
     2. Case (% matches pattern `%%(%)%%;`)
 
@@ -20431,7 +20455,7 @@ relation InstDecl_ok: p TC_0 |- instantiation : % %
 
                 1. Result in: % % |- % : TC_1 instantiationIR
 
-        1. Else Phantom#1117
+        1. Else Phantom#1118
 
 relation FuncDecl_ok: p TC_0 |- (annotationList (typeOrVoid name typeParameterListOpt ( parameterList )) blockStatement) : % %
 
@@ -20465,11 +20489,11 @@ relation FuncDecl_ok: p TC_0 |- (annotationList (typeOrVoid name typeParameterLi
 
                             1. Result in: % % |- % : TC_4 functionDeclarationIR
 
-                      1. Else Phantom#1118
+                      1. Else Phantom#1119
 
-              1. Else Phantom#1119
+              1. Else Phantom#1120
 
-      1. Else Phantom#1120
+      1. Else Phantom#1121
 
 relation ActionDecl_ok: p TC_0 |- (annotationList action name ( parameterList ) blockStatement) : % %
 
@@ -20497,9 +20521,9 @@ relation ActionDecl_ok: p TC_0 |- (annotationList action name ( parameterList ) 
 
                       1. Result in: % % |- % : TC_3 actionDeclarationIR
 
-                1. Else Phantom#1121
+                1. Else Phantom#1122
 
-      1. Else Phantom#1122
+      1. Else Phantom#1123
 
 relation Decl_ok: TC_0 |- declaration : % %
 
@@ -20567,7 +20591,7 @@ relation Decl_ok: TC_0 |- declaration : % %
 
                       1. Result in: % |- % : TC_1 ((error{ (nameIR)* }) as declarationIR)
 
-            1. Else Phantom#1123
+            1. Else Phantom#1124
 
   6. Case (% has type matchKindDeclaration)
 
@@ -20589,7 +20613,7 @@ relation Decl_ok: TC_0 |- declaration : % %
 
                     1. Result in: % |- % : TC_1 ((match_kind{ (nameIR)* }) as declarationIR)
 
-            1. Else Phantom#1124
+            1. Else Phantom#1125
 
   7. Case (% has type externFunctionDeclaration)
 
@@ -20619,9 +20643,9 @@ relation Decl_ok: TC_0 |- declaration : % %
 
                             1. Result in: % |- % : TC_4 (externFunctionDeclarationIR as declarationIR)
 
-                      1. Else Phantom#1125
+                      1. Else Phantom#1126
 
-              1. Else Phantom#1126
+              1. Else Phantom#1127
 
   8. Case (% has type externObjectDeclaration)
 
@@ -20669,7 +20693,7 @@ relation Decl_ok: TC_0 |- declaration : % %
 
                                               1. Result in: % |- % : TC_6 (externObjectDeclarationIR as declarationIR)
 
-                    1. Else Phantom#1127
+                    1. Else Phantom#1128
 
   9. Case (% has type parserDeclaration)
 
@@ -20717,15 +20741,15 @@ relation Decl_ok: TC_0 |- declaration : % %
 
                                               1. Result in: % |- % : TC_6 (parserDeclarationIR as declarationIR)
 
-                                        1. Else Phantom#1128
+                                        1. Else Phantom#1129
 
-                            1. Else Phantom#1129
+                            1. Else Phantom#1130
 
-                  1. Else Phantom#1130
+                  1. Else Phantom#1131
 
-              1. Else Phantom#1131
+              1. Else Phantom#1132
 
-          1. Else Phantom#1132
+          1. Else Phantom#1133
 
   10. Case (% has type controlDeclaration)
 
@@ -20773,15 +20797,15 @@ relation Decl_ok: TC_0 |- declaration : % %
 
                                               1. Result in: % |- % : TC_6 (controlDeclarationIR as declarationIR)
 
-                                        1. Else Phantom#1133
+                                        1. Else Phantom#1134
 
-                            1. Else Phantom#1134
+                            1. Else Phantom#1135
 
-                  1. Else Phantom#1135
+                  1. Else Phantom#1136
 
-              1. Else Phantom#1136
+              1. Else Phantom#1137
 
-          1. Else Phantom#1137
+          1. Else Phantom#1138
 
   11. Case (% has type enumTypeDeclaration)
 
@@ -20819,7 +20843,7 @@ relation Decl_ok: TC_0 |- declaration : % %
 
                                     1. Result in: % |- % : TC_2 (enumTypeDeclarationIR as declarationIR)
 
-                      1. Else Phantom#1138
+                      1. Else Phantom#1139
 
         2. Case (% matches pattern `%ENUM%%{%%}`)
 
@@ -20857,11 +20881,11 @@ relation Decl_ok: TC_0 |- declaration : % %
 
                                           1. Result in: % |- % : TC_3 (enumTypeDeclarationIR as declarationIR)
 
-                                    1. Else Phantom#1139
+                                    1. Else Phantom#1140
 
-                    1. Else Phantom#1140
+                    1. Else Phantom#1141
 
-                  1. Else Phantom#1141
+                  1. Else Phantom#1142
 
   12. Case (% has type structTypeDeclaration)
 
@@ -20891,9 +20915,9 @@ relation Decl_ok: TC_0 |- declaration : % %
 
                             1. Result in: % |- % : TC_2 (structTypeDeclarationIR as declarationIR)
 
-                      1. Else Phantom#1142
+                      1. Else Phantom#1143
 
-              1. Else Phantom#1143
+              1. Else Phantom#1144
 
   13. Case (% has type headerTypeDeclaration)
 
@@ -20923,9 +20947,9 @@ relation Decl_ok: TC_0 |- declaration : % %
 
                             1. Result in: % |- % : TC_2 (headerTypeDeclarationIR as declarationIR)
 
-                      1. Else Phantom#1144
+                      1. Else Phantom#1145
 
-              1. Else Phantom#1145
+              1. Else Phantom#1146
 
   14. Case (% has type headerUnionTypeDeclaration)
 
@@ -20955,9 +20979,9 @@ relation Decl_ok: TC_0 |- declaration : % %
 
                             1. Result in: % |- % : TC_2 (headerUnionTypeDeclarationIR as declarationIR)
 
-                      1. Else Phantom#1146
+                      1. Else Phantom#1147
 
-              1. Else Phantom#1147
+              1. Else Phantom#1148
 
   15. Case (% has type typedefDeclaration)
 
@@ -20997,11 +21021,11 @@ relation Decl_ok: TC_0 |- declaration : % %
 
                                       1. Result in: % |- % : TC_1 (typedefDeclarationIR as declarationIR)
 
-                                1. Else Phantom#1148
+                                1. Else Phantom#1149
 
-                          1. Else Phantom#1149
+                          1. Else Phantom#1150
 
-                        1. Else Phantom#1150
+                        1. Else Phantom#1151
 
                 2. Case (% has type derivedTypeDeclaration)
 
@@ -21043,7 +21067,7 @@ relation Decl_ok: TC_0 |- declaration : % %
 
                                                       1. Result in: % |- % : TC_1 (typedefDeclarationIR as declarationIR)
 
-                                                1. Else Phantom#1151
+                                                1. Else Phantom#1152
 
                                         2. Case false
 
@@ -21063,15 +21087,15 @@ relation Decl_ok: TC_0 |- declaration : % %
 
                                                         1. Result in: % |- % : TC_1 (typedefDeclarationIR as declarationIR)
 
-                                                  1. Else Phantom#1152
+                                                  1. Else Phantom#1153
 
-                                          1. Else Phantom#1153
+                                          1. Else Phantom#1154
 
-                                  1. Else Phantom#1154
+                                  1. Else Phantom#1155
 
-                            1. Else Phantom#1155
+                            1. Else Phantom#1156
 
-                      1. Else Phantom#1156
+                      1. Else Phantom#1157
 
         2. Case (% matches pattern `%TYPE%%;`)
 
@@ -21099,11 +21123,11 @@ relation Decl_ok: TC_0 |- declaration : % %
 
                                 1. Result in: % |- % : TC_1 (typedefDeclarationIR as declarationIR)
 
-                          1. Else Phantom#1157
+                          1. Else Phantom#1158
 
-                    1. Else Phantom#1158
+                    1. Else Phantom#1159
 
-                  1. Else Phantom#1159
+                  1. Else Phantom#1160
 
   16. Case (% has type parserTypeDeclaration)
 
@@ -21129,7 +21153,7 @@ relation Decl_ok: TC_0 |- declaration : % %
 
                         1. Result in: % |- % : TC_4 (parserTypeDeclarationIR as declarationIR)
 
-                  1. Else Phantom#1160
+                  1. Else Phantom#1161
 
   17. Case (% has type controlTypeDeclaration)
 
@@ -21155,7 +21179,7 @@ relation Decl_ok: TC_0 |- declaration : % %
 
                         1. Result in: % |- % : TC_4 (controlTypeDeclarationIR as declarationIR)
 
-                  1. Else Phantom#1161
+                  1. Else Phantom#1162
 
   18. Case (% has type packageTypeDeclaration)
 
@@ -21195,9 +21219,9 @@ relation Decl_ok: TC_0 |- declaration : % %
 
                                       1. Result in: % |- % : TC_5 (packageTypeDeclarationIR as declarationIR)
 
-                                1. Else Phantom#1162
+                                1. Else Phantom#1163
 
-                      1. Else Phantom#1163
+                      1. Else Phantom#1164
 
 relation Decls_ok: typingContext |- (declaration)* : % %
 
@@ -21207,7 +21231,7 @@ relation Decls_ok: typingContext |- (declaration)* : % %
 
     1. Result in: % |- % : typingContext []
 
-  1. Else Phantom#1164
+  1. Else Phantom#1165
 
   2. If (((declaration)* matches pattern _ :: _)), then
 
@@ -21219,7 +21243,7 @@ relation Decls_ok: typingContext |- (declaration)* : % %
 
           1. Result in: % |- % : TC_2 declarationIR_h :: (declarationIR_t)*
 
-  2. Else Phantom#1165
+  2. Else Phantom#1166
 
 relation Program_ok: |- p4program : %
 
@@ -21251,9 +21275,9 @@ relation Call_convention_expr_ok: p TC actctxt |- (annotationList direction type
 
           1. Result in: % % % |- % @ % : typedExpressionIR_arg_cast
 
-      1. Else Phantom#1166
+      1. Else Phantom#1167
 
-1. Else Phantom#1167
+1. Else Phantom#1168
 
 2. Group out-inout: p TC actctxt |- (annotationList direction typeIR_param id parameterInitializerOptIR) @ typedExpressionIR_arg : %
 
@@ -21267,11 +21291,11 @@ relation Call_convention_expr_ok: p TC actctxt |- (annotationList direction type
 
           1. Result in: % % % |- % @ % : typedExpressionIR_arg
 
-        1. Else Phantom#1168
+        1. Else Phantom#1169
 
-      1. Else Phantom#1169
+      1. Else Phantom#1170
 
-  1. Else Phantom#1170
+  1. Else Phantom#1171
 
 3. If ((direction matches pattern ``EMPTY`)), then
 
@@ -21289,7 +21313,7 @@ relation Call_convention_expr_ok: p TC actctxt |- (annotationList direction type
 
               1. Result in: % % % |- % @ % : typedExpressionIR_arg_cast
 
-          1. Else Phantom#1171
+          1. Else Phantom#1172
 
       2. Case (% matches pattern `NOACTION`)
 
@@ -21303,11 +21327,11 @@ relation Call_convention_expr_ok: p TC actctxt |- (annotationList direction type
 
                 1. Result in: % % % |- % @ % : typedExpressionIR_arg_cast
 
-              1. Else Phantom#1172
+              1. Else Phantom#1173
 
-          1. Else Phantom#1173
+          1. Else Phantom#1174
 
-3. Else Phantom#1174
+3. Else Phantom#1175
 
 relation Call_convention_argument_ok: p TC actctxt |- parameterIR @ argumentIR : %
 
@@ -21345,7 +21369,7 @@ relation Call_convention_argument_ok: p TC actctxt |- parameterIR @ argumentIR :
 
             1. Result in: % % % |- % @ % : (nameIR =_)
 
-          1. Else Phantom#1175
+          1. Else Phantom#1176
 
   4. Case (% matches pattern `_`)
 
@@ -21357,7 +21381,7 @@ relation Call_convention_argument_ok: p TC actctxt |- parameterIR @ argumentIR :
 
           1. Result in: % % % |- % @ % : (_)
 
-        1. Else Phantom#1176
+        1. Else Phantom#1177
 
 relation Call_convention_ok: p TC actctxt |- (parameterIR)* @ (argumentIR)* : %
 
@@ -21369,9 +21393,9 @@ relation Call_convention_ok: p TC actctxt |- (parameterIR)* @ (argumentIR)* : %
 
       1. Result in: % % % |- % @ % : []
 
-    1. Else Phantom#1177
+    1. Else Phantom#1178
 
-  1. Else Phantom#1178
+  1. Else Phantom#1179
 
   2. If (((parameterIR)* matches pattern _ :: _)), then
 
@@ -21387,9 +21411,9 @@ relation Call_convention_ok: p TC actctxt |- (parameterIR)* @ (argumentIR)* : %
 
               1. Result in: % % % |- % @ % : argumentIR_h_cast :: (argumentIR_t_cast)*
 
-      1. Else Phantom#1179
+      1. Else Phantom#1180
 
-  2. Else Phantom#1180
+  2. Else Phantom#1181
 
 def $is_static_callableTypeIR(callableTypeIR)
 
@@ -21477,13 +21501,13 @@ relation CallableTarget_ok: p TC |- callableTarget : %
 
           1. Result in: % % |- % : (( callableTargetIR ))
 
-  1. Else Phantom#1181
+  1. Else Phantom#1182
 
   2. If ((callableTarget = ((this) as callableTarget))), then
 
     1. Result in: % % |- % : ((` "this") as callableTargetIR)
 
-  2. Else Phantom#1182
+  2. Else Phantom#1183
 
 relation CallableTarget_lvalue_ok: p TC |- lvalue : %
 
@@ -21521,13 +21545,13 @@ relation CallableType_ok: p TC |- callableTargetIR < (typeArgumentIR)* >( (argum
 
                       1. Result in: % % |- % < % >( % ): (actionTypeIR as callableTypeIR) <# [] >(# (id_default)* # (id_optional)* )
 
-                    1. Else Phantom#1183
+                    1. Else Phantom#1184
 
-                1. Else Phantom#1184
+                1. Else Phantom#1185
 
-            1. Else Phantom#1185
+            1. Else Phantom#1186
 
-      1. Else Phantom#1186
+      1. Else Phantom#1187
 
       2. Group functionTypeIR: p TC |- (prefixedNameIR as callableTargetIR) < (typeArgumentIR)* >( (argumentIR)* ): % <# % >(# % # % )
 
@@ -21553,13 +21577,13 @@ relation CallableType_ok: p TC |- callableTargetIR < (typeArgumentIR)* >( (argum
 
                             1. Result in: % % |- % < % >( % ): (functionTypeIR as callableTypeIR) <# (typeId_impl)* >(# (id_default)* # (id_optional)* )
 
-                          1. Else Phantom#1187
+                          1. Else Phantom#1188
 
-                    1. Else Phantom#1188
+                    1. Else Phantom#1189
 
-              1. Else Phantom#1189
+              1. Else Phantom#1190
 
-          1. Else Phantom#1190
+          1. Else Phantom#1191
 
   2. Case (% matches pattern `%.%`)
 
@@ -21587,9 +21611,9 @@ relation CallableType_ok: p TC |- callableTargetIR < (typeArgumentIR)* >( (argum
 
                           1. Result in: % % |- % < % >( % ): (methodTypeIR as callableTypeIR) <# [] >(# [] # [] )
 
-                      1. Else Phantom#1191
+                      1. Else Phantom#1192
 
-                    1. Else Phantom#1192
+                    1. Else Phantom#1193
 
               2. Case (% is in ["isValid"])
 
@@ -21611,7 +21635,7 @@ relation CallableType_ok: p TC |- callableTargetIR < (typeArgumentIR)* >( (argum
 
                           1. Result in: % % |- % < % >( % ): (methodTypeIR as callableTypeIR) <# [] >(# [] # [] )
 
-                    1. Else Phantom#1193
+                    1. Else Phantom#1194
 
               3. Case (% is in ["setValid", "setInvalid"])
 
@@ -21625,11 +21649,11 @@ relation CallableType_ok: p TC |- callableTargetIR < (typeArgumentIR)* >( (argum
 
                         1. Result in: % % |- % < % >( % ): (methodTypeIR as callableTypeIR) <# [] >(# [] # [] )
 
-                    1. Else Phantom#1194
+                    1. Else Phantom#1195
 
-            1. Else Phantom#1195
+            1. Else Phantom#1196
 
-          1. Else Phantom#1196
+          1. Else Phantom#1197
 
           2. If (((argumentIR)* matches pattern [ _/1 ])), then
 
@@ -21647,13 +21671,13 @@ relation CallableType_ok: p TC |- callableTargetIR < (typeArgumentIR)* >( (argum
 
                         1. Result in: % % |- % < % >( % ): (methodTypeIR as callableTypeIR) <# [] >(# [] # [] )
 
-                  1. Else Phantom#1197
+                  1. Else Phantom#1198
 
-            1. Else Phantom#1198
+            1. Else Phantom#1199
 
-          2. Else Phantom#1199
+          2. Else Phantom#1200
 
-      1. Else Phantom#1200
+      1. Else Phantom#1201
 
       2. Group externMethodTypeIR: p TC |- (typedExpressionIR_base . nameIR) < (typeArgumentIR)* >( (argumentIR)* ): % <# % >(# % # % )
 
@@ -21685,13 +21709,13 @@ relation CallableType_ok: p TC |- callableTargetIR < (typeArgumentIR)* >( (argum
 
                                   1. Result in: % % |- % < % >( % ): (externMethodTypeIR as callableTypeIR) <# (typeId_impl)* >(# (id_default)* # (id_optional)* )
 
-                                1. Else Phantom#1201
+                                1. Else Phantom#1202
 
-                          1. Else Phantom#1202
+                          1. Else Phantom#1203
 
-                    1. Else Phantom#1203
+                    1. Else Phantom#1204
 
-            1. Else Phantom#1204
+            1. Else Phantom#1205
 
       3. If ((nameIR = "apply")), then
 
@@ -21723,9 +21747,9 @@ relation CallableType_ok: p TC |- callableTargetIR < (typeArgumentIR)* >( (argum
 
                                   1. Result in: % % |- % < % >( % ): (parserApplyMethodTypeIR as callableTypeIR) <# [] >(# (id_default)* # (id_optional)* )
 
-                              1. Else Phantom#1205
+                              1. Else Phantom#1206
 
-                1. Else Phantom#1206
+                1. Else Phantom#1207
 
           2. Group controlApplyMethodTypeIR: p TC |- (typedExpressionIR_base . "apply") < [] >( (argumentIR)* ): % <# % >(# % # % )
 
@@ -21753,9 +21777,9 @@ relation CallableType_ok: p TC |- callableTargetIR < (typeArgumentIR)* >( (argum
 
                                   1. Result in: % % |- % < % >( % ): (controlApplyMethodTypeIR as callableTypeIR) <# [] >(# (id_default)* # (id_optional)* )
 
-                              1. Else Phantom#1207
+                              1. Else Phantom#1208
 
-                1. Else Phantom#1208
+                1. Else Phantom#1209
 
           3. If (((argumentIR)* matches pattern [])), then
 
@@ -21773,13 +21797,13 @@ relation CallableType_ok: p TC |- callableTargetIR < (typeArgumentIR)* >( (argum
 
                         1. Result in: % % |- % < % >( % ): (tableApplyMethodTypeIR as callableTypeIR) <# [] >(# [] # [] )
 
-                  1. Else Phantom#1209
+                  1. Else Phantom#1210
 
-          3. Else Phantom#1210
+          3. Else Phantom#1211
 
-        1. Else Phantom#1211
+        1. Else Phantom#1212
 
-      3. Else Phantom#1212
+      3. Else Phantom#1213
 
   3. Case (% matches pattern `(%)`)
 
@@ -21791,7 +21815,7 @@ relation CallableType_ok: p TC |- callableTargetIR < (typeArgumentIR)* >( (argum
 
           1. Result in: % % |- % < % >( % ): callableTypeIR <# (typeId_inserted)* >(# (id_default)* # (id_optional)* )
 
-1. Else Phantom#1213
+1. Else Phantom#1214
 
 relation Call_ok: p TC |- callableTypeIR < (typeArgumentIR)* # (typeId)* >( (argumentIR)* # (id_default)* # (id_optional)* ): % < % >( % )
 
@@ -21817,11 +21841,11 @@ relation Call_ok: p TC |- callableTypeIR < (typeArgumentIR)* # (typeId)* >( (arg
 
                     1. Result in: % % |- % < % # % >( % # % # % ): ((void) as typeIR) < [] >( (argumentIR_cast)* )
 
-                1. Else Phantom#1214
+                1. Else Phantom#1215
 
-        1. Else Phantom#1215
+        1. Else Phantom#1216
 
-      1. Else Phantom#1216
+      1. Else Phantom#1217
 
   2. Case (% has type definedFunctionTypeIR)
 
@@ -21857,11 +21881,11 @@ relation Call_ok: p TC |- callableTypeIR < (typeArgumentIR)* # (typeId)* >( (arg
 
                                   1. Result in: % % |- % < % # % >( % # % # % ): typeIR_ret_inferred < (typeArgumentIR_inferred)* >( (argumentIR_cast)* )
 
-                              1. Else Phantom#1217
+                              1. Else Phantom#1218
 
-                            1. Else Phantom#1218
+                            1. Else Phantom#1219
 
-                1. Else Phantom#1219
+                1. Else Phantom#1220
 
   3. Case (% has type externFunctionTypeIR)
 
@@ -21897,11 +21921,11 @@ relation Call_ok: p TC |- callableTypeIR < (typeArgumentIR)* # (typeId)* >( (arg
 
                                   1. Result in: % % |- % < % # % >( % # % # % ): typeIR_ret_inferred < (typeArgumentIR_inferred)* >( (argumentIR_cast)* )
 
-                              1. Else Phantom#1220
+                              1. Else Phantom#1221
 
-                            1. Else Phantom#1221
+                            1. Else Phantom#1222
 
-                1. Else Phantom#1222
+                1. Else Phantom#1223
 
   4. Case (% has type builtinMethodTypeIR)
 
@@ -21921,9 +21945,9 @@ relation Call_ok: p TC |- callableTypeIR < (typeArgumentIR)* # (typeId)* >( (arg
 
                   1. Result in: % % |- % < % # % >( % # % # % ): typeIR_ret < (typeArgumentIR)* >( (argumentIR_cast)* )
 
-              1. Else Phantom#1223
+              1. Else Phantom#1224
 
-      1. Else Phantom#1224
+      1. Else Phantom#1225
 
   5. Case (% has type externMethodTypeIR)
 
@@ -21961,13 +21985,13 @@ relation Call_ok: p TC |- callableTypeIR < (typeArgumentIR)* # (typeId)* >( (arg
 
                                     1. Result in: % % |- % < % # % >( % # % # % ): typeIR_ret_inferred < (typeArgumentIR_inferred)* >( (argumentIR_cast)* )
 
-                                1. Else Phantom#1225
+                                1. Else Phantom#1226
 
-                              1. Else Phantom#1226
+                              1. Else Phantom#1227
 
-                  1. Else Phantom#1227
+                  1. Else Phantom#1228
 
-        1. Else Phantom#1228
+        1. Else Phantom#1229
 
       2. Group externMethodTypeIR-abstract: p TC |- (externMethodTypeIR as callableTypeIR) < (typeArgumentIR)* # (typeId)* >( (argumentIR)* # (id_default)* # (id_optional)* ): % < % >( % )
 
@@ -22001,13 +22025,13 @@ relation Call_ok: p TC |- callableTypeIR < (typeArgumentIR)* # (typeId)* >( (arg
 
                                     1. Result in: % % |- % < % # % >( % # % # % ): typeIR_ret_inferred < (typeArgumentIR_inferred)* >( (argumentIR_cast)* )
 
-                                1. Else Phantom#1229
+                                1. Else Phantom#1230
 
-                              1. Else Phantom#1230
+                              1. Else Phantom#1231
 
-                  1. Else Phantom#1231
+                  1. Else Phantom#1232
 
-        1. Else Phantom#1232
+        1. Else Phantom#1233
 
   6. Case (% has type parserApplyMethodTypeIR)
 
@@ -22029,11 +22053,11 @@ relation Call_ok: p TC |- callableTypeIR < (typeArgumentIR)* # (typeId)* >( (arg
 
                     1. Result in: % % |- % < % # % >( % # % # % ): ((void) as typeIR) < [] >( (argumentIR_cast)* )
 
-                1. Else Phantom#1233
+                1. Else Phantom#1234
 
-        1. Else Phantom#1234
+        1. Else Phantom#1235
 
-      1. Else Phantom#1235
+      1. Else Phantom#1236
 
   7. Case (% has type controlApplyMethodTypeIR)
 
@@ -22055,11 +22079,11 @@ relation Call_ok: p TC |- callableTypeIR < (typeArgumentIR)* # (typeId)* >( (arg
 
                     1. Result in: % % |- % < % # % >( % # % # % ): ((void) as typeIR) < [] >( (argumentIR_cast)* )
 
-                1. Else Phantom#1236
+                1. Else Phantom#1237
 
-        1. Else Phantom#1237
+        1. Else Phantom#1238
 
-      1. Else Phantom#1238
+      1. Else Phantom#1239
 
   8. Case (% has type tableApplyMethodTypeIR)
 
@@ -22083,17 +22107,17 @@ relation Call_ok: p TC |- callableTypeIR < (typeArgumentIR)* # (typeId)* >( (arg
 
                       1. Result in: % % |- % < % # % >( % # % # % ): (tableMetadataStructTypeIR as typeIR) < [] >( [] )
 
-                    1. Else Phantom#1239
+                    1. Else Phantom#1240
 
-              1. Else Phantom#1240
+              1. Else Phantom#1241
 
-            1. Else Phantom#1241
+            1. Else Phantom#1242
 
-          1. Else Phantom#1242
+          1. Else Phantom#1243
 
-        1. Else Phantom#1243
+        1. Else Phantom#1244
 
-      1. Else Phantom#1244
+      1. Else Phantom#1245
 
 relation ConstructorType_ok: p TC |- (prefixedNameIR < (typeArgumentIR)* >) ( (argumentIR)* ): % <# % >(# % # % )
 
@@ -22115,11 +22139,11 @@ relation ConstructorType_ok: p TC |- (prefixedNameIR < (typeArgumentIR)* >) ( (a
 
                 1. Result in: % % |- % ( % ): constructorTypeIR <# (typeId_impl)* >(# (id_default)* # (id_optional)* )
 
-              1. Else Phantom#1245
+              1. Else Phantom#1246
 
-      1. Else Phantom#1246
+      1. Else Phantom#1247
 
-  1. Else Phantom#1247
+  1. Else Phantom#1248
 
   2. (Let (typeDefIR)? be $find_typeDef_t(p, TC, prefixedNameIR))
 
@@ -22143,13 +22167,13 @@ relation ConstructorType_ok: p TC |- (prefixedNameIR < (typeArgumentIR)* >) ( (a
 
                       1. Result in: % % |- % ( % ): constructorTypeIR <# (typeId_impl)* >(# (id_default)* # (id_optional)* )
 
-                    1. Else Phantom#1248
+                    1. Else Phantom#1249
 
-            1. Else Phantom#1249
+            1. Else Phantom#1250
 
-        1. Else Phantom#1250
+        1. Else Phantom#1251
 
-    1. Else Phantom#1251
+    1. Else Phantom#1252
 
   3. If (((typeArgumentIR)* = [])), then
 
@@ -22179,15 +22203,15 @@ relation ConstructorType_ok: p TC |- (prefixedNameIR < (typeArgumentIR)* >) ( (a
 
                             1. Result in: % % |- % ( % ): constructorTypeIR <# (typeId_impl)* >(# (id_default)* # (id_optional)* )
 
-                          1. Else Phantom#1252
+                          1. Else Phantom#1253
 
-                  1. Else Phantom#1253
+                  1. Else Phantom#1254
 
-          1. Else Phantom#1254
+          1. Else Phantom#1255
 
-      1. Else Phantom#1255
+      1. Else Phantom#1256
 
-  3. Else Phantom#1256
+  3. Else Phantom#1257
 
 syntax instctxt = 
    | named
@@ -22231,15 +22255,15 @@ relation Inst_ok: cursor TC instctxt |- constructorTypeIR < (typeArgumentIR)* # 
 
                                   1. Result in: % % % |- % < % # % >( % # % # % ): typeIR_object_inferred < (typeArgumentIR_inferred)* >( (argumentIR_cast)* )
 
-                              1. Else Phantom#1257
+                              1. Else Phantom#1258
 
-                            1. Else Phantom#1258
+                            1. Else Phantom#1259
 
-                1. Else Phantom#1259
+                1. Else Phantom#1260
 
-        1. Else Phantom#1260
+        1. Else Phantom#1261
 
-1. Else Phantom#1261
+1. Else Phantom#1262
 
 2. Group non-package: cursor TC instctxt |- constructorTypeIR < (typeArgumentIR)* # (typeId_infer)* >( (argumentIR)* # (id_default)* # (id_optional)* ): % < % >( % )
 
@@ -22275,13 +22299,13 @@ relation Inst_ok: cursor TC instctxt |- constructorTypeIR < (typeArgumentIR)* # 
 
                                 1. Result in: % % % |- % < % # % >( % # % # % ): typeIR_object_inferred < (typeArgumentIR_inferred)* >( (argumentIR_cast)* )
 
-                            1. Else Phantom#1262
+                            1. Else Phantom#1263
 
-                          1. Else Phantom#1263
+                          1. Else Phantom#1264
 
-              1. Else Phantom#1264
+              1. Else Phantom#1265
 
-      1. Else Phantom#1265
+      1. Else Phantom#1266
 
 def $reduce_serenum(typedExpressionIR)
 
@@ -22951,7 +22975,7 @@ def $result_concat(typeIR, typeIR')
 
             1. Return ((int< (w_a + w_b) >) as typeIR)
 
-      1. Else Phantom#1266
+      1. Else Phantom#1267
 
   2. Case (% has type fixedBitTypeIR)
 
@@ -22971,7 +22995,7 @@ def $result_concat(typeIR, typeIR')
 
             1. Return ((bit< (w_a + w_b) >) as typeIR)
 
-      1. Else Phantom#1267
+      1. Else Phantom#1268
 
   3. Case (% has type typedefTypeIR)
 
@@ -22979,7 +23003,7 @@ def $result_concat(typeIR, typeIR')
 
       1. Return $result_concat(typeIR_l, typeIR')
 
-1. Else Phantom#1268
+1. Else Phantom#1269
 
 2. If ((typeIR' has type typedefTypeIR)), then
 
@@ -22989,9 +23013,9 @@ def $result_concat(typeIR, typeIR')
 
       1. Return $result_concat(typeIR, typeIR_r)
 
-    1. Else Phantom#1269
+    1. Else Phantom#1270
 
-2. Else Phantom#1270
+2. Else Phantom#1271
 
 tbl def $compat_logical(typeIR'', typeIR''')
 =
@@ -23221,7 +23245,7 @@ relation ParameterList_ok_inner: p typingContext |- (parameter)* : % % # %
 
     1. Result in: % % |- % : typingContext [] # []
 
-  1. Else Phantom#1271
+  1. Else Phantom#1272
 
   2. If (((parameter)* matches pattern _ :: _)), then
 
@@ -23237,7 +23261,7 @@ relation ParameterList_ok_inner: p typingContext |- (parameter)* : % % # %
 
               1. Result in: % % |- % : TC_2 (parameterIR)* # (typeId_fresh)*
 
-  2. Else Phantom#1272
+  2. Else Phantom#1273
 
 relation ForUpdateStmt_ok: TC |- forUpdateStatement : %
 
@@ -23257,7 +23281,7 @@ relation ForUpdateStmt_ok: TC |- forUpdateStatement : %
 
               1. Result in: % |- % : (callableTargetIR < (typeArgumentIR)* >( (argumentIR)* ))
 
-          1. Else Phantom#1273
+          1. Else Phantom#1274
 
     2. Case (% matches pattern `%<%>(%)`)
 
@@ -23271,7 +23295,7 @@ relation ForUpdateStmt_ok: TC |- forUpdateStatement : %
 
               1. Result in: % |- % : (callableTargetIR < (typeArgumentIR)* >( (argumentIR)* ))
 
-          1. Else Phantom#1274
+          1. Else Phantom#1275
 
     3. Case (% matches pattern `%%%`)
 
@@ -23287,9 +23311,9 @@ relation ForUpdateStmt_ok: TC |- forUpdateStatement : %
 
                 1. Result in: % |- % : (typedLvalueIR assignop typedExpressionIR)
 
-              1. Else Phantom#1275
+              1. Else Phantom#1276
 
-          1. Else Phantom#1276
+          1. Else Phantom#1277
 
 relation ForUpdateStmtList_ok: TC |- forUpdateStatementList : %
 
@@ -23329,11 +23353,11 @@ relation ForInitStmt_ok: typingContext |- forInitStatement : % %
 
                         1. Result in: % |- % : TC_1 (annotationList typeIR nameIR ?())
 
-                  1. Else Phantom#1277
+                  1. Else Phantom#1278
 
-                1. Else Phantom#1278
+                1. Else Phantom#1279
 
-              1. Else Phantom#1279
+              1. Else Phantom#1280
 
           2. Case (% has type initializer)
 
@@ -23361,13 +23385,13 @@ relation ForInitStmt_ok: typingContext |- forInitStatement : % %
 
                                   1. Result in: % |- % : TC_1 (annotationList typeIR nameIR ?((= typedExpressionIR_init_cast)))
 
-                          1. Else Phantom#1280
+                          1. Else Phantom#1281
 
-                    1. Else Phantom#1281
+                    1. Else Phantom#1282
 
-                  1. Else Phantom#1282
+                  1. Else Phantom#1283
 
-                1. Else Phantom#1283
+                1. Else Phantom#1284
 
     2. Case (% has type forUpdateStatement)
 
@@ -23385,7 +23409,7 @@ relation ForInitStmts_ok: typingContext |- (forInitStatement)* : % %
 
     1. Result in: % |- % : typingContext []
 
-  1. Else Phantom#1284
+  1. Else Phantom#1285
 
   2. If (((forInitStatement)* matches pattern _ :: _)), then
 
@@ -23397,7 +23421,7 @@ relation ForInitStmts_ok: typingContext |- (forInitStatement)* : % %
 
           1. Result in: % |- % : TC_2 forInitStatementIR_h :: (forInitStatementIR_t)*
 
-  2. Else Phantom#1285
+  2. Else Phantom#1286
 
 relation ForInitStmtList_ok: TC_0 |- forInitStatementList : % %
 
@@ -23435,7 +23459,7 @@ relation ForCollectionExpr_ok: TC typeIR_var |- forCollectionExpression : %
 
                       1. Result in: % % |- % : (typedExpressionIR as forCollectionExpressionIR)
 
-                    1. Else Phantom#1286
+                    1. Else Phantom#1287
 
                 2. Case (% has type headerStackTypeIR)
 
@@ -23445,9 +23469,9 @@ relation ForCollectionExpr_ok: TC typeIR_var |- forCollectionExpression : %
 
                       1. Result in: % % |- % : (typedExpressionIR as forCollectionExpressionIR)
 
-                    1. Else Phantom#1287
+                    1. Else Phantom#1288
 
-              1. Else Phantom#1288
+              1. Else Phantom#1289
 
     2. Case (% matches pattern `%..%`)
 
@@ -23477,11 +23501,11 @@ relation ForCollectionExpr_ok: TC typeIR_var |- forCollectionExpression : %
 
                               1. Result in: % % |- % : (typedExpressionIR_l_casted .. typedExpressionIR_r_casted)
 
-                            1. Else Phantom#1289
+                            1. Else Phantom#1290
 
-                    1. Else Phantom#1290
+                    1. Else Phantom#1291
 
-              1. Else Phantom#1291
+              1. Else Phantom#1292
 
 tbl def $compat_range(typeIR'', typeIR''')
 =
@@ -23604,15 +23628,15 @@ relation SwitchLabel_table_ok: TC typeId_table |- switchLabel : %
 
                                 1. Result in: % % |- % : (typedExpressionIR_label as switchLabelIR)
 
-                            1. Else Phantom#1292
+                            1. Else Phantom#1293
 
-                        1. Else Phantom#1293
+                        1. Else Phantom#1294
 
-                    1. Else Phantom#1294
+                    1. Else Phantom#1295
 
-          1. Else Phantom#1295
+          1. Else Phantom#1296
 
-  1. Else Phantom#1296
+  1. Else Phantom#1297
 
 relation SwitchCase_table_ok: TC f l typeId_table |- switchCase : % % # %
 
@@ -23650,7 +23674,7 @@ relation SwitchCases_table_ok: TC f l typeId_table |- (switchCase)* : % % # %
 
     1. Result in: % % % % |- % : f [] # []
 
-  1. Else Phantom#1297
+  1. Else Phantom#1298
 
   2. If (((switchCase)* matches pattern _ :: _)), then
 
@@ -23662,7 +23686,7 @@ relation SwitchCases_table_ok: TC f l typeId_table |- (switchCase)* : % % # %
 
           1. Result in: % % % % |- % : f_t switchCaseIR_h :: (switchCaseIR_t)* # switchLabel_h :: (switchLabel_t)*
 
-  2. Else Phantom#1298
+  2. Else Phantom#1299
 
 relation SwitchCaseList_table_ok: TC f l typeId_table |- switchCaseList : % % # %
 
@@ -23704,9 +23728,9 @@ relation SwitchLabel_general_ok: TC typeIR |- switchLabel : %
 
                       1. Result in: % % |- % : (typedExpressionIR_label_cast as switchLabelIR)
 
-                    1. Else Phantom#1299
+                    1. Else Phantom#1300
 
-              1. Else Phantom#1300
+              1. Else Phantom#1301
 
 relation SwitchCase_general_ok: TC f l typeIR_switch |- switchCase : % % # %
 
@@ -23744,7 +23768,7 @@ relation SwitchCases_general_ok: TC f l typeIR_switch |- (switchCase)* : % % # %
 
     1. Result in: % % % % |- % : f [] # []
 
-  1. Else Phantom#1301
+  1. Else Phantom#1302
 
   2. If (((switchCase)* matches pattern _ :: _)), then
 
@@ -23756,7 +23780,7 @@ relation SwitchCases_general_ok: TC f l typeIR_switch |- (switchCase)* : % % # %
 
           1. Result in: % % % % |- % : f_t switchCaseIR_h :: (switchCaseIR_t)* # switchLabel_h :: (switchLabel_t)*
 
-  2. Else Phantom#1302
+  2. Else Phantom#1303
 
 relation SwitchCaseList_general_ok: TC f l typeIR_switch |- switchCaseList : % % # %
 
@@ -23817,7 +23841,7 @@ relation BlockElementStmts_ok: typingContext flow l |- (blockElementStatement)* 
 
     1. Result in: % % % |- % : typingContext flow []
 
-  1. Else Phantom#1303
+  1. Else Phantom#1304
 
   2. If (((blockElementStatement)* matches pattern _ :: _)), then
 
@@ -23829,7 +23853,7 @@ relation BlockElementStmts_ok: typingContext flow l |- (blockElementStatement)* 
 
           1. Result in: % % % |- % : TC_2 f_2 blockElementStatementIR_h :: (blockElementStatementIR_t)*
 
-  2. Else Phantom#1304
+  2. Else Phantom#1305
 
 relation InstDecl_non_objectInitializer_ok: p TC_0 |- annotationList prefixedTypeName < typeArgumentList >( argumentList ) name ;: % %
 
@@ -23883,7 +23907,7 @@ relation ObjectDecl_ok: p TC_0 typeFrame externMethodTypeDefEnv |- objectDeclara
 
                     1. Result in: % % % % |- % : typeFrame_init externMethodTypeDefEnv (instantiationIR as objectDeclarationIR)
 
-              1. Else Phantom#1305
+              1. Else Phantom#1306
 
     2. Case (% has type functionDeclaration)
 
@@ -23921,11 +23945,11 @@ relation ObjectDecl_ok: p TC_0 typeFrame externMethodTypeDefEnv |- objectDeclara
 
                                       1. Result in: % % % % |- % : typeFrame externMethodTypeDefEnv_init (functionDeclarationIR as objectDeclarationIR)
 
-                                1. Else Phantom#1306
+                                1. Else Phantom#1307
 
-                        1. Else Phantom#1307
+                        1. Else Phantom#1308
 
-                  1. Else Phantom#1308
+                  1. Else Phantom#1309
 
 relation ObjectDecls_ok: p TC typeFrame externMethodTypeDefEnv |- (objectDeclaration)* : % % %
 
@@ -23935,7 +23959,7 @@ relation ObjectDecls_ok: p TC typeFrame externMethodTypeDefEnv |- (objectDeclara
 
     1. Result in: % % % % |- % : typeFrame externMethodTypeDefEnv []
 
-  1. Else Phantom#1309
+  1. Else Phantom#1310
 
   2. If (((objectDeclaration)* matches pattern _ :: _)), then
 
@@ -23947,7 +23971,7 @@ relation ObjectDecls_ok: p TC typeFrame externMethodTypeDefEnv |- (objectDeclara
 
           1. Result in: % % % % |- % : typeFrame_2 externMethodTypeDefEnv_2 objectDeclarationIR_h :: (objectDeclarationIR_t)*
 
-  2. Else Phantom#1310
+  2. Else Phantom#1311
 
 relation ObjectDeclList_ok: p TC |- objectDeclarationList : % % %
 
@@ -23965,7 +23989,7 @@ def $subst_externMethodTypeDefEnv(externMethodTypeDefEnv_extern, set<pair<callab
 
   1. Return externMethodTypeDefEnv_extern
 
-1. Else Phantom#1311
+1. Else Phantom#1312
 
 2. (Let ({ (pair<callableId, externMethodTypeDefIR>)* }) be set<pair<callableId, externMethodTypeDefIR>>)
 
@@ -23993,13 +24017,13 @@ def $subst_externMethodTypeDefEnv(externMethodTypeDefEnv_extern, set<pair<callab
 
                         1. Return $subst_externMethodTypeDefEnv(externMethodTypeDefEnv_extern_subst, ({ ((callableId_init_t : externMethodTypeDefIR_init_t))* }))
 
-                    1. Else Phantom#1312
+                    1. Else Phantom#1313
 
-              1. Else Phantom#1313
+              1. Else Phantom#1314
 
-          1. Else Phantom#1314
+          1. Else Phantom#1315
 
-  1. Else Phantom#1315
+  1. Else Phantom#1316
 
 relation InstDecl_objectInitializer_ok: p TC_0 |- annotationList prefixedTypeName < typeArgumentList >( argumentList ) name ={ objectDeclarationList };: % %
 
@@ -24045,9 +24069,9 @@ relation InstDecl_objectInitializer_ok: p TC_0 |- annotationList prefixedTypeNam
 
                                         1. Result in: % % |- % % < % >( % ) % ={ % };: TC_2 instantiationIR
 
-                              1. Else Phantom#1316
+                              1. Else Phantom#1317
 
-                  1. Else Phantom#1317
+                  1. Else Phantom#1318
 
 def $split_externConstructorOrMethodPrototypeList(externConstructorOrMethodPrototypeList)
 
@@ -24067,9 +24091,9 @@ def $split_externConstructorOrMethodPrototypeList(externConstructorOrMethodProto
 
               1. Return ((externConstructorPrototype)*, (externMethodPrototype)*)
 
-          1. Else Phantom#1318
+          1. Else Phantom#1319
 
-    1. Else Phantom#1319
+    1. Else Phantom#1320
 
 def $constructorTypeDef_of_externConstructorPrototypeIR(typeParameterListIR_expl, typeIR, (_annotationList nameIR <, typeParameterListIR_impl >( (parameterIR)* );))
 
@@ -24101,9 +24125,9 @@ relation Enum_serializable_field_ok: TC_0 nameIR_enum typeIR |- (name = expressi
 
                     1. Result in: % % % |- % : TC_1 (nameIR = value)
 
-          1. Else Phantom#1320
+          1. Else Phantom#1321
 
-      1. Else Phantom#1321
+      1. Else Phantom#1322
 
 relation Enum_serializable_fields_ok: typingContext nameIR_enum typeIR |- (namedExpression)* : % %
 
@@ -24113,7 +24137,7 @@ relation Enum_serializable_fields_ok: typingContext nameIR_enum typeIR |- (named
 
     1. Result in: % % % |- % : typingContext []
 
-  1. Else Phantom#1322
+  1. Else Phantom#1323
 
   2. If (((namedExpression)* matches pattern _ :: _)), then
 
@@ -24127,7 +24151,7 @@ relation Enum_serializable_fields_ok: typingContext nameIR_enum typeIR |- (named
 
             1. Result in: % % % |- % : TC_2 (namedValueIR)*
 
-  2. Else Phantom#1323
+  2. Else Phantom#1324
 
 relation Enum_serializable_fieldList_ok: TC_0 nameIR_enum typeIR |- namedExpressionList : % %
 
@@ -24175,7 +24199,7 @@ relation SelectCase_keyset_simple_ok: TC typeIR_key |- simpleKeysetExpression : 
 
                             1. Result in: % % |- % : (typedExpressionIR_cast as simpleKeysetExpressionIR)
 
-                      1. Else Phantom#1324
+                      1. Else Phantom#1325
 
                 2. Case false
 
@@ -24187,7 +24211,7 @@ relation SelectCase_keyset_simple_ok: TC typeIR_key |- simpleKeysetExpression : 
 
                         1. Result in: % % |- % : (typedExpressionIR_cast as simpleKeysetExpressionIR)
 
-                  1. Else Phantom#1325
+                  1. Else Phantom#1326
 
   2. Case (% matches pattern `%&&&%`)
 
@@ -24227,13 +24251,13 @@ relation SelectCase_keyset_simple_ok: TC typeIR_key |- simpleKeysetExpression : 
 
                                       1. Result in: % % |- % : (typedExpressionIR_l_casted &&& typedExpressionIR_r_casted)
 
-                                  1. Else Phantom#1326
+                                  1. Else Phantom#1327
 
-                            1. Else Phantom#1327
+                            1. Else Phantom#1328
 
-                    1. Else Phantom#1328
+                    1. Else Phantom#1329
 
-              1. Else Phantom#1329
+              1. Else Phantom#1330
 
   3. Case (% matches pattern `%..%`)
 
@@ -24275,15 +24299,15 @@ relation SelectCase_keyset_simple_ok: TC typeIR_key |- simpleKeysetExpression : 
 
                                         1. Result in: % % |- % : (typedExpressionIR_l_casted .. typedExpressionIR_r_casted)
 
-                                    1. Else Phantom#1330
+                                    1. Else Phantom#1331
 
-                              1. Else Phantom#1331
+                              1. Else Phantom#1332
 
-                          1. Else Phantom#1332
+                          1. Else Phantom#1333
 
-                    1. Else Phantom#1333
+                    1. Else Phantom#1334
 
-              1. Else Phantom#1334
+              1. Else Phantom#1335
 
   4. Case (% matches pattern `DEFAULT`)
 
@@ -24372,7 +24396,7 @@ relation SelectCase_keyset_ok: TC (typeIR)* |- keysetExpression : %
 
             1. Result in: % % |- % : (simpleKeysetExpressionIR as keysetExpressionIR)
 
-      1. Else Phantom#1335
+      1. Else Phantom#1336
 
       2. If ((keysetExpression has type simpleKeysetExpression)), then
 
@@ -24396,9 +24420,9 @@ relation SelectCase_keyset_ok: TC (typeIR)* |- keysetExpression : %
 
                   1. Result in: % % |- % : (simpleKeysetExpressionIR as keysetExpressionIR)
 
-          1. Else Phantom#1336
+          1. Else Phantom#1337
 
-      2. Else Phantom#1337
+      2. Else Phantom#1338
 
       3. Case analysis on keysetExpression
 
@@ -24414,9 +24438,9 @@ relation SelectCase_keyset_ok: TC (typeIR)* |- keysetExpression : %
 
             1. Result in: % % |- % : (simpleKeysetExpressionIR as keysetExpressionIR)
 
-      3. Else Phantom#1338
+      3. Else Phantom#1339
 
-  1. Else Phantom#1339
+  1. Else Phantom#1340
 
   2. If ((keysetExpression has type expression)), then
 
@@ -24430,9 +24454,9 @@ relation SelectCase_keyset_ok: TC (typeIR)* |- keysetExpression : %
 
             1. Result in: % % |- % : (simpleKeysetExpressionIR as keysetExpressionIR)
 
-      1. Else Phantom#1340
+      1. Else Phantom#1341
 
-  2. Else Phantom#1341
+  2. Else Phantom#1342
 
   3. If (((typeIR)* = [])), then
 
@@ -24440,9 +24464,9 @@ relation SelectCase_keyset_ok: TC (typeIR)* |- keysetExpression : %
 
       1. Result in: % % |- % : ((default) as keysetExpressionIR)
 
-    1. Else Phantom#1342
+    1. Else Phantom#1343
 
-  3. Else Phantom#1343
+  3. Else Phantom#1344
 
   4. Case analysis on keysetExpression
 
@@ -24454,7 +24478,7 @@ relation SelectCase_keyset_ok: TC (typeIR)* |- keysetExpression : %
 
           1. Result in: % % |- % : (simpleKeysetExpressionIR as keysetExpressionIR)
 
-      1. Else Phantom#1344
+      1. Else Phantom#1345
 
     2. Case (% = ((_) as keysetExpression))
 
@@ -24464,9 +24488,9 @@ relation SelectCase_keyset_ok: TC (typeIR)* |- keysetExpression : %
 
           1. Result in: % % |- % : (simpleKeysetExpressionIR as keysetExpressionIR)
 
-      1. Else Phantom#1345
+      1. Else Phantom#1346
 
-  4. Else Phantom#1346
+  4. Else Phantom#1347
 
 2. If ((keysetExpression has type tupleKeysetExpression)), then
 
@@ -24508,9 +24532,9 @@ relation SelectCase_keyset_ok: TC (typeIR)* |- keysetExpression : %
 
                 1. Result in: % % |- % : ((( [simpleKeysetExpressionIR] )) as keysetExpressionIR)
 
-          1. Else Phantom#1347
+          1. Else Phantom#1348
 
-      1. Else Phantom#1348
+      1. Else Phantom#1349
 
       2. Case analysis on tupleKeysetExpression
 
@@ -24522,7 +24546,7 @@ relation SelectCase_keyset_ok: TC (typeIR)* |- keysetExpression : %
 
               1. Result in: % % |- % : ((( [simpleKeysetExpressionIR] )) as keysetExpressionIR)
 
-          1. Else Phantom#1349
+          1. Else Phantom#1350
 
         2. Case (% matches pattern `(_)`)
 
@@ -24532,7 +24556,7 @@ relation SelectCase_keyset_ok: TC (typeIR)* |- keysetExpression : %
 
               1. Result in: % % |- % : ((( [simpleKeysetExpressionIR] )) as keysetExpressionIR)
 
-          1. Else Phantom#1350
+          1. Else Phantom#1351
 
         3. Case (% matches pattern `(%,%)`)
 
@@ -24548,11 +24572,11 @@ relation SelectCase_keyset_ok: TC (typeIR)* |- keysetExpression : %
 
                     1. Result in: % % |- % : ((( (simpleKeysetExpressionIR)* )) as keysetExpressionIR)
 
-                1. Else Phantom#1351
+                1. Else Phantom#1352
 
-      2. Else Phantom#1352
+      2. Else Phantom#1353
 
-2. Else Phantom#1353
+2. Else Phantom#1354
 
 relation SelectCase_ok: TC (nameIR_state)* (typeIR_key)* |- (keysetExpression : name ;) : %
 
@@ -24566,7 +24590,7 @@ relation SelectCase_ok: TC (nameIR_state)* (typeIR_key)* |- (keysetExpression : 
 
         1. Result in: % % % |- % : (keysetExpressionIR : nameIR ;)
 
-      1. Else Phantom#1354
+      1. Else Phantom#1355
 
 relation ParserStmts_ok: typingContext |- (parserStatement)* : % %
 
@@ -24576,7 +24600,7 @@ relation ParserStmts_ok: typingContext |- (parserStatement)* : % %
 
     1. Result in: % |- % : typingContext []
 
-  1. Else Phantom#1355
+  1. Else Phantom#1356
 
   2. If (((parserStatement)* matches pattern _ :: _)), then
 
@@ -24588,7 +24612,7 @@ relation ParserStmts_ok: typingContext |- (parserStatement)* : % %
 
           1. Result in: % |- % : TC_2 parserStatementIR_h :: (parserStatementIR_t)*
 
-  2. Else Phantom#1356
+  2. Else Phantom#1357
 
 relation ParserLocalDecls_ok: typingContext |- (parserLocalDeclaration)* : % %
 
@@ -24598,7 +24622,7 @@ relation ParserLocalDecls_ok: typingContext |- (parserLocalDeclaration)* : % %
 
     1. Result in: % |- % : typingContext []
 
-  1. Else Phantom#1357
+  1. Else Phantom#1358
 
   2. If (((parserLocalDeclaration)* matches pattern _ :: _)), then
 
@@ -24610,7 +24634,7 @@ relation ParserLocalDecls_ok: typingContext |- (parserLocalDeclaration)* : % %
 
           1. Result in: % |- % : TC_2 parserLocalDeclarationIR_h :: (parserLocalDeclarationIR_t)*
 
-  2. Else Phantom#1358
+  2. Else Phantom#1359
 
 tbl def $compat_table_exact_optional_key(typeIR'')
 =
@@ -24810,9 +24834,9 @@ relation TableEntry_keyset_simple_ok: TC TBLC |- (typeIR_key : text) @ simpleKey
 
                               1. Result in: % % |- % @ % : (lpm n) (typedExpressionIR_set as simpleKeysetExpressionIR)
 
-                        1. Else Phantom#1359
+                        1. Else Phantom#1360
 
-              1. Else Phantom#1360
+              1. Else Phantom#1361
 
           2. Case (% =/= "lpm")
 
@@ -24844,13 +24868,13 @@ relation TableEntry_keyset_simple_ok: TC TBLC |- (typeIR_key : text) @ simpleKey
 
                                       1. Result in: % % |- % @ % : (non_lpm) (typedExpressionIR_set as simpleKeysetExpressionIR)
 
-                                1. Else Phantom#1361
+                                1. Else Phantom#1362
 
-                        1. Else Phantom#1362
+                        1. Else Phantom#1363
 
-                    1. Else Phantom#1363
+                    1. Else Phantom#1364
 
-                1. Else Phantom#1364
+                1. Else Phantom#1365
 
               2. Case false
 
@@ -24868,7 +24892,7 @@ relation TableEntry_keyset_simple_ok: TC TBLC |- (typeIR_key : text) @ simpleKey
 
                             1. Result in: % % |- % @ % : (non_lpm) (typedExpressionIR_set as simpleKeysetExpressionIR)
 
-                      1. Else Phantom#1365
+                      1. Else Phantom#1366
 
   2. Case (% matches pattern `%&&&%`)
 
@@ -24928,19 +24952,19 @@ relation TableEntry_keyset_simple_ok: TC TBLC |- (typeIR_key : text) @ simpleKey
 
                                                           1. Result in: % % |- % @ % : (lpm n_prefix) (typedExpressionIR_l_reduced &&& typedExpressionIR_r_reduced)
 
-                                                    1. Else Phantom#1366
+                                                    1. Else Phantom#1367
 
-                                              1. Else Phantom#1367
+                                              1. Else Phantom#1368
 
-                                          1. Else Phantom#1368
+                                          1. Else Phantom#1369
 
-                                    1. Else Phantom#1369
+                                    1. Else Phantom#1370
 
-                              1. Else Phantom#1370
+                              1. Else Phantom#1371
 
-                        1. Else Phantom#1371
+                        1. Else Phantom#1372
 
-              1. Else Phantom#1372
+              1. Else Phantom#1373
 
           2. Case (% = "ternary")
 
@@ -24968,13 +24992,13 @@ relation TableEntry_keyset_simple_ok: TC TBLC |- (typeIR_key : text) @ simpleKey
 
                                   1. Result in: % % |- % @ % : (non_lpm) (typedExpressionIR_l_reduced &&& typedExpressionIR_r_reduced)
 
-                              1. Else Phantom#1373
+                              1. Else Phantom#1374
 
-                        1. Else Phantom#1374
+                        1. Else Phantom#1375
 
-                  1. Else Phantom#1375
+                  1. Else Phantom#1376
 
-        1. Else Phantom#1376
+        1. Else Phantom#1377
 
   3. Case (% matches pattern `DEFAULT`)
 
@@ -24992,7 +25016,7 @@ relation TableEntry_keyset_simple_ok: TC TBLC |- (typeIR_key : text) @ simpleKey
 
                 1. Result in: % % |- % @ % : (lpm n) (default)
 
-            1. Else Phantom#1377
+            1. Else Phantom#1378
 
         2. Case (% =/= "lpm")
 
@@ -25000,7 +25024,7 @@ relation TableEntry_keyset_simple_ok: TC TBLC |- (typeIR_key : text) @ simpleKey
 
             1. Result in: % % |- % @ % : (non_lpm) (default)
 
-          1. Else Phantom#1378
+          1. Else Phantom#1379
 
   4. Case (% matches pattern `_`)
 
@@ -25016,7 +25040,7 @@ relation TableEntry_keyset_simple_ok: TC TBLC |- (typeIR_key : text) @ simpleKey
 
               1. Result in: % % |- % @ % : (lpm 0) (_)
 
-            1. Else Phantom#1379
+            1. Else Phantom#1380
 
         2. Case (% =/= "lpm")
 
@@ -25024,9 +25048,9 @@ relation TableEntry_keyset_simple_ok: TC TBLC |- (typeIR_key : text) @ simpleKey
 
             1. Result in: % % |- % @ % : (non_lpm) (_)
 
-          1. Else Phantom#1380
+          1. Else Phantom#1381
 
-1. Else Phantom#1381
+1. Else Phantom#1382
 
 2. If ((text = "range")), then
 
@@ -25060,15 +25084,15 @@ relation TableEntry_keyset_simple_ok: TC TBLC |- (typeIR_key : text) @ simpleKey
 
                               1. Result in: % % |- % @ % : (non_lpm) (typedExpressionIR_l_reduced .. typedExpressionIR_r_reduced)
 
-                          1. Else Phantom#1382
+                          1. Else Phantom#1383
 
-                    1. Else Phantom#1383
+                    1. Else Phantom#1384
 
-              1. Else Phantom#1384
+              1. Else Phantom#1385
 
-  1. Else Phantom#1385
+  1. Else Phantom#1386
 
-2. Else Phantom#1386
+2. Else Phantom#1387
 
 def $is_singleton_list_expression(expression)
 
@@ -25096,9 +25120,9 @@ relation TableEntry_keysets_simple_ok: TC TBLC tableEntryState |- (matchKey)* @ 
 
       1. Result in: % % % |- % @ % : tableEntryState []
 
-    1. Else Phantom#1387
+    1. Else Phantom#1388
 
-  1. Else Phantom#1388
+  1. Else Phantom#1389
 
   2. If (((matchKey)* matches pattern _ :: _)), then
 
@@ -25116,9 +25140,9 @@ relation TableEntry_keysets_simple_ok: TC TBLC tableEntryState |- (matchKey)* @ 
 
                 1. Result in: % % % |- % @ % : TBLS_3 simpleKeysetExpressionIR_h :: (simpleKeysetExpressionIR_t)*
 
-      1. Else Phantom#1389
+      1. Else Phantom#1390
 
-  2. Else Phantom#1390
+  2. Else Phantom#1391
 
 def $is_tableKeysProperty(tableProperty)
 
@@ -25174,7 +25198,7 @@ def $insert_NoAction_tablePropertyIR(TBLC, (tablePropertyIR)*)
 
             1. (Let (_annotationList tableActionReferenceIR #( _parameterListIR , _parameterListIR' );) be tableActionIR)*
 
-              1. (Let tableActionReferenceIR_NoAction be ((. "NoAction") [] ( [] )))
+              1. (Let tableActionReferenceIR_NoAction be ((. "NoAction") ?() ( [] )))
 
                 1. Case analysis on tableActionReferenceIR_NoAction is in (tableActionReferenceIR)*
 
@@ -25206,7 +25230,7 @@ relation ControlLocalDecls_ok: typingContext |- (controlLocalDeclaration)* : % %
 
     1. Result in: % |- % : typingContext []
 
-  1. Else Phantom#1391
+  1. Else Phantom#1392
 
   2. If (((controlLocalDeclaration)* matches pattern _ :: _)), then
 
@@ -25218,7 +25242,7 @@ relation ControlLocalDecls_ok: typingContext |- (controlLocalDeclaration)* : % %
 
           1. Result in: % |- % : TC_2 controlLocalDeclarationIR_h :: (controlLocalDeclarationIR_t)*
 
-  2. Else Phantom#1392
+  2. Else Phantom#1393
 
 relation Expr_lvalue_ok: p TC |- (expressionIR # (( typeIR ctk )))
 
@@ -25242,11 +25266,11 @@ relation Expr_lvalue_ok: p TC |- (expressionIR # (( typeIR ctk )))
 
                   1. The relation holds
 
-                1. Else Phantom#1393
+                1. Else Phantom#1394
 
-              1. Else Phantom#1394
+              1. Else Phantom#1395
 
-          1. Else Phantom#1395
+          1. Else Phantom#1396
 
   2. Case (% has type memberAccessExpressionIR)
 
@@ -25274,17 +25298,17 @@ relation Expr_lvalue_ok: p TC |- (expressionIR # (( typeIR ctk )))
 
                           1. The relation holds
 
-                        1. Else Phantom#1396
+                        1. Else Phantom#1397
 
-                      1. Else Phantom#1397
+                      1. Else Phantom#1398
 
                     2. Case false
 
                       1. The relation holds
 
-            1. Else Phantom#1398
+            1. Else Phantom#1399
 
-      1. Else Phantom#1399
+      1. Else Phantom#1400
 
   3. Case (% has type indexAccessExpressionIR)
 
@@ -25296,7 +25320,7 @@ relation Expr_lvalue_ok: p TC |- (expressionIR # (( typeIR ctk )))
 
           1. The relation holds
 
-        1. Else Phantom#1400
+        1. Else Phantom#1401
 
   4. Case (% has type sliceAccessExpressionIR)
 
@@ -25308,9 +25332,9 @@ relation Expr_lvalue_ok: p TC |- (expressionIR # (( typeIR ctk )))
 
           1. The relation holds
 
-        1. Else Phantom#1401
+        1. Else Phantom#1402
 
-1. Else Phantom#1402
+1. Else Phantom#1403
 
 syntax infer = 
    | knownas typeIR
@@ -25330,7 +25354,7 @@ def $infer((typeId)*, (parameterIR)*, (argumentIR)*)
 
   1. Return $empty_map<typeId, typeIR>
 
-1. Else Phantom#1403
+1. Else Phantom#1404
 
 2. If (((typeId)* =/= [])), then
 
@@ -25346,7 +25370,7 @@ def $infer((typeId)*, (parameterIR)*, (argumentIR)*)
 
             1. Return inference_resolved
 
-2. Else Phantom#1404
+2. Else Phantom#1405
 
 def $infer'(constraint, parameterIR, argumentIR)
 
@@ -25588,7 +25612,7 @@ def $merge_constraint(constraint_pre, constraint_post)
 
       1. Return $merge_constraint'(constraint_pre, constraint_post, (typeId_pre)*, ({ [] }))
 
-    1. Else Phantom#1405
+    1. Else Phantom#1406
 
 def $merge_constraint'(constraint_pre, constraint_post, (typeId)*, constraint)
 
@@ -25610,7 +25634,7 @@ def $merge_constraint'(constraint_pre, constraint_post, (typeId)*, constraint)
 
             1. Return $merge_constraint'(constraint_pre, constraint_post, (typeId_t)*, constraint_updated)
 
-        1. Else Phantom#1406
+        1. Else Phantom#1407
 
         2. (Let (infer)? be $find_map<typeId, infer>(constraint_post, typeId_h))
 
@@ -25626,11 +25650,11 @@ def $merge_constraint'(constraint_pre, constraint_post, (typeId)*, constraint)
 
                     1. Return $merge_constraint'(constraint_pre, constraint_post, (typeId_t)*, constraint_updated)
 
-              1. Else Phantom#1407
+              1. Else Phantom#1408
 
-          1. Else Phantom#1408
+          1. Else Phantom#1409
 
-      1. Else Phantom#1409
+      1. Else Phantom#1410
 
       2. (Let (infer)? be $find_map<typeId, infer>(constraint_pre, typeId_h))
 
@@ -25648,7 +25672,7 @@ def $merge_constraint'(constraint_pre, constraint_post, (typeId)*, constraint)
 
                     1. Return $merge_constraint'(constraint_pre, constraint_post, (typeId_t)*, constraint_updated)
 
-                1. Else Phantom#1410
+                1. Else Phantom#1411
 
                 2. (Let (infer'')? be $find_map<typeId, infer>(constraint_post, typeId_h))
 
@@ -25674,15 +25698,15 @@ def $merge_constraint'(constraint_pre, constraint_post, (typeId)*, constraint)
 
                                 1. Return $merge_constraint'(constraint_pre, constraint_post, (typeId_t)*, constraint_updated)
 
-                            1. Else Phantom#1411
+                            1. Else Phantom#1412
 
-                      1. Else Phantom#1412
+                      1. Else Phantom#1413
 
-                  1. Else Phantom#1413
+                  1. Else Phantom#1414
 
-            1. Else Phantom#1414
+            1. Else Phantom#1415
 
-        1. Else Phantom#1415
+        1. Else Phantom#1416
 
 def $merge_constraints(constraint_pre, (constraint)*)
 
@@ -25710,7 +25734,7 @@ def $resolve_constraint(({ ((typeId : infer))* }))
 
     1. Return ({ ((typeId : typeIR))* })
 
-1. Else Phantom#1416
+1. Else Phantom#1417
 
 def $resolve_type_alias(typeIR)
 
@@ -25734,7 +25758,7 @@ def $resolve_type_alias(typeIR)
 
       1. Return (nameIR_alias, (typeIR_arg)*)
 
-1. Else Phantom#1417
+1. Else Phantom#1418
 
 def $instantiable_extern(cursor, TC, instctxt)
 
@@ -25854,7 +25878,7 @@ def $instantiable(p, TC, instctxt, typeIR)
 
       1. Return $instantiable_table(p, TC, instctxt)
 
-  1. Else Phantom#1418
+  1. Else Phantom#1419
 
 def $callable_action(cursor, TC)
 
@@ -26188,7 +26212,7 @@ def $parameterListIR_of_externMethodDef(externMethodDef)
 
     1. Return parameterListIR
 
-1. Else Phantom#1419
+1. Else Phantom#1420
 
 def $parameterListIR_of_parserApplyMethodDef((parser_apply( parameterListIR ){ _parserLocalDeclarationListIR ; _stateEnv }))
 
@@ -26377,7 +26401,7 @@ def $find_store(store, objectId)
 
       1. Return object'
 
-  1. Else Phantom#1420
+  1. Else Phantom#1421
 
 syntax globalInstLayer = {constructor constructorDefEnv, type typeDefEnv, callable callableDefEnv, frame frame}
 
@@ -26413,7 +26437,7 @@ def $exit_i(IC)
 
       1. Return IC[local.frames = (frame_t)*]
 
-  1. Else Phantom#1421
+  1. Else Phantom#1422
 
 def $enter_path_i(IC, id)
 
@@ -26453,7 +26477,7 @@ def $add_var_i(cursor, IC, id, value)
 
         1. Return IC[global.frame = frame]
 
-    1. Else Phantom#1422
+    1. Else Phantom#1423
 
   2. Case (% matches pattern `BLOCK`)
 
@@ -26463,7 +26487,7 @@ def $add_var_i(cursor, IC, id, value)
 
         1. Return IC[block.frame = frame]
 
-    1. Else Phantom#1423
+    1. Else Phantom#1424
 
   3. Case (% matches pattern `LOCAL`)
 
@@ -26479,9 +26503,9 @@ def $add_var_i(cursor, IC, id, value)
 
               1. Return IC[local.frames = frame_h' :: (frame_t)*]
 
-          1. Else Phantom#1424
+          1. Else Phantom#1425
 
-      1. Else Phantom#1425
+      1. Else Phantom#1426
 
 def $add_vars_i(p, IC, (id)*, (value)*)
 
@@ -26493,7 +26517,7 @@ def $add_vars_i(p, IC, (id)*, (value)*)
 
       1. Return IC
 
-    1. Else Phantom#1426
+    1. Else Phantom#1427
 
   2. Case (% matches pattern _ :: _)
 
@@ -26509,7 +26533,7 @@ def $add_vars_i(p, IC, (id)*, (value)*)
 
               1. Return IC''
 
-      1. Else Phantom#1427
+      1. Else Phantom#1428
 
 def $add_typeDef_i(cursor, IC, typeId, typeDefIR)
 
@@ -26519,7 +26543,7 @@ def $add_typeDef_i(cursor, IC, typeId, typeDefIR)
 
     1. Return IC[global.type = typeDefEnv]
 
-1. Else Phantom#1428
+1. Else Phantom#1429
 
 def $add_parserState_i(IC, nameIR, parserStateIR)
 
@@ -26529,7 +26553,7 @@ def $add_parserState_i(IC, nameIR, parserStateIR)
 
     1. Return IC[block.state = stateEnv]
 
-1. Else Phantom#1429
+1. Else Phantom#1430
 
 def $add_type_i(cursor, IC, typeId, typeIR)
 
@@ -26547,7 +26571,7 @@ def $add_type_i(cursor, IC, typeId, typeIR)
 
       1. Return IC[local.type = theta]
 
-1. Else Phantom#1430
+1. Else Phantom#1431
 
 def $add_types_i(p, IC, (typeId)*, (typeIR)*)
 
@@ -26559,7 +26583,7 @@ def $add_types_i(p, IC, (typeId)*, (typeIR)*)
 
       1. Return IC
 
-    1. Else Phantom#1431
+    1. Else Phantom#1432
 
   2. Case (% matches pattern _ :: _)
 
@@ -26573,7 +26597,7 @@ def $add_types_i(p, IC, (typeId)*, (typeIR)*)
 
             1. Return $add_types_i(p, IC', (typeId_t)*, (typeIR_t)*)
 
-      1. Else Phantom#1432
+      1. Else Phantom#1433
 
 def $add_callableDef_overload_i(cursor, IC, callableId, callableDef)
 
@@ -26587,7 +26611,7 @@ def $add_callableDef_overload_i(cursor, IC, callableId, callableDef)
 
         1. Return IC[global.callable = callableDefEnv]
 
-    1. Else Phantom#1433
+    1. Else Phantom#1434
 
   2. Case (% matches pattern `BLOCK`)
 
@@ -26597,9 +26621,9 @@ def $add_callableDef_overload_i(cursor, IC, callableId, callableDef)
 
         1. Return IC[block.callable = callableDefEnv]
 
-    1. Else Phantom#1434
+    1. Else Phantom#1435
 
-1. Else Phantom#1435
+1. Else Phantom#1436
 
 def $add_callableDef_non_overload_i(cursor, IC, callableId, callableDef)
 
@@ -26617,7 +26641,7 @@ def $add_callableDef_non_overload_i(cursor, IC, callableId, callableDef)
 
             1. Return IC[global.callable = callableDefEnv]
 
-        1. Else Phantom#1436
+        1. Else Phantom#1437
 
   2. Case (% matches pattern `BLOCK`)
 
@@ -26631,9 +26655,9 @@ def $add_callableDef_non_overload_i(cursor, IC, callableId, callableDef)
 
             1. Return IC[block.callable = callableDefEnv]
 
-        1. Else Phantom#1437
+        1. Else Phantom#1438
 
-1. Else Phantom#1438
+1. Else Phantom#1439
 
 def $find_callableDef_non_overload_i(p, IC, prefixedNameIR)
 
@@ -26641,9 +26665,23 @@ def $find_callableDef_non_overload_i(p, IC, prefixedNameIR)
 
   1. (Let (. nameIR) be prefixedNameIR)
 
-    1. Return $find_non_overloaded<callableDef>(IC.global.callable, nameIR)
+    1. If ((?() = $find_non_overloaded<callableDef>(IC.global.callable, nameIR))), then
 
-1. Else Phantom#1439
+      1. Return ?()
+
+    1. Else Phantom#1440
+
+    2. (Let ((callableId, callableDef))? be $find_non_overloaded<callableDef>(IC.global.callable, nameIR))
+
+      1. If ((((callableId, callableDef))? matches pattern (_))), then
+
+        1. (Let ?((callableId, callableDef)) be ((callableId, callableDef))?)
+
+          1. Return ?(((global), callableId, callableDef))
+
+      1. Else Phantom#1441
+
+1. Else Phantom#1442
 
 2. Case analysis on p
 
@@ -26653,9 +26691,9 @@ def $find_callableDef_non_overload_i(p, IC, prefixedNameIR)
 
       1. (Let (` nameIR) be prefixedNameIR)
 
-        1. Return $find_non_overloaded<callableDef>(IC.global.callable, nameIR)
+        1. Return $find_callableDef_non_overload_i((global), IC, (. nameIR))
 
-    1. Else Phantom#1440
+    1. Else Phantom#1443
 
   2. Case (% matches pattern `BLOCK`)
 
@@ -26669,17 +26707,17 @@ def $find_callableDef_non_overload_i(p, IC, prefixedNameIR)
 
             1. (Let ?((callableId, callableDef)) be ((callableId, callableDef))?)
 
-              1. Return ?((callableId, callableDef))
+              1. Return ?(((block), callableId, callableDef))
 
-          1. Else Phantom#1441
+          1. Else Phantom#1444
 
         2. If ((?() = $find_non_overloaded<callableDef>(IC.block.callable, nameIR))), then
 
           1. Return $find_callableDef_non_overload_i((global), IC, (` nameIR))
 
-        2. Else Phantom#1442
+        2. Else Phantom#1445
 
-    1. Else Phantom#1443
+    1. Else Phantom#1446
 
   3. Case (% matches pattern `LOCAL`)
 
@@ -26689,7 +26727,7 @@ def $find_callableDef_non_overload_i(p, IC, prefixedNameIR)
 
         1. Return $find_callableDef_non_overload_i((block), IC, (` nameIR))
 
-    1. Else Phantom#1444
+    1. Else Phantom#1447
 
 def $add_constructorDef_i(IC, callableId, constructorDef)
 
@@ -26707,7 +26745,7 @@ def $add_constructorDefs_i(IC, (callableId)*, (constructorDef)*)
 
       1. Return IC
 
-    1. Else Phantom#1445
+    1. Else Phantom#1448
 
   2. Case (% matches pattern _ :: _)
 
@@ -26723,7 +26761,7 @@ def $add_constructorDefs_i(IC, (callableId)*, (constructorDef)*)
 
               1. Return IC''
 
-      1. Else Phantom#1446
+      1. Else Phantom#1449
 
 def $find_var_i(prefixedNameIR, p, IC)
 
@@ -26741,7 +26779,7 @@ def $find_var_i(prefixedNameIR, p, IC)
 
             1. Return value'
 
-        1. Else Phantom#1447
+        1. Else Phantom#1450
 
   2. Case (% matches pattern ``%`)
 
@@ -26759,7 +26797,7 @@ def $find_var_i(prefixedNameIR, p, IC)
 
                 1. Return value'
 
-            1. Else Phantom#1448
+            1. Else Phantom#1451
 
         2. Case (% matches pattern `BLOCK`)
 
@@ -26771,13 +26809,13 @@ def $find_var_i(prefixedNameIR, p, IC)
 
                 1. Return value'
 
-            1. Else Phantom#1449
+            1. Else Phantom#1452
 
           2. If ((?() = $find_map<id, value>(IC.block.frame, id))), then
 
             1. Return $find_var_i((` id), (global), IC)
 
-          2. Else Phantom#1450
+          2. Else Phantom#1453
 
         3. Case (% matches pattern `LOCAL`)
 
@@ -26789,13 +26827,13 @@ def $find_var_i(prefixedNameIR, p, IC)
 
                 1. Return value'
 
-            1. Else Phantom#1451
+            1. Else Phantom#1454
 
           2. If ((?() = $find_maps<id, value>(IC.local.frames, id))), then
 
             1. Return $find_var_i((` id), (block), IC)
 
-          2. Else Phantom#1452
+          2. Else Phantom#1455
 
 def $find_typeDef_i(_cursor, IC, prefixedNameIR)
 
@@ -26887,7 +26925,7 @@ relation Expr_inst: p IC STO |- (expressionIR # expressionNoteIR) : % %
 
         1. Result in: % % % |- % : STO (stringLiteral as value)
 
-  1. Else Phantom#1453
+  1. Else Phantom#1456
 
 2. Case analysis on expressionIR
 
@@ -26933,7 +26971,7 @@ relation Expr_inst: p IC STO |- (expressionIR # expressionNoteIR) : % %
 
               1. Result in: % % % |- % : STO_2 $bin_op(binop, value_l, value_r)
 
-        1. Else Phantom#1454
+        1. Else Phantom#1457
 
         2. Case analysis on binop
 
@@ -26953,7 +26991,7 @@ relation Expr_inst: p IC STO |- (expressionIR # expressionNoteIR) : % %
 
                     1. Result in: % % % |- % : STO_2 value_r
 
-              1. Else Phantom#1455
+              1. Else Phantom#1458
 
           2. Case (% matches pattern `||`)
 
@@ -26971,9 +27009,9 @@ relation Expr_inst: p IC STO |- (expressionIR # expressionNoteIR) : % %
 
                     1. Result in: % % % |- % : STO_2 value_r
 
-              1. Else Phantom#1456
+              1. Else Phantom#1459
 
-        2. Else Phantom#1457
+        2. Else Phantom#1460
 
   5. Case (% has type ternaryExpressionIR)
 
@@ -26997,7 +27035,7 @@ relation Expr_inst: p IC STO |- (expressionIR # expressionNoteIR) : % %
 
                 1. Result in: % % % |- % : STO_2 value_false
 
-          1. Else Phantom#1458
+          1. Else Phantom#1461
 
   6. Case (% has type castExpressionIR)
 
@@ -27117,11 +27155,11 @@ relation Expr_inst: p IC STO |- (expressionIR # expressionNoteIR) : % %
 
                                 1. Result in: % % % |- % : STO ((typeId . nameIR . value') as value)
 
-                            1. Else Phantom#1459
+                            1. Else Phantom#1462
 
-                    1. Else Phantom#1460
+                    1. Else Phantom#1463
 
-                1. Else Phantom#1461
+                1. Else Phantom#1464
 
         2. Case (% has type typedExpressionIR)
 
@@ -27141,9 +27179,9 @@ relation Expr_inst: p IC STO |- (expressionIR # expressionNoteIR) : % %
 
                         1. Result in: % % % |- % : STO ((d (n_size as int)) as value)
 
-                      1. Else Phantom#1462
+                      1. Else Phantom#1465
 
-                  1. Else Phantom#1463
+                  1. Else Phantom#1466
 
               2. (Expr_inst: p IC STO |- typedExpressionIR_base : STO_1 value)
 
@@ -27163,7 +27201,7 @@ relation Expr_inst: p IC STO |- (expressionIR # expressionNoteIR) : % %
 
                               1. Result in: % % % |- % : STO_1 value''
 
-                          1. Else Phantom#1464
+                          1. Else Phantom#1467
 
                   2. Case (% has type headerValue)
 
@@ -27179,7 +27217,7 @@ relation Expr_inst: p IC STO |- (expressionIR # expressionNoteIR) : % %
 
                               1. Result in: % % % |- % : STO_1 value''
 
-                          1. Else Phantom#1465
+                          1. Else Phantom#1468
 
                   3. Case (% has type headerUnionValue)
 
@@ -27195,9 +27233,9 @@ relation Expr_inst: p IC STO |- (expressionIR # expressionNoteIR) : % %
 
                               1. Result in: % % % |- % : STO_1 value''
 
-                          1. Else Phantom#1466
+                          1. Else Phantom#1469
 
-                1. Else Phantom#1467
+                1. Else Phantom#1470
 
   12. Case (% has type indexAccessExpressionIR)
 
@@ -27231,9 +27269,9 @@ relation Expr_inst: p IC STO |- (expressionIR # expressionNoteIR) : % %
 
                                 1. Result in: % % % |- % : STO_2 value'
 
-                            1. Else Phantom#1468
+                            1. Else Phantom#1471
 
-                        1. Else Phantom#1469
+                        1. Else Phantom#1472
 
                   2. Case (% has type headerStackValue)
 
@@ -27251,13 +27289,13 @@ relation Expr_inst: p IC STO |- (expressionIR # expressionNoteIR) : % %
 
                                 1. Result in: % % % |- % : STO_2 value'
 
-                            1. Else Phantom#1470
+                            1. Else Phantom#1473
 
-                        1. Else Phantom#1471
+                        1. Else Phantom#1474
 
-                1. Else Phantom#1472
+                1. Else Phantom#1475
 
-            1. Else Phantom#1473
+            1. Else Phantom#1476
 
   13. Case (% has type sliceAccessExpressionIR)
 
@@ -27313,7 +27351,7 @@ relation Expr_inst: p IC STO |- (expressionIR # expressionNoteIR) : % %
 
                         1. Result in: % % % |- % : STO $sizeof(typeIR_base, nameIR)
 
-                      1. Else Phantom#1474
+                      1. Else Phantom#1477
 
                 2. Case (% matches pattern `TYPE%.%`)
 
@@ -27335,7 +27373,7 @@ relation Expr_inst: p IC STO |- (expressionIR # expressionNoteIR) : % %
 
                                   1. Result in: % % % |- % : STO $sizeof(typeIR_base, nameIR)
 
-                                1. Else Phantom#1475
+                                1. Else Phantom#1478
 
                             2. Case false
 
@@ -27347,13 +27385,13 @@ relation Expr_inst: p IC STO |- (expressionIR # expressionNoteIR) : % %
 
                                     1. Result in: % % % |- % : STO $sizeof(typeIR_base, nameIR)
 
-                                  1. Else Phantom#1476
+                                  1. Else Phantom#1479
 
-                              1. Else Phantom#1477
+                              1. Else Phantom#1480
 
-                      1. Else Phantom#1478
+                      1. Else Phantom#1481
 
-              1. Else Phantom#1479
+              1. Else Phantom#1482
 
             2. If ((callableTargetIR matches pattern `(%)`)), then
 
@@ -27365,7 +27403,7 @@ relation Expr_inst: p IC STO |- (expressionIR # expressionNoteIR) : % %
 
                     1. Result in: % % % |- % : STO_1 value
 
-            2. Else Phantom#1480
+            2. Else Phantom#1483
 
   15. Case (% has type parenthesizedExpressionIR)
 
@@ -27377,7 +27415,7 @@ relation Expr_inst: p IC STO |- (expressionIR # expressionNoteIR) : % %
 
           1. Result in: % % % |- % : STO_1 value
 
-2. Else Phantom#1481
+2. Else Phantom#1484
 
 relation Exprs_inst: p IC store |- (typedExpressionIR)* : % %
 
@@ -27387,7 +27425,7 @@ relation Exprs_inst: p IC store |- (typedExpressionIR)* : % %
 
     1. Result in: % % % |- % : store []
 
-  1. Else Phantom#1482
+  1. Else Phantom#1485
 
   2. If (((typedExpressionIR)* matches pattern _ :: _)), then
 
@@ -27399,7 +27437,7 @@ relation Exprs_inst: p IC store |- (typedExpressionIR)* : % %
 
           1. Result in: % % % |- % : STO_2 value_h :: (value_t)*
 
-  2. Else Phantom#1483
+  2. Else Phantom#1486
 
 relation Argument_inst: p IC STO_0 |- argumentIR : % %
 
@@ -27425,7 +27463,7 @@ relation Argument_inst: p IC STO_0 |- argumentIR : % %
 
           1. Result in: % % % |- % : STO_1 value
 
-1. Else Phantom#1484
+1. Else Phantom#1487
 
 relation DirectApplicationStmt_inst: p IC STO_0 |- (constructorTargetIR .apply( argumentListIR );) : % % %
 
@@ -27551,7 +27589,7 @@ relation Stmt_inst: p IC STO |- statementIR : % % %
 
                 1. Result in: % % % |- % : IC STO_1 (forStatementIR' as statementIR)
 
-      1. Else Phantom#1485
+      1. Else Phantom#1488
 
       2. Group forStatementIR-in: p IC STO |- (forStatementIR as statementIR) : % % %
 
@@ -27579,9 +27617,9 @@ relation Stmt_inst: p IC STO |- statementIR : % % %
 
                     1. Result in: % % % |- % : IC STO_1 (forStatementIR' as statementIR)
 
-              1. Else Phantom#1486
+              1. Else Phantom#1489
 
-        1. Else Phantom#1487
+        1. Else Phantom#1490
 
   8. Case (% has type breakStatementIR)
 
@@ -27609,7 +27647,7 @@ relation Stmt_inst: p IC STO |- statementIR : % % %
 
           1. Result in: % % % |- % : IC STO_1 ((switch( typedExpressionIR ){ switchCaseListIR_inst }) as statementIR)
 
-1. Else Phantom#1488
+1. Else Phantom#1491
 
 2. If ((p matches pattern `LOCAL`)), then
 
@@ -27637,9 +27675,9 @@ relation Stmt_inst: p IC STO |- statementIR : % % %
 
                 1. Result in: % % % |- % : IC_3 STO_1 ((annotationList { blockElementStatementListIR_inst }) as statementIR)
 
-  1. Else Phantom#1489
+  1. Else Phantom#1492
 
-2. Else Phantom#1490
+2. Else Phantom#1493
 
 relation BlockElementStmt_inst: instContext store |- blockElementStatementIR : % % %
 
@@ -27677,7 +27715,7 @@ relation BlockElementStmtList_inst: instContext store |- (blockElementStatementI
 
     1. Result in: % % |- % : instContext store []
 
-  1. Else Phantom#1491
+  1. Else Phantom#1494
 
   2. If (((blockElementStatementIR)* matches pattern _ :: _)), then
 
@@ -27689,7 +27727,7 @@ relation BlockElementStmtList_inst: instContext store |- (blockElementStatementI
 
           1. Result in: % % |- % : IC_2 STO_2 blockElementStatementIR_h_inst :: (blockElementStatementIR_t_inst)*
 
-  2. Else Phantom#1492
+  2. Else Phantom#1495
 
 relation Block_inst: IC_0 STO_0 |- (annotationList { blockElementStatementListIR }) : % % %
 
@@ -27739,7 +27777,7 @@ relation ExternMethods_inst: instContext |- (externMethodPrototypeIR)* : %
 
     1. Result in: % |- % : instContext
 
-  1. Else Phantom#1493
+  1. Else Phantom#1496
 
   2. If (((externMethodPrototypeIR)* matches pattern _ :: _)), then
 
@@ -27751,7 +27789,7 @@ relation ExternMethods_inst: instContext |- (externMethodPrototypeIR)* : %
 
           1. Result in: % |- % : IC_2
 
-  2. Else Phantom#1494
+  2. Else Phantom#1497
 
 relation ParserStmt_inst: IC_0 STO |- parserStatementIR : % % %
 
@@ -27789,7 +27827,7 @@ relation ParserStmt_inst: IC_0 STO |- parserStatementIR : % % %
 
               1. Result in: % % |- % : IC_1 STO_1 (emptyStatementIR_inst as parserStatementIR)
 
-          1. Else Phantom#1495
+          1. Else Phantom#1498
 
   4. Case (% has type assignmentStatementIR)
 
@@ -27805,7 +27843,7 @@ relation ParserStmt_inst: IC_0 STO |- parserStatementIR : % % %
 
               1. Result in: % % |- % : IC_1 STO_1 (assignmentStatementIR_inst as parserStatementIR)
 
-          1. Else Phantom#1496
+          1. Else Phantom#1499
 
   5. Case (% has type callStatementIR)
 
@@ -27821,7 +27859,7 @@ relation ParserStmt_inst: IC_0 STO |- parserStatementIR : % % %
 
               1. Result in: % % |- % : IC_1 STO_1 (callStatementIR_inst as parserStatementIR)
 
-          1. Else Phantom#1497
+          1. Else Phantom#1500
 
   6. Case (% has type directApplicationStatementIR)
 
@@ -27881,7 +27919,7 @@ relation ParserStmts_inst: instContext store |- (parserStatementIR)* : % % %
 
     1. Result in: % % |- % : instContext store []
 
-  1. Else Phantom#1498
+  1. Else Phantom#1501
 
   2. If (((parserStatementIR)* matches pattern _ :: _)), then
 
@@ -27893,7 +27931,7 @@ relation ParserStmts_inst: instContext store |- (parserStatementIR)* : % % %
 
           1. Result in: % % |- % : IC_2 STO_2 parserStatementIR_h_inst :: (parserStatementIR_t_inst)*
 
-  2. Else Phantom#1499
+  2. Else Phantom#1502
 
 relation ParserState_inst: IC_0 STO_0 |- parserStateIR : % %
 
@@ -27917,7 +27955,7 @@ relation ParserStates_inst: instContext store |- (parserStateIR)* : % %
 
     1. Result in: % % |- % : instContext store
 
-  1. Else Phantom#1500
+  1. Else Phantom#1503
 
   2. If (((parserStateIR)* matches pattern _ :: _)), then
 
@@ -27929,7 +27967,7 @@ relation ParserStates_inst: instContext store |- (parserStateIR)* : % %
 
           1. Result in: % % |- % : IC_2 STO_2
 
-  2. Else Phantom#1501
+  2. Else Phantom#1504
 
 relation ParserLocalDecl_inst: IC_0 STO |- parserLocalDeclarationIR : % % %
 
@@ -27995,9 +28033,9 @@ relation ParserLocalDecl_inst: IC_0 STO |- parserLocalDeclarationIR : % % %
 
                                 1. Result in: % % |- % : IC_0 STO_2 (constantDeclarationIR as parserLocalDeclarationIR)
 
-                1. Else Phantom#1502
+                1. Else Phantom#1505
 
-          1. Else Phantom#1503
+          1. Else Phantom#1506
 
 relation ParserLocalDecls_inst: instContext store |- (parserLocalDeclarationIR)* : % % %
 
@@ -28007,7 +28045,7 @@ relation ParserLocalDecls_inst: instContext store |- (parserLocalDeclarationIR)*
 
     1. Result in: % % |- % : instContext store []
 
-  1. Else Phantom#1504
+  1. Else Phantom#1507
 
   2. If (((parserLocalDeclarationIR)* matches pattern _ :: _)), then
 
@@ -28019,7 +28057,7 @@ relation ParserLocalDecls_inst: instContext store |- (parserLocalDeclarationIR)*
 
           1. Result in: % % |- % : IC_2 STO_2 parserLocalDeclarationIR_h_inst :: (parserLocalDeclarationIR_t_inst)*
 
-  2. Else Phantom#1505
+  2. Else Phantom#1508
 
 relation TableAction_inst: IC STO |- (annotationList tableActionReferenceIR #( parameterListIR , parameterListIR_control );) : % %
 
@@ -28027,11 +28065,11 @@ relation TableAction_inst: IC STO |- (annotationList tableActionReferenceIR #( p
 
   1. (Let (prefixedNameIR _controlPlaneNameIR ( argumentListIR )) be tableActionReferenceIR)
 
-    1. (Let ((callableId, callableDef))? be $find_callableDef_non_overload_i((local), IC, prefixedNameIR))
+    1. (Let ((cursor, callableId, callableDef))? be $find_callableDef_non_overload_i((local), IC, prefixedNameIR))
 
-      1. If ((((callableId, callableDef))? matches pattern (_))), then
+      1. If ((((cursor, callableId, callableDef))? matches pattern (_))), then
 
-        1. (Let ?((_callableId, callableDef)) be ((callableId, callableDef))?)
+        1. (Let ?((cursor, _callableId, callableDef)) be ((cursor, callableId, callableDef))?)
 
           1. If ((callableDef has type actionDef)), then
 
@@ -28045,19 +28083,33 @@ relation TableAction_inst: IC STO |- (annotationList tableActionReferenceIR #( p
 
                     1. (Let [nameIR_anno] be (nameIR')*)
 
-                      1. (Let controlPlaneNameIR be IC.path ++ [nameIR_anno])
+                      1. Case analysis on $starts_with(nameIR_anno, ".")
 
-                        1. (Let tableActionReferenceIR' be (prefixedNameIR controlPlaneNameIR ( argumentListIR )))
+                        1. Case true
 
-                          1. (Let tableActionIR be (annotationList tableActionReferenceIR' #( parameterListIR , parameterListIR_control );))
+                          1. (Let controlPlaneNameIR be ?($strip_prefix(nameIR_anno, ".")))
 
-                            1. Result in: % % |- % : STO tableActionIR
+                            1. (Let tableActionReferenceIR' be (prefixedNameIR controlPlaneNameIR ( argumentListIR )))
 
-                  1. Else Phantom#1506
+                              1. (Let tableActionIR be (annotationList tableActionReferenceIR' #( parameterListIR , parameterListIR_control );))
+
+                                1. Result in: % % |- % : STO tableActionIR
+
+                        2. Case false
+
+                          1. (Let controlPlaneNameIR be $ite<controlPlaneNameIR>((cursor = (global)), ?(nameIR_anno), ?($join_text(IC.path ++ [nameIR_anno], "."))))
+
+                            1. (Let tableActionReferenceIR' be (prefixedNameIR controlPlaneNameIR ( argumentListIR )))
+
+                              1. (Let tableActionIR be (annotationList tableActionReferenceIR' #( parameterListIR , parameterListIR_control );))
+
+                                1. Result in: % % |- % : STO tableActionIR
+
+                  1. Else Phantom#1509
 
                 2. If (([] = $name_annotation(annotationList_actionDef))), then
 
-                  1. (Let controlPlaneNameIR be IC.path ++ [nameIR])
+                  1. (Let controlPlaneNameIR be $ite<controlPlaneNameIR>((cursor = (global)), ?(nameIR), ?($join_text(IC.path ++ [nameIR], "."))))
 
                     1. (Let tableActionReferenceIR' be (prefixedNameIR controlPlaneNameIR ( argumentListIR )))
 
@@ -28065,11 +28117,11 @@ relation TableAction_inst: IC STO |- (annotationList tableActionReferenceIR #( p
 
                         1. Result in: % % |- % : STO tableActionIR
 
-                2. Else Phantom#1507
+                2. Else Phantom#1510
 
-          1. Else Phantom#1508
+          1. Else Phantom#1511
 
-      1. Else Phantom#1509
+      1. Else Phantom#1512
 
 relation TableActions_inst: IC store |- (tableActionIR)* : % %
 
@@ -28079,7 +28131,7 @@ relation TableActions_inst: IC store |- (tableActionIR)* : % %
 
     1. Result in: % % |- % : store []
 
-  1. Else Phantom#1510
+  1. Else Phantom#1513
 
   2. If (((tableActionIR)* matches pattern _ :: _)), then
 
@@ -28091,7 +28143,7 @@ relation TableActions_inst: IC store |- (tableActionIR)* : % %
 
           1. Result in: % % |- % : STO_1 tableActionIR_h_inst :: (tableActionIR_t_inst)*
 
-  2. Else Phantom#1511
+  2. Else Phantom#1514
 
 relation TableProperty_inst: IC STO |- tablePropertyIR : % %
 
@@ -28169,7 +28221,7 @@ relation TableProperties_inst: IC store |- (tablePropertyIR)* : % %
 
     1. Result in: % % |- % : store []
 
-  1. Else Phantom#1512
+  1. Else Phantom#1515
 
   2. If (((tablePropertyIR)* matches pattern _ :: _)), then
 
@@ -28181,7 +28233,7 @@ relation TableProperties_inst: IC store |- (tablePropertyIR)* : % %
 
           1. Result in: % % |- % : STO_2 tablePropertyIR_h_inst :: (tablePropertyIR_t_inst)*
 
-  2. Else Phantom#1513
+  2. Else Phantom#1516
 
 relation ControlLocalDecl_inst: IC_0 STO |- controlLocalDeclarationIR : % % %
 
@@ -28261,7 +28313,7 @@ relation ControlLocalDecl_inst: IC_0 STO |- controlLocalDeclarationIR : % % %
 
                                     1. Result in: % % |- % : IC_1 STO_2 ?((constantDeclarationIR as controlLocalDeclarationIR))
 
-                              1. Else Phantom#1514
+                              1. Else Phantom#1517
 
                               2. (Let (nameIR')* be $name_annotation(annotationList))
 
@@ -28279,9 +28331,9 @@ relation ControlLocalDecl_inst: IC_0 STO |- controlLocalDeclarationIR : % % %
 
                                             1. Result in: % % |- % : IC_1 STO_3 ?((constantDeclarationIR as controlLocalDeclarationIR))
 
-                                1. Else Phantom#1515
+                                1. Else Phantom#1518
 
-                  1. Else Phantom#1516
+                  1. Else Phantom#1519
 
 relation ControlLocalDecls_inst: instContext store |- (controlLocalDeclarationIR)* : % % %
 
@@ -28291,7 +28343,7 @@ relation ControlLocalDecls_inst: instContext store |- (controlLocalDeclarationIR
 
     1. Result in: % % |- % : instContext store []
 
-  1. Else Phantom#1517
+  1. Else Phantom#1520
 
   2. If (((controlLocalDeclarationIR)* matches pattern _ :: _)), then
 
@@ -28315,7 +28367,7 @@ relation ControlLocalDecls_inst: instContext store |- (controlLocalDeclarationIR
 
                 1. Result in: % % |- % : IC_2 STO_2 controlLocalDeclarationIR_h_inst :: (controlLocalDeclarationIR_t_inst)*
 
-  2. Else Phantom#1518
+  2. Else Phantom#1521
 
 relation ConstDecl_inst: p IC_0 |- (annotationList const typeIR nameIR (=`value value) ;) : %
 
@@ -28363,7 +28415,7 @@ relation InstDecl_inst: p IC_0 STO_0 |- (annotationList typeIR constructorTarget
 
                                   1. Result in: % % % |- % : IC_1 STO_3 constantDeclarationIR
 
-          1. Else Phantom#1519
+          1. Else Phantom#1522
 
       2. (Let nameIR' be $name_annotation_default(annotationList, nameIR))
 
@@ -28383,7 +28435,7 @@ relation InstDecl_inst: p IC_0 STO_0 |- (annotationList typeIR constructorTarget
 
                       1. Result in: % % % |- % : IC_1 STO_2 constantDeclarationIR
 
-            1. Else Phantom#1520
+            1. Else Phantom#1523
 
 relation FuncDecl_inst: p IC_0 |- (annotationList (typeIR nameIR < typeParameterListIR_expl , typeParameterListIR_impl >( parameterListIR )) blockStatementIR) : %
 
@@ -28727,11 +28779,11 @@ relation Decl_inst: IC_0 STO |- declarationIR : % %
 
                                               1. Result in: % % |- % : IC_1 STO
 
-                                      1. Else Phantom#1521
+                                      1. Else Phantom#1524
 
-                              1. Else Phantom#1522
+                              1. Else Phantom#1525
 
-                        1. Else Phantom#1523
+                        1. Else Phantom#1526
 
         2. Case (% matches pattern `%TYPE%%;`)
 
@@ -28797,7 +28849,7 @@ relation Decls_inst: instContext store |- (declarationIR)* : % %
 
     1. Result in: % % |- % : instContext store
 
-  1. Else Phantom#1524
+  1. Else Phantom#1527
 
   2. If (((declarationIR)* matches pattern _ :: _)), then
 
@@ -28809,7 +28861,7 @@ relation Decls_inst: instContext store |- (declarationIR)* : % %
 
           1. Result in: % % |- % : IC_2 STO_2
 
-  2. Else Phantom#1525
+  2. Else Phantom#1528
 
 relation Program_inst: |- p4program : % %
 
@@ -28847,9 +28899,9 @@ relation Copy_in_inst: store p_caller IC_caller (argumentIR)* @ p_callee instCon
 
       1. Result in: % % % % @ % % % ~> store instContext
 
-    1. Else Phantom#1526
+    1. Else Phantom#1529
 
-  1. Else Phantom#1527
+  1. Else Phantom#1530
 
   2. If (((argumentIR)* matches pattern _ :: _)), then
 
@@ -28865,9 +28917,9 @@ relation Copy_in_inst: store p_caller IC_caller (argumentIR)* @ p_callee instCon
 
               1. Result in: % % % % @ % % % ~> STO_2 IC_callee_2
 
-      1. Else Phantom#1528
+      1. Else Phantom#1531
 
-  2. Else Phantom#1529
+  2. Else Phantom#1532
 
 relation Copy_in_argument_inst_default: store p_caller IC_caller @ p_callee IC_callee_0 parameterIR ~> % %
 
@@ -28901,7 +28953,7 @@ relation Copy_in_argument_inst_default: store p_caller IC_caller @ p_callee IC_c
 
                 1. Result in: % % % @ % % % ~> store IC_callee_1
 
-    1. Else Phantom#1530
+    1. Else Phantom#1533
 
 relation Copy_in_inst_default: store p_caller IC_caller @ p_callee instContext (parameterIR)* ~> % %
 
@@ -28911,7 +28963,7 @@ relation Copy_in_inst_default: store p_caller IC_caller @ p_callee instContext (
 
     1. Result in: % % % @ % % % ~> store instContext
 
-  1. Else Phantom#1531
+  1. Else Phantom#1534
 
   2. If (((parameterIR)* matches pattern _ :: _)), then
 
@@ -28923,7 +28975,7 @@ relation Copy_in_inst_default: store p_caller IC_caller @ p_callee instContext (
 
           1. Result in: % % % @ % % % ~> STO_2 IC_callee_2
 
-  2. Else Phantom#1532
+  2. Else Phantom#1535
 
 relation Constructor_inst: p IC |- prefixedNameIR < (typeArgumentIR)* >( (argumentIR)* ): % < % >(# % # % )
 
@@ -28939,9 +28991,9 @@ relation Constructor_inst: p IC |- prefixedNameIR < (typeArgumentIR)* >( (argume
 
           1. Result in: % % |- % < % >( % ): constructorDef < (typeArgumentIR)* >(# (id_default)* # (id_optional)* )
 
-      1. Else Phantom#1533
+      1. Else Phantom#1536
 
-  1. Else Phantom#1534
+  1. Else Phantom#1537
 
   2. (Let (typeDefIR)? be $find_typeDef_i(p, IC, prefixedNameIR))
 
@@ -28959,11 +29011,11 @@ relation Constructor_inst: p IC |- prefixedNameIR < (typeArgumentIR)* >( (argume
 
                 1. Result in: % % |- % < % >( % ): constructorDef < (typeArgumentIR)* >(# (id_default)* # (id_optional)* )
 
-            1. Else Phantom#1535
+            1. Else Phantom#1538
 
-        1. Else Phantom#1536
+        1. Else Phantom#1539
 
-    1. Else Phantom#1537
+    1. Else Phantom#1540
 
   3. If (((typeArgumentIR)* = [])), then
 
@@ -28987,13 +29039,13 @@ relation Constructor_inst: p IC |- prefixedNameIR < (typeArgumentIR)* >( (argume
 
                       1. Result in: % % |- % < % >( % ): constructorDef < (typeArgumentIR')* >(# (id_default)* # (id_optional)* )
 
-                  1. Else Phantom#1538
+                  1. Else Phantom#1541
 
-          1. Else Phantom#1539
+          1. Else Phantom#1542
 
-      1. Else Phantom#1540
+      1. Else Phantom#1543
 
-  3. Else Phantom#1541
+  3. Else Phantom#1544
 
 relation Constructor_call: p IC STO_0 |- constructorDef < (typeArgumentIR)* >( (argumentIR)* # (id_default)* # (id_optional)* ): % %
 
@@ -29051,9 +29103,9 @@ relation Constructor_call: p IC STO_0 |- constructorDef < (typeArgumentIR)* >( (
 
                                                     1. Result in: % % % |- % < % >( % # % # % ): STO_2 object_extern
 
-                                      1. Else Phantom#1542
+                                      1. Else Phantom#1545
 
-                              1. Else Phantom#1543
+                              1. Else Phantom#1546
 
   2. Case (% has type parserObjectConstructorDef)
 
@@ -29131,7 +29183,7 @@ relation Constructor_call: p IC STO_0 |- constructorDef < (typeArgumentIR)* >( (
 
                                         1. Result in: % % % |- % < % >( % # % # % ): STO_4 object_control
 
-                                  1. Else Phantom#1544
+                                  1. Else Phantom#1547
 
   4. Case (% has type packageObjectConstructorDef)
 
@@ -29181,7 +29233,7 @@ relation SwitchCase_inst: p IC store |- switchCaseIR : % %
 
               1. Result in: % % % |- % : STO_1 (switchLabelIR : blockStatementIR_inst)
 
-          1. Else Phantom#1545
+          1. Else Phantom#1548
 
     2. Case (% matches pattern `%:`)
 
@@ -29197,7 +29249,7 @@ relation SwitchCases_inst: p IC store |- (switchCaseIR)* : % %
 
     1. Result in: % % % |- % : store []
 
-  1. Else Phantom#1546
+  1. Else Phantom#1549
 
   2. If (((switchCaseIR)* matches pattern _ :: _)), then
 
@@ -29209,7 +29261,7 @@ relation SwitchCases_inst: p IC store |- (switchCaseIR)* : % %
 
           1. Result in: % % % |- % : STO_2 switchCaseIR_h' :: (switchCaseIR_t')*
 
-  2. Else Phantom#1547
+  2. Else Phantom#1550
 
 def $merge_frames(frame, ({ ((id : value))* }))
 
@@ -29221,7 +29273,7 @@ def $merge_externMethodDefEnvs(externMethodDefEnv, set<pair<callableId, callable
 
   1. Return externMethodDefEnv
 
-1. Else Phantom#1548
+1. Else Phantom#1551
 
 2. (Let ({ (pair<callableId, callableDef>)* }) be set<pair<callableId, callableDef>>)
 
@@ -29239,9 +29291,9 @@ def $merge_externMethodDefEnvs(externMethodDefEnv, set<pair<callableId, callable
 
               1. Return $merge_externMethodDefEnvs(externMethodDefEnv_post, ({ ((callableId_t : callableDef_t))* }))
 
-      1. Else Phantom#1549
+      1. Else Phantom#1552
 
-  1. Else Phantom#1550
+  1. Else Phantom#1553
 
 relation ObjectDecl_inst: IC_0 store |- objectDeclarationIR : % %
 
@@ -29273,7 +29325,7 @@ relation ObjectDecls_inst: instContext store |- (objectDeclarationIR)* : % %
 
     1. Result in: % % |- % : instContext store
 
-  1. Else Phantom#1551
+  1. Else Phantom#1554
 
   2. If (((objectDeclarationIR)* matches pattern _ :: _)), then
 
@@ -29285,7 +29337,7 @@ relation ObjectDecls_inst: instContext store |- (objectDeclarationIR)* : % %
 
           1. Result in: % % |- % : IC_2 STO_2
 
-  2. Else Phantom#1552
+  2. Else Phantom#1555
 
 def $callableId_of_externMethodPrototypeIR(externMethodPrototypeIR)
 
@@ -29351,15 +29403,15 @@ def $init_table((tablePropertyIR)*)
 
                                 1. Return TBL
 
-                          1. Else Phantom#1553
+                          1. Else Phantom#1556
 
-                  1. Else Phantom#1554
+                  1. Else Phantom#1557
 
-              1. Else Phantom#1555
+              1. Else Phantom#1558
 
-        1. Else Phantom#1556
+        1. Else Phantom#1559
 
-    1. Else Phantom#1557
+    1. Else Phantom#1560
 
 def $init_tableKeys((tablePropertyIR)*)
 
@@ -29375,15 +29427,15 @@ def $init_tableKeys((tablePropertyIR)*)
 
           1. Return tableKeysPropertyIR'
 
-      1. Else Phantom#1558
+      1. Else Phantom#1561
 
-  1. Else Phantom#1559
+  1. Else Phantom#1562
 
 2. If (([] = $filter_<tablePropertyIR>((tablePropertyIR)*, ((tablePropertyIR has type tableKeysPropertyIR))*))), then
 
   1. Return (key={ [] })
 
-2. Else Phantom#1560
+2. Else Phantom#1563
 
 def $init_tableEntries((tablePropertyIR)*)
 
@@ -29399,15 +29451,15 @@ def $init_tableEntries((tablePropertyIR)*)
 
           1. Return tableEntriesPropertyIR'
 
-      1. Else Phantom#1561
+      1. Else Phantom#1564
 
-  1. Else Phantom#1562
+  1. Else Phantom#1565
 
 2. If (([] = $filter_<tablePropertyIR>((tablePropertyIR)*, ((tablePropertyIR has type tableEntriesPropertyIR))*))), then
 
   1. Return ((`empty) ?() entries={ [] })
 
-2. Else Phantom#1563
+2. Else Phantom#1566
 
 syntax globalEvalLayer = globalInstLayer
 
@@ -29431,7 +29483,7 @@ def $exit_e(EC)
 
       1. Return EC[local.frames = (frame_t)*]
 
-  1. Else Phantom#1564
+  1. Else Phantom#1567
 
 def $inherit_e(cursor, EC)
 
@@ -29505,7 +29557,7 @@ def $add_var_e(cursor, EC, prefixedNameIR, value)
 
           1. Return EC[block.frame = frame]
 
-    1. Else Phantom#1565
+    1. Else Phantom#1568
 
   3. Case (% matches pattern `LOCAL`)
 
@@ -29523,9 +29575,9 @@ def $add_var_e(cursor, EC, prefixedNameIR, value)
 
                 1. Return EC[local.frames = frame_h' :: (frame_t)*]
 
-          1. Else Phantom#1566
+          1. Else Phantom#1569
 
-    1. Else Phantom#1567
+    1. Else Phantom#1570
 
 def $add_vars_e(p, EC, (prefixedNameIR)*, (value)*)
 
@@ -29537,7 +29589,7 @@ def $add_vars_e(p, EC, (prefixedNameIR)*, (value)*)
 
       1. Return EC
 
-    1. Else Phantom#1568
+    1. Else Phantom#1571
 
   2. Case (% matches pattern _ :: _)
 
@@ -29553,7 +29605,7 @@ def $add_vars_e(p, EC, (prefixedNameIR)*, (value)*)
 
               1. Return EC''
 
-      1. Else Phantom#1569
+      1. Else Phantom#1572
 
 def $update_var_e(p, EC, prefixedNameIR, value)
 
@@ -29565,7 +29617,7 @@ def $update_var_e(p, EC, prefixedNameIR, value)
 
       1. Return EC[global.frame = frame]
 
-1. Else Phantom#1570
+1. Else Phantom#1573
 
 2. Case analysis on p
 
@@ -29583,9 +29635,9 @@ def $update_var_e(p, EC, prefixedNameIR, value)
 
               1. Return EC[global.frame = frame']
 
-          1. Else Phantom#1571
+          1. Else Phantom#1574
 
-    1. Else Phantom#1572
+    1. Else Phantom#1575
 
   2. Case (% matches pattern `BLOCK`)
 
@@ -29607,7 +29659,7 @@ def $update_var_e(p, EC, prefixedNameIR, value)
 
               1. Return $update_var_e((global), EC, (` id), value)
 
-    1. Else Phantom#1573
+    1. Else Phantom#1576
 
   3. Case (% matches pattern `LOCAL`)
 
@@ -29619,7 +29671,7 @@ def $update_var_e(p, EC, prefixedNameIR, value)
 
           1. Return $update_var_e((block), EC, (` id), value)
 
-        1. Else Phantom#1574
+        1. Else Phantom#1577
 
         2. (Let (frame)* be EC.local.frames)
 
@@ -29643,9 +29695,9 @@ def $update_var_e(p, EC, prefixedNameIR, value)
 
                       1. Return EC_pop'[local.frames = frame_h :: EC_pop'.local.frames]
 
-          1. Else Phantom#1575
+          1. Else Phantom#1578
 
-    1. Else Phantom#1576
+    1. Else Phantom#1579
 
 def $find_var_e(prefixedNameIR, p, EC)
 
@@ -29663,7 +29715,7 @@ def $find_var_e(prefixedNameIR, p, EC)
 
             1. Return value'
 
-        1. Else Phantom#1577
+        1. Else Phantom#1580
 
   2. Case (% matches pattern ``%`)
 
@@ -29681,7 +29733,7 @@ def $find_var_e(prefixedNameIR, p, EC)
 
                 1. Return value'
 
-            1. Else Phantom#1578
+            1. Else Phantom#1581
 
         2. Case (% matches pattern `BLOCK`)
 
@@ -29693,13 +29745,13 @@ def $find_var_e(prefixedNameIR, p, EC)
 
                 1. Return value'
 
-            1. Else Phantom#1579
+            1. Else Phantom#1582
 
           2. If ((?() = $find_map<id, value>(EC.block.frame, id))), then
 
             1. Return $find_var_e((` id), (global), EC)
 
-          2. Else Phantom#1580
+          2. Else Phantom#1583
 
         3. Case (% matches pattern `LOCAL`)
 
@@ -29711,13 +29763,13 @@ def $find_var_e(prefixedNameIR, p, EC)
 
                 1. Return value'
 
-            1. Else Phantom#1581
+            1. Else Phantom#1584
 
           2. If ((?() = $find_maps<id, value>(EC.local.frames, id))), then
 
             1. Return $find_var_e((` id), (block), EC)
 
-          2. Else Phantom#1582
+          2. Else Phantom#1585
 
 def $find_typeDef_e(_cursor, EC, prefixedNameIR)
 
@@ -29753,15 +29805,15 @@ def $find_type_e(cursor, EC, nameIR)
 
           1. Return ?(typeIR')
 
-      1. Else Phantom#1583
+      1. Else Phantom#1586
 
     2. If ((?() = $find_map<typeId, typeIR>(EC.local.type, nameIR))), then
 
       1. Return $find_type_e((block), EC, nameIR)
 
-    2. Else Phantom#1584
+    2. Else Phantom#1587
 
-1. Else Phantom#1585
+1. Else Phantom#1588
 
 def $find_callableDef_overloaded_e(cursor, EC, prefixedNameIR, (argumentIR)*)
 
@@ -29785,13 +29837,13 @@ def $find_callableDef_overloaded_e(cursor, EC, prefixedNameIR, (argumentIR)*)
 
                   1. Return ?((callableId : ((global), callableDef) # (id_default)* # (id_optional)*))
 
-              1. Else Phantom#1586
+              1. Else Phantom#1589
 
             2. If ((?() = $find_overloaded<callableDef>(EC.global.callable, callTargetKey, $parameterListIR_of_callableDef))), then
 
               1. Return ?()
 
-            2. Else Phantom#1587
+            2. Else Phantom#1590
 
       2. Case (% matches pattern `.%`)
 
@@ -29807,13 +29859,13 @@ def $find_callableDef_overloaded_e(cursor, EC, prefixedNameIR, (argumentIR)*)
 
                   1. Return ?((callableId : ((global), callableDef) # (id_default)* # (id_optional)*))
 
-              1. Else Phantom#1588
+              1. Else Phantom#1591
 
             2. If ((?() = $find_overloaded<callableDef>(EC.global.callable, callTargetKey, $parameterListIR_of_callableDef))), then
 
               1. Return ?()
 
-            2. Else Phantom#1589
+            2. Else Phantom#1592
 
   2. Case (% matches pattern `BLOCK`)
 
@@ -29831,15 +29883,15 @@ def $find_callableDef_overloaded_e(cursor, EC, prefixedNameIR, (argumentIR)*)
 
                 1. Return ?((callableId : ((block), callableDef) # (id_default)* # (id_optional)*))
 
-            1. Else Phantom#1590
+            1. Else Phantom#1593
 
           2. If ((?() = $find_overloaded<callableDef>(EC.block.callable, callTargetKey, $parameterListIR_of_callableDef))), then
 
             1. Return $find_callableDef_overloaded_e((global), EC, (` nameIR), (argumentIR)*)
 
-          2. Else Phantom#1591
+          2. Else Phantom#1594
 
-    1. Else Phantom#1592
+    1. Else Phantom#1595
 
   3. Case (% matches pattern `LOCAL`)
 
@@ -29849,7 +29901,7 @@ def $find_callableDef_overloaded_e(cursor, EC, prefixedNameIR, (argumentIR)*)
 
         1. Return $find_callableDef_overloaded_e((block), EC, (` nameIR), (argumentIR)*)
 
-    1. Else Phantom#1593
+    1. Else Phantom#1596
 
 def $find_constructorDef_e(EC, prefixedNameIR, (argumentIR)*)
 
@@ -29981,7 +30033,7 @@ def $update_object_qualified_e(ARCH_0, objectId, object)
 
     1. Return ARCH_1
 
-1. Else Phantom#1594
+1. Else Phantom#1597
 
 def $update_object_unqualified_e(ARCH_0, id, object)
 
@@ -30003,9 +30055,9 @@ def $update_object_unqualified_e(ARCH_0, id, object)
 
                 1. Return ARCH_1
 
-          1. Else Phantom#1595
+          1. Else Phantom#1598
 
-      1. Else Phantom#1596
+      1. Else Phantom#1599
 
 def $update_objectState_e(ARCH_0, objectId, objectState)
 
@@ -30093,7 +30145,7 @@ relation Expr_eval: p EC ARCH |- (expressionIR # expressionNoteIR) : % % %
 
           1. Result in: % % % |- % : EC ARCH expressionResult
 
-  1. Else Phantom#1597
+  1. Else Phantom#1600
 
 2. Case analysis on expressionIR
 
@@ -30173,9 +30225,9 @@ relation Expr_eval: p EC ARCH |- (expressionIR # expressionNoteIR) : % % %
 
                         1. Result in: % % % |- % : EC_1 ARCH_1 expressionResult
 
-                  1. Else Phantom#1598
+                  1. Else Phantom#1601
 
-        1. Else Phantom#1599
+        1. Else Phantom#1602
 
         2. Case analysis on binop
 
@@ -30189,7 +30241,7 @@ relation Expr_eval: p EC ARCH |- (expressionIR # expressionNoteIR) : % % %
 
                   1. Result in: % % % |- % : EC_1 ARCH_1 (abortResult as expressionResult)
 
-              1. Else Phantom#1600
+              1. Else Phantom#1603
 
               2. Case analysis on expressionResult
 
@@ -30205,7 +30257,7 @@ relation Expr_eval: p EC ARCH |- (expressionIR # expressionNoteIR) : % % %
 
                     1. Result in: % % % |- % : EC_2 ARCH_2 expressionResult_r
 
-              2. Else Phantom#1601
+              2. Else Phantom#1604
 
           2. Case (% matches pattern `||`)
 
@@ -30217,7 +30269,7 @@ relation Expr_eval: p EC ARCH |- (expressionIR # expressionNoteIR) : % % %
 
                   1. Result in: % % % |- % : EC_1 ARCH_1 (abortResult as expressionResult)
 
-              1. Else Phantom#1602
+              1. Else Phantom#1605
 
               2. Case analysis on expressionResult
 
@@ -30233,9 +30285,9 @@ relation Expr_eval: p EC ARCH |- (expressionIR # expressionNoteIR) : % % %
 
                     1. Result in: % % % |- % : EC_2 ARCH_2 expressionResult_r
 
-              2. Else Phantom#1603
+              2. Else Phantom#1606
 
-        2. Else Phantom#1604
+        2. Else Phantom#1607
 
   5. Case (% has type ternaryExpressionIR)
 
@@ -30251,7 +30303,7 @@ relation Expr_eval: p EC ARCH |- (expressionIR # expressionNoteIR) : % % %
 
               1. Result in: % % % |- % : EC_1 ARCH_1 (abortResult as expressionResult)
 
-          1. Else Phantom#1605
+          1. Else Phantom#1608
 
           2. Case analysis on expressionResult
 
@@ -30267,7 +30319,7 @@ relation Expr_eval: p EC ARCH |- (expressionIR # expressionNoteIR) : % % %
 
                 1. Result in: % % % |- % : EC_2 ARCH_2 expressionResult_false
 
-          2. Else Phantom#1606
+          2. Else Phantom#1609
 
   6. Case (% has type castExpressionIR)
 
@@ -30463,11 +30515,11 @@ relation Expr_eval: p EC ARCH |- (expressionIR # expressionNoteIR) : % % %
 
                                   1. Result in: % % % |- % : EC ARCH expressionResult
 
-                            1. Else Phantom#1607
+                            1. Else Phantom#1610
 
-                    1. Else Phantom#1608
+                    1. Else Phantom#1611
 
-                1. Else Phantom#1609
+                1. Else Phantom#1612
 
         2. Case (% has type typedExpressionIR)
 
@@ -30531,7 +30583,7 @@ relation Expr_eval: p EC ARCH |- (expressionIR # expressionNoteIR) : % % %
 
                                                   1. Result in: % % % |- % : EC_1 ARCH_1 expressionResult'
 
-                                          1. Else Phantom#1610
+                                          1. Else Phantom#1613
 
                                 3. Case (% = "lastIndex")
 
@@ -30547,9 +30599,9 @@ relation Expr_eval: p EC ARCH |- (expressionIR # expressionNoteIR) : % % %
 
                                             1. Result in: % % % |- % : EC_1 ARCH_1 expressionResult'
 
-                                    1. Else Phantom#1611
+                                    1. Else Phantom#1614
 
-                              1. Else Phantom#1612
+                              1. Else Phantom#1615
 
                         2. Case (% has type structValue)
 
@@ -30567,7 +30619,7 @@ relation Expr_eval: p EC ARCH |- (expressionIR # expressionNoteIR) : % % %
 
                                       1. Result in: % % % |- % : EC_1 ARCH_1 expressionResult'
 
-                                1. Else Phantom#1613
+                                1. Else Phantom#1616
 
                         3. Case (% has type headerValue)
 
@@ -30585,7 +30637,7 @@ relation Expr_eval: p EC ARCH |- (expressionIR # expressionNoteIR) : % % %
 
                                       1. Result in: % % % |- % : EC_1 ARCH_1 expressionResult'
 
-                                1. Else Phantom#1614
+                                1. Else Phantom#1617
 
                         4. Case (% has type headerUnionValue)
 
@@ -30603,9 +30655,9 @@ relation Expr_eval: p EC ARCH |- (expressionIR # expressionNoteIR) : % % %
 
                                       1. Result in: % % % |- % : EC_1 ARCH_1 expressionResult'
 
-                                1. Else Phantom#1615
+                                1. Else Phantom#1618
 
-                      1. Else Phantom#1616
+                      1. Else Phantom#1619
 
               2. (Expr_eval: p EC ARCH |- typedExpressionIR_base : EC_1 ARCH_1 expressionResult)
 
@@ -30639,11 +30691,11 @@ relation Expr_eval: p EC ARCH |- (expressionIR # expressionNoteIR) : % % %
 
                                 1. Result in: % % % |- % : EC_1 ARCH_1 expressionResult'
 
-                          1. Else Phantom#1617
+                          1. Else Phantom#1620
 
-                    1. Else Phantom#1618
+                    1. Else Phantom#1621
 
-                1. Else Phantom#1619
+                1. Else Phantom#1622
 
   12. Case (% has type indexAccessExpressionIR)
 
@@ -30691,9 +30743,9 @@ relation Expr_eval: p EC ARCH |- (expressionIR # expressionNoteIR) : % % %
 
                                         1. Result in: % % % |- % : EC_1 ARCH_1 expressionResult
 
-                                  1. Else Phantom#1620
+                                  1. Else Phantom#1623
 
-                          1. Else Phantom#1621
+                          1. Else Phantom#1624
 
                       2. Case (% has type headerStackValue)
 
@@ -30719,13 +30771,13 @@ relation Expr_eval: p EC ARCH |- (expressionIR # expressionNoteIR) : % % %
 
                                             1. Result in: % % % |- % : EC_1 ARCH_1 expressionResult
 
-                                      1. Else Phantom#1622
+                                      1. Else Phantom#1625
 
-                          1. Else Phantom#1623
+                          1. Else Phantom#1626
 
-                    1. Else Phantom#1624
+                    1. Else Phantom#1627
 
-                1. Else Phantom#1625
+                1. Else Phantom#1628
 
   13. Case (% has type sliceAccessExpressionIR)
 
@@ -30755,7 +30807,7 @@ relation Expr_eval: p EC ARCH |- (expressionIR # expressionNoteIR) : % % %
 
                       1. Result in: % % % |- % : EC_1 ARCH_1 expressionResult
 
-                1. Else Phantom#1626
+                1. Else Phantom#1629
 
   14. Case (% has type callExpressionIR)
 
@@ -30801,9 +30853,9 @@ relation Expr_eval: p EC ARCH |- (expressionIR # expressionNoteIR) : % % %
 
                                 1. Result in: % % % |- % : EC_2 ARCH_2 ((` value') as expressionResult)
 
-                            1. Else Phantom#1627
+                            1. Else Phantom#1630
 
-      1. Else Phantom#1628
+      1. Else Phantom#1631
 
   15. Case (% has type parenthesizedExpressionIR)
 
@@ -30815,7 +30867,7 @@ relation Expr_eval: p EC ARCH |- (expressionIR # expressionNoteIR) : % % %
 
           1. Result in: % % % |- % : EC_1 ARCH_1 expressionResult
 
-2. Else Phantom#1629
+2. Else Phantom#1632
 
 syntax expressionListResult = 
    | ` value*
@@ -30830,7 +30882,7 @@ relation Exprs_eval: p evalContext arch |- (typedExpressionIR)* : % % %
 
     1. Result in: % % % |- % : evalContext arch ((` []) as expressionListResult)
 
-  1. Else Phantom#1630
+  1. Else Phantom#1633
 
   2. If (((typedExpressionIR)* matches pattern _ :: _)), then
 
@@ -30866,7 +30918,7 @@ relation Exprs_eval: p evalContext arch |- (typedExpressionIR)* : % % %
 
                       1. Result in: % % % |- % : EC_2 ARCH_2 ((` value_h :: (value_t)*) as expressionListResult)
 
-  2. Else Phantom#1631
+  2. Else Phantom#1634
 
 syntax keysetExpressionResult = 
    | ` setValue*
@@ -30907,7 +30959,7 @@ relation Argument_eval: p EC_0 ARCH_0 |- argumentIR : % % %
 
           1. Result in: % % % |- % : EC_1 ARCH_1 expressionResult
 
-1. Else Phantom#1632
+1. Else Phantom#1635
 
 syntax storageReferenceResult = 
    | ` storageReference?
@@ -30934,7 +30986,7 @@ relation Argument_eval_lvalue: p EC_0 ARCH_0 |- argumentIR : % % %
 
                 1. Result in: % % % |- % : EC_1 ARCH_1 storageReferenceResult
 
-          1. Else Phantom#1633
+          1. Else Phantom#1636
 
   2. Case (% matches pattern `%=%`)
 
@@ -30952,7 +31004,7 @@ relation Argument_eval_lvalue: p EC_0 ARCH_0 |- argumentIR : % % %
 
                 1. Result in: % % % |- % : EC_1 ARCH_1 storageReferenceResult
 
-          1. Else Phantom#1634
+          1. Else Phantom#1637
 
   3. Case (% matches pattern `%=_`)
 
@@ -31022,7 +31074,7 @@ relation Lvalue_eval: p EC ARCH |- (lvalueIR # lvalueNoteIR) : % % %
 
                                     1. Result in: % % % |- % : EC_1 ARCH_1 (rejectTransitionResult as storageReferenceResult)
 
-                                1. Else Phantom#1635
+                                1. Else Phantom#1638
 
                                 2. If ((n_idx < n_size)), then
 
@@ -31030,9 +31082,9 @@ relation Lvalue_eval: p EC ARCH |- (lvalueIR # lvalueNoteIR) : % % %
 
                                     1. Result in: % % % |- % : EC_1 ARCH_1 storageReferenceResult'
 
-                                2. Else Phantom#1636
+                                2. Else Phantom#1639
 
-                              1. Else Phantom#1637
+                              1. Else Phantom#1640
 
                         2. Case false
 
@@ -31040,7 +31092,7 @@ relation Lvalue_eval: p EC ARCH |- (lvalueIR # lvalueNoteIR) : % % %
 
                             1. Result in: % % % |- % : EC_1 ARCH_1 storageReferenceResult'
 
-                1. Else Phantom#1638
+                1. Else Phantom#1641
 
   3. Case (% matches pattern `%[%]`)
 
@@ -31088,9 +31140,9 @@ relation Lvalue_eval: p EC ARCH |- (lvalueIR # lvalueNoteIR) : % % %
 
                                   1. Result in: % % % |- % : EC_2 ARCH_2 storageReferenceResult'
 
-                            1. Else Phantom#1639
+                            1. Else Phantom#1642
 
-                1. Else Phantom#1640
+                1. Else Phantom#1643
 
   4. Case (% matches pattern `%[%:%]`)
 
@@ -31138,9 +31190,9 @@ relation Lvalue_eval: p EC ARCH |- (lvalueIR # lvalueNoteIR) : % % %
 
                                   1. Result in: % % % |- % : EC_1 ARCH_1 storageReferenceResult'
 
-                            1. Else Phantom#1641
+                            1. Else Phantom#1644
 
-                1. Else Phantom#1642
+                1. Else Phantom#1645
 
   5. Case (% matches pattern `(%)`)
 
@@ -31198,11 +31250,11 @@ relation Lvalue_read: p EC ARCH |- storageReference : %
 
                                 1. Result in: % % % |- % : value'
 
-                            1. Else Phantom#1643
+                            1. Else Phantom#1646
 
-                      1. Else Phantom#1644
+                      1. Else Phantom#1647
 
-                  1. Else Phantom#1645
+                  1. Else Phantom#1648
 
             2. Case (% has type headerStackValue)
 
@@ -31218,9 +31270,9 @@ relation Lvalue_read: p EC ARCH |- storageReference : %
 
                         1. Result in: % % % |- % : value
 
-                    1. Else Phantom#1646
+                    1. Else Phantom#1649
 
-                  1. Else Phantom#1647
+                  1. Else Phantom#1650
 
             3. Case (% has type structValue)
 
@@ -31236,7 +31288,7 @@ relation Lvalue_read: p EC ARCH |- storageReference : %
 
                         1. Result in: % % % |- % : value'
 
-                    1. Else Phantom#1648
+                    1. Else Phantom#1651
 
             4. Case (% has type headerValue)
 
@@ -31252,7 +31304,7 @@ relation Lvalue_read: p EC ARCH |- storageReference : %
 
                         1. Result in: % % % |- % : value'
 
-                    1. Else Phantom#1649
+                    1. Else Phantom#1652
 
             5. Case (% has type headerUnionValue)
 
@@ -31268,9 +31320,9 @@ relation Lvalue_read: p EC ARCH |- storageReference : %
 
                         1. Result in: % % % |- % : value'
 
-                    1. Else Phantom#1650
+                    1. Else Phantom#1653
 
-          1. Else Phantom#1651
+          1. Else Phantom#1654
 
   3. Case (% matches pattern `%[%]`)
 
@@ -31306,7 +31358,7 @@ relation Lvalue_read: p EC ARCH |- storageReference : %
 
                                   1. Result in: % % % |- % : value''
 
-                            1. Else Phantom#1652
+                            1. Else Phantom#1655
 
                           2. Case false
 
@@ -31320,11 +31372,11 @@ relation Lvalue_read: p EC ARCH |- storageReference : %
 
                                     1. Result in: % % % |- % : value'''
 
-                              1. Else Phantom#1653
+                              1. Else Phantom#1656
 
-              1. Else Phantom#1654
+              1. Else Phantom#1657
 
-      1. Else Phantom#1655
+      1. Else Phantom#1658
 
   4. Case (% matches pattern `%[%:%]`)
 
@@ -31378,7 +31430,7 @@ relation Lvalue_write: p EC_0 ARCH |- storageReference -> value : %
 
                           1. Result in: % % % |- % -> % : EC_1
 
-                  1. Else Phantom#1656
+                  1. Else Phantom#1659
 
             2. Case (% has type structValue)
 
@@ -31454,13 +31506,13 @@ relation Lvalue_write: p EC_0 ARCH |- storageReference -> value : %
 
                                                 1. Result in: % % % |- % -> % : EC_1
 
-                                1. Else Phantom#1657
+                                1. Else Phantom#1660
 
-                          1. Else Phantom#1658
+                          1. Else Phantom#1661
 
-                      1. Else Phantom#1659
+                      1. Else Phantom#1662
 
-          1. Else Phantom#1660
+          1. Else Phantom#1663
 
   3. Case (% matches pattern `%[%]`)
 
@@ -31500,15 +31552,15 @@ relation Lvalue_write: p EC_0 ARCH |- storageReference -> value : %
 
                                       1. Result in: % % % |- % -> % : EC_1
 
-                            1. Else Phantom#1661
+                            1. Else Phantom#1664
 
                           2. Case false
 
                             1. Result in: % % % |- % -> % : EC_0
 
-              1. Else Phantom#1662
+              1. Else Phantom#1665
 
-      1. Else Phantom#1663
+      1. Else Phantom#1666
 
   4. Case (% matches pattern `%[%:%]`)
 
@@ -31601,7 +31653,7 @@ relation Stmt_eval: p EC ARCH |- statementIR : % % %
 
                               1. Result in: % % % |- % : EC_3 ARCH_2 ((`empty) as statementResult)
 
-                1. Else Phantom#1664
+                1. Else Phantom#1667
 
   3. Case (% has type callStatementIR)
 
@@ -31679,7 +31731,7 @@ relation Stmt_eval: p EC ARCH |- statementIR : % % %
 
                     1. Result in: % % % |- % : EC_cond ARCH_cond (abortResult as statementResult)
 
-                1. Else Phantom#1665
+                1. Else Phantom#1668
 
                 2. Case analysis on expressionResult
 
@@ -31693,7 +31745,7 @@ relation Stmt_eval: p EC ARCH |- statementIR : % % %
 
                     1. Result in: % % % |- % : EC_cond ARCH_cond ((`empty) as statementResult)
 
-                2. Else Phantom#1666
+                2. Else Phantom#1669
 
           2. Case (% matches pattern `IF(%)%ELSE%`)
 
@@ -31707,7 +31759,7 @@ relation Stmt_eval: p EC ARCH |- statementIR : % % %
 
                     1. Result in: % % % |- % : EC_cond ARCH_cond (abortResult as statementResult)
 
-                1. Else Phantom#1667
+                1. Else Phantom#1670
 
                 2. Case analysis on expressionResult
 
@@ -31723,9 +31775,9 @@ relation Stmt_eval: p EC ARCH |- statementIR : % % %
 
                       1. Result in: % % % |- % : EC_else ARCH_else statementResult
 
-                2. Else Phantom#1668
+                2. Else Phantom#1671
 
-1. Else Phantom#1669
+1. Else Phantom#1672
 
 2. If ((p matches pattern `LOCAL`)), then
 
@@ -31797,9 +31849,9 @@ relation Stmt_eval: p EC ARCH |- statementIR : % % %
 
                             1. Result in: % % % |- % : EC_4 ARCH_2 statementResult'
 
-                  1. Else Phantom#1670
+                  1. Else Phantom#1673
 
-        1. Else Phantom#1671
+        1. Else Phantom#1674
 
         2. Group forStatementIR-in: (local) EC ARCH |- (forStatementIR as statementIR) : % % %
 
@@ -31847,7 +31899,7 @@ relation Stmt_eval: p EC ARCH |- statementIR : % % %
 
                   1. Result in: % % % |- % : EC_1 ARCH_1 statementResult
 
-          1. Else Phantom#1672
+          1. Else Phantom#1675
 
     3. Case (% has type breakStatement)
 
@@ -31901,9 +31953,9 @@ relation Stmt_eval: p EC ARCH |- statementIR : % % %
 
                         1. Result in: % % % |- % : EC_2 ARCH_2 statementResult
 
-  1. Else Phantom#1673
+  1. Else Phantom#1676
 
-2. Else Phantom#1674
+2. Else Phantom#1677
 
 relation BlockElementStmt_eval: EC_0 arch |- blockElementStatementIR : % % %
 
@@ -31943,7 +31995,7 @@ relation BlockElementStmtList_eval: evalContext arch |- (blockElementStatementIR
 
     1. Result in: % % |- % : evalContext arch ((`empty) as statementResult)
 
-  1. Else Phantom#1675
+  1. Else Phantom#1678
 
   2. If (((blockElementStatementIR)* matches pattern _ :: _)), then
 
@@ -31955,7 +32007,7 @@ relation BlockElementStmtList_eval: evalContext arch |- (blockElementStatementIR
 
           1. Result in: % % |- % : EC_1 ARCH_1 statementResult
 
-        1. Else Phantom#1676
+        1. Else Phantom#1679
 
         2. If ((statementResult has type continueEmptyResult)), then
 
@@ -31965,9 +32017,9 @@ relation BlockElementStmtList_eval: evalContext arch |- (blockElementStatementIR
 
               1. Result in: % % |- % : EC_2 ARCH_2 statementResult'
 
-        2. Else Phantom#1677
+        2. Else Phantom#1680
 
-  2. Else Phantom#1678
+  2. Else Phantom#1681
 
 relation Block_eval: EC_0 ARCH_0 |- (annotationList { blockElementStatementListIR }) : % % %
 
@@ -32017,7 +32069,7 @@ relation ParserStmt_eval: EC_0 ARCH |- parserStatementIR : % % %
 
                 1. Result in: % % |- % : EC_1 ARCH_1 ((`empty) as parserStatementResult)
 
-          1. Else Phantom#1679
+          1. Else Phantom#1682
 
   3. Case (% has type emptyStatementIR)
 
@@ -32033,7 +32085,7 @@ relation ParserStmt_eval: EC_0 ARCH |- parserStatementIR : % % %
 
               1. Result in: % % |- % : EC_1 ARCH_1 ((`empty) as parserStatementResult)
 
-          1. Else Phantom#1680
+          1. Else Phantom#1683
 
   4. Case (% has type assignmentStatementIR)
 
@@ -32057,7 +32109,7 @@ relation ParserStmt_eval: EC_0 ARCH |- parserStatementIR : % % %
 
                 1. Result in: % % |- % : EC_1 ARCH_1 ((`empty) as parserStatementResult)
 
-          1. Else Phantom#1681
+          1. Else Phantom#1684
 
   5. Case (% has type callStatementIR)
 
@@ -32081,7 +32133,7 @@ relation ParserStmt_eval: EC_0 ARCH |- parserStatementIR : % % %
 
                 1. Result in: % % |- % : EC_1 ARCH_1 ((`empty) as parserStatementResult)
 
-          1. Else Phantom#1682
+          1. Else Phantom#1685
 
   6. Case (% has type parserBlockStatementIR)
 
@@ -32117,7 +32169,7 @@ relation ParserStmt_eval: EC_0 ARCH |- parserStatementIR : % % %
 
                     1. Result in: % % |- % : EC_cond ARCH_cond (rejectTransitionResult as parserStatementResult)
 
-                1. Else Phantom#1683
+                1. Else Phantom#1686
 
                 2. Case analysis on expressionResult
 
@@ -32131,7 +32183,7 @@ relation ParserStmt_eval: EC_0 ARCH |- parserStatementIR : % % %
 
                     1. Result in: % % |- % : EC_cond ARCH_cond ((`empty) as parserStatementResult)
 
-                2. Else Phantom#1684
+                2. Else Phantom#1687
 
           2. Case (% matches pattern `IF(%)%ELSE%`)
 
@@ -32153,9 +32205,9 @@ relation ParserStmt_eval: EC_0 ARCH |- parserStatementIR : % % %
 
                       1. Result in: % % |- % : EC_else ARCH_else parserStatementResult
 
-                1. Else Phantom#1685
+                1. Else Phantom#1688
 
-1. Else Phantom#1686
+1. Else Phantom#1689
 
 relation ParserStmts_eval: evalContext arch |- (parserStatementIR)* : % % %
 
@@ -32165,7 +32217,7 @@ relation ParserStmts_eval: evalContext arch |- (parserStatementIR)* : % % %
 
     1. Result in: % % |- % : evalContext arch ((`empty) as parserStatementResult)
 
-  1. Else Phantom#1687
+  1. Else Phantom#1690
 
   2. If (((parserStatementIR)* matches pattern _ :: _)), then
 
@@ -32189,7 +32241,7 @@ relation ParserStmts_eval: evalContext arch |- (parserStatementIR)* : % % %
 
                 1. Result in: % % |- % : EC_2 ARCH_2 parserStatementResult'
 
-  2. Else Phantom#1688
+  2. Else Phantom#1691
 
 syntax transitionResult = 
    | accept
@@ -32236,7 +32288,7 @@ relation ParserSelect_eval: EC_0 ARCH_0 |- selectExpressionIR : % % %
 
                         1. Result in: % % |- % : EC_2 ARCH_2 (rejectTransitionResult as transitionResult)
 
-                    1. Else Phantom#1689
+                    1. Else Phantom#1692
 
                     2. If (((nameIR_state)? matches pattern (_))), then
 
@@ -32246,9 +32298,9 @@ relation ParserSelect_eval: EC_0 ARCH_0 |- selectExpressionIR : % % %
 
                           1. Result in: % % |- % : EC_3 ARCH_3 transitionResult
 
-                    2. Else Phantom#1690
+                    2. Else Phantom#1693
 
-      1. Else Phantom#1691
+      1. Else Phantom#1694
 
 relation ParserTransition_eval: evalContext arch |- (transition stateExpressionIR) : % % %
 
@@ -32272,13 +32324,13 @@ relation ParserTransition_eval: evalContext arch |- (transition stateExpressionI
 
               1. Result in: % % |- % : evalContext arch ((reject errorValue) as transitionResult)
 
-        1. Else Phantom#1692
+        1. Else Phantom#1695
 
         2. If (((nameIR =/= "accept") /\ (nameIR =/= "reject"))), then
 
           1. Result in: % % |- % : evalContext arch ((state nameIR) as transitionResult)
 
-        2. Else Phantom#1693
+        2. Else Phantom#1696
 
     2. Case (% has type selectExpressionIR)
 
@@ -32346,7 +32398,7 @@ relation ParserState_trans: EC_0 ARCH_0 |-transition nameIR : % % %
 
                   1. Result in: % % |-transition % : EC_2 ARCH_2 transitionResult'
 
-    1. Else Phantom#1694
+    1. Else Phantom#1697
 
 syntax parserDeclarationResult = parserStatementResult
 
@@ -32386,9 +32438,9 @@ relation ParserLocalDecl_eval: EC_0 ARCH |- parserLocalDeclarationIR : % % %
 
                 1. Result in: % % |- % : EC_1 ARCH_1 ((`empty) as parserDeclarationResult)
 
-          1. Else Phantom#1695
+          1. Else Phantom#1698
 
-1. Else Phantom#1696
+1. Else Phantom#1699
 
 relation ParserLocalDecls_eval: evalContext arch |- (parserLocalDeclarationIR)* : % % %
 
@@ -32398,7 +32450,7 @@ relation ParserLocalDecls_eval: evalContext arch |- (parserLocalDeclarationIR)* 
 
     1. Result in: % % |- % : evalContext arch ((`empty) as parserDeclarationResult)
 
-  1. Else Phantom#1697
+  1. Else Phantom#1700
 
   2. If (((parserLocalDeclarationIR)* matches pattern _ :: _)), then
 
@@ -32420,7 +32472,7 @@ relation ParserLocalDecls_eval: evalContext arch |- (parserLocalDeclarationIR)* 
 
               1. Result in: % % |- % : EC_2 ARCH_2 parserStatementResult
 
-  2. Else Phantom#1698
+  2. Else Phantom#1701
 
 syntax tableResult = 
    | exit
@@ -32488,7 +32540,7 @@ relation Table_eval: EC_0 ARCH_0 |- typeId TBL : % % %
 
                                         1. Result in: % % |- % % : EC_3 ARCH_3 ((return ?((tableMetadataStructValue as value))) as tableResult)
 
-                          1. Else Phantom#1699
+                          1. Else Phantom#1702
 
 syntax controlBodyResult = 
    | exit
@@ -32514,13 +32566,13 @@ relation ControlBody_eval: EC_0 ARCH_0 |- controlBodyIR : % % %
 
           1. Result in: % % |- % : EC_1 ARCH_1 ((exit) as controlBodyResult)
 
-    1. Else Phantom#1700
+    1. Else Phantom#1703
 
     2. If ((statementResult = ((return ?()) as statementResult))), then
 
       1. Result in: % % |- % : EC_1 ARCH_1 ((return ?()) as controlBodyResult)
 
-    2. Else Phantom#1701
+    2. Else Phantom#1704
 
 syntax controlLocalDeclarationResult = 
    | `empty
@@ -32562,9 +32614,9 @@ relation ControlLocalDecl_eval: EC_0 ARCH |- controlLocalDeclarationIR : % % %
 
                 1. Result in: % % |- % : EC_1 ARCH_1 ((`empty) as controlLocalDeclarationResult)
 
-          1. Else Phantom#1702
+          1. Else Phantom#1705
 
-1. Else Phantom#1703
+1. Else Phantom#1706
 
 relation ControlLocalDecls_eval: evalContext arch |- (controlLocalDeclarationIR)* : % % %
 
@@ -32574,7 +32626,7 @@ relation ControlLocalDecls_eval: evalContext arch |- (controlLocalDeclarationIR)
 
     1. Result in: % % |- % : evalContext arch ((`empty) as controlLocalDeclarationResult)
 
-  1. Else Phantom#1704
+  1. Else Phantom#1707
 
   2. If (((controlLocalDeclarationIR)* matches pattern _ :: _)), then
 
@@ -32598,7 +32650,7 @@ relation ControlLocalDecls_eval: evalContext arch |- (controlLocalDeclarationIR)
 
                 1. Result in: % % |- % : EC_2 ARCH_2 controlLocalDeclarationResult'
 
-  2. Else Phantom#1705
+  2. Else Phantom#1708
 
 syntax declarationResult = 
    | `empty
@@ -32682,9 +32734,9 @@ relation Callee_eval: p EC ARCH |- callableTargetIR <_>( argumentListIR ): % % %
 
                       1. Result in: % % % |- % <_>( % ): EC ARCH ((` (actionCallee as callee)) as calleeResult)
 
-              1. Else Phantom#1706
+              1. Else Phantom#1709
 
-          1. Else Phantom#1707
+          1. Else Phantom#1710
 
       2. Group externFunctionCallee: p EC ARCH |- (referenceExpressionIR as callableTargetIR) <_>( argumentListIR ): % % %
 
@@ -32704,9 +32756,9 @@ relation Callee_eval: p EC ARCH |- callableTargetIR <_>( argumentListIR ): % % %
 
                       1. Result in: % % % |- % <_>( % ): EC ARCH ((` (externFunctionCallee as callee)) as calleeResult)
 
-              1. Else Phantom#1708
+              1. Else Phantom#1711
 
-          1. Else Phantom#1709
+          1. Else Phantom#1712
 
       3. Group definedFunctionCallee: p EC ARCH |- (referenceExpressionIR as callableTargetIR) <_>( argumentListIR ): % % %
 
@@ -32726,9 +32778,9 @@ relation Callee_eval: p EC ARCH |- callableTargetIR <_>( argumentListIR ): % % %
 
                       1. Result in: % % % |- % <_>( % ): EC ARCH ((` (definedFunctionCallee as callee)) as calleeResult)
 
-              1. Else Phantom#1710
+              1. Else Phantom#1713
 
-          1. Else Phantom#1711
+          1. Else Phantom#1714
 
   2. Case (% matches pattern `%.%`)
 
@@ -32750,9 +32802,9 @@ relation Callee_eval: p EC ARCH |- callableTargetIR <_>( argumentListIR ): % % %
 
                     1. Result in: % % % |- % <_>( % ): EC_1 ARCH_1 (abortResult as calleeResult)
 
-                1. Else Phantom#1712
+                1. Else Phantom#1715
 
-          1. Else Phantom#1713
+          1. Else Phantom#1716
 
         2. Case analysis on nameIR
 
@@ -32782,13 +32834,13 @@ relation Callee_eval: p EC ARCH |- callableTargetIR <_>( argumentListIR ): % % %
 
                                   1. Result in: % % % |- % <_>( % ): EC_1 ARCH_1 ((` (builtinMethodCallee as callee)) as calleeResult)
 
-                          1. Else Phantom#1714
+                          1. Else Phantom#1717
 
-                      1. Else Phantom#1715
+                      1. Else Phantom#1718
 
-                1. Else Phantom#1716
+                1. Else Phantom#1719
 
-            1. Else Phantom#1717
+            1. Else Phantom#1720
 
           2. Case (% = "pop_front")
 
@@ -32816,13 +32868,13 @@ relation Callee_eval: p EC ARCH |- callableTargetIR <_>( argumentListIR ): % % %
 
                                   1. Result in: % % % |- % <_>( % ): EC_1 ARCH_1 ((` (builtinMethodCallee as callee)) as calleeResult)
 
-                          1. Else Phantom#1718
+                          1. Else Phantom#1721
 
-                      1. Else Phantom#1719
+                      1. Else Phantom#1722
 
-                1. Else Phantom#1720
+                1. Else Phantom#1723
 
-            1. Else Phantom#1721
+            1. Else Phantom#1724
 
           3. Case (% = "isValid")
 
@@ -32848,13 +32900,13 @@ relation Callee_eval: p EC ARCH |- callableTargetIR <_>( argumentListIR ): % % %
 
                                 1. Result in: % % % |- % <_>( % ): EC_1 ARCH_1 ((` (builtinMethodCallee as callee)) as calleeResult)
 
-                          1. Else Phantom#1722
+                          1. Else Phantom#1725
 
-                      1. Else Phantom#1723
+                      1. Else Phantom#1726
 
-                1. Else Phantom#1724
+                1. Else Phantom#1727
 
-            1. Else Phantom#1725
+            1. Else Phantom#1728
 
           4. Case (% = "setValid")
 
@@ -32880,13 +32932,13 @@ relation Callee_eval: p EC ARCH |- callableTargetIR <_>( argumentListIR ): % % %
 
                                 1. Result in: % % % |- % <_>( % ): EC_1 ARCH_1 ((` (builtinMethodCallee as callee)) as calleeResult)
 
-                          1. Else Phantom#1726
+                          1. Else Phantom#1729
 
-                      1. Else Phantom#1727
+                      1. Else Phantom#1730
 
-                1. Else Phantom#1728
+                1. Else Phantom#1731
 
-            1. Else Phantom#1729
+            1. Else Phantom#1732
 
           5. Case (% = "setInvalid")
 
@@ -32912,15 +32964,15 @@ relation Callee_eval: p EC ARCH |- callableTargetIR <_>( argumentListIR ): % % %
 
                                 1. Result in: % % % |- % <_>( % ): EC_1 ARCH_1 ((` (builtinMethodCallee as callee)) as calleeResult)
 
-                          1. Else Phantom#1730
+                          1. Else Phantom#1733
 
-                      1. Else Phantom#1731
+                      1. Else Phantom#1734
 
-                1. Else Phantom#1732
+                1. Else Phantom#1735
 
-            1. Else Phantom#1733
+            1. Else Phantom#1736
 
-        2. Else Phantom#1734
+        2. Else Phantom#1737
 
       2. Group externMethodCallee: p EC ARCH |- (typedExpressionIR . nameIR) <_>( argumentListIR ): % % %
 
@@ -32982,21 +33034,21 @@ relation Callee_eval: p EC ARCH |- callableTargetIR <_>( argumentListIR ): % % %
 
                                                           1. Result in: % % % |- % <_>( % ): EC_1 ARCH_1 ((` (externMethodCallee as callee)) as calleeResult)
 
-                                                      1. Else Phantom#1735
+                                                      1. Else Phantom#1738
 
-                                                  1. Else Phantom#1736
+                                                  1. Else Phantom#1739
 
-                                              1. Else Phantom#1737
+                                              1. Else Phantom#1740
 
-                                      1. Else Phantom#1738
+                                      1. Else Phantom#1741
 
-                                  1. Else Phantom#1739
+                                  1. Else Phantom#1742
 
-                            1. Else Phantom#1740
+                            1. Else Phantom#1743
 
-                      1. Else Phantom#1741
+                      1. Else Phantom#1744
 
-          1. Else Phantom#1742
+          1. Else Phantom#1745
 
       3. If ((nameIR = "apply")), then
 
@@ -33058,17 +33110,17 @@ relation Callee_eval: p EC ARCH |- callableTargetIR <_>( argumentListIR ): % % %
 
                                                           1. Result in: % % % |- % <_>( % ): EC_1 ARCH_1 ((` (parserApplyMethodCallee as callee)) as calleeResult)
 
-                                                    1. Else Phantom#1743
+                                                    1. Else Phantom#1746
 
-                                        1. Else Phantom#1744
+                                        1. Else Phantom#1747
 
-                                    1. Else Phantom#1745
+                                    1. Else Phantom#1748
 
-                              1. Else Phantom#1746
+                              1. Else Phantom#1749
 
-                        1. Else Phantom#1747
+                        1. Else Phantom#1750
 
-            1. Else Phantom#1748
+            1. Else Phantom#1751
 
         2. Group controlApplyMethodCallee: p EC ARCH |- (typedExpressionIR . "apply") <_>( argumentListIR ): % % %
 
@@ -33128,21 +33180,21 @@ relation Callee_eval: p EC ARCH |- callableTargetIR <_>( argumentListIR ): % % %
 
                                                           1. Result in: % % % |- % <_>( % ): EC_1 ARCH_1 ((` (controlApplyMethodCallee as callee)) as calleeResult)
 
-                                                    1. Else Phantom#1749
+                                                    1. Else Phantom#1752
 
-                                        1. Else Phantom#1750
+                                        1. Else Phantom#1753
 
-                                    1. Else Phantom#1751
+                                    1. Else Phantom#1754
 
-                              1. Else Phantom#1752
+                              1. Else Phantom#1755
 
-                        1. Else Phantom#1753
+                        1. Else Phantom#1756
 
-            1. Else Phantom#1754
+            1. Else Phantom#1757
 
-      3. Else Phantom#1755
+      3. Else Phantom#1758
 
-1. Else Phantom#1756
+1. Else Phantom#1759
 
 2. (Let (argumentIR)* be argumentListIR)
 
@@ -33200,21 +33252,21 @@ relation Callee_eval: p EC ARCH |- callableTargetIR <_>( argumentListIR ): % % %
 
                                                 1. Result in: % % % |- % <_>( % ): EC_1 ARCH_1 ((` (tableApplyMethodCallee as callee)) as calleeResult)
 
-                                          1. Else Phantom#1757
+                                          1. Else Phantom#1760
 
-                                      1. Else Phantom#1758
+                                      1. Else Phantom#1761
 
-                                1. Else Phantom#1759
+                                1. Else Phantom#1762
 
-                          1. Else Phantom#1760
+                          1. Else Phantom#1763
 
-              1. Else Phantom#1761
+              1. Else Phantom#1764
 
-        1. Else Phantom#1762
+        1. Else Phantom#1765
 
-      1. Else Phantom#1763
+      1. Else Phantom#1766
 
-  1. Else Phantom#1764
+  1. Else Phantom#1767
 
 syntax copyInArgumentResult = 
    | ` storageReference?
@@ -33245,7 +33297,7 @@ relation Copy_in_argument: ARCH_0 |- p_caller EC_caller_0 (annotationList direct
 
               1. Result in: % |- % % % @ % % % ~> ARCH_1 EC_caller_1 EC_callee_1 # ((` ?()) as copyInArgumentResult)
 
-  1. Else Phantom#1765
+  1. Else Phantom#1768
 
 2. Case analysis on direction
 
@@ -33277,7 +33329,7 @@ relation Copy_in_argument: ARCH_0 |- p_caller EC_caller_0 (annotationList direct
 
                       1. Result in: % |- % % % @ % % % ~> ARCH_1 EC_caller_1 EC_callee_1 # ((` ?(storageReference')) as copyInArgumentResult)
 
-              1. Else Phantom#1766
+              1. Else Phantom#1769
 
   2. Case (% matches pattern `OUT`)
 
@@ -33305,7 +33357,7 @@ relation Copy_in_argument: ARCH_0 |- p_caller EC_caller_0 (annotationList direct
 
                     1. Result in: % |- % % % @ % % % ~> ARCH_1 EC_caller_1 EC_callee_1 # ((` (storageReference)?) as copyInArgumentResult)
 
-2. Else Phantom#1767
+2. Else Phantom#1770
 
 syntax copyInResult = 
    | ` storageReference?*
@@ -33324,9 +33376,9 @@ relation Copy_in: p_shared arch |- p_caller evalContext (parameterIR)* @ p_calle
 
         1. Result in: % % |- % % % @ % % % ~> arch evalContext EC_callee_1 # ((` []) as copyInResult)
 
-    1. Else Phantom#1768
+    1. Else Phantom#1771
 
-  1. Else Phantom#1769
+  1. Else Phantom#1772
 
   2. If (((parameterIR)* matches pattern _ :: _)), then
 
@@ -33372,11 +33424,11 @@ relation Copy_in: p_shared arch |- p_caller evalContext (parameterIR)* @ p_calle
 
                                 1. Result in: % % |- % % % @ % % % ~> ARCH_2 EC_caller_2 EC_callee_2 # ((` ((storageReference')?)*) as copyInResult)
 
-                          1. Else Phantom#1770
+                          1. Else Phantom#1773
 
-      1. Else Phantom#1771
+      1. Else Phantom#1774
 
-  2. Else Phantom#1772
+  2. Else Phantom#1775
 
 relation Copy_in_default: (parameterIR)* @ p_callee EC_callee_0 ~> %
 
@@ -33396,9 +33448,9 @@ relation Copy_in_default: (parameterIR)* @ p_callee EC_callee_0 ~> %
 
               1. Result in: % @ % % ~> EC_callee_1
 
-        1. Else Phantom#1773
+        1. Else Phantom#1776
 
-    1. Else Phantom#1774
+    1. Else Phantom#1777
 
 relation Copy_out_argument: ARCH |- p_caller EC_caller_0 (annotationList direction typeIR nameIR parameterInitializerOptIR) @ p_callee EC_callee (storageReference)? ~> %
 
@@ -33410,9 +33462,9 @@ relation Copy_out_argument: ARCH |- p_caller EC_caller_0 (annotationList directi
 
       1. Result in: % |- % % % @ % % % ~> EC_caller_0
 
-    1. Else Phantom#1775
+    1. Else Phantom#1778
 
-1. Else Phantom#1776
+1. Else Phantom#1779
 
 2. Group out-inout: ARCH |- p_caller EC_caller_0 (annotationList direction typeIR nameIR parameterInitializerOptIR) @ p_callee EC_callee (storageReference)? ~> %
 
@@ -33424,7 +33476,7 @@ relation Copy_out_argument: ARCH |- p_caller EC_caller_0 (annotationList directi
 
         1. Result in: % |- % % % @ % % % ~> EC_caller_0
 
-      1. Else Phantom#1777
+      1. Else Phantom#1780
 
     2. Case (% matches pattern (_))
 
@@ -33438,7 +33490,7 @@ relation Copy_out_argument: ARCH |- p_caller EC_caller_0 (annotationList directi
 
               1. Result in: % |- % % % @ % % % ~> EC_caller_1
 
-        1. Else Phantom#1778
+        1. Else Phantom#1781
 
 relation Copy_out: p_shared ARCH |- p_caller EC_caller_0 parameterListIR @ p_callee EC_callee ((storageReference)?)* ~> %
 
@@ -33496,7 +33548,7 @@ relation Call_eval: p EC_0 ARCH_0 |- callee @< typeArgumentListIR >( argumentLis
 
                                     1. Result in: % % % |- % @< % >( % ): EC_2 ARCH_2 ((exit) as callResult)
 
-                              1. Else Phantom#1779
+                              1. Else Phantom#1782
 
                               2. If ((actionResult = ((return ?()) as actionResult))), then
 
@@ -33504,11 +33556,11 @@ relation Call_eval: p EC_0 ARCH_0 |- callee @< typeArgumentListIR >( argumentLis
 
                                   1. Result in: % % % |- % @< % >( % ): EC_2 ARCH_2 ((return ?()) as callResult)
 
-                              2. Else Phantom#1780
+                              2. Else Phantom#1783
 
-                    1. Else Phantom#1781
+                    1. Else Phantom#1784
 
-        1. Else Phantom#1782
+        1. Else Phantom#1785
 
     2. Case (% has type definedFunctionCallee)
 
@@ -33548,7 +33600,7 @@ relation Call_eval: p EC_0 ARCH_0 |- callee @< typeArgumentListIR >( argumentLis
 
                                   1. Result in: % % % |- % @< % >( % ): EC_2 ARCH_2 (definedFunctionResult as callResult)
 
-  1. Else Phantom#1783
+  1. Else Phantom#1786
 
   2. (Let (argumentIR)* be argumentListIR)
 
@@ -33592,7 +33644,7 @@ relation Call_eval: p EC_0 ARCH_0 |- callee @< typeArgumentListIR >( argumentLis
 
                                     1. Result in: % % % |- % @< % >( % ): EC_2 ARCH_2 callResult
 
-    1. Else Phantom#1784
+    1. Else Phantom#1787
 
   3. If ((callee has type builtinMethodCallee)), then
 
@@ -33672,9 +33724,9 @@ relation Call_eval: p EC_0 ARCH_0 |- callee @< typeArgumentListIR >( argumentLis
 
                                                                         1. Result in: % % % |- % @< % >( % ): EC_2 ARCH_1 ((return ?()) as callResult)
 
-                                                          1. Else Phantom#1785
+                                                          1. Else Phantom#1788
 
-                                                  1. Else Phantom#1786
+                                                  1. Else Phantom#1789
 
                                                   2. If ((n_count >= n_size)), then
 
@@ -33688,17 +33740,17 @@ relation Call_eval: p EC_0 ARCH_0 |- callee @< typeArgumentListIR >( argumentLis
 
                                                             1. Result in: % % % |- % @< % >( % ): EC_2 ARCH_1 ((return ?()) as callResult)
 
-                                                  2. Else Phantom#1787
+                                                  2. Else Phantom#1790
 
-                                              1. Else Phantom#1788
+                                              1. Else Phantom#1791
 
-                                        1. Else Phantom#1789
+                                        1. Else Phantom#1792
 
-                          1. Else Phantom#1790
+                          1. Else Phantom#1793
 
-                      1. Else Phantom#1791
+                      1. Else Phantom#1794
 
-                    1. Else Phantom#1792
+                    1. Else Phantom#1795
 
                   2. Case (% = "pop_front")
 
@@ -33760,9 +33812,9 @@ relation Call_eval: p EC_0 ARCH_0 |- callee @< typeArgumentListIR >( argumentLis
 
                                                                       1. Result in: % % % |- % @< % >( % ): EC_2 ARCH_1 ((return ?()) as callResult)
 
-                                                      1. Else Phantom#1793
+                                                      1. Else Phantom#1796
 
-                                                  1. Else Phantom#1794
+                                                  1. Else Phantom#1797
 
                                                   2. If ((n_count >= n_size)), then
 
@@ -33780,23 +33832,23 @@ relation Call_eval: p EC_0 ARCH_0 |- callee @< typeArgumentListIR >( argumentLis
 
                                                                 1. Result in: % % % |- % @< % >( % ): EC_2 ARCH_1 ((return ?()) as callResult)
 
-                                                        1. Else Phantom#1795
+                                                        1. Else Phantom#1798
 
-                                                  2. Else Phantom#1796
+                                                  2. Else Phantom#1799
 
-                                              1. Else Phantom#1797
+                                              1. Else Phantom#1800
 
-                                        1. Else Phantom#1798
+                                        1. Else Phantom#1801
 
-                          1. Else Phantom#1799
+                          1. Else Phantom#1802
 
-                      1. Else Phantom#1800
+                      1. Else Phantom#1803
 
-                    1. Else Phantom#1801
+                    1. Else Phantom#1804
 
-                1. Else Phantom#1802
+                1. Else Phantom#1805
 
-          1. Else Phantom#1803
+          1. Else Phantom#1806
 
           2. If ((argumentListIR = [])), then
 
@@ -33838,11 +33890,11 @@ relation Call_eval: p EC_0 ARCH_0 |- callee @< typeArgumentListIR >( argumentLis
 
                                       1. Result in: % % % |- % @< % >( % ): EC_0 ARCH_0 (returnResult as callResult)
 
-                        1. Else Phantom#1804
+                        1. Else Phantom#1807
 
-                    1. Else Phantom#1805
+                    1. Else Phantom#1808
 
-                  1. Else Phantom#1806
+                  1. Else Phantom#1809
 
                 2. Case (% = "setValid")
 
@@ -33866,11 +33918,11 @@ relation Call_eval: p EC_0 ARCH_0 |- callee @< typeArgumentListIR >( argumentLis
 
                                     1. Result in: % % % |- % @< % >( % ): EC_1 ARCH_0 (returnResult as callResult)
 
-                        1. Else Phantom#1807
+                        1. Else Phantom#1810
 
-                    1. Else Phantom#1808
+                    1. Else Phantom#1811
 
-                  1. Else Phantom#1809
+                  1. Else Phantom#1812
 
                 3. Case (% = "setInvalid")
 
@@ -33894,19 +33946,19 @@ relation Call_eval: p EC_0 ARCH_0 |- callee @< typeArgumentListIR >( argumentLis
 
                                     1. Result in: % % % |- % @< % >( % ): EC_1 ARCH_0 (returnResult as callResult)
 
-                        1. Else Phantom#1810
+                        1. Else Phantom#1813
 
-                    1. Else Phantom#1811
+                    1. Else Phantom#1814
 
-                  1. Else Phantom#1812
+                  1. Else Phantom#1815
 
-              1. Else Phantom#1813
+              1. Else Phantom#1816
 
-          2. Else Phantom#1814
+          2. Else Phantom#1817
 
-      1. Else Phantom#1815
+      1. Else Phantom#1818
 
-  3. Else Phantom#1816
+  3. Else Phantom#1819
 
   4. (Let (argumentIR)* be argumentListIR)
 
@@ -33956,9 +34008,9 @@ relation Call_eval: p EC_0 ARCH_0 |- callee @< typeArgumentListIR >( argumentLis
 
                                           1. Result in: % % % |- % @< % >( % ): EC_2 ARCH_2 callResult
 
-            1. Else Phantom#1817
+            1. Else Phantom#1820
 
-    1. Else Phantom#1818
+    1. Else Phantom#1821
 
 2. Case analysis on callee
 
@@ -34028,9 +34080,9 @@ relation Call_eval: p EC_0 ARCH_0 |- callee @< typeArgumentListIR >( argumentLis
 
                                             1. Result in: % % % |- % @< % >( % ): EC_2 ARCH_3 ((return ?()) as callResult)
 
-                                    1. Else Phantom#1819
+                                    1. Else Phantom#1822
 
-                    1. Else Phantom#1820
+                    1. Else Phantom#1823
 
   2. Case (% has type controlApplyMethodCallee)
 
@@ -34092,7 +34144,7 @@ relation Call_eval: p EC_0 ARCH_0 |- callee @< typeArgumentListIR >( argumentLis
 
                                               1. Result in: % % % |- % @< % >( % ): EC_2 ARCH_3 ((exit) as callResult)
 
-                                        1. Else Phantom#1821
+                                        1. Else Phantom#1824
 
                                         2. If ((controlBodyResult = ((return ?()) as controlBodyResult))), then
 
@@ -34100,9 +34152,9 @@ relation Call_eval: p EC_0 ARCH_0 |- callee @< typeArgumentListIR >( argumentLis
 
                                             1. Result in: % % % |- % @< % >( % ): EC_2 ARCH_3 ((return ?()) as callResult)
 
-                                        2. Else Phantom#1822
+                                        2. Else Phantom#1825
 
-                      1. Else Phantom#1823
+                      1. Else Phantom#1826
 
   3. Case (% has type tableApplyMethodCallee)
 
@@ -34142,9 +34194,9 @@ relation Call_eval: p EC_0 ARCH_0 |- callee @< typeArgumentListIR >( argumentLis
 
                               1. Result in: % % % |- % @< % >( % ): EC_1 ARCH_1 (returnResult as callResult)
 
-                1. Else Phantom#1824
+                1. Else Phantom#1827
 
-2. Else Phantom#1825
+2. Else Phantom#1828
 
 extern relation ExternFunctionCall_eval: evalContext arch |- nameIR ( (nameIR')* ): % % %
 
@@ -34160,7 +34212,7 @@ def $match_keysets((setValue)*, (value)*)
 
       1. Return true
 
-    1. Else Phantom#1826
+    1. Else Phantom#1829
 
   2. Case (% matches pattern [ _/1 ])
 
@@ -34174,9 +34226,9 @@ def $match_keysets((setValue)*, (value)*)
 
             1. Return $match_keyset(setValue', value_key)
 
-          1. Else Phantom#1827
+          1. Else Phantom#1830
 
-      1. Else Phantom#1828
+      1. Else Phantom#1831
 
   3. Case (% matches pattern _ :: _)
 
@@ -34200,19 +34252,19 @@ def $match_keysets((setValue)*, (value)*)
 
                   1. Return false
 
-            1. Else Phantom#1829
+            1. Else Phantom#1832
 
-          1. Else Phantom#1830
+          1. Else Phantom#1833
 
-      1. Else Phantom#1831
+      1. Else Phantom#1834
 
-1. Else Phantom#1832
+1. Else Phantom#1835
 
 2. If (((setValue)* = [(set{...})])), then
 
   1. Return true
 
-2. Else Phantom#1833
+2. Else Phantom#1836
 
 def $match_keyset(setValue, value_key)
 
@@ -34301,11 +34353,11 @@ relation Expr_eval_keyset_simple: EC_0 ARCH_0 |- simpleKeysetExpressionIR : % % 
 
                                   1. Result in: % % |- % : EC_1 ARCH_1 ((` setValue) as simpleKeysetExpressionResult)
 
-                            1. Else Phantom#1834
+                            1. Else Phantom#1837
 
-                        1. Else Phantom#1835
+                        1. Else Phantom#1838
 
-                1. Else Phantom#1836
+                1. Else Phantom#1839
 
   2. Case (% matches pattern `%&&&%`)
 
@@ -34383,7 +34435,7 @@ relation Expr_eval_keyset_simple: EC_0 ARCH_0 |- simpleKeysetExpressionIR : % % 
 
                           1. Result in: % % |- % : EC_2 ARCH_2 ((` setValue) as simpleKeysetExpressionResult)
 
-1. Else Phantom#1837
+1. Else Phantom#1840
 
 2. Group default-any: EC_0 ARCH_0 |- simpleKeysetExpressionIR : % % %
 
@@ -34393,7 +34445,7 @@ relation Expr_eval_keyset_simple: EC_0 ARCH_0 |- simpleKeysetExpressionIR : % % 
 
       1. Result in: % % |- % : EC_0 ARCH_0 ((` setValue) as simpleKeysetExpressionResult)
 
-  1. Else Phantom#1838
+  1. Else Phantom#1841
 
 relation Exprs_eval_keyset_simple: evalContext arch |- (simpleKeysetExpressionIR)* : % % %
 
@@ -34403,7 +34455,7 @@ relation Exprs_eval_keyset_simple: evalContext arch |- (simpleKeysetExpressionIR
 
     1. Result in: % % |- % : evalContext arch ((` []) as keysetExpressionResult)
 
-  1. Else Phantom#1839
+  1. Else Phantom#1842
 
   2. If (((simpleKeysetExpressionIR)* matches pattern _ :: _)), then
 
@@ -34441,7 +34493,7 @@ relation Exprs_eval_keyset_simple: evalContext arch |- (simpleKeysetExpressionIR
 
                         1. Result in: % % |- % : EC_2 ARCH_2 keysetExpressionResult'
 
-  2. Else Phantom#1840
+  2. Else Phantom#1843
 
 relation ForUpdateStmt_eval: EC_0 ARCH_0 |- forUpdateStatementIR : % % %
 
@@ -34473,7 +34525,7 @@ relation ForUpdateStmts_eval: evalContext arch |- (forUpdateStatementIR)* : % % 
 
     1. Result in: % % |- % : evalContext arch ((`empty) as statementResult)
 
-  1. Else Phantom#1841
+  1. Else Phantom#1844
 
   2. If (((forUpdateStatementIR)* matches pattern _ :: _)), then
 
@@ -34497,9 +34549,9 @@ relation ForUpdateStmts_eval: evalContext arch |- (forUpdateStatementIR)* : % % 
 
                 1. Result in: % % |- % : EC_2 ARCH_2 statementResult'
 
-        1. Else Phantom#1842
+        1. Else Phantom#1845
 
-  2. Else Phantom#1843
+  2. Else Phantom#1846
 
 relation ForInitStmt_eval: EC_0 arch |- forInitStatementIR : % % %
 
@@ -34521,7 +34573,7 @@ relation ForInitStmt_eval: EC_0 arch |- forInitStatementIR : % % %
 
                 1. Result in: % % |- % : EC_1 arch ((`empty) as statementResult)
 
-        1. Else Phantom#1844
+        1. Else Phantom#1847
 
       2. (Let (annotationList typeIR nameIR initializerOptIR) be forInitStatementIR)
 
@@ -34547,7 +34599,7 @@ relation ForInitStmt_eval: EC_0 arch |- forInitStatementIR : % % %
 
                       1. Result in: % % |- % : EC_2 ARCH_1 ((`empty) as statementResult)
 
-        1. Else Phantom#1845
+        1. Else Phantom#1848
 
     2. Case (% has type forUpdateStatementIR)
 
@@ -34565,7 +34617,7 @@ relation ForInitStmts_eval: evalContext arch |- (forInitStatementIR)* : % % %
 
     1. Result in: % % |- % : evalContext arch ((`empty) as statementResult)
 
-  1. Else Phantom#1846
+  1. Else Phantom#1849
 
   2. If (((forInitStatementIR)* matches pattern _ :: _)), then
 
@@ -34589,9 +34641,9 @@ relation ForInitStmts_eval: evalContext arch |- (forInitStatementIR)* : % % %
 
                 1. Result in: % % |- % : EC_2 ARCH_2 statementResult'
 
-        1. Else Phantom#1847
+        1. Else Phantom#1850
 
-  2. Else Phantom#1848
+  2. Else Phantom#1851
 
 relation ForThreeClauseStmt_eval: EC_0 ARCH_0 |- typedExpressionIR statementIR forUpdateStatementListIR : % % %
 
@@ -34605,7 +34657,7 @@ relation ForThreeClauseStmt_eval: EC_0 ARCH_0 |- typedExpressionIR statementIR f
 
         1. Result in: % % |- % % % : EC_1 ARCH_1 (abortResult as statementResult)
 
-    1. Else Phantom#1849
+    1. Else Phantom#1852
 
     2. Case analysis on expressionResult
 
@@ -34637,7 +34689,7 @@ relation ForThreeClauseStmt_eval: EC_0 ARCH_0 |- typedExpressionIR statementIR f
 
                 1. Result in: % % |- % % % : EC_2 ARCH_2 ((`empty) as statementResult)
 
-          1. Else Phantom#1850
+          1. Else Phantom#1853
 
           2. If (((statementResult = ((`empty) as statementResult)) \/ (statementResult = ((continue) as statementResult)))), then
 
@@ -34659,11 +34711,11 @@ relation ForThreeClauseStmt_eval: EC_0 ARCH_0 |- typedExpressionIR statementIR f
 
                       1. Result in: % % |- % % % : EC_4 ARCH_4 statementResult''
 
-              1. Else Phantom#1851
+              1. Else Phantom#1854
 
-          2. Else Phantom#1852
+          2. Else Phantom#1855
 
-    2. Else Phantom#1853
+    2. Else Phantom#1856
 
 relation ForCollectionExpr_eval: EC_0 ARCH_0 |- forCollectionExpressionIR : % % %
 
@@ -34707,7 +34759,7 @@ relation ForCollectionExpr_eval: EC_0 ARCH_0 |- forCollectionExpressionIR : % % 
 
                         1. Result in: % % |- % : EC_1 ARCH_1 ((` (value')*) as expressionListResult)
 
-                1. Else Phantom#1854
+                1. Else Phantom#1857
 
   2. Case (% matches pattern `%..%`)
 
@@ -34763,21 +34815,21 @@ def $values_of_setValue((set< typeIR >), setValue)
 
           1. Return value_l :: $values_of_setValue((set< typeIR >), (set{ value_l_inc .. value_r }))
 
-    1. Else Phantom#1855
+    1. Else Phantom#1858
 
     2. If ($bin_eq(value_l, value_r)), then
 
       1. Return [value_l]
 
-    2. Else Phantom#1856
+    2. Else Phantom#1859
 
     3. If ($bin_gt(value_l, value_r)), then
 
       1. Return []
 
-    3. Else Phantom#1857
+    3. Else Phantom#1860
 
-1. Else Phantom#1858
+1. Else Phantom#1861
 
 relation ForInStmt_eval: evalContext arch |- nameIR (value)* statementIR : % % %
 
@@ -34787,7 +34839,7 @@ relation ForInStmt_eval: evalContext arch |- nameIR (value)* statementIR : % % %
 
     1. Result in: % % |- % % % : evalContext arch ((`empty) as statementResult)
 
-  1. Else Phantom#1859
+  1. Else Phantom#1862
 
   2. If (((value)* matches pattern _ :: _)), then
 
@@ -34817,7 +34869,7 @@ relation ForInStmt_eval: evalContext arch |- nameIR (value)* statementIR : % % %
 
                 1. Result in: % % |- % % % : EC_2 ARCH_1 ((`empty) as statementResult)
 
-          1. Else Phantom#1860
+          1. Else Phantom#1863
 
           2. If (((statementResult = ((`empty) as statementResult)) \/ (statementResult = ((continue) as statementResult)))), then
 
@@ -34825,9 +34877,9 @@ relation ForInStmt_eval: evalContext arch |- nameIR (value)* statementIR : % % %
 
               1. Result in: % % |- % % % : EC_3 ARCH_2 statementResult'
 
-          2. Else Phantom#1861
+          2. Else Phantom#1864
 
-  2. Else Phantom#1862
+  2. Else Phantom#1865
 
 relation Switch_table_eval: EC_0 ARCH_0 |-switch( id_enum ){ (switchCaseIR)* }: % % %
 
@@ -34885,7 +34937,7 @@ relation SwitchCases_table_eval: id |- (switchCaseIR)* : %
 
     1. Result in: % |- % : ?()
 
-  1. Else Phantom#1863
+  1. Else Phantom#1866
 
   2. If (((switchCaseIR)* matches pattern _ :: _)), then
 
@@ -34929,9 +34981,9 @@ relation SwitchCases_table_eval: id |- (switchCaseIR)* : %
 
                           1. Result in: % |- % : ?(blockStatementIR)
 
-                      1. Else Phantom#1864
+                      1. Else Phantom#1867
 
-                  1. Else Phantom#1865
+                  1. Else Phantom#1868
 
               2. Case false
 
@@ -34939,7 +34991,7 @@ relation SwitchCases_table_eval: id |- (switchCaseIR)* : %
 
                   1. Result in: % |- % : (blockStatementIR)?
 
-  2. Else Phantom#1866
+  2. Else Phantom#1869
 
 def $is_non_fallthrough_switchCaseIR(switchCaseIR)
 
@@ -34993,7 +35045,7 @@ relation SwitchLabel_general_eval: cursor EC_0 ARCH_0 |- switchLabelIR : % % %
 
             1. Result in: % % % |- % : EC_1 ARCH_1 expressionResult
 
-1. Else Phantom#1867
+1. Else Phantom#1870
 
 def $match_switchLabelIR_general(value, value')
 
@@ -35017,7 +35069,7 @@ relation SwitchCases_general_eval: cursor EC_0 ARCH_0 value |- (switchCaseIR)* :
 
       1. Result in: % % % % |- % : EC_0 ARCH_0 ?()
 
-    1. Else Phantom#1868
+    1. Else Phantom#1871
 
     2. If (((switchCaseIR)* matches pattern _ :: _)), then
 
@@ -35047,7 +35099,7 @@ relation SwitchCases_general_eval: cursor EC_0 ARCH_0 value |- (switchCaseIR)* :
 
                           1. Result in: % % % % |- % : EC_2 ARCH_2 (blockStatementIR)?
 
-                1. Else Phantom#1869
+                1. Else Phantom#1872
 
           2. Case (% matches pattern `%:`)
 
@@ -35075,9 +35127,9 @@ relation SwitchCases_general_eval: cursor EC_0 ARCH_0 value |- (switchCaseIR)* :
 
                                   1. Result in: % % % % |- % : EC_1 ARCH_1 ?(blockStatementIR)
 
-                              1. Else Phantom#1870
+                              1. Else Phantom#1873
 
-                          1. Else Phantom#1871
+                          1. Else Phantom#1874
 
                       2. Case false
 
@@ -35085,11 +35137,11 @@ relation SwitchCases_general_eval: cursor EC_0 ARCH_0 value |- (switchCaseIR)* :
 
                           1. Result in: % % % % |- % : EC_2 ARCH_2 (blockStatementIR)?
 
-                1. Else Phantom#1872
+                1. Else Phantom#1875
 
-    2. Else Phantom#1873
+    2. Else Phantom#1876
 
-1. Else Phantom#1874
+1. Else Phantom#1877
 
 syntax selectCaseMatchResult = 
    | ` nameIR?
@@ -35123,7 +35175,7 @@ relation SelectCase_match: EC_0 ARCH_0 (value_key)* |- (keysetExpressionIR : nam
 
               1. Result in: % % % |- % : EC_1 ARCH_1 ((` ?(nameIR)) as selectCaseMatchResult)
 
-    1. Else Phantom#1875
+    1. Else Phantom#1878
 
 relation SelectCases_match: evalContext arch (value_key)* |- (selectCaseIR)* : % % %
 
@@ -35133,7 +35185,7 @@ relation SelectCases_match: evalContext arch (value_key)* |- (selectCaseIR)* : %
 
     1. Result in: % % % |- % : evalContext arch ((` ?()) as selectCaseMatchResult)
 
-  1. Else Phantom#1876
+  1. Else Phantom#1879
 
   2. If (((selectCaseIR)* matches pattern _ :: _)), then
 
@@ -35159,7 +35211,7 @@ relation SelectCases_match: evalContext arch (value_key)* |- (selectCaseIR)* : %
 
                   1. Result in: % % % |- % : EC_1 ARCH_1 ((` ?(nameIR_state)) as selectCaseMatchResult)
 
-              1. Else Phantom#1877
+              1. Else Phantom#1880
 
         2. If ((selectCaseMatchResult = ((` ?()) as selectCaseMatchResult))), then
 
@@ -35167,9 +35219,9 @@ relation SelectCases_match: evalContext arch (value_key)* |- (selectCaseIR)* : %
 
             1. Result in: % % % |- % : EC_2 ARCH_2 selectCaseMatchResult'
 
-        2. Else Phantom#1878
+        2. Else Phantom#1881
 
-  2. Else Phantom#1879
+  2. Else Phantom#1882
 
 syntax tableKeyValue = 
    | value : nameIR
@@ -35200,7 +35252,7 @@ relation TableKey_eval: EC_0 ARCH_0 |- (typedExpressionIR # nameIR' : nameIR ann
 
             1. Result in: % % |- % : EC_1 ARCH_1 ((` tableKeyValue) as tableKeyResult)
 
-    1. Else Phantom#1880
+    1. Else Phantom#1883
 
 syntax tableKeysResult = 
    | ` tableKeyValue*
@@ -35214,7 +35266,7 @@ relation TableKeys_eval: evalContext arch |- (tableKeyIR)* : % % %
 
     1. Result in: % % |- % : evalContext arch ((` []) as tableKeysResult)
 
-  1. Else Phantom#1881
+  1. Else Phantom#1884
 
   2. If (((tableKeyIR)* matches pattern _ :: _)), then
 
@@ -35252,7 +35304,7 @@ relation TableKeys_eval: evalContext arch |- (tableKeyIR)* : % % %
 
                         1. Result in: % % |- % : EC_2 ARCH_2 ((` (tableKeyValue)*) as tableKeysResult)
 
-  2. Else Phantom#1882
+  2. Else Phantom#1885
 
 def $get_tableEntryPriority((tableEntryPriorityIR)?)
 
@@ -35274,7 +35326,7 @@ def $get_tableEntryPriority((tableEntryPriorityIR)?)
 
             1. Return ?(n)
 
-        1. Else Phantom#1883
+        1. Else Phantom#1886
 
 syntax tableMatch = 
    | nat? : tableActionReferenceIR
@@ -35319,7 +35371,7 @@ relation TableMatch_eval: EC_0 ARCH_0 |- (tableKeyValue)* @ tableEntryIR : % % %
 
                       1. Result in: % % |- % @ % : EC_1 ARCH_1 ((` ?(tableMatch)) as tableMatchResult)
 
-        1. Else Phantom#1884
+        1. Else Phantom#1887
 
 syntax tableMatchesResult = 
    | ` tableMatch*
@@ -35333,7 +35385,7 @@ relation TableMatches_eval: evalContext arch |- (tableKeyValue)* @ (tableEntryIR
 
     1. Result in: % % |- % @ % : evalContext arch ((` []) as tableMatchesResult)
 
-  1. Else Phantom#1885
+  1. Else Phantom#1888
 
   2. If (((tableEntryIR)* matches pattern _ :: _)), then
 
@@ -35371,7 +35423,7 @@ relation TableMatches_eval: evalContext arch |- (tableKeyValue)* @ (tableEntryIR
 
                         1. Result in: % % |- % @ % : EC_2 ARCH_2 ((` (tableMatch)*) as tableMatchesResult)
 
-  2. Else Phantom#1886
+  2. Else Phantom#1889
 
 def $largest_priority_wins(TBL)
 
@@ -35393,17 +35445,17 @@ def $largest_priority_wins(TBL)
 
                 1. Return b
 
-            1. Else Phantom#1887
+            1. Else Phantom#1890
 
-        1. Else Phantom#1888
+        1. Else Phantom#1891
 
-    1. Else Phantom#1889
+    1. Else Phantom#1892
 
   2. If (([] = $filter_<tableCustomPropertyIR>((tableCustomPropertyIR)*, ($is_largest_priority_wins(tableCustomPropertyIR))*))), then
 
     1. Return true
 
-  2. Else Phantom#1890
+  2. Else Phantom#1893
 
 def $is_largest_priority_wins(tableCustomPropertyIR)
 
@@ -35437,7 +35489,7 @@ def $select_action(TBL, (tableMatch)*)
 
         1. Return tableActionReferenceIR
 
-1. Else Phantom#1891
+1. Else Phantom#1894
 
 2. If ((|(tableMatch)*| > 1)), then
 
@@ -35461,7 +35513,7 @@ def $select_action(TBL, (tableMatch)*)
 
                     1. Return tableActionReferenceIR_h
 
-                1. Else Phantom#1892
+                1. Else Phantom#1895
 
             2. Case false
 
@@ -35471,11 +35523,11 @@ def $select_action(TBL, (tableMatch)*)
 
                   1. Return tableActionReferenceIR_h
 
-              1. Else Phantom#1893
+              1. Else Phantom#1896
 
-    1. Else Phantom#1894
+    1. Else Phantom#1897
 
-2. Else Phantom#1895
+2. Else Phantom#1898
 
 relation Copy_out_inner: ARCH |- p_caller evalContext (parameterIR)* @ p_callee EC_callee ((storageReference)?)* ~> %
 
@@ -35487,9 +35539,9 @@ relation Copy_out_inner: ARCH |- p_caller evalContext (parameterIR)* @ p_callee 
 
       1. Result in: % |- % % % @ % % % ~> evalContext
 
-    1. Else Phantom#1896
+    1. Else Phantom#1899
 
-  1. Else Phantom#1897
+  1. Else Phantom#1900
 
   2. If (((parameterIR)* matches pattern _ :: _)), then
 
@@ -35507,9 +35559,9 @@ relation Copy_out_inner: ARCH |- p_caller evalContext (parameterIR)* @ p_callee 
 
                 1. Result in: % |- % % % @ % % % ~> EC_caller_2
 
-        1. Else Phantom#1898
+        1. Else Phantom#1901
 
-  2. Else Phantom#1899
+  2. Else Phantom#1902
 
 syntax actionResult = 
    | exit
@@ -35535,13 +35587,13 @@ relation ActionBody_eval: EC_0 ARCH_0 |- blockStatementIR : % % %
 
           1. Result in: % % |- % : EC_1 ARCH_1 ((exit) as actionResult)
 
-    1. Else Phantom#1900
+    1. Else Phantom#1903
 
     2. If ((statementResult = ((return ?()) as statementResult))), then
 
       1. Result in: % % |- % : EC_1 ARCH_1 ((return ?()) as actionResult)
 
-    2. Else Phantom#1901
+    2. Else Phantom#1904
 
 syntax definedFunctionResult = 
    | exit
@@ -35573,7 +35625,7 @@ relation DefinedFunctionBody_eval: EC_0 ARCH_0 |- blockStatementIR : % % %
 
           1. Result in: % % |- % : EC_1 ARCH_1 (returnResult as definedFunctionResult)
 
-    1. Else Phantom#1902
+    1. Else Phantom#1905
 
 def $isValid_fieldValue((value id ;))
 
@@ -35615,11 +35667,11 @@ relation Extern_init: EC ARCH_0 |- nameIR_extern nameIR : %
 
                       1. Result in: % % |- % % : ARCH_2
 
-          1. Else Phantom#1903
+          1. Else Phantom#1906
 
-        1. Else Phantom#1904
+        1. Else Phantom#1907
 
-      1. Else Phantom#1905
+      1. Else Phantom#1908
 
 relation Program_init: |- p4program : % %
 
@@ -35795,7 +35847,7 @@ def $tableObject_create_entry_priority(tableEntryPriorityInterface)
 
     1. Return ?()
 
-  1. Else Phantom#1906
+  1. Else Phantom#1909
 
 2. If ((tableEntryPriorityInterface matches pattern (_))), then
 
@@ -35807,9 +35859,9 @@ def $tableObject_create_entry_priority(tableEntryPriorityInterface)
 
         1. Return ?((priority= (d (n_priority as int)) :))
 
-    1. Else Phantom#1907
+    1. Else Phantom#1910
 
-2. Else Phantom#1908
+2. Else Phantom#1911
 
 def $needs_priority_tableKeysPropertyIR((key={ (tableKeyIR)* }))
 
@@ -35851,11 +35903,11 @@ def $tableObject_create_entry_key(EC, (nameIR_key, text, typeIR), (tableKeyInter
 
                               1. Return simpleKeysetExpressionIR
 
-                      1. Else Phantom#1909
+                      1. Else Phantom#1912
 
-            1. Else Phantom#1910
+            1. Else Phantom#1913
 
-      1. Else Phantom#1911
+      1. Else Phantom#1914
 
   2. Case (% = "ternary")
 
@@ -35899,9 +35951,9 @@ def $tableObject_create_entry_key(EC, (nameIR_key, text, typeIR), (tableKeyInter
 
                                           1. Return simpleKeysetExpressionIR
 
-                                    1. Else Phantom#1912
+                                    1. Else Phantom#1915
 
-                        1. Else Phantom#1913
+                        1. Else Phantom#1916
 
             2. Case (% matches pattern ``BIN%`)
 
@@ -35935,13 +35987,13 @@ def $tableObject_create_entry_key(EC, (nameIR_key, text, typeIR), (tableKeyInter
 
                                           1. Return simpleKeysetExpressionIR
 
-                                    1. Else Phantom#1914
+                                    1. Else Phantom#1917
 
-                        1. Else Phantom#1915
+                        1. Else Phantom#1918
 
-          1. Else Phantom#1916
+          1. Else Phantom#1919
 
-      1. Else Phantom#1917
+      1. Else Phantom#1920
 
   3. Case (% = "lpm")
 
@@ -35989,11 +36041,11 @@ def $tableObject_create_entry_key(EC, (nameIR_key, text, typeIR), (tableKeyInter
 
                                               1. Return simpleKeysetExpressionIR
 
-                                        1. Else Phantom#1918
+                                        1. Else Phantom#1921
 
-                            1. Else Phantom#1919
+                            1. Else Phantom#1922
 
-                  1. Else Phantom#1920
+                  1. Else Phantom#1923
 
             2. Case (% matches pattern ``BIN%`)
 
@@ -36031,11 +36083,11 @@ def $tableObject_create_entry_key(EC, (nameIR_key, text, typeIR), (tableKeyInter
 
                                               1. Return simpleKeysetExpressionIR
 
-                                        1. Else Phantom#1921
+                                        1. Else Phantom#1924
 
-                            1. Else Phantom#1922
+                            1. Else Phantom#1925
 
-                  1. Else Phantom#1923
+                  1. Else Phantom#1926
 
             3. Case (% matches pattern `%`SLASH%`)
 
@@ -36075,17 +36127,17 @@ def $tableObject_create_entry_key(EC, (nameIR_key, text, typeIR), (tableKeyInter
 
                                                 1. Return simpleKeysetExpressionIR
 
-                                          1. Else Phantom#1924
+                                          1. Else Phantom#1927
 
-                                  1. Else Phantom#1925
+                                  1. Else Phantom#1928
 
-                        1. Else Phantom#1926
+                        1. Else Phantom#1929
 
-                    1. Else Phantom#1927
+                    1. Else Phantom#1930
 
-          1. Else Phantom#1928
+          1. Else Phantom#1931
 
-      1. Else Phantom#1929
+      1. Else Phantom#1932
 
   4. Case (% = "optional")
 
@@ -36129,17 +36181,17 @@ def $tableObject_create_entry_key(EC, (nameIR_key, text, typeIR), (tableKeyInter
 
                                           1. Return simpleKeysetExpressionIR
 
-                                    1. Else Phantom#1930
+                                    1. Else Phantom#1933
 
-                        1. Else Phantom#1931
+                        1. Else Phantom#1934
 
-              1. Else Phantom#1932
+              1. Else Phantom#1935
 
-          1. Else Phantom#1933
+          1. Else Phantom#1936
 
-      1. Else Phantom#1934
+      1. Else Phantom#1937
 
-1. Else Phantom#1935
+1. Else Phantom#1938
 
 def $tableObject_create_entry_keys(evalContext, ((nameIR, nameIR, typeIR))*, tableKeysetInterface)
 
@@ -36147,7 +36199,7 @@ def $tableObject_create_entry_keys(evalContext, ((nameIR, nameIR, typeIR))*, tab
 
   1. Return []
 
-1. Else Phantom#1936
+1. Else Phantom#1939
 
 2. (Let (tableKeyInterface)* be tableKeysetInterface)
 
@@ -36159,7 +36211,7 @@ def $tableObject_create_entry_keys(evalContext, ((nameIR, nameIR, typeIR))*, tab
 
         1. Return simpleKeysetExpressionIR_h :: $tableObject_create_entry_keys(evalContext, ((nameIR_key_t, nameIR_matchKind_t, typeIR_t))*, (tableKeyInterface)*)
 
-  1. Else Phantom#1937
+  1. Else Phantom#1940
 
 def $interface_of_tableKeyIR((typedExpressionIR # nameIR_key : nameIR_matchKind annotationList ;))
 
@@ -36179,7 +36231,7 @@ def $tableObject_create_entry_keyset(EC, (key={ (tableKeyIR)* }), (tableKeyInter
 
         1. Return ((( (simpleKeysetExpressionIR)* )) as keysetExpressionIR)
 
-    1. Else Phantom#1938
+    1. Else Phantom#1941
 
 def $alias_to_original_lookup_map((parameterIR)*)
 
@@ -36217,15 +36269,15 @@ def $align_tableActionArgumentInterfaces((parameterIR)*, ((nameIR_arg, i_arg))*)
 
               1. Return (i_aligned)*
 
-          1. Else Phantom#1939
+          1. Else Phantom#1942
 
-    1. Else Phantom#1940
+    1. Else Phantom#1943
 
 def $align_tableActionArgumentInterfaces'(({ ((id_arg : i_arg))* }), (_annotationList _direction _typeIR nameIR_param _parameterInitializerOptIR))
 
 1. Return $find_map<id, int>(({ ((id_arg : i_arg))* }), nameIR_param)
 
-def $find_tableActionIR_by_name((tableActionIR)*, nameIR)
+def $find_tableActionIR_qualified((tableActionIR)*, nameIR)
 
 1. Case analysis on (tableActionIR)*
 
@@ -36237,43 +36289,41 @@ def $find_tableActionIR_by_name((tableActionIR)*, nameIR)
 
     1. (Let tableActionIR_h :: (tableActionIR_t)* be (tableActionIR)*)
 
-      1. (Let (annotationList (prefixedNameIR _controlPlaneNameIR ( (argumentIR_data)* )) #( _parameterListIR , (parameterIR_control)* );) be tableActionIR_h)
+      1. (Let (annotationList tableActionReferenceIR #( _parameterListIR , (parameterIR_control)* );) be tableActionIR_h)
 
-        1. (Let nameIR_action be $flatten_prefixedNameIR(prefixedNameIR))
+        1. (Let (prefixedNameIR controlPlaneNameIR ( (argumentIR_data)* )) be tableActionReferenceIR)
 
-          1. If (([] = $name_annotation(annotationList))), then
+          1. If ((?(nameIR) =/= controlPlaneNameIR)), then
 
-            1. Case analysis on nameIR_action
+            1. Return $find_tableActionIR_qualified((tableActionIR_t)*, nameIR)
 
-              1. Case (% = nameIR)
+          1. Else Phantom#1944
 
-                1. Return ?((nameIR_action, tableActionIR_h))
+          2. If ((?(nameIR) = controlPlaneNameIR)), then
 
-              2. Case (% =/= nameIR)
+            1. (Let nameIR_action be $flatten_prefixedNameIR(prefixedNameIR))
 
-                1. Return $find_tableActionIR_by_name((tableActionIR_t)*, nameIR)
+              1. Return ?((nameIR_action, tableActionIR_h))
 
-          1. Else Phantom#1941
+          2. Else Phantom#1945
 
-          2. (Let (nameIR_annotation)* be $name_annotation(annotationList))
+def $find_tableActionIR_unqualified((tableActionIR)*, nameIR)
 
-            1. If (((nameIR_annotation)* =/= [])), then
+1. (Let (nameIR_split)* be $split_text(nameIR, "."))
 
-              1. (Let b_hit be ((nameIR = nameIR_action) \/ nameIR is in (nameIR_annotation)*))
+  1. If ((|(nameIR_split)*| > 1)), then
 
-                1. Case analysis on b_hit
+    1. Return ?()
 
-                  1. Case true
+  1. Else Phantom#1946
 
-                    1. Return ?((nameIR_action, tableActionIR_h))
+  2. If ((|(nameIR_split)*| = 1)), then
 
-                  2. Case false
+    1. Return $find_tableActionIR_unqualified'((tableActionIR)*, (nameIR_split)*[0])
 
-                    1. Return $find_tableActionIR_by_name((tableActionIR_t)*, nameIR)
+  2. Else Phantom#1947
 
-            1. Else Phantom#1942
-
-def $find_tableActionIR_by_dotPrefix((tableActionIR)*, nameIR)
+def $find_tableActionIR_unqualified'((tableActionIR)*, nameIR)
 
 1. Case analysis on (tableActionIR)*
 
@@ -36285,55 +36335,43 @@ def $find_tableActionIR_by_dotPrefix((tableActionIR)*, nameIR)
 
     1. (Let tableActionIR_h :: (tableActionIR_t)* be (tableActionIR)*)
 
-      1. (Let (annotationList (_prefixedNameIR _controlPlaneNameIR ( _argumentListIR )) #( _parameterListIR , _parameterListIR' );) be tableActionIR_h)
+      1. (Let (annotationList tableActionReferenceIR #( _parameterListIR , (parameterIR_control)* );) be tableActionIR_h)
 
-        1. If (([] = $name_annotation(annotationList))), then
+        1. (Let (prefixedNameIR controlPlaneNameIR ( (argumentIR_data)* )) be tableActionReferenceIR)
 
-          1. Return $find_tableActionIR_by_dotPrefix((tableActionIR_t)*, nameIR)
+          1. If ((controlPlaneNameIR matches pattern (_))), then
 
-        1. Else Phantom#1943
+            1. (Let ?(nameIR_controlPlane) be controlPlaneNameIR)
 
-      2. (Let (annotationList (prefixedNameIR _controlPlaneNameIR ( (argumentIR_data)* )) #( _parameterListIR , (parameterIR_control)* );) be tableActionIR_h)
+              1. (Let (nameIR_split)* be $split_text(nameIR_controlPlane, "."))
 
-        1. (Let (nameIR_annotation)* be $name_annotation(annotationList))
+                1. (Let (nameIR')* be $rev_<nameIR>((nameIR_split)*))
 
-          1. If (((nameIR_annotation)* =/= [])), then
+                  1. If (((nameIR')* matches pattern _ :: _)), then
 
-            1. If (([] = $filter_<nameIR>((nameIR_annotation)*, ($starts_with(nameIR_annotation, "."))*))), then
+                    1. (Let nameIR_unqualified :: (_nameIR)* be (nameIR')*)
 
-              1. Return $find_tableActionIR_by_dotPrefix((tableActionIR_t)*, nameIR)
+                      1. If ((nameIR =/= nameIR_unqualified)), then
 
-            1. Else Phantom#1944
+                        1. Return $find_tableActionIR_unqualified'((tableActionIR_t)*, nameIR)
 
-          1. Else Phantom#1945
+                      1. Else Phantom#1948
 
-          2. (Let (nameIR_annotation_dotPrefix)* be $filter_<nameIR>((nameIR_annotation)*, ($starts_with(nameIR_annotation, "."))*))
+                      2. If ((nameIR = nameIR_unqualified)), then
 
-            1. If (((nameIR_annotation_dotPrefix)* =/= [])), then
+                        1. (Let nameIR_action be $flatten_prefixedNameIR(prefixedNameIR))
 
-              1. (Let (nameIR_annotation_strip)* be ($strip_prefix(nameIR_annotation_dotPrefix, "."))*)
+                          1. Return ?((nameIR_action, tableActionIR_h))
 
-                1. If (~nameIR is in (nameIR_annotation_strip)*), then
+                      2. Else Phantom#1949
 
-                  1. Return $find_tableActionIR_by_dotPrefix((tableActionIR_t)*, nameIR)
+                  1. Else Phantom#1950
 
-                1. Else Phantom#1946
-
-            1. Else Phantom#1947
-
-            2. (Let (nameIR_annotation_strip)* be ($strip_prefix(nameIR_annotation_dotPrefix, "."))*)
-
-              1. If (nameIR is in (nameIR_annotation_strip)*), then
-
-                1. (Let nameIR_action be $flatten_prefixedNameIR(prefixedNameIR))
-
-                  1. Return ?((nameIR_action, tableActionIR_h))
-
-              1. Else Phantom#1948
+          1. Else Phantom#1951
 
 def $tableObject_create_entry_action(EC, (actions={ (tableActionIR)* }), (nameIR_action_update, (tableActionArgumentInterface_update)*))
 
-1. (Let ((nameIR, tableActionIR))? be $find_tableActionIR_by_dotPrefix((tableActionIR)*, nameIR_action_update))
+1. (Let ((nameIR, tableActionIR))? be $find_tableActionIR_qualified((tableActionIR)*, nameIR_action_update))
 
   1. If ((((nameIR, tableActionIR))? matches pattern (_))), then
 
@@ -36357,13 +36395,13 @@ def $tableObject_create_entry_action(EC, (actions={ (tableActionIR)* }), (nameIR
 
                       1. Return ((` nameIR_found) controlPlaneNameIR ( (argumentIR)* ))
 
-                1. Else Phantom#1949
+                1. Else Phantom#1952
 
-  1. Else Phantom#1950
+  1. Else Phantom#1953
 
-2. If ((?() = $find_tableActionIR_by_dotPrefix((tableActionIR)*, nameIR_action_update))), then
+2. If ((?() = $find_tableActionIR_qualified((tableActionIR)*, nameIR_action_update))), then
 
-  1. (Let ((nameIR, tableActionIR))? be $find_tableActionIR_by_name((tableActionIR)*, nameIR_action_update))
+  1. (Let ((nameIR, tableActionIR))? be $find_tableActionIR_unqualified((tableActionIR)*, nameIR_action_update))
 
     1. If ((((nameIR, tableActionIR))? matches pattern (_))), then
 
@@ -36387,11 +36425,11 @@ def $tableObject_create_entry_action(EC, (actions={ (tableActionIR)* }), (nameIR
 
                         1. Return ((` nameIR_found) controlPlaneNameIR ( (argumentIR)* ))
 
-                  1. Else Phantom#1951
+                  1. Else Phantom#1954
 
-    1. Else Phantom#1952
+    1. Else Phantom#1955
 
-2. Else Phantom#1953
+2. Else Phantom#1956
 
 def $tableObject_add_entry(EC, (table typeId { frame TBL }), tableEntryPriorityInterface, tableKeysetInterface, tableActionInterface)
 
@@ -36413,7 +36451,7 @@ def $tableObject_add_entry(EC, (table typeId { frame TBL }), tableEntryPriorityI
 
                 1. Return (table typeId { frame TBL_updated })
 
-  1. Else Phantom#1954
+  1. Else Phantom#1957
 
 def $tableObject_add_default_action(EC, (table typeId { frame TBL }), tableActionInterface)
 
@@ -36429,7 +36467,7 @@ def $tableObject_add_default_action(EC, (table typeId { frame TBL }), tableActio
 
           1. Return (table typeId { frame TBL_updated })
 
-  1. Else Phantom#1955
+  1. Else Phantom#1958
 
 relation V1Model_init: |- p4program : % %
 
@@ -36467,9 +36505,9 @@ relation V1Model_init_packet_in: EC_0 ARCH_0 |- objectState_packet_in : % %
 
                       1. Result in: % % |- % : EC_1 ARCH_2
 
-            1. Else Phantom#1956
+            1. Else Phantom#1959
 
-        1. Else Phantom#1957
+        1. Else Phantom#1960
 
 relation V1Model_init_packet_out: EC_0 ARCH_0 |- objectState_packet_out : % %
 
@@ -36497,9 +36535,9 @@ relation V1Model_init_packet_out: EC_0 ARCH_0 |- objectState_packet_out : % %
 
                       1. Result in: % % |- % : EC_1 ARCH_2
 
-            1. Else Phantom#1958
+            1. Else Phantom#1961
 
-        1. Else Phantom#1959
+        1. Else Phantom#1962
 
 relation V1Model_init_globals: EC_0 ARCH |- i_port : %
 
@@ -36549,15 +36587,15 @@ relation V1Model_init_globals: EC_0 ARCH |- i_port : %
 
                                             1. Result in: % % |- % : EC_4
 
-                              1. Else Phantom#1960
+                              1. Else Phantom#1963
 
-                    1. Else Phantom#1961
+                    1. Else Phantom#1964
 
-              1. Else Phantom#1962
+              1. Else Phantom#1965
 
-        1. Else Phantom#1963
+        1. Else Phantom#1966
 
-    1. Else Phantom#1964
+    1. Else Phantom#1967
 
 def $V1Model_setup_packet_in_argument(EC)
 
@@ -36573,7 +36611,7 @@ def $V1Model_setup_packet_in_argument(EC)
 
           1. Return argumentIR_packet_in
 
-  1. Else Phantom#1965
+  1. Else Phantom#1968
 
 def $V1Model_setup_packet_out_argument(EC)
 
@@ -36589,7 +36627,7 @@ def $V1Model_setup_packet_out_argument(EC)
 
           1. Return argumentIR_packet_out
 
-  1. Else Phantom#1966
+  1. Else Phantom#1969
 
 def $V1Model_setup_hdr_argument(ARCH)
 
@@ -36613,11 +36651,11 @@ def $V1Model_setup_hdr_argument(ARCH)
 
                   1. Return argumentIR_hdr
 
-            1. Else Phantom#1967
+            1. Else Phantom#1970
 
-      1. Else Phantom#1968
+      1. Else Phantom#1971
 
-  1. Else Phantom#1969
+  1. Else Phantom#1972
 
 def $V1Model_setup_meta_argument(ARCH)
 
@@ -36641,11 +36679,11 @@ def $V1Model_setup_meta_argument(ARCH)
 
                   1. Return argumentIR_meta
 
-            1. Else Phantom#1970
+            1. Else Phantom#1973
 
-      1. Else Phantom#1971
+      1. Else Phantom#1974
 
-  1. Else Phantom#1972
+  1. Else Phantom#1975
 
 def $V1Model_setup_standard_metadata_argument(EC)
 
@@ -36661,7 +36699,7 @@ def $V1Model_setup_standard_metadata_argument(EC)
 
           1. Return argumentIR_standard_metadata
 
-  1. Else Phantom#1973
+  1. Else Phantom#1976
 
 def $V1Model_setup_main_callee(EC, ARCH)
 
@@ -36699,15 +36737,15 @@ def $V1Model_setup_main_callee(EC, ARCH)
 
                                 1. Return typedExpressionIR_main
 
-                        1. Else Phantom#1974
+                        1. Else Phantom#1977
 
-                  1. Else Phantom#1975
+                  1. Else Phantom#1978
 
-            1. Else Phantom#1976
+            1. Else Phantom#1979
 
-        1. Else Phantom#1977
+        1. Else Phantom#1980
 
-  1. Else Phantom#1978
+  1. Else Phantom#1981
 
 def $V1Model_setup_parser_callee(EC, ARCH, typedExpressionIR_main)
 
@@ -36745,15 +36783,15 @@ def $V1Model_setup_parser_callee(EC, ARCH, typedExpressionIR_main)
 
                                 1. Return typedExpressionIR_parser
 
-                        1. Else Phantom#1979
+                        1. Else Phantom#1982
 
-                  1. Else Phantom#1980
+                  1. Else Phantom#1983
 
-            1. Else Phantom#1981
+            1. Else Phantom#1984
 
-        1. Else Phantom#1982
+        1. Else Phantom#1985
 
-  1. Else Phantom#1983
+  1. Else Phantom#1986
 
 def $V1Model_setup_verify_callee(EC, ARCH, typedExpressionIR_main)
 
@@ -36791,15 +36829,15 @@ def $V1Model_setup_verify_callee(EC, ARCH, typedExpressionIR_main)
 
                                 1. Return typedExpressionIR_verify
 
-                        1. Else Phantom#1984
+                        1. Else Phantom#1987
 
-                  1. Else Phantom#1985
+                  1. Else Phantom#1988
 
-            1. Else Phantom#1986
+            1. Else Phantom#1989
 
-        1. Else Phantom#1987
+        1. Else Phantom#1990
 
-  1. Else Phantom#1988
+  1. Else Phantom#1991
 
 def $V1Model_setup_ingress_callee(EC, ARCH, typedExpressionIR_main)
 
@@ -36837,15 +36875,15 @@ def $V1Model_setup_ingress_callee(EC, ARCH, typedExpressionIR_main)
 
                                 1. Return typedExpressionIR_ingress
 
-                        1. Else Phantom#1989
+                        1. Else Phantom#1992
 
-                  1. Else Phantom#1990
+                  1. Else Phantom#1993
 
-            1. Else Phantom#1991
+            1. Else Phantom#1994
 
-        1. Else Phantom#1992
+        1. Else Phantom#1995
 
-  1. Else Phantom#1993
+  1. Else Phantom#1996
 
 def $V1Model_setup_egress_callee(EC, ARCH, typedExpressionIR_main)
 
@@ -36883,15 +36921,15 @@ def $V1Model_setup_egress_callee(EC, ARCH, typedExpressionIR_main)
 
                                 1. Return typedExpressionIR_egress
 
-                        1. Else Phantom#1994
+                        1. Else Phantom#1997
 
-                  1. Else Phantom#1995
+                  1. Else Phantom#1998
 
-            1. Else Phantom#1996
+            1. Else Phantom#1999
 
-        1. Else Phantom#1997
+        1. Else Phantom#2000
 
-  1. Else Phantom#1998
+  1. Else Phantom#2001
 
 def $V1Model_setup_check_callee(EC, ARCH, typedExpressionIR_main)
 
@@ -36929,15 +36967,15 @@ def $V1Model_setup_check_callee(EC, ARCH, typedExpressionIR_main)
 
                                 1. Return typedExpressionIR_check
 
-                        1. Else Phantom#1999
+                        1. Else Phantom#2002
 
-                  1. Else Phantom#2000
+                  1. Else Phantom#2003
 
-            1. Else Phantom#2001
+            1. Else Phantom#2004
 
-        1. Else Phantom#2002
+        1. Else Phantom#2005
 
-  1. Else Phantom#2003
+  1. Else Phantom#2006
 
 def $V1Model_setup_deparse_callee(EC, ARCH, typedExpressionIR_main)
 
@@ -36969,13 +37007,13 @@ def $V1Model_setup_deparse_callee(EC, ARCH, typedExpressionIR_main)
 
                           1. Return typedExpressionIR_deparse
 
-                  1. Else Phantom#2004
+                  1. Else Phantom#2007
 
-            1. Else Phantom#2005
+            1. Else Phantom#2008
 
-        1. Else Phantom#2006
+        1. Else Phantom#2009
 
-  1. Else Phantom#2007
+  1. Else Phantom#2010
 
 relation V1Model_parser: EC_0 ARCH_0 |- % % %
 
@@ -37013,7 +37051,7 @@ relation V1Model_parser: EC_0 ARCH_0 |- % % %
 
                           1. Result in: % % |- EC_1 ARCH_1 (rejectTransitionResult as transitionResult)
 
-                    1. Else Phantom#2008
+                    1. Else Phantom#2011
 
 relation V1Model_verify: EC_0 ARCH_0 |- % % %
 
@@ -37047,7 +37085,7 @@ relation V1Model_verify: EC_0 ARCH_0 |- % % %
 
                       1. Result in: % % |- EC_1 ARCH_1 ((exit) as callResult)
 
-                1. Else Phantom#2009
+                1. Else Phantom#2012
 
 relation V1Model_ingress: EC_0 ARCH_0 |- % % %
 
@@ -37083,7 +37121,7 @@ relation V1Model_ingress: EC_0 ARCH_0 |- % % %
 
                         1. Result in: % % |- EC_1 ARCH_1 ((return ?()) as callResult)
 
-                  1. Else Phantom#2010
+                  1. Else Phantom#2013
 
 relation V1Model_egress: EC_0 ARCH_0 |- % % %
 
@@ -37119,7 +37157,7 @@ relation V1Model_egress: EC_0 ARCH_0 |- % % %
 
                         1. Result in: % % |- EC_1 ARCH_1 ((exit) as callResult)
 
-                  1. Else Phantom#2011
+                  1. Else Phantom#2014
 
 relation V1Model_check: EC_0 ARCH_0 |- % % %
 
@@ -37153,7 +37191,7 @@ relation V1Model_check: EC_0 ARCH_0 |- % % %
 
                       1. Result in: % % |- EC_1 ARCH_1 ((exit) as callResult)
 
-                1. Else Phantom#2012
+                1. Else Phantom#2015
 
 relation V1Model_deparse: EC_0 ARCH_0 |- % % %
 
@@ -37187,7 +37225,7 @@ relation V1Model_deparse: EC_0 ARCH_0 |- % % %
 
                       1. Result in: % % |- EC_1 ARCH_1 ((exit) as callResult)
 
-                1. Else Phantom#2013
+                1. Else Phantom#2016
 
 def $field_list_annotation_index(annotationList)
 
@@ -37309,13 +37347,13 @@ def $V1Model_meta_fields_of_index(ARCH, integerLiteral_index)
 
                       1. Return (nameIR_field)*
 
-                1. Else Phantom#2014
+                1. Else Phantom#2017
 
-            1. Else Phantom#2015
+            1. Else Phantom#2018
 
-      1. Else Phantom#2016
+      1. Else Phantom#2019
 
-  1. Else Phantom#2017
+  1. Else Phantom#2020
 
 relation V1Model_copy_meta_fields: EC_capture EC_0 ARCH |- (nameIR)* : %
 
@@ -37325,7 +37363,7 @@ relation V1Model_copy_meta_fields: EC_capture EC_0 ARCH |- (nameIR)* : %
 
     1. Result in: % % % |- % : EC_0
 
-  1. Else Phantom#2018
+  1. Else Phantom#2021
 
   2. If (((nameIR)* matches pattern _ :: _)), then
 
@@ -37341,7 +37379,7 @@ relation V1Model_copy_meta_fields: EC_capture EC_0 ARCH |- (nameIR)* : %
 
               1. Result in: % % % |- % : EC_2
 
-  2. Else Phantom#2019
+  2. Else Phantom#2022
 
 relation V1Model_setup_preserved_meta_fields: EC_0 ARCH |- integerLiteral_index : %
 
@@ -37371,11 +37409,11 @@ relation V1Model_setup_preserved_meta_fields: EC_0 ARCH |- integerLiteral_index 
 
                         1. Result in: % % |- % : EC_2
 
-              1. Else Phantom#2020
+              1. Else Phantom#2023
 
-        1. Else Phantom#2021
+        1. Else Phantom#2024
 
-    1. Else Phantom#2022
+    1. Else Phantom#2025
 
 relation EBPF_init: |- p4program : % %
 
@@ -37413,9 +37451,9 @@ relation EBPF_init_packet_in: EC_0 ARCH_0 |- objectState_packet_in : % %
 
                       1. Result in: % % |- % : EC_1 ARCH_2
 
-            1. Else Phantom#2023
+            1. Else Phantom#2026
 
-        1. Else Phantom#2024
+        1. Else Phantom#2027
 
 relation EBPF_init_globals: EC_0 ARCH |- %
 
@@ -37443,11 +37481,11 @@ relation EBPF_init_globals: EC_0 ARCH |- %
 
                       1. Result in: % % |- EC_2
 
-              1. Else Phantom#2025
+              1. Else Phantom#2028
 
-        1. Else Phantom#2026
+        1. Else Phantom#2029
 
-    1. Else Phantom#2027
+    1. Else Phantom#2030
 
 def $eBPF_setup_packet_in_argument(EC)
 
@@ -37463,7 +37501,7 @@ def $eBPF_setup_packet_in_argument(EC)
 
           1. Return argumentIR_packet_in
 
-  1. Else Phantom#2028
+  1. Else Phantom#2031
 
 def $eBPF_setup_headers_argument(ARCH)
 
@@ -37487,11 +37525,11 @@ def $eBPF_setup_headers_argument(ARCH)
 
                   1. Return argumentIR_headers
 
-            1. Else Phantom#2029
+            1. Else Phantom#2032
 
-      1. Else Phantom#2030
+      1. Else Phantom#2033
 
-  1. Else Phantom#2031
+  1. Else Phantom#2034
 
 def $eBPF_setup_main_callee(EC, ARCH)
 
@@ -37523,13 +37561,13 @@ def $eBPF_setup_main_callee(EC, ARCH)
 
                           1. Return typedExpressionIR_main
 
-                  1. Else Phantom#2032
+                  1. Else Phantom#2035
 
-            1. Else Phantom#2033
+            1. Else Phantom#2036
 
-        1. Else Phantom#2034
+        1. Else Phantom#2037
 
-  1. Else Phantom#2035
+  1. Else Phantom#2038
 
 def $eBPF_setup_parse_callee(EC, ARCH, typedExpressionIR_main)
 
@@ -37561,13 +37599,13 @@ def $eBPF_setup_parse_callee(EC, ARCH, typedExpressionIR_main)
 
                           1. Return typedExpressionIR_parse
 
-                  1. Else Phantom#2036
+                  1. Else Phantom#2039
 
-            1. Else Phantom#2037
+            1. Else Phantom#2040
 
-        1. Else Phantom#2038
+        1. Else Phantom#2041
 
-  1. Else Phantom#2039
+  1. Else Phantom#2042
 
 def $eBPF_setup_filter_callee(EC, ARCH, typedExpressionIR_main)
 
@@ -37599,13 +37637,13 @@ def $eBPF_setup_filter_callee(EC, ARCH, typedExpressionIR_main)
 
                           1. Return typedExpressionIR_filter
 
-                  1. Else Phantom#2040
+                  1. Else Phantom#2043
 
-            1. Else Phantom#2041
+            1. Else Phantom#2044
 
-        1. Else Phantom#2042
+        1. Else Phantom#2045
 
-  1. Else Phantom#2043
+  1. Else Phantom#2046
 
 relation EBPF_parse: EC_0 ARCH_0 |- % % %
 
@@ -37639,7 +37677,7 @@ relation EBPF_parse: EC_0 ARCH_0 |- % % %
 
                       1. Result in: % % |- EC_1 ARCH_1 (rejectTransitionResult as transitionResult)
 
-                1. Else Phantom#2044
+                1. Else Phantom#2047
 
 relation EBPF_filter: EC_0 ARCH_0 |- % % %
 
@@ -37673,7 +37711,7 @@ relation EBPF_filter: EC_0 ARCH_0 |- % % %
 
                       1. Result in: % % |- EC_1 ARCH_1 ((exit) as callResult)
 
-                1. Else Phantom#2045
+                1. Else Phantom#2048
 
 relation PSA_init: |- p4program : % %
 
@@ -37707,11 +37745,11 @@ def $PSA_setup_normal_meta_argument(ARCH)
 
                   1. Return argumentIR_normal_meta
 
-            1. Else Phantom#2046
+            1. Else Phantom#2049
 
-      1. Else Phantom#2047
+      1. Else Phantom#2050
 
-  1. Else Phantom#2048
+  1. Else Phantom#2051
 
 def $PSA_setup_clone_i2e_meta_argument(ARCH)
 
@@ -37735,11 +37773,11 @@ def $PSA_setup_clone_i2e_meta_argument(ARCH)
 
                   1. Return argumentIR_clone_i2e_meta
 
-            1. Else Phantom#2049
+            1. Else Phantom#2052
 
-      1. Else Phantom#2050
+      1. Else Phantom#2053
 
-  1. Else Phantom#2051
+  1. Else Phantom#2054
 
 def $PSA_setup_clone_e2e_meta_argument(ARCH)
 
@@ -37763,11 +37801,11 @@ def $PSA_setup_clone_e2e_meta_argument(ARCH)
 
                   1. Return argumentIR_clone_e2e_meta
 
-            1. Else Phantom#2052
+            1. Else Phantom#2055
 
-      1. Else Phantom#2053
+      1. Else Phantom#2056
 
-  1. Else Phantom#2054
+  1. Else Phantom#2057
 
 def $PSA_setup_resubmit_meta_argument(ARCH)
 
@@ -37791,11 +37829,11 @@ def $PSA_setup_resubmit_meta_argument(ARCH)
 
                   1. Return argumentIR_resubmit_meta
 
-            1. Else Phantom#2055
+            1. Else Phantom#2058
 
-      1. Else Phantom#2056
+      1. Else Phantom#2059
 
-  1. Else Phantom#2057
+  1. Else Phantom#2060
 
 def $PSA_setup_recirculate_meta_argument(ARCH)
 
@@ -37819,11 +37857,11 @@ def $PSA_setup_recirculate_meta_argument(ARCH)
 
                   1. Return argumentIR_recirculate_meta
 
-            1. Else Phantom#2058
+            1. Else Phantom#2061
 
-      1. Else Phantom#2059
+      1. Else Phantom#2062
 
-  1. Else Phantom#2060
+  1. Else Phantom#2063
 
 def $PSA_setup_main_callee(EC, ARCH)
 
@@ -37905,29 +37943,29 @@ def $PSA_setup_main_callee(EC, ARCH)
 
                                                                             1. Return typedExpressionIR_main
 
-                                                                  1. Else Phantom#2061
+                                                                  1. Else Phantom#2064
 
-                                                            1. Else Phantom#2062
+                                                            1. Else Phantom#2065
 
-                                                      1. Else Phantom#2063
+                                                      1. Else Phantom#2066
 
-                                                1. Else Phantom#2064
+                                                1. Else Phantom#2067
 
-                                          1. Else Phantom#2065
+                                          1. Else Phantom#2068
 
-                                    1. Else Phantom#2066
+                                    1. Else Phantom#2069
 
-                              1. Else Phantom#2067
+                              1. Else Phantom#2070
 
-                        1. Else Phantom#2068
+                        1. Else Phantom#2071
 
-                  1. Else Phantom#2069
+                  1. Else Phantom#2072
 
-            1. Else Phantom#2070
+            1. Else Phantom#2073
 
-        1. Else Phantom#2071
+        1. Else Phantom#2074
 
-  1. Else Phantom#2072
+  1. Else Phantom#2075
 
 relation PSA_ingress_init_packet_in: EC_0 ARCH_0 |- objectState_packet_in : % %
 
@@ -37955,9 +37993,9 @@ relation PSA_ingress_init_packet_in: EC_0 ARCH_0 |- objectState_packet_in : % %
 
                       1. Result in: % % |- % : EC_1 ARCH_2
 
-            1. Else Phantom#2073
+            1. Else Phantom#2076
 
-        1. Else Phantom#2074
+        1. Else Phantom#2077
 
 relation PSA_ingress_init_packet_out: EC_0 ARCH_0 |- objectState_packet_out : % %
 
@@ -37985,9 +38023,9 @@ relation PSA_ingress_init_packet_out: EC_0 ARCH_0 |- objectState_packet_out : % 
 
                       1. Result in: % % |- % : EC_1 ARCH_2
 
-            1. Else Phantom#2075
+            1. Else Phantom#2078
 
-        1. Else Phantom#2076
+        1. Else Phantom#2079
 
 relation PSA_ingress_init_parser_input_metadata: EC_0 ARCH |- i_port t_path : %
 
@@ -38175,27 +38213,27 @@ relation PSA_ingress_init_globals: EC_0 ARCH |- i_port : %
 
                                                                                             1. Result in: % % |- % : EC_10
 
-                                                                                1. Else Phantom#2077
+                                                                                1. Else Phantom#2080
 
-                                                                          1. Else Phantom#2078
+                                                                          1. Else Phantom#2081
 
-                                                                    1. Else Phantom#2079
+                                                                    1. Else Phantom#2082
 
-                                                              1. Else Phantom#2080
+                                                              1. Else Phantom#2083
 
-                                                  1. Else Phantom#2081
+                                                  1. Else Phantom#2084
 
-                                        1. Else Phantom#2082
+                                        1. Else Phantom#2085
 
-                              1. Else Phantom#2083
+                              1. Else Phantom#2086
 
-                    1. Else Phantom#2084
+                    1. Else Phantom#2087
 
-              1. Else Phantom#2085
+              1. Else Phantom#2088
 
-        1. Else Phantom#2086
+        1. Else Phantom#2089
 
-    1. Else Phantom#2087
+    1. Else Phantom#2090
 
 def $PSA_setup_ingress_packet_in_argument(EC)
 
@@ -38211,7 +38249,7 @@ def $PSA_setup_ingress_packet_in_argument(EC)
 
           1. Return argumentIR_packet_in
 
-  1. Else Phantom#2088
+  1. Else Phantom#2091
 
 def $PSA_setup_ingress_packet_out_argument(EC)
 
@@ -38227,7 +38265,7 @@ def $PSA_setup_ingress_packet_out_argument(EC)
 
           1. Return argumentIR_packet_out
 
-  1. Else Phantom#2089
+  1. Else Phantom#2092
 
 def $PSA_setup_ingress_hdr_argument(ARCH)
 
@@ -38251,11 +38289,11 @@ def $PSA_setup_ingress_hdr_argument(ARCH)
 
                   1. Return argumentIR_hdr
 
-            1. Else Phantom#2090
+            1. Else Phantom#2093
 
-      1. Else Phantom#2091
+      1. Else Phantom#2094
 
-  1. Else Phantom#2092
+  1. Else Phantom#2095
 
 def $PSA_setup_ingress_user_meta_argument(ARCH)
 
@@ -38279,11 +38317,11 @@ def $PSA_setup_ingress_user_meta_argument(ARCH)
 
                   1. Return argumentIR_user_meta
 
-            1. Else Phantom#2093
+            1. Else Phantom#2096
 
-      1. Else Phantom#2094
+      1. Else Phantom#2097
 
-  1. Else Phantom#2095
+  1. Else Phantom#2098
 
 def $PSA_setup_ingress_parser_input_metadata_argument(EC)
 
@@ -38299,7 +38337,7 @@ def $PSA_setup_ingress_parser_input_metadata_argument(EC)
 
           1. Return argumentIR_parser_input_metadata
 
-  1. Else Phantom#2096
+  1. Else Phantom#2099
 
 def $PSA_setup_ingress_input_metadata_argument(EC)
 
@@ -38315,7 +38353,7 @@ def $PSA_setup_ingress_input_metadata_argument(EC)
 
           1. Return argumentIR_input_metadata
 
-  1. Else Phantom#2097
+  1. Else Phantom#2100
 
 def $PSA_setup_ingress_output_metadata_argument(EC)
 
@@ -38331,7 +38369,7 @@ def $PSA_setup_ingress_output_metadata_argument(EC)
 
           1. Return argumentIR_output_metadata
 
-  1. Else Phantom#2098
+  1. Else Phantom#2101
 
 def $PSA_setup_ingress_pipeline_callee(EC, ARCH, typedExpressionIR_main)
 
@@ -38395,23 +38433,23 @@ def $PSA_setup_ingress_pipeline_callee(EC, ARCH, typedExpressionIR_main)
 
                                                           1. Return typedExpressionIR_ingress_pipeline
 
-                                                1. Else Phantom#2099
+                                                1. Else Phantom#2102
 
-                                          1. Else Phantom#2100
+                                          1. Else Phantom#2103
 
-                                    1. Else Phantom#2101
+                                    1. Else Phantom#2104
 
-                              1. Else Phantom#2102
+                              1. Else Phantom#2105
 
-                        1. Else Phantom#2103
+                        1. Else Phantom#2106
 
-                  1. Else Phantom#2104
+                  1. Else Phantom#2107
 
-            1. Else Phantom#2105
+            1. Else Phantom#2108
 
-        1. Else Phantom#2106
+        1. Else Phantom#2109
 
-  1. Else Phantom#2107
+  1. Else Phantom#2110
 
 def $PSA_setup_ingress_parser_callee(EC, ARCH, typedExpressionIR_ingress_pipeline)
 
@@ -38463,19 +38501,19 @@ def $PSA_setup_ingress_parser_callee(EC, ARCH, typedExpressionIR_ingress_pipelin
 
                                               1. Return typedExpressionIR_ingress_parser
 
-                                    1. Else Phantom#2108
+                                    1. Else Phantom#2111
 
-                              1. Else Phantom#2109
+                              1. Else Phantom#2112
 
-                        1. Else Phantom#2110
+                        1. Else Phantom#2113
 
-                  1. Else Phantom#2111
+                  1. Else Phantom#2114
 
-            1. Else Phantom#2112
+            1. Else Phantom#2115
 
-        1. Else Phantom#2113
+        1. Else Phantom#2116
 
-  1. Else Phantom#2114
+  1. Else Phantom#2117
 
 def $PSA_setup_ingress_callee(EC, ARCH, typedExpressionIR_ingress_pipeline)
 
@@ -38515,15 +38553,15 @@ def $PSA_setup_ingress_callee(EC, ARCH, typedExpressionIR_ingress_pipeline)
 
                                   1. Return typedExpressionIR_ingress
 
-                        1. Else Phantom#2115
+                        1. Else Phantom#2118
 
-                  1. Else Phantom#2116
+                  1. Else Phantom#2119
 
-            1. Else Phantom#2117
+            1. Else Phantom#2120
 
-        1. Else Phantom#2118
+        1. Else Phantom#2121
 
-  1. Else Phantom#2119
+  1. Else Phantom#2122
 
 def $PSA_setup_ingress_deparser_callee(EC, ARCH, typedExpressionIR_ingress_pipeline)
 
@@ -38581,21 +38619,21 @@ def $PSA_setup_ingress_deparser_callee(EC, ARCH, typedExpressionIR_ingress_pipel
 
                                                     1. Return typedExpressionIR_ingress_deparser
 
-                                          1. Else Phantom#2120
+                                          1. Else Phantom#2123
 
-                                    1. Else Phantom#2121
+                                    1. Else Phantom#2124
 
-                              1. Else Phantom#2122
+                              1. Else Phantom#2125
 
-                        1. Else Phantom#2123
+                        1. Else Phantom#2126
 
-                  1. Else Phantom#2124
+                  1. Else Phantom#2127
 
-            1. Else Phantom#2125
+            1. Else Phantom#2128
 
-        1. Else Phantom#2126
+        1. Else Phantom#2129
 
-  1. Else Phantom#2127
+  1. Else Phantom#2130
 
 relation PSA_ingress_parser: EC_0 ARCH_0 |- % % %
 
@@ -38639,7 +38677,7 @@ relation PSA_ingress_parser: EC_0 ARCH_0 |- % % %
 
                                 1. Result in: % % |- EC_1 ARCH_1 (rejectTransitionResult as transitionResult)
 
-                          1. Else Phantom#2128
+                          1. Else Phantom#2131
 
 relation PSA_ingress: EC_0 ARCH_0 |- % % %
 
@@ -38679,7 +38717,7 @@ relation PSA_ingress: EC_0 ARCH_0 |- % % %
 
                             1. Result in: % % |- EC_1 ARCH_1 ((return ?()) as callResult)
 
-                      1. Else Phantom#2129
+                      1. Else Phantom#2132
 
 relation PSA_ingress_deparser: EC_0 ARCH_0 |- % % %
 
@@ -38725,7 +38763,7 @@ relation PSA_ingress_deparser: EC_0 ARCH_0 |- % % %
 
                                   1. Result in: % % |- EC_1 ARCH_1 ((exit) as callResult)
 
-                            1. Else Phantom#2130
+                            1. Else Phantom#2133
 
 relation PSA_egress_init_packet_in: EC_0 ARCH_0 |- objectState_packet_in : % %
 
@@ -38753,9 +38791,9 @@ relation PSA_egress_init_packet_in: EC_0 ARCH_0 |- objectState_packet_in : % %
 
                       1. Result in: % % |- % : EC_1 ARCH_2
 
-            1. Else Phantom#2131
+            1. Else Phantom#2134
 
-        1. Else Phantom#2132
+        1. Else Phantom#2135
 
 relation PSA_egress_init_packet_out: EC_0 ARCH_0 |- objectState_packet_out : % %
 
@@ -38783,9 +38821,9 @@ relation PSA_egress_init_packet_out: EC_0 ARCH_0 |- objectState_packet_out : % %
 
                       1. Result in: % % |- % : EC_1 ARCH_2
 
-            1. Else Phantom#2133
+            1. Else Phantom#2136
 
-        1. Else Phantom#2134
+        1. Else Phantom#2137
 
 relation PSA_egress_init_parser_input_metadata: EC_0 ARCH |- i_port t_path : %
 
@@ -38977,25 +39015,25 @@ relation PSA_egress_init_globals: EC_0 ARCH |- i_port : %
 
                                                                                         1. Result in: % % |- % : EC_8
 
-                                                                                  1. Else Phantom#2135
+                                                                                  1. Else Phantom#2138
 
-                                                                        1. Else Phantom#2136
+                                                                        1. Else Phantom#2139
 
-                                                            1. Else Phantom#2137
+                                                            1. Else Phantom#2140
 
-                                                  1. Else Phantom#2138
+                                                  1. Else Phantom#2141
 
-                                        1. Else Phantom#2139
+                                        1. Else Phantom#2142
 
-                              1. Else Phantom#2140
+                              1. Else Phantom#2143
 
-                    1. Else Phantom#2141
+                    1. Else Phantom#2144
 
-              1. Else Phantom#2142
+              1. Else Phantom#2145
 
-        1. Else Phantom#2143
+        1. Else Phantom#2146
 
-    1. Else Phantom#2144
+    1. Else Phantom#2147
 
 def $PSA_setup_egress_packet_in_argument(EC)
 
@@ -39011,7 +39049,7 @@ def $PSA_setup_egress_packet_in_argument(EC)
 
           1. Return argumentIR_packet_in
 
-  1. Else Phantom#2145
+  1. Else Phantom#2148
 
 def $PSA_setup_egress_packet_out_argument(EC)
 
@@ -39027,7 +39065,7 @@ def $PSA_setup_egress_packet_out_argument(EC)
 
           1. Return argumentIR_packet_out
 
-  1. Else Phantom#2146
+  1. Else Phantom#2149
 
 def $PSA_setup_egress_hdr_argument(ARCH)
 
@@ -39051,11 +39089,11 @@ def $PSA_setup_egress_hdr_argument(ARCH)
 
                   1. Return argumentIR_hdr
 
-            1. Else Phantom#2147
+            1. Else Phantom#2150
 
-      1. Else Phantom#2148
+      1. Else Phantom#2151
 
-  1. Else Phantom#2149
+  1. Else Phantom#2152
 
 def $PSA_setup_egress_user_meta_argument(ARCH)
 
@@ -39079,11 +39117,11 @@ def $PSA_setup_egress_user_meta_argument(ARCH)
 
                   1. Return argumentIR_user_meta
 
-            1. Else Phantom#2150
+            1. Else Phantom#2153
 
-      1. Else Phantom#2151
+      1. Else Phantom#2154
 
-  1. Else Phantom#2152
+  1. Else Phantom#2155
 
 def $PSA_setup_egress_parser_input_metadata_argument(EC)
 
@@ -39099,7 +39137,7 @@ def $PSA_setup_egress_parser_input_metadata_argument(EC)
 
           1. Return argumentIR_parser_input_metadata
 
-  1. Else Phantom#2153
+  1. Else Phantom#2156
 
 def $PSA_setup_egress_input_metadata_argument(EC)
 
@@ -39115,7 +39153,7 @@ def $PSA_setup_egress_input_metadata_argument(EC)
 
           1. Return argumentIR_input_metadata
 
-  1. Else Phantom#2154
+  1. Else Phantom#2157
 
 def $PSA_setup_egress_output_metadata_argument(EC)
 
@@ -39131,7 +39169,7 @@ def $PSA_setup_egress_output_metadata_argument(EC)
 
           1. Return argumentIR_output_metadata
 
-  1. Else Phantom#2155
+  1. Else Phantom#2158
 
 def $PSA_setup_egress_deparser_input_metadata_argument(EC)
 
@@ -39147,7 +39185,7 @@ def $PSA_setup_egress_deparser_input_metadata_argument(EC)
 
           1. Return argumentIR_deparser_input_metadata
 
-  1. Else Phantom#2156
+  1. Else Phantom#2159
 
 def $PSA_setup_egress_pipeline_callee(EC, ARCH, typedExpressionIR_main)
 
@@ -39211,23 +39249,23 @@ def $PSA_setup_egress_pipeline_callee(EC, ARCH, typedExpressionIR_main)
 
                                                           1. Return typedExpressionIR_egress_pipeline
 
-                                                1. Else Phantom#2157
+                                                1. Else Phantom#2160
 
-                                          1. Else Phantom#2158
+                                          1. Else Phantom#2161
 
-                                    1. Else Phantom#2159
+                                    1. Else Phantom#2162
 
-                              1. Else Phantom#2160
+                              1. Else Phantom#2163
 
-                        1. Else Phantom#2161
+                        1. Else Phantom#2164
 
-                  1. Else Phantom#2162
+                  1. Else Phantom#2165
 
-            1. Else Phantom#2163
+            1. Else Phantom#2166
 
-        1. Else Phantom#2164
+        1. Else Phantom#2167
 
-  1. Else Phantom#2165
+  1. Else Phantom#2168
 
 def $PSA_setup_egress_parser_callee(EC, ARCH, typedExpressionIR_egress_pipeline)
 
@@ -39285,21 +39323,21 @@ def $PSA_setup_egress_parser_callee(EC, ARCH, typedExpressionIR_egress_pipeline)
 
                                                     1. Return typedExpressionIR_egress_parser
 
-                                          1. Else Phantom#2166
+                                          1. Else Phantom#2169
 
-                                    1. Else Phantom#2167
+                                    1. Else Phantom#2170
 
-                              1. Else Phantom#2168
+                              1. Else Phantom#2171
 
-                        1. Else Phantom#2169
+                        1. Else Phantom#2172
 
-                  1. Else Phantom#2170
+                  1. Else Phantom#2173
 
-            1. Else Phantom#2171
+            1. Else Phantom#2174
 
-        1. Else Phantom#2172
+        1. Else Phantom#2175
 
-  1. Else Phantom#2173
+  1. Else Phantom#2176
 
 def $PSA_setup_egress_callee(EC, ARCH, typedExpressionIR_egress_pipeline)
 
@@ -39339,15 +39377,15 @@ def $PSA_setup_egress_callee(EC, ARCH, typedExpressionIR_egress_pipeline)
 
                                   1. Return typedExpressionIR_egress
 
-                        1. Else Phantom#2174
+                        1. Else Phantom#2177
 
-                  1. Else Phantom#2175
+                  1. Else Phantom#2178
 
-            1. Else Phantom#2176
+            1. Else Phantom#2179
 
-        1. Else Phantom#2177
+        1. Else Phantom#2180
 
-  1. Else Phantom#2178
+  1. Else Phantom#2181
 
 def $PSA_setup_egress_deparser_callee(EC, ARCH, typedExpressionIR_egress_pipeline)
 
@@ -39399,19 +39437,19 @@ def $PSA_setup_egress_deparser_callee(EC, ARCH, typedExpressionIR_egress_pipelin
 
                                               1. Return typedExpressionIR_egress_deparser
 
-                                    1. Else Phantom#2179
+                                    1. Else Phantom#2182
 
-                              1. Else Phantom#2180
+                              1. Else Phantom#2183
 
-                        1. Else Phantom#2181
+                        1. Else Phantom#2184
 
-                  1. Else Phantom#2182
+                  1. Else Phantom#2185
 
-            1. Else Phantom#2183
+            1. Else Phantom#2186
 
-        1. Else Phantom#2184
+        1. Else Phantom#2187
 
-  1. Else Phantom#2185
+  1. Else Phantom#2188
 
 relation PSA_egress_parser: EC_0 ARCH_0 |- % % %
 
@@ -39457,7 +39495,7 @@ relation PSA_egress_parser: EC_0 ARCH_0 |- % % %
 
                                   1. Result in: % % |- EC_1 ARCH_1 (rejectTransitionResult as transitionResult)
 
-                            1. Else Phantom#2186
+                            1. Else Phantom#2189
 
 relation PSA_egress: EC_0 ARCH_0 |- % % %
 
@@ -39497,7 +39535,7 @@ relation PSA_egress: EC_0 ARCH_0 |- % % %
 
                             1. Result in: % % |- EC_1 ARCH_1 ((return ?()) as callResult)
 
-                      1. Else Phantom#2187
+                      1. Else Phantom#2190
 
 relation PSA_egress_deparser: EC_0 ARCH_0 |- % % %
 
@@ -39543,4 +39581,4 @@ relation PSA_egress_deparser: EC_0 ARCH_0 |- % % %
 
                                   1. Result in: % % |- EC_1 ARCH_1 ((exit) as callResult)
 
-                            1. Else Phantom#2188
+                            1. Else Phantom#2191

--- a/p4spec/test/lang/struct.expected
+++ b/p4spec/test/lang/struct.expected
@@ -60,11 +60,17 @@ def $join_text((text)*, t_sep)
 
   3. Case (% matches pattern _ :: _)
 
-    1. (Let t_h :: (t_t)* be (text)*)
+    1. (Let t_h1 :: (text')* be (text)*)
 
-      1. Return t_h ++ t_sep ++ $join_text((t_t)*, t_sep)
+      1. If (((text')* matches pattern _ :: _)), then
 
-1. Else Phantom#0
+        1. (Let t_h2 :: (t_t)* be (text')*)
+
+          1. Return t_h1 ++ t_sep ++ $join_text(t_h2 :: (t_t)*, t_sep)
+
+      1. Else Phantom#0
+
+1. Else Phantom#1
 
 def $replace_text(t, t_old, t_new)
 
@@ -76,7 +82,7 @@ def $replace_text'(n_len, n_len', t, t_old, t_new)
 
   1. Return t
 
-1. Else Phantom#1
+1. Else Phantom#2
 
 2. If ((n_len < n_len')), then
 
@@ -84,7 +90,7 @@ def $replace_text'(n_len, n_len', t, t_old, t_new)
 
     1. Return $replace_text'((n_len + 1), n_len', t_replaced, t_old, t_new)
 
-2. Else Phantom#2
+2. Else Phantom#3
 
 def $replace_text_except(t, t_old, t_new)
 
@@ -96,7 +102,7 @@ def $replace_text_except'(n_len, n_len', t, t_old, t_new)
 
   1. Return t
 
-1. Else Phantom#3
+1. Else Phantom#4
 
 2. If ((n_len < n_len')), then
 
@@ -104,7 +110,7 @@ def $replace_text_except'(n_len, n_len', t, t_old, t_new)
 
     1. Return $replace_text_except'((n_len + 1), n_len', t_replaced, t_old, t_new)
 
-2. Else Phantom#4
+2. Else Phantom#5
 
 builtin def $strip_prefix(text, text')
 
@@ -180,7 +186,7 @@ def $contains'(n_len, n_len', t, t_c)
 
   1. Return false
 
-1. Else Phantom#5
+1. Else Phantom#6
 
 2. If ((n_len < n_len')), then
 
@@ -194,7 +200,7 @@ def $contains'(n_len, n_len', t, t_c)
 
       1. Return $contains'((n_len + 1), n_len', t, t_c)
 
-2. Else Phantom#6
+2. Else Phantom#7
 
 def $is_some_<X>((X)?)
 
@@ -268,7 +274,7 @@ def $init_(nat)
 
           1. Return n :: $init_(n)
 
-      1. Else Phantom#7
+      1. Else Phantom#8
 
 def $repeat_<X>(X, nat)
 
@@ -288,7 +294,7 @@ def $repeat_<X>(X, nat)
 
           1. Return [X] ++ $repeat_<X>(X, n)
 
-      1. Else Phantom#8
+      1. Else Phantom#9
 
 builtin def $rev_<X>((X)*)
 
@@ -306,7 +312,7 @@ def $filter_<X>((X)*, (bool)*)
 
       1. Return []
 
-    1. Else Phantom#9
+    1. Else Phantom#10
 
   2. Case (% matches pattern _ :: _)
 
@@ -326,7 +332,7 @@ def $filter_<X>((X)*, (bool)*)
 
               1. Return $filter_<X>((X_t)*, (b_t)*)
 
-      1. Else Phantom#10
+      1. Else Phantom#11
 
 builtin def $assoc_<X, Y>(X, ((X, Y))*)
 
@@ -396,13 +402,13 @@ def $modulo(n_a, n_b)
 
   1. Return ?((n_a \ n_b))
 
-1. Else Phantom#11
+1. Else Phantom#12
 
 2. If ((n_b = 0)), then
 
   1. Return ?()
 
-2. Else Phantom#12
+2. Else Phantom#13
 
 def $modulo_42(n)
 
@@ -414,7 +420,7 @@ def $modulo_42(n)
 
       1. Return n_result
 
-  1. Else Phantom#13
+  1. Else Phantom#14
 
 syntax trailingCommaOpt = 
    | `empty
@@ -670,7 +676,7 @@ def $flatten_parameterList(parameterList)
 
       1. Return [parameter]
 
-1. Else Phantom#14
+1. Else Phantom#15
 
 2. If ((parameterList has type nonEmptyParameterList)), then
 
@@ -682,9 +688,9 @@ def $flatten_parameterList(parameterList)
 
         1. Return $flatten_parameterList((nonEmptyParameterList' as parameterList)) ++ [parameter]
 
-    1. Else Phantom#15
+    1. Else Phantom#16
 
-2. Else Phantom#16
+2. Else Phantom#17
 
 syntax constructorParameter = parameter
 
@@ -1682,7 +1688,7 @@ def $flatten_argumentList(argumentList)
 
       1. Return [argument]
 
-1. Else Phantom#17
+1. Else Phantom#18
 
 2. If ((argumentList has type argumentListNonEmpty)), then
 
@@ -1694,9 +1700,9 @@ def $flatten_argumentList(argumentList)
 
         1. Return $flatten_argumentList((argumentListNonEmpty' as argumentList)) ++ [argument]
 
-    1. Else Phantom#18
+    1. Else Phantom#19
 
-2. Else Phantom#19
+2. Else Phantom#20
 
 syntax lvalue = 
    | `id text
@@ -1782,9 +1788,9 @@ def $expression_as_lvalue(expression)
 
                 1. Return ?((lvalue' . member))
 
-            1. Else Phantom#20
+            1. Else Phantom#21
 
-      1. Else Phantom#21
+      1. Else Phantom#22
 
   3. Case (% has type indexAccessExpression)
 
@@ -1798,7 +1804,7 @@ def $expression_as_lvalue(expression)
 
             1. Return ?((lvalue_base [ expression_index ]))
 
-        1. Else Phantom#22
+        1. Else Phantom#23
 
   4. Case (% has type sliceAccessExpression)
 
@@ -1812,7 +1818,7 @@ def $expression_as_lvalue(expression)
 
             1. Return ?((lvalue_base [ expression_hi : expression_lo ]))
 
-        1. Else Phantom#23
+        1. Else Phantom#24
 
   5. Case (% has type parenthesizedExpression)
 
@@ -1826,9 +1832,9 @@ def $expression_as_lvalue(expression)
 
             1. Return ?((( lvalue' )))
 
-        1. Else Phantom#24
+        1. Else Phantom#25
 
-1. Else Phantom#25
+1. Else Phantom#26
 
 syntax emptyStatement = 
    | ;
@@ -1892,7 +1898,7 @@ def $flatten_forUpdateStatementList(forUpdateStatementList)
 
       1. Return [forUpdateStatement]
 
-1. Else Phantom#26
+1. Else Phantom#27
 
 2. If ((forUpdateStatementList has type forUpdateStatementListNonEmpty)), then
 
@@ -1904,9 +1910,9 @@ def $flatten_forUpdateStatementList(forUpdateStatementList)
 
         1. Return $flatten_forUpdateStatementList((forUpdateStatementListNonEmpty' as forUpdateStatementList)) ++ [forUpdateStatement]
 
-    1. Else Phantom#27
+    1. Else Phantom#28
 
-2. Else Phantom#28
+2. Else Phantom#29
 
 syntax forInitStatement = 
    | annotationList type name initializerOpt
@@ -1943,7 +1949,7 @@ def $flatten_forInitStatementList(forInitStatementList)
 
       1. Return [forInitStatement]
 
-1. Else Phantom#29
+1. Else Phantom#30
 
 2. If ((forInitStatementList has type forInitStatementListNonEmpty)), then
 
@@ -1955,9 +1961,9 @@ def $flatten_forInitStatementList(forInitStatementList)
 
         1. Return $flatten_forInitStatementList((forInitStatementListNonEmpty' as forInitStatementList)) ++ [forInitStatement]
 
-    1. Else Phantom#30
+    1. Else Phantom#31
 
-2. Else Phantom#31
+2. Else Phantom#32
 
 syntax forCollectionExpression = 
    | true
@@ -2777,7 +2783,7 @@ def $flatten_annotationList(annotationList)
 
       1. Return [annotation]
 
-1. Else Phantom#32
+1. Else Phantom#33
 
 2. If ((annotationList has type annotationListNonEmpty)), then
 
@@ -2789,9 +2795,9 @@ def $flatten_annotationList(annotationList)
 
         1. Return $flatten_annotationList((annotationListNonEmpty' as annotationList)) ++ [annotation]
 
-    1. Else Phantom#33
+    1. Else Phantom#34
 
-2. Else Phantom#34
+2. Else Phantom#35
 
 syntax p4program = 
    | `empty
@@ -2857,7 +2863,7 @@ def $fresh_typeIds(nat)
 
           1. Return $fresh_typeId :: $fresh_typeIds(n)
 
-      1. Else Phantom#35
+      1. Else Phantom#36
 
 syntax callTargetId = 
    | nameIR ( id* )
@@ -2884,7 +2890,7 @@ def $callableId'(parameterList)
 
       1. Return [$name(name)]
 
-1. Else Phantom#36
+1. Else Phantom#37
 
 2. If ((parameterList has type nonEmptyParameterList)), then
 
@@ -2896,9 +2902,9 @@ def $callableId'(parameterList)
 
         1. Return $callableId'((nonEmptyParameterList' as parameterList)) ++ [$name(name)]
 
-    1. Else Phantom#37
+    1. Else Phantom#38
 
-2. Else Phantom#38
+2. Else Phantom#39
 
 def $constructorId(name, constructorParameterListOpt)
 
@@ -3187,7 +3193,7 @@ def $update_headerUnion((fieldValue)*, nameIR)
 
                 1. Return (value_field_h_update nameIR_field_h ;) :: $update_headerUnion((fieldValue_t)*, nameIR)
 
-          1. Else Phantom#39
+          1. Else Phantom#40
 
 def $isValid_header(value)
 
@@ -3199,7 +3205,7 @@ def $isValid_header(value)
 
       1. Return b_valid
 
-1. Else Phantom#40
+1. Else Phantom#41
 
 def $invalidate_value(value)
 
@@ -3217,7 +3223,7 @@ def $invalidate_value(value)
 
       1. Return ($invalidate_headerUnion(headerUnionValue) as value)
 
-1. Else Phantom#41
+1. Else Phantom#42
 
 def $invalidate_header((header typeId { _bool ; (fieldValue)* }))
 
@@ -3237,7 +3243,7 @@ def $write_value_from_bits(value, n_var, (b)*)
 
     1. Return value_updated
 
-  1. Else Phantom#42
+  1. Else Phantom#43
 
 def $write_value_from_bits'(value, n_var, (bool)*)
 
@@ -3251,7 +3257,7 @@ def $write_value_from_bits'(value, n_var, (bool)*)
 
         1. Return (((`b b_h) as value), (b_t)*)
 
-    1. Else Phantom#43
+    1. Else Phantom#44
 
   2. Case (% has type integerLiteral)
 
@@ -3279,9 +3285,9 @@ def $write_value_from_bits'(value, n_var, (bool)*)
 
                           1. Return (((w w i) as value), (b_t)*)
 
-                  1. Else Phantom#44
+                  1. Else Phantom#45
 
-            1. Else Phantom#45
+            1. Else Phantom#46
 
         2. Case (% matches pattern `%S%`)
 
@@ -3303,11 +3309,11 @@ def $write_value_from_bits'(value, n_var, (bool)*)
 
                           1. Return (((w s i) as value), (b_t)*)
 
-                  1. Else Phantom#46
+                  1. Else Phantom#47
 
-            1. Else Phantom#47
+            1. Else Phantom#48
 
-      1. Else Phantom#48
+      1. Else Phantom#49
 
   3. Case (% has type structValue)
 
@@ -3337,7 +3343,7 @@ def $write_value_from_bits'(value, n_var, (bool)*)
 
             1. Return (((typeId . "__UNSPECIFIED" . value_updated) as value), (b_rest)*)
 
-      1. Else Phantom#49
+      1. Else Phantom#50
 
   6. Case (% has type headerStackValue)
 
@@ -3347,7 +3353,7 @@ def $write_value_from_bits'(value, n_var, (bool)*)
 
         1. Return (((header_stack[ (value_updated)* ( n_idx ; n_size )]) as value), (b_rest)*)
 
-1. Else Phantom#50
+1. Else Phantom#51
 
 2. If ((value has type integerValue)), then
 
@@ -3361,7 +3367,7 @@ def $write_value_from_bits'(value, n_var, (bool)*)
 
           1. Return (((n_max . 0 v i) as value), (bool)*)
 
-        1. Else Phantom#51
+        1. Else Phantom#52
 
         2. If ((|(bool)*| >= n_var)), then
 
@@ -3379,13 +3385,13 @@ def $write_value_from_bits'(value, n_var, (bool)*)
 
                       1. Return (((n_max . n_var v i') as value), (b_t)*)
 
-              1. Else Phantom#52
+              1. Else Phantom#53
 
-        2. Else Phantom#53
+        2. Else Phantom#54
 
-    1. Else Phantom#54
+    1. Else Phantom#55
 
-2. Else Phantom#55
+2. Else Phantom#56
 
 def $write_values_from_bits'((value)*, n_var, (b)*)
 
@@ -3457,7 +3463,7 @@ def $write_bits_from_value(value)
 
             1. Return $int_to_bits_unsigned(w, i)
 
-      1. Else Phantom#56
+      1. Else Phantom#57
 
   3. Case (% has type headerStackValue)
 
@@ -3479,7 +3485,7 @@ def $write_bits_from_value(value)
 
         1. Return $concat_<bool>(($write_bits_from_value(value_field))*)
 
-      1. Else Phantom#57
+      1. Else Phantom#58
 
     2. (Let (header _typeId { bool ; (_fieldValue)* }) be (value as headerValue))
 
@@ -3487,7 +3493,7 @@ def $write_bits_from_value(value)
 
         1. Return []
 
-      1. Else Phantom#58
+      1. Else Phantom#59
 
   6. Case (% has type headerUnionValue)
 
@@ -3505,9 +3511,9 @@ def $write_bits_from_value(value)
 
           1. Return $write_bits_from_value(value')
 
-      1. Else Phantom#59
+      1. Else Phantom#60
 
-1. Else Phantom#60
+1. Else Phantom#61
 
 2. If ((value has type integerValue)), then
 
@@ -3519,9 +3525,9 @@ def $write_bits_from_value(value)
 
         1. Return $int_to_bits_unsigned(w, i)
 
-    1. Else Phantom#61
+    1. Else Phantom#62
 
-2. Else Phantom#62
+2. Else Phantom#63
 
 syntax voidTypeIR = 
    | void
@@ -4529,7 +4535,7 @@ def $callableTypeIR_of_callableTypeDefIR(callableTypeDefIR)
 
       1. Return (controlApplyMethodTypeDefIR as callableTypeIR)
 
-1. Else Phantom#63
+1. Else Phantom#64
 
 def $typeParameterListIR_of_callableTypeDefIR(callableTypeDefIR)
 
@@ -4577,7 +4583,7 @@ def $typeParameterListIR_of_callableTypeDefIR(callableTypeDefIR)
 
     1. Return ([], [])
 
-1. Else Phantom#64
+1. Else Phantom#65
 
 def $parameterListIR_of_callableTypeDefIR(callableTypeDefIR)
 
@@ -4999,9 +5005,9 @@ def $capture_avoiding_(theta, (typeParameterIR)*, B)
 
                 1. Return (theta_fresh, (typeParameterIR_fresh)*)
 
-            1. Else Phantom#65
+            1. Else Phantom#66
 
-    1. Else Phantom#66
+    1. Else Phantom#67
 
 def $capture_avoiding(theta, (typeParameterIR_expl)*, (typeParameterIR_impl)*, B)
 
@@ -5027,9 +5033,9 @@ def $capture_avoiding(theta, (typeParameterIR_expl)*, (typeParameterIR_impl)*, B
 
                     1. Return (theta_fresh, (typeParameterIR_expl_fresh)*, (typeParameterIR_impl_fresh)*)
 
-            1. Else Phantom#67
+            1. Else Phantom#68
 
-    1. Else Phantom#68
+    1. Else Phantom#69
 
 def $subst_typeIR(set<pair<typeId, typeIR>>, typeIR)
 
@@ -5063,13 +5069,13 @@ def $subst_typeIR'(theta, typeIR)
 
             1. Return typeIR''
 
-        1. Else Phantom#69
+        1. Else Phantom#70
 
       2. If ((?() = $find_map<typeId, typeIR>(theta, typeId))), then
 
         1. Return ((` typeId) as typeIR)
 
-      2. Else Phantom#70
+      2. Else Phantom#71
 
   3. Case (% has type typedefTypeIR)
 
@@ -5185,7 +5191,7 @@ def $subst_typeIR'(theta, typeIR)
 
                   1. Return (externObjectTypeIR_subst as typeIR)
 
-            1. Else Phantom#71
+            1. Else Phantom#72
 
   14. Case (% has type parserObjectTypeIR)
 
@@ -5447,7 +5453,7 @@ def $subst_callableTypeDefIR'(theta, callableTypeDefIR)
 
             1. Return (actionTypeDefIR_subst as callableTypeDefIR)
 
-        1. Else Phantom#72
+        1. Else Phantom#73
 
   2. Case (% has type definedFunctionTypeDefIR)
 
@@ -5523,7 +5529,7 @@ def $subst_callableTypeDefIR'(theta, callableTypeDefIR)
 
             1. Return (parserApplyMethodTypeDefIR_subst as callableTypeDefIR)
 
-        1. Else Phantom#73
+        1. Else Phantom#74
 
   6. Case (% has type controlApplyMethodTypeDefIR)
 
@@ -5537,9 +5543,9 @@ def $subst_callableTypeDefIR'(theta, callableTypeDefIR)
 
             1. Return (controlApplyMethodTypeDefIR_subst as callableTypeDefIR)
 
-        1. Else Phantom#74
+        1. Else Phantom#75
 
-1. Else Phantom#75
+1. Else Phantom#76
 
 def $subst_constructorTypeIR(set<pair<typeId, typeIR>>, constructorTypeIR)
 
@@ -5575,7 +5581,7 @@ def $specialize_typeDefIR(typeDefIR_base, (typeArgumentIR)*)
 
             1. Return typeIR_spec
 
-    1. Else Phantom#76
+    1. Else Phantom#77
 
 def $specialize_callableTypeDefIR(callableTypeDefIR_base, (typeArgumentIR)*)
 
@@ -5597,7 +5603,7 @@ def $specialize_callableTypeDefIR(callableTypeDefIR_base, (typeArgumentIR)*)
 
                 1. Return (callableTypeIR_spec, (typeId_fresh)*)
 
-    1. Else Phantom#77
+    1. Else Phantom#78
 
     2. If (((|(typeParameterIR_expl)*| > 0) /\ (|(typeArgumentIR)*| = 0))), then
 
@@ -5613,7 +5619,7 @@ def $specialize_callableTypeDefIR(callableTypeDefIR_base, (typeArgumentIR)*)
 
                 1. Return (callableTypeIR_spec, (typeId_fresh)*)
 
-    2. Else Phantom#78
+    2. Else Phantom#79
 
 def $specialize_constructorTypeDefIR((constructor< (typeParameterIR_expl)* , (typeParameterIR_impl)* >( (constructorParameterIR)* ): typeIR), (typeArgumentIR)*)
 
@@ -5631,7 +5637,7 @@ def $specialize_constructorTypeDefIR((constructor< (typeParameterIR_expl)* , (ty
 
             1. Return (constructorTypeIR_spec, (typeId_fresh)*)
 
-  1. Else Phantom#79
+  1. Else Phantom#80
 
   2. If (((|(typeParameterIR_expl)*| > 0) /\ (|(typeArgumentIR)*| = 0))), then
 
@@ -5645,7 +5651,7 @@ def $specialize_constructorTypeDefIR((constructor< (typeParameterIR_expl)* , (ty
 
             1. Return (constructorTypeIR_spec, (typeId_fresh)*)
 
-  2. Else Phantom#80
+  2. Else Phantom#81
 
 relation Type_alpha: typeIR ~~ typeIR'
 
@@ -5665,9 +5671,9 @@ relation Type_alpha: typeIR ~~ typeIR'
 
               1. The relation holds
 
-          1. Else Phantom#81
+          1. Else Phantom#82
 
-      1. Else Phantom#82
+      1. Else Phantom#83
 
   2. Case (% has type nameTypeIR)
 
@@ -5683,11 +5689,11 @@ relation Type_alpha: typeIR ~~ typeIR'
 
               1. The relation holds
 
-          1. Else Phantom#83
+          1. Else Phantom#84
 
-      1. Else Phantom#84
+      1. Else Phantom#85
 
-1. Else Phantom#85
+1. Else Phantom#86
 
 2. Group typedefTypeIR: typeIR ~~ typeIR'
 
@@ -5699,9 +5705,9 @@ relation Type_alpha: typeIR ~~ typeIR'
 
         1. The relation holds
 
-      1. Else Phantom#86
+      1. Else Phantom#87
 
-  1. Else Phantom#87
+  1. Else Phantom#88
 
   2. If ((typeIR' has type typedefTypeIR)), then
 
@@ -5713,11 +5719,11 @@ relation Type_alpha: typeIR ~~ typeIR'
 
           1. The relation holds
 
-        1. Else Phantom#88
+        1. Else Phantom#89
 
-      1. Else Phantom#89
+      1. Else Phantom#90
 
-  2. Else Phantom#90
+  2. Else Phantom#91
 
 3. Case analysis on typeIR
 
@@ -5737,11 +5743,11 @@ relation Type_alpha: typeIR ~~ typeIR'
 
                 1. The relation holds
 
-              1. Else Phantom#91
+              1. Else Phantom#92
 
-          1. Else Phantom#92
+          1. Else Phantom#93
 
-      1. Else Phantom#93
+      1. Else Phantom#94
 
   2. Case (% has type listTypeIR)
 
@@ -5757,9 +5763,9 @@ relation Type_alpha: typeIR ~~ typeIR'
 
               1. The relation holds
 
-            1. Else Phantom#94
+            1. Else Phantom#95
 
-      1. Else Phantom#95
+      1. Else Phantom#96
 
   3. Case (% has type tupleTypeIR)
 
@@ -5775,9 +5781,9 @@ relation Type_alpha: typeIR ~~ typeIR'
 
               1. The relation holds
 
-            1. Else Phantom#96
+            1. Else Phantom#97
 
-      1. Else Phantom#97
+      1. Else Phantom#98
 
   4. Case (% has type headerStackTypeIR)
 
@@ -5795,11 +5801,11 @@ relation Type_alpha: typeIR ~~ typeIR'
 
                 1. The relation holds
 
-              1. Else Phantom#98
+              1. Else Phantom#99
 
-          1. Else Phantom#99
+          1. Else Phantom#100
 
-      1. Else Phantom#100
+      1. Else Phantom#101
 
   5. Case (% has type structTypeIR)
 
@@ -5817,11 +5823,11 @@ relation Type_alpha: typeIR ~~ typeIR'
 
                 1. The relation holds
 
-              1. Else Phantom#101
+              1. Else Phantom#102
 
-          1. Else Phantom#102
+          1. Else Phantom#103
 
-      1. Else Phantom#103
+      1. Else Phantom#104
 
   6. Case (% has type headerTypeIR)
 
@@ -5839,11 +5845,11 @@ relation Type_alpha: typeIR ~~ typeIR'
 
                 1. The relation holds
 
-              1. Else Phantom#104
+              1. Else Phantom#105
 
-          1. Else Phantom#105
+          1. Else Phantom#106
 
-      1. Else Phantom#106
+      1. Else Phantom#107
 
   7. Case (% has type headerUnionTypeIR)
 
@@ -5861,13 +5867,13 @@ relation Type_alpha: typeIR ~~ typeIR'
 
                 1. The relation holds
 
-              1. Else Phantom#107
+              1. Else Phantom#108
 
-          1. Else Phantom#108
+          1. Else Phantom#109
 
-      1. Else Phantom#109
+      1. Else Phantom#110
 
-3. Else Phantom#110
+3. Else Phantom#111
 
 4. Group enumTypeIR: typeIR ~~ typeIR'
 
@@ -5881,7 +5887,7 @@ relation Type_alpha: typeIR ~~ typeIR'
 
           1. The relation holds
 
-        1. Else Phantom#111
+        1. Else Phantom#112
 
     2. Case (% has type serializableEnumTypeIR)
 
@@ -5899,15 +5905,15 @@ relation Type_alpha: typeIR ~~ typeIR'
 
                   1. The relation holds
 
-                1. Else Phantom#112
+                1. Else Phantom#113
 
-              1. Else Phantom#113
+              1. Else Phantom#114
 
-            1. Else Phantom#114
+            1. Else Phantom#115
 
-        1. Else Phantom#115
+        1. Else Phantom#116
 
-  1. Else Phantom#116
+  1. Else Phantom#117
 
 5. Case analysis on typeIR
 
@@ -5927,11 +5933,11 @@ relation Type_alpha: typeIR ~~ typeIR'
 
                 1. The relation holds
 
-              1. Else Phantom#117
+              1. Else Phantom#118
 
-          1. Else Phantom#118
+          1. Else Phantom#119
 
-      1. Else Phantom#119
+      1. Else Phantom#120
 
   2. Case (% has type parserObjectTypeIR)
 
@@ -5947,9 +5953,9 @@ relation Type_alpha: typeIR ~~ typeIR'
 
               1. The relation holds
 
-            1. Else Phantom#120
+            1. Else Phantom#121
 
-      1. Else Phantom#121
+      1. Else Phantom#122
 
   3. Case (% has type controlObjectTypeIR)
 
@@ -5965,9 +5971,9 @@ relation Type_alpha: typeIR ~~ typeIR'
 
               1. The relation holds
 
-            1. Else Phantom#122
+            1. Else Phantom#123
 
-      1. Else Phantom#123
+      1. Else Phantom#124
 
   4. Case (% has type packageObjectTypeIR)
 
@@ -5983,9 +5989,9 @@ relation Type_alpha: typeIR ~~ typeIR'
 
               1. The relation holds
 
-            1. Else Phantom#124
+            1. Else Phantom#125
 
-      1. Else Phantom#125
+      1. Else Phantom#126
 
   5. Case (% has type tableObjectTypeIR)
 
@@ -6001,9 +6007,9 @@ relation Type_alpha: typeIR ~~ typeIR'
 
               1. The relation holds
 
-          1. Else Phantom#126
+          1. Else Phantom#127
 
-      1. Else Phantom#127
+      1. Else Phantom#128
 
   6. Case (% has type defaultTypeIR)
 
@@ -6017,7 +6023,7 @@ relation Type_alpha: typeIR ~~ typeIR'
 
             1. The relation holds
 
-      1. Else Phantom#128
+      1. Else Phantom#129
 
   7. Case (% has type invalidHeaderTypeIR)
 
@@ -6031,7 +6037,7 @@ relation Type_alpha: typeIR ~~ typeIR'
 
             1. The relation holds
 
-      1. Else Phantom#129
+      1. Else Phantom#130
 
   8. Case (% has type sequenceTypeIR)
 
@@ -6057,9 +6063,9 @@ relation Type_alpha: typeIR ~~ typeIR'
 
                         1. The relation holds
 
-                      1. Else Phantom#130
+                      1. Else Phantom#131
 
-                  1. Else Phantom#131
+                  1. Else Phantom#132
 
               2. Case (% matches pattern `SEQ<%,...>`)
 
@@ -6073,11 +6079,11 @@ relation Type_alpha: typeIR ~~ typeIR'
 
                         1. The relation holds
 
-                      1. Else Phantom#132
+                      1. Else Phantom#133
 
-                  1. Else Phantom#133
+                  1. Else Phantom#134
 
-      1. Else Phantom#134
+      1. Else Phantom#135
 
   9. Case (% has type recordTypeIR)
 
@@ -6107,13 +6113,13 @@ relation Type_alpha: typeIR ~~ typeIR'
 
                             1. The relation holds
 
-                          1. Else Phantom#135
+                          1. Else Phantom#136
 
-                        1. Else Phantom#136
+                        1. Else Phantom#137
 
-                      1. Else Phantom#137
+                      1. Else Phantom#138
 
-                  1. Else Phantom#138
+                  1. Else Phantom#139
 
               2. Case (% matches pattern `RECORD{%,...}`)
 
@@ -6131,15 +6137,15 @@ relation Type_alpha: typeIR ~~ typeIR'
 
                             1. The relation holds
 
-                          1. Else Phantom#139
+                          1. Else Phantom#140
 
-                        1. Else Phantom#140
+                        1. Else Phantom#141
 
-                      1. Else Phantom#141
+                      1. Else Phantom#142
 
-                  1. Else Phantom#142
+                  1. Else Phantom#143
 
-      1. Else Phantom#143
+      1. Else Phantom#144
 
   10. Case (% has type setTypeIR)
 
@@ -6155,9 +6161,9 @@ relation Type_alpha: typeIR ~~ typeIR'
 
               1. The relation holds
 
-            1. Else Phantom#144
+            1. Else Phantom#145
 
-      1. Else Phantom#145
+      1. Else Phantom#146
 
   11. Case (% has type tableMetadataTypeIR)
 
@@ -6173,11 +6179,11 @@ relation Type_alpha: typeIR ~~ typeIR'
 
               1. The relation holds
 
-          1. Else Phantom#146
+          1. Else Phantom#147
 
-      1. Else Phantom#147
+      1. Else Phantom#148
 
-5. Else Phantom#148
+5. Else Phantom#149
 
 relation ParameterType_alpha: (annotationList direction typeIR_a id parameterInitializerOptIR) ~~ (annotationList' direction' typeIR_b id' parameterInitializerOptIR')
 
@@ -6189,9 +6195,9 @@ relation ParameterType_alpha: (annotationList direction typeIR_a id parameterIni
 
       1. The relation holds
 
-    1. Else Phantom#149
+    1. Else Phantom#150
 
-1. Else Phantom#150
+1. Else Phantom#151
 
 relation ExternMethodType_alpha: externMethodTypeIR ~~ externMethodTypeIR'
 
@@ -6215,13 +6221,13 @@ relation ExternMethodType_alpha: externMethodTypeIR ~~ externMethodTypeIR'
 
                   1. The relation holds
 
-                1. Else Phantom#151
+                1. Else Phantom#152
 
-              1. Else Phantom#152
+              1. Else Phantom#153
 
-            1. Else Phantom#153
+            1. Else Phantom#154
 
-        1. Else Phantom#154
+        1. Else Phantom#155
 
     2. Case (% matches pattern `EXTERN_METHODABSTRACT%(%):%`)
 
@@ -6239,13 +6245,13 @@ relation ExternMethodType_alpha: externMethodTypeIR ~~ externMethodTypeIR'
 
                   1. The relation holds
 
-                1. Else Phantom#155
+                1. Else Phantom#156
 
-              1. Else Phantom#156
+              1. Else Phantom#157
 
-            1. Else Phantom#157
+            1. Else Phantom#158
 
-        1. Else Phantom#158
+        1. Else Phantom#159
 
 relation ExternMethodTypeDef_alpha: externMethodTypeDefIR_a ~~ externMethodTypeDefIR_b
 
@@ -6297,19 +6303,19 @@ relation ExternMethodTypeDef_alpha: externMethodTypeDefIR_a ~~ externMethodTypeD
 
                                               1. The relation holds
 
-                                            1. Else Phantom#159
+                                            1. Else Phantom#160
 
-                                        1. Else Phantom#160
+                                        1. Else Phantom#161
 
-                                  1. Else Phantom#161
+                                  1. Else Phantom#162
 
-                        1. Else Phantom#162
+                        1. Else Phantom#163
 
-                  1. Else Phantom#163
+                  1. Else Phantom#164
 
-        1. Else Phantom#164
+        1. Else Phantom#165
 
-      1. Else Phantom#165
+      1. Else Phantom#166
 
 syntax ctk = 
    | lctk
@@ -6384,11 +6390,11 @@ def $joins_ctk((ctk)*)
 
                 1. Return $joins_ctk(ctk_d :: (ctk_c)*)
 
-            1. Else Phantom#166
+            1. Else Phantom#167
 
-      1. Else Phantom#167
+      1. Else Phantom#168
 
-1. Else Phantom#168
+1. Else Phantom#169
 
 builtin def $pow2(nat)
 
@@ -6446,9 +6452,9 @@ def $un_bnot(value)
 
             1. Return ((w w i'') as value)
 
-    1. Else Phantom#169
+    1. Else Phantom#170
 
-1. Else Phantom#170
+1. Else Phantom#171
 
 def $un_lnot(value)
 
@@ -6458,7 +6464,7 @@ def $un_lnot(value)
 
     1. Return ((`b ~b) as value)
 
-1. Else Phantom#171
+1. Else Phantom#172
 
 def $un_plus(value)
 
@@ -6486,7 +6492,7 @@ def $un_plus(value)
 
           1. Return ((w s i) as value)
 
-1. Else Phantom#172
+1. Else Phantom#173
 
 def $un_minus(value)
 
@@ -6518,7 +6524,7 @@ def $un_minus(value)
 
             1. Return ((w s i') as value)
 
-1. Else Phantom#173
+1. Else Phantom#174
 
 def $bin_op(binop, value_l, value_r)
 
@@ -6600,7 +6606,7 @@ def $bin_op(binop, value_l, value_r)
 
     1. Return $bin_concat(value_l, value_r)
 
-1. Else Phantom#174
+1. Else Phantom#175
 
 def $bin_plus(value, value')
 
@@ -6624,9 +6630,9 @@ def $bin_plus(value, value')
 
                   1. Return ((d (i_l + i_r)) as value)
 
-              1. Else Phantom#175
+              1. Else Phantom#176
 
-          1. Else Phantom#176
+          1. Else Phantom#177
 
       2. Case (% matches pattern `%W%`)
 
@@ -6650,11 +6656,11 @@ def $bin_plus(value, value')
 
                           1. Return ((w w i) as value)
 
-                  1. Else Phantom#177
+                  1. Else Phantom#178
 
-              1. Else Phantom#178
+              1. Else Phantom#179
 
-          1. Else Phantom#179
+          1. Else Phantom#180
 
       3. Case (% matches pattern `%S%`)
 
@@ -6678,13 +6684,13 @@ def $bin_plus(value, value')
 
                           1. Return ((w s i) as value)
 
-                  1. Else Phantom#180
+                  1. Else Phantom#181
 
-              1. Else Phantom#181
+              1. Else Phantom#182
 
-          1. Else Phantom#182
+          1. Else Phantom#183
 
-1. Else Phantom#183
+1. Else Phantom#184
 
 def $bin_satplus(value, value')
 
@@ -6716,11 +6722,11 @@ def $bin_satplus(value, value')
 
                           1. Return ((w w i') as value)
 
-                  1. Else Phantom#184
+                  1. Else Phantom#185
 
-              1. Else Phantom#185
+              1. Else Phantom#186
 
-          1. Else Phantom#186
+          1. Else Phantom#187
 
       2. Case (% matches pattern `%S%`)
 
@@ -6758,9 +6764,9 @@ def $bin_satplus(value, value')
 
                                         1. Return ((w s i'') as value)
 
-                              1. Else Phantom#187
+                              1. Else Phantom#188
 
-                          1. Else Phantom#188
+                          1. Else Phantom#189
 
                           2. If ((i <= (0 as int))), then
 
@@ -6778,19 +6784,19 @@ def $bin_satplus(value, value')
 
                                         1. Return ((w s i'') as value)
 
-                              1. Else Phantom#189
+                              1. Else Phantom#190
 
-                          2. Else Phantom#190
+                          2. Else Phantom#191
 
-                  1. Else Phantom#191
+                  1. Else Phantom#192
 
-              1. Else Phantom#192
+              1. Else Phantom#193
 
-          1. Else Phantom#193
+          1. Else Phantom#194
 
-    1. Else Phantom#194
+    1. Else Phantom#195
 
-1. Else Phantom#195
+1. Else Phantom#196
 
 def $bin_minus(value, value')
 
@@ -6814,9 +6820,9 @@ def $bin_minus(value, value')
 
                   1. Return ((d (i_l - i_r)) as value)
 
-              1. Else Phantom#196
+              1. Else Phantom#197
 
-          1. Else Phantom#197
+          1. Else Phantom#198
 
       2. Case (% matches pattern `%W%`)
 
@@ -6840,11 +6846,11 @@ def $bin_minus(value, value')
 
                           1. Return ((w w i) as value)
 
-                  1. Else Phantom#198
+                  1. Else Phantom#199
 
-              1. Else Phantom#199
+              1. Else Phantom#200
 
-          1. Else Phantom#200
+          1. Else Phantom#201
 
       3. Case (% matches pattern `%S%`)
 
@@ -6868,13 +6874,13 @@ def $bin_minus(value, value')
 
                           1. Return ((w s i) as value)
 
-                  1. Else Phantom#201
+                  1. Else Phantom#202
 
-              1. Else Phantom#202
+              1. Else Phantom#203
 
-          1. Else Phantom#203
+          1. Else Phantom#204
 
-1. Else Phantom#204
+1. Else Phantom#205
 
 def $bin_satminus(value, value')
 
@@ -6904,11 +6910,11 @@ def $bin_satminus(value, value')
 
                         1. Return ((w w i') as value)
 
-                  1. Else Phantom#205
+                  1. Else Phantom#206
 
-              1. Else Phantom#206
+              1. Else Phantom#207
 
-          1. Else Phantom#207
+          1. Else Phantom#208
 
       2. Case (% matches pattern `%S%`)
 
@@ -6946,9 +6952,9 @@ def $bin_satminus(value, value')
 
                                         1. Return ((w s i'') as value)
 
-                              1. Else Phantom#208
+                              1. Else Phantom#209
 
-                          1. Else Phantom#209
+                          1. Else Phantom#210
 
                           2. If ((i <= (0 as int))), then
 
@@ -6966,19 +6972,19 @@ def $bin_satminus(value, value')
 
                                         1. Return ((w s i'') as value)
 
-                              1. Else Phantom#210
+                              1. Else Phantom#211
 
-                          2. Else Phantom#211
+                          2. Else Phantom#212
 
-                  1. Else Phantom#212
+                  1. Else Phantom#213
 
-              1. Else Phantom#213
+              1. Else Phantom#214
 
-          1. Else Phantom#214
+          1. Else Phantom#215
 
-    1. Else Phantom#215
+    1. Else Phantom#216
 
-1. Else Phantom#216
+1. Else Phantom#217
 
 def $bin_mul(value, value')
 
@@ -7002,9 +7008,9 @@ def $bin_mul(value, value')
 
                   1. Return ((d (i_l * i_r)) as value)
 
-              1. Else Phantom#217
+              1. Else Phantom#218
 
-          1. Else Phantom#218
+          1. Else Phantom#219
 
       2. Case (% matches pattern `%W%`)
 
@@ -7028,11 +7034,11 @@ def $bin_mul(value, value')
 
                           1. Return ((w w i) as value)
 
-                  1. Else Phantom#219
+                  1. Else Phantom#220
 
-              1. Else Phantom#220
+              1. Else Phantom#221
 
-          1. Else Phantom#221
+          1. Else Phantom#222
 
       3. Case (% matches pattern `%S%`)
 
@@ -7056,13 +7062,13 @@ def $bin_mul(value, value')
 
                           1. Return ((w s i) as value)
 
-                  1. Else Phantom#222
+                  1. Else Phantom#223
 
-              1. Else Phantom#223
+              1. Else Phantom#224
 
-          1. Else Phantom#224
+          1. Else Phantom#225
 
-1. Else Phantom#225
+1. Else Phantom#226
 
 def $bin_div(value, value')
 
@@ -7084,13 +7090,13 @@ def $bin_div(value, value')
 
                 1. Return ((d (i_l / i_r)) as value)
 
-            1. Else Phantom#226
+            1. Else Phantom#227
 
-        1. Else Phantom#227
+        1. Else Phantom#228
 
-    1. Else Phantom#228
+    1. Else Phantom#229
 
-1. Else Phantom#229
+1. Else Phantom#230
 
 def $bin_mod(value, value')
 
@@ -7112,13 +7118,13 @@ def $bin_mod(value, value')
 
                 1. Return ((d (i_l \ i_r)) as value)
 
-            1. Else Phantom#230
+            1. Else Phantom#231
 
-        1. Else Phantom#231
+        1. Else Phantom#232
 
-    1. Else Phantom#232
+    1. Else Phantom#233
 
-1. Else Phantom#233
+1. Else Phantom#234
 
 def $bin_shl(value, value')
 
@@ -7158,7 +7164,7 @@ def $bin_shl(value, value')
 
                       1. Return ((d $shl(i_l, i_r')) as value)
 
-          1. Else Phantom#234
+          1. Else Phantom#235
 
       2. Case (% matches pattern `%W%`)
 
@@ -7194,7 +7200,7 @@ def $bin_shl(value, value')
 
                         1. Return ((w_l w i) as value)
 
-          1. Else Phantom#235
+          1. Else Phantom#236
 
       3. Case (% matches pattern `%S%`)
 
@@ -7234,9 +7240,9 @@ def $bin_shl(value, value')
 
                           1. Return ((w_l s i) as value)
 
-          1. Else Phantom#236
+          1. Else Phantom#237
 
-1. Else Phantom#237
+1. Else Phantom#238
 
 def $bin_shr(value, value')
 
@@ -7276,7 +7282,7 @@ def $bin_shr(value, value')
 
                       1. Return ((d $shr(i_l, i_r')) as value)
 
-          1. Else Phantom#238
+          1. Else Phantom#239
 
       2. Case (% matches pattern `%W%`)
 
@@ -7312,7 +7318,7 @@ def $bin_shr(value, value')
 
                         1. Return ((w_l w i) as value)
 
-          1. Else Phantom#239
+          1. Else Phantom#240
 
       3. Case (% matches pattern `%S%`)
 
@@ -7344,9 +7350,9 @@ def $bin_shr(value, value')
 
                                   1. Return ((w_l s i') as value)
 
-                          1. Else Phantom#240
+                          1. Else Phantom#241
 
-                      1. Else Phantom#241
+                      1. Else Phantom#242
 
                       2. If ((i_l' >= (0 as int))), then
 
@@ -7356,7 +7362,7 @@ def $bin_shr(value, value')
 
                             1. Return ((w_l s i') as value)
 
-                      2. Else Phantom#242
+                      2. Else Phantom#243
 
                 2. Case (% matches pattern `%W%`)
 
@@ -7378,9 +7384,9 @@ def $bin_shr(value, value')
 
                                   1. Return ((w_l s i') as value)
 
-                          1. Else Phantom#243
+                          1. Else Phantom#244
 
-                      1. Else Phantom#244
+                      1. Else Phantom#245
 
                       2. If ((i_l' >= (0 as int))), then
 
@@ -7390,7 +7396,7 @@ def $bin_shr(value, value')
 
                             1. Return ((w_l s i') as value)
 
-                      2. Else Phantom#245
+                      2. Else Phantom#246
 
                 3. Case (% matches pattern `%S%`)
 
@@ -7414,9 +7420,9 @@ def $bin_shr(value, value')
 
                                     1. Return ((w_l s i') as value)
 
-                            1. Else Phantom#246
+                            1. Else Phantom#247
 
-                        1. Else Phantom#247
+                        1. Else Phantom#248
 
                         2. If ((i_l' >= (0 as int))), then
 
@@ -7426,11 +7432,11 @@ def $bin_shr(value, value')
 
                               1. Return ((w_l s i') as value)
 
-                        2. Else Phantom#248
+                        2. Else Phantom#249
 
-          1. Else Phantom#249
+          1. Else Phantom#250
 
-1. Else Phantom#250
+1. Else Phantom#251
 
 def $bin_le(value, value')
 
@@ -7454,9 +7460,9 @@ def $bin_le(value, value')
 
                   1. Return (i_l <= i_r)
 
-              1. Else Phantom#251
+              1. Else Phantom#252
 
-          1. Else Phantom#252
+          1. Else Phantom#253
 
       2. Case (% matches pattern `%W%`)
 
@@ -7474,11 +7480,11 @@ def $bin_le(value, value')
 
                     1. Return (i_l <= i_r)
 
-                  1. Else Phantom#253
+                  1. Else Phantom#254
 
-              1. Else Phantom#254
+              1. Else Phantom#255
 
-          1. Else Phantom#255
+          1. Else Phantom#256
 
       3. Case (% matches pattern `%S%`)
 
@@ -7500,13 +7506,13 @@ def $bin_le(value, value')
 
                         1. Return (i_l' <= i_r')
 
-                  1. Else Phantom#256
+                  1. Else Phantom#257
 
-              1. Else Phantom#257
+              1. Else Phantom#258
 
-          1. Else Phantom#258
+          1. Else Phantom#259
 
-1. Else Phantom#259
+1. Else Phantom#260
 
 def $bin_ge(value, value')
 
@@ -7530,9 +7536,9 @@ def $bin_ge(value, value')
 
                   1. Return (i_l >= i_r)
 
-              1. Else Phantom#260
+              1. Else Phantom#261
 
-          1. Else Phantom#261
+          1. Else Phantom#262
 
       2. Case (% matches pattern `%W%`)
 
@@ -7550,11 +7556,11 @@ def $bin_ge(value, value')
 
                     1. Return (i_l >= i_r)
 
-                  1. Else Phantom#262
+                  1. Else Phantom#263
 
-              1. Else Phantom#263
+              1. Else Phantom#264
 
-          1. Else Phantom#264
+          1. Else Phantom#265
 
       3. Case (% matches pattern `%S%`)
 
@@ -7576,13 +7582,13 @@ def $bin_ge(value, value')
 
                         1. Return (i_l' >= i_r')
 
-                  1. Else Phantom#265
+                  1. Else Phantom#266
 
-              1. Else Phantom#266
+              1. Else Phantom#267
 
-          1. Else Phantom#267
+          1. Else Phantom#268
 
-1. Else Phantom#268
+1. Else Phantom#269
 
 def $bin_lt(value, value')
 
@@ -7606,9 +7612,9 @@ def $bin_lt(value, value')
 
                   1. Return (i_l < i_r)
 
-              1. Else Phantom#269
+              1. Else Phantom#270
 
-          1. Else Phantom#270
+          1. Else Phantom#271
 
       2. Case (% matches pattern `%W%`)
 
@@ -7626,11 +7632,11 @@ def $bin_lt(value, value')
 
                     1. Return (i_l < i_r)
 
-                  1. Else Phantom#271
+                  1. Else Phantom#272
 
-              1. Else Phantom#272
+              1. Else Phantom#273
 
-          1. Else Phantom#273
+          1. Else Phantom#274
 
       3. Case (% matches pattern `%S%`)
 
@@ -7652,13 +7658,13 @@ def $bin_lt(value, value')
 
                         1. Return (i_l' < i_r')
 
-                  1. Else Phantom#274
+                  1. Else Phantom#275
 
-              1. Else Phantom#275
+              1. Else Phantom#276
 
-          1. Else Phantom#276
+          1. Else Phantom#277
 
-1. Else Phantom#277
+1. Else Phantom#278
 
 def $bin_gt(value, value')
 
@@ -7682,9 +7688,9 @@ def $bin_gt(value, value')
 
                   1. Return (i_l > i_r)
 
-              1. Else Phantom#278
+              1. Else Phantom#279
 
-          1. Else Phantom#279
+          1. Else Phantom#280
 
       2. Case (% matches pattern `%W%`)
 
@@ -7702,11 +7708,11 @@ def $bin_gt(value, value')
 
                     1. Return (i_l > i_r)
 
-                  1. Else Phantom#280
+                  1. Else Phantom#281
 
-              1. Else Phantom#281
+              1. Else Phantom#282
 
-          1. Else Phantom#282
+          1. Else Phantom#283
 
       3. Case (% matches pattern `%S%`)
 
@@ -7728,13 +7734,13 @@ def $bin_gt(value, value')
 
                         1. Return (i_l' > i_r')
 
-                  1. Else Phantom#283
+                  1. Else Phantom#284
 
-              1. Else Phantom#284
+              1. Else Phantom#285
 
-          1. Else Phantom#285
+          1. Else Phantom#286
 
-1. Else Phantom#286
+1. Else Phantom#287
 
 def $bin_eq(value, value')
 
@@ -7750,7 +7756,7 @@ def $bin_eq(value, value')
 
           1. Return (b_a = b_b)
 
-      1. Else Phantom#287
+      1. Else Phantom#288
 
   2. Case (% has type errorValue)
 
@@ -7762,7 +7768,7 @@ def $bin_eq(value, value')
 
           1. Return (id_a = id_b)
 
-      1. Else Phantom#288
+      1. Else Phantom#289
 
   3. Case (% has type matchKindValue)
 
@@ -7774,7 +7780,7 @@ def $bin_eq(value, value')
 
           1. Return (id_a = id_b)
 
-      1. Else Phantom#289
+      1. Else Phantom#290
 
   4. Case (% has type stringValue)
 
@@ -7786,7 +7792,7 @@ def $bin_eq(value, value')
 
           1. Return (stringValue_a = stringValue_b)
 
-      1. Else Phantom#290
+      1. Else Phantom#291
 
   5. Case (% has type integerLiteral)
 
@@ -7808,9 +7814,9 @@ def $bin_eq(value, value')
 
                     1. Return (i_a = i_b)
 
-                1. Else Phantom#291
+                1. Else Phantom#292
 
-            1. Else Phantom#292
+            1. Else Phantom#293
 
         2. Case (% matches pattern `%W%`)
 
@@ -7826,9 +7832,9 @@ def $bin_eq(value, value')
 
                     1. Return ((w_a = w_b) /\ (i_a = i_b))
 
-                1. Else Phantom#293
+                1. Else Phantom#294
 
-            1. Else Phantom#294
+            1. Else Phantom#295
 
         3. Case (% matches pattern `%S%`)
 
@@ -7844,9 +7850,9 @@ def $bin_eq(value, value')
 
                     1. Return ((w_a = w_b) /\ (i_a = i_b))
 
-                1. Else Phantom#295
+                1. Else Phantom#296
 
-            1. Else Phantom#296
+            1. Else Phantom#297
 
   6. Case (% has type listValue)
 
@@ -7858,7 +7864,7 @@ def $bin_eq(value, value')
 
           1. Return ((|(value_a)*| = |(value_b)*|) /\ $forall_(($bin_eq(value_a, value_b))*))
 
-      1. Else Phantom#297
+      1. Else Phantom#298
 
   7. Case (% has type tupleValue)
 
@@ -7870,7 +7876,7 @@ def $bin_eq(value, value')
 
           1. Return ((|(value_a)*| = |(value_b)*|) /\ $forall_(($bin_eq(value_a, value_b))*))
 
-      1. Else Phantom#298
+      1. Else Phantom#299
 
   8. Case (% has type headerStackValue)
 
@@ -7882,7 +7888,7 @@ def $bin_eq(value, value')
 
           1. Return (((|(value_a)*| = |(value_b)*|) /\ $forall_(($bin_eq(value_a, value_b))*)) /\ (n_size_a = n_size_b))
 
-      1. Else Phantom#299
+      1. Else Phantom#300
 
   9. Case (% has type structValue)
 
@@ -7898,7 +7904,7 @@ def $bin_eq(value, value')
 
               1. Return ((((typeId_a = typeId_b) /\ (|(fieldValue_a)*| = |(fieldValue_b)*|)) /\ $forall_(($bin_eq(value_field_a, value_field_b))*)) /\ $forall_(((nameIR_field_a = nameIR_field_b))*))
 
-      1. Else Phantom#300
+      1. Else Phantom#301
 
   10. Case (% has type headerValue)
 
@@ -7914,7 +7920,7 @@ def $bin_eq(value, value')
 
               1. Return ((((typeId_a = typeId_b) /\ (|(fieldValue_a)*| = |(fieldValue_b)*|)) /\ $forall_(($bin_eq(value_field_a, value_field_b))*)) /\ $forall_(((nameIR_field_a = nameIR_field_b))*))
 
-      1. Else Phantom#301
+      1. Else Phantom#302
 
   11. Case (% has type headerUnionValue)
 
@@ -7930,7 +7936,7 @@ def $bin_eq(value, value')
 
               1. Return ((((typeId_a = typeId_b) /\ (|(fieldValue_a)*| = |(fieldValue_b)*|)) /\ $forall_(($bin_eq(value_field_a, value_field_b))*)) /\ $forall_(((nameIR_field_a = nameIR_field_b))*))
 
-      1. Else Phantom#302
+      1. Else Phantom#303
 
   12. Case (% has type enumValue)
 
@@ -7952,9 +7958,9 @@ def $bin_eq(value, value')
 
                     1. Return ((typeId_a = typeId_b) /\ (nameIR_field_a = nameIR_field_b))
 
-                1. Else Phantom#303
+                1. Else Phantom#304
 
-            1. Else Phantom#304
+            1. Else Phantom#305
 
         2. Case (% matches pattern `%.%.%`)
 
@@ -7970,9 +7976,9 @@ def $bin_eq(value, value')
 
                     1. Return ((typeId_a = typeId_b) /\ $bin_eq(value_field_a, value_field_b))
 
-                1. Else Phantom#305
+                1. Else Phantom#306
 
-            1. Else Phantom#306
+            1. Else Phantom#307
 
   13. Case (% has type invalidHeaderValue)
 
@@ -7984,9 +7990,9 @@ def $bin_eq(value, value')
 
           1. Return true
 
-      1. Else Phantom#307
+      1. Else Phantom#308
 
-1. Else Phantom#308
+1. Else Phantom#309
 
 2. If ((value has type integerValue)), then
 
@@ -8006,13 +8012,13 @@ def $bin_eq(value, value')
 
                 1. Return ((w_max_a = w_max_b) /\ (i_a = i_b))
 
-            1. Else Phantom#309
+            1. Else Phantom#310
 
-        1. Else Phantom#310
+        1. Else Phantom#311
 
-    1. Else Phantom#311
+    1. Else Phantom#312
 
-2. Else Phantom#312
+2. Else Phantom#313
 
 def $bin_ne(value_l, value_r)
 
@@ -8044,11 +8050,11 @@ def $bin_band(value, value')
 
                       1. Return ((w w i) as value)
 
-                  1. Else Phantom#313
+                  1. Else Phantom#314
 
-              1. Else Phantom#314
+              1. Else Phantom#315
 
-          1. Else Phantom#315
+          1. Else Phantom#316
 
       2. Case (% matches pattern `%S%`)
 
@@ -8072,15 +8078,15 @@ def $bin_band(value, value')
 
                           1. Return ((w s i) as value)
 
-                  1. Else Phantom#316
+                  1. Else Phantom#317
 
-              1. Else Phantom#317
+              1. Else Phantom#318
 
-          1. Else Phantom#318
+          1. Else Phantom#319
 
-    1. Else Phantom#319
+    1. Else Phantom#320
 
-1. Else Phantom#320
+1. Else Phantom#321
 
 def $bin_bxor(value, value')
 
@@ -8108,11 +8114,11 @@ def $bin_bxor(value, value')
 
                       1. Return ((w w i) as value)
 
-                  1. Else Phantom#321
+                  1. Else Phantom#322
 
-              1. Else Phantom#322
+              1. Else Phantom#323
 
-          1. Else Phantom#323
+          1. Else Phantom#324
 
       2. Case (% matches pattern `%S%`)
 
@@ -8136,15 +8142,15 @@ def $bin_bxor(value, value')
 
                           1. Return ((w s i) as value)
 
-                  1. Else Phantom#324
+                  1. Else Phantom#325
 
-              1. Else Phantom#325
+              1. Else Phantom#326
 
-          1. Else Phantom#326
+          1. Else Phantom#327
 
-    1. Else Phantom#327
+    1. Else Phantom#328
 
-1. Else Phantom#328
+1. Else Phantom#329
 
 def $bin_bor(value, value')
 
@@ -8172,11 +8178,11 @@ def $bin_bor(value, value')
 
                       1. Return ((w w i) as value)
 
-                  1. Else Phantom#329
+                  1. Else Phantom#330
 
-              1. Else Phantom#330
+              1. Else Phantom#331
 
-          1. Else Phantom#331
+          1. Else Phantom#332
 
       2. Case (% matches pattern `%S%`)
 
@@ -8200,15 +8206,15 @@ def $bin_bor(value, value')
 
                           1. Return ((w s i) as value)
 
-                  1. Else Phantom#332
+                  1. Else Phantom#333
 
-              1. Else Phantom#333
+              1. Else Phantom#334
 
-          1. Else Phantom#334
+          1. Else Phantom#335
 
-    1. Else Phantom#335
+    1. Else Phantom#336
 
-1. Else Phantom#336
+1. Else Phantom#337
 
 def $bin_concat(value, value')
 
@@ -8256,9 +8262,9 @@ def $bin_concat(value, value')
 
                             1. Return ((w w i) as value)
 
-              1. Else Phantom#337
+              1. Else Phantom#338
 
-          1. Else Phantom#338
+          1. Else Phantom#339
 
       2. Case (% matches pattern `%S%`)
 
@@ -8302,13 +8308,13 @@ def $bin_concat(value, value')
 
                               1. Return ((w s i) as value)
 
-              1. Else Phantom#339
+              1. Else Phantom#340
 
-          1. Else Phantom#340
+          1. Else Phantom#341
 
-    1. Else Phantom#341
+    1. Else Phantom#342
 
-1. Else Phantom#342
+1. Else Phantom#343
 
 def $cast_op(typeIR, value)
 
@@ -8416,7 +8422,7 @@ def $cast_op(typeIR, value)
 
         1. Return $cast_set(typeIR_unroll, setValue)
 
-1. Else Phantom#343
+1. Else Phantom#344
 
 def $default(typeIR)
 
@@ -8520,7 +8526,7 @@ def $default(typeIR)
 
           1. Return ((typeId . id_f_h) as value)
 
-      1. Else Phantom#344
+      1. Else Phantom#345
 
   16. Case (% has type serializableEnumTypeIR)
 
@@ -8536,7 +8542,7 @@ def $default(typeIR)
 
               1. Return ((typeId . id_zero . value_zero) as value)
 
-          1. Else Phantom#345
+          1. Else Phantom#346
 
         2. If ((?() = $assoc_<value, id>(value_zero, ((value_field, nameIR_field))*))), then
 
@@ -8544,9 +8550,9 @@ def $default(typeIR)
 
             1. Return ((typeId . id_zero . value_zero) as value)
 
-        2. Else Phantom#346
+        2. Else Phantom#347
 
-1. Else Phantom#347
+1. Else Phantom#348
 
 def $cast_to_enum(enumTypeIR, value)
 
@@ -8556,7 +8562,7 @@ def $cast_to_enum(enumTypeIR, value)
 
     1. Return $cast_to_enum'(typeId, typeIR, (valueFieldIR)*, value)
 
-1. Else Phantom#348
+1. Else Phantom#349
 
 def $cast_to_enum'(typeId, typeIR, (valueFieldIR)*, value_target)
 
@@ -8596,7 +8602,7 @@ def $cast_bool(typeIR, boolValue)
 
       1. Return ((`b b) as value)
 
-  1. Else Phantom#349
+  1. Else Phantom#350
 
 2. Case analysis on typeIR
 
@@ -8614,7 +8620,7 @@ def $cast_bool(typeIR, boolValue)
 
           1. Return ((w w (0 as int)) as value)
 
-      1. Else Phantom#350
+      1. Else Phantom#351
 
   2. Case (% has type newTypeIR)
 
@@ -8628,7 +8634,7 @@ def $cast_bool(typeIR, boolValue)
 
       1. Return ((set{ $cast_bool(typeIR', boolValue) }) as value)
 
-2. Else Phantom#351
+2. Else Phantom#352
 
 def $cast_int(typeIR, integerValue)
 
@@ -8656,9 +8662,9 @@ def $cast_int(typeIR, integerValue)
 
                 1. Return ((`b (i =/= (0 as int))) as value)
 
-          1. Else Phantom#352
+          1. Else Phantom#353
 
-      1. Else Phantom#353
+      1. Else Phantom#354
 
   2. Case (% has type intTypeIR)
 
@@ -8688,7 +8694,7 @@ def $cast_int(typeIR, integerValue)
 
                 1. Return ((d $bitstr_to_int((w as int), i)) as value)
 
-      1. Else Phantom#354
+      1. Else Phantom#355
 
   3. Case (% has type fixedBitTypeIR)
 
@@ -8726,7 +8732,7 @@ def $cast_int(typeIR, integerValue)
 
                     1. Return ((w_to w i_cast) as value)
 
-      1. Else Phantom#355
+      1. Else Phantom#356
 
   4. Case (% has type fixedIntTypeIR)
 
@@ -8764,7 +8770,7 @@ def $cast_int(typeIR, integerValue)
 
                     1. Return ((w_to s i_cast) as value)
 
-      1. Else Phantom#356
+      1. Else Phantom#357
 
   5. Case (% has type varBitTypeIR)
 
@@ -8778,9 +8784,9 @@ def $cast_int(typeIR, integerValue)
 
             1. Return ((w_max . w v i) as value)
 
-          1. Else Phantom#357
+          1. Else Phantom#358
 
-      1. Else Phantom#358
+      1. Else Phantom#359
 
   6. Case (% has type newTypeIR)
 
@@ -8810,7 +8816,7 @@ def $cast_int(typeIR, integerValue)
 
                 1. Return $cast_op(typeIR', ((w s i) as value))
 
-      1. Else Phantom#359
+      1. Else Phantom#360
 
   7. Case (% has type enumTypeIR)
 
@@ -8834,9 +8840,9 @@ def $cast_int(typeIR, integerValue)
 
                 1. Return $cast_to_enum(enumTypeIR, ((w s i) as value))
 
-          1. Else Phantom#360
+          1. Else Phantom#361
 
-      1. Else Phantom#361
+      1. Else Phantom#362
 
   8. Case (% has type setTypeIR)
 
@@ -8866,9 +8872,9 @@ def $cast_int(typeIR, integerValue)
 
                 1. Return ((set{ $cast_op(typeIR', ((w s i) as value)) }) as value)
 
-      1. Else Phantom#362
+      1. Else Phantom#363
 
-1. Else Phantom#363
+1. Else Phantom#364
 
 def $cast_error(typeIR, errorValue)
 
@@ -8880,7 +8886,7 @@ def $cast_error(typeIR, errorValue)
 
       1. Return ((error. nameIR) as value)
 
-  1. Else Phantom#364
+  1. Else Phantom#365
 
 2. If ((typeIR has type setTypeIR)), then
 
@@ -8888,7 +8894,7 @@ def $cast_error(typeIR, errorValue)
 
     1. Return ((set{ $cast_op(typeIR', (errorValue as value)) }) as value)
 
-2. Else Phantom#365
+2. Else Phantom#366
 
 def $cast_list(typeIR, (list[ (value)* ]))
 
@@ -8898,7 +8904,7 @@ def $cast_list(typeIR, (list[ (value)* ]))
 
     1. Return ((list[ ($cast_op(typeIR', value))* ]) as value)
 
-1. Else Phantom#366
+1. Else Phantom#367
 
 def $cast_header_stack(typeIR, (header_stack[ (value)* ( n_idx ; n_size )]))
 
@@ -8910,9 +8916,9 @@ def $cast_header_stack(typeIR, (header_stack[ (value)* ( n_idx ; n_size )]))
 
       1. Return ((header_stack[ (value)* ( n_idx ; n_size' )]) as value)
 
-    1. Else Phantom#367
+    1. Else Phantom#368
 
-1. Else Phantom#368
+1. Else Phantom#369
 
 def $cast_struct(typeIR, (struct typeId { ((value_field nameIR_field ;))* }))
 
@@ -8924,9 +8930,9 @@ def $cast_struct(typeIR, (struct typeId { ((value_field nameIR_field ;))* }))
 
       1. Return ((struct typeId' { ((value_field nameIR_field ;))* }) as value)
 
-    1. Else Phantom#369
+    1. Else Phantom#370
 
-1. Else Phantom#370
+1. Else Phantom#371
 
 def $cast_header(typeIR, (header typeId { b ; ((value_field nameIR_field ;))* }))
 
@@ -8938,9 +8944,9 @@ def $cast_header(typeIR, (header typeId { b ; ((value_field nameIR_field ;))* })
 
       1. Return ((header typeId' { b ; ((value_field nameIR_field ;))* }) as value)
 
-    1. Else Phantom#371
+    1. Else Phantom#372
 
-1. Else Phantom#372
+1. Else Phantom#373
 
 def $cast_enum(typeIR, enumValue)
 
@@ -8958,9 +8964,9 @@ def $cast_enum(typeIR, enumValue)
 
             1. Return ((typeId . nameIR) as value)
 
-          1. Else Phantom#373
+          1. Else Phantom#374
 
-      1. Else Phantom#374
+      1. Else Phantom#375
 
   2. Case (% has type serializableEnumTypeIR)
 
@@ -8974,9 +8980,9 @@ def $cast_enum(typeIR, enumValue)
 
             1. Return ((typeId . nameIR . value) as value)
 
-          1. Else Phantom#375
+          1. Else Phantom#376
 
-      1. Else Phantom#376
+      1. Else Phantom#377
 
   3. Case (% has type setTypeIR)
 
@@ -8984,7 +8990,7 @@ def $cast_enum(typeIR, enumValue)
 
       1. Return ((set{ $cast_op(typeIR', (enumValue as value)) }) as value)
 
-1. Else Phantom#377
+1. Else Phantom#378
 
 2. If ((enumValue matches pattern `%.%.%`)), then
 
@@ -8994,9 +9000,9 @@ def $cast_enum(typeIR, enumValue)
 
       1. Return $cast_op(typeIR, value)
 
-    1. Else Phantom#378
+    1. Else Phantom#379
 
-2. Else Phantom#379
+2. Else Phantom#380
 
 def $cast_sequence(typeIR, sequenceValue)
 
@@ -9012,7 +9018,7 @@ def $cast_sequence(typeIR, sequenceValue)
 
           1. Return ((list[ ($cast_op(typeIR', value))* ]) as value)
 
-      1. Else Phantom#380
+      1. Else Phantom#381
 
   2. Case (% has type tupleTypeIR)
 
@@ -9024,7 +9030,7 @@ def $cast_sequence(typeIR, sequenceValue)
 
           1. Return ((tuple( ($cast_op(typeIR', value))* )) as value)
 
-      1. Else Phantom#381
+      1. Else Phantom#382
 
   3. Case (% has type headerStackTypeIR)
 
@@ -9040,7 +9046,7 @@ def $cast_sequence(typeIR, sequenceValue)
 
               1. Return ((header_stack[ (value_cast)* ( n_idx ; n_size )]) as value)
 
-      1. Else Phantom#382
+      1. Else Phantom#383
 
   4. Case (% has type structTypeIR)
 
@@ -9054,7 +9060,7 @@ def $cast_sequence(typeIR, sequenceValue)
 
             1. Return ((struct typeId { ((value_cast nameIR_field ;))* }) as value)
 
-      1. Else Phantom#383
+      1. Else Phantom#384
 
   5. Case (% has type headerTypeIR)
 
@@ -9068,9 +9074,9 @@ def $cast_sequence(typeIR, sequenceValue)
 
             1. Return ((header typeId { true ; ((value_cast nameIR_field ;))* }) as value)
 
-      1. Else Phantom#384
+      1. Else Phantom#385
 
-1. Else Phantom#385
+1. Else Phantom#386
 
 def $cast_record(typeIR, recordValue)
 
@@ -9094,9 +9100,9 @@ def $cast_record(typeIR, recordValue)
 
                   1. Return ((struct typeId { ((value_field_cast nameIR_field ;))* }) as value)
 
-            1. Else Phantom#386
+            1. Else Phantom#387
 
-      1. Else Phantom#387
+      1. Else Phantom#388
 
   2. Case (% has type headerTypeIR)
 
@@ -9116,11 +9122,11 @@ def $cast_record(typeIR, recordValue)
 
                   1. Return ((header typeId { true ; ((value_field_cast nameIR_field ;))* }) as value)
 
-            1. Else Phantom#388
+            1. Else Phantom#389
 
-      1. Else Phantom#389
+      1. Else Phantom#390
 
-1. Else Phantom#390
+1. Else Phantom#391
 
 def $cast_default(typeIR, defaultValue)
 
@@ -9142,7 +9148,7 @@ def $cast_invalid_header(typeIR)
 
       1. Return $default((headerUnionTypeIR as typeIR))
 
-1. Else Phantom#391
+1. Else Phantom#392
 
 def $cast_set(typeIR, setValue)
 
@@ -9178,9 +9184,9 @@ def $cast_set(typeIR, setValue)
 
               1. Return ((set{ value_l_cast .. value_u_cast }) as value)
 
-    1. Else Phantom#392
+    1. Else Phantom#393
 
-1. Else Phantom#393
+1. Else Phantom#394
 
 def $bitacc_op(value, value', value'')
 
@@ -9212,13 +9218,13 @@ def $bitacc_op(value, value', value'')
 
                           1. Return ((w w i) as value)
 
-                    1. Else Phantom#394
+                    1. Else Phantom#395
 
-        1. Else Phantom#395
+        1. Else Phantom#396
 
-    1. Else Phantom#396
+    1. Else Phantom#397
 
-1. Else Phantom#397
+1. Else Phantom#398
 
 def $bitacc_replace_op(value, value', value'', value''')
 
@@ -9262,21 +9268,21 @@ def $bitacc_replace_op(value, value', value'', value''')
 
                                       1. Return ((w w i) as value)
 
-                                1. Else Phantom#398
+                                1. Else Phantom#399
 
-                            1. Else Phantom#399
+                            1. Else Phantom#400
 
-                    1. Else Phantom#400
+                    1. Else Phantom#401
 
-                1. Else Phantom#401
+                1. Else Phantom#402
 
-            1. Else Phantom#402
+            1. Else Phantom#403
 
-        1. Else Phantom#403
+        1. Else Phantom#404
 
-    1. Else Phantom#404
+    1. Else Phantom#405
 
-1. Else Phantom#405
+1. Else Phantom#406
 
 def $sizeof(typeIR, text)
 
@@ -9298,7 +9304,7 @@ def $sizeof(typeIR, text)
 
     1. Return $sizeof_maxSizeInBytes(typeIR)
 
-1. Else Phantom#406
+1. Else Phantom#407
 
 def $sizeof_minSizeInBits(typeIR)
 
@@ -9378,7 +9384,7 @@ def $sizeof_minSizeInBits'(typeIR)
 
       1. Return $min_nat(($sizeof_minSizeInBits'(typeIR'))*)
 
-1. Else Phantom#407
+1. Else Phantom#408
 
 def $sizeof_minSizeInBytes(typeIR)
 
@@ -9466,7 +9472,7 @@ def $sizeof_maxSizeInBits'(typeIR)
 
       1. Return $max_nat(($sizeof_maxSizeInBits'(typeIR'))*)
 
-1. Else Phantom#408
+1. Else Phantom#409
 
 def $sizeof_maxSizeInBytes(typeIR)
 
@@ -9753,7 +9759,7 @@ def $typedLvalueIR_as_typedExpressionIR((lvalueIR # (( typeIR ))))
 
             1. Return ?(((((typedExpressionIR' as memberAccessBaseIR) . nameIR) as expressionIR) # (( typeIR (dyn) ))))
 
-        1. Else Phantom#409
+        1. Else Phantom#410
 
   3. Case (% matches pattern `%[%]`)
 
@@ -9767,7 +9773,7 @@ def $typedLvalueIR_as_typedExpressionIR((lvalueIR # (( typeIR ))))
 
             1. Return ?((((typedExpressionIR_base [ typedExpressionIR_index ]) as expressionIR) # (( typeIR (dyn) ))))
 
-        1. Else Phantom#410
+        1. Else Phantom#411
 
   4. Case (% matches pattern `%[%:%]`)
 
@@ -9781,9 +9787,9 @@ def $typedLvalueIR_as_typedExpressionIR((lvalueIR # (( typeIR ))))
 
             1. Return ?((((typedExpressionIR_base [ typedExpressionIR_hi : typedExpressionIR_lo ]) as expressionIR) # (( typeIR (dyn) ))))
 
-        1. Else Phantom#411
+        1. Else Phantom#412
 
-1. Else Phantom#412
+1. Else Phantom#413
 
 def $typedExpressionIR_as_typedLvalueIR((expressionIR # (( typeIR _ctk ))))
 
@@ -9811,9 +9817,9 @@ def $typedExpressionIR_as_typedLvalueIR((expressionIR # (( typeIR _ctk ))))
 
                 1. Return ?(((typedLvalueIR' . nameIR) # (( typeIR ))))
 
-            1. Else Phantom#413
+            1. Else Phantom#414
 
-      1. Else Phantom#414
+      1. Else Phantom#415
 
   3. Case (% has type indexAccessExpressionIR)
 
@@ -9827,7 +9833,7 @@ def $typedExpressionIR_as_typedLvalueIR((expressionIR # (( typeIR _ctk ))))
 
             1. Return ?(((typedLvalueIR_base [ typedExpressionIR_index ]) # (( typeIR ))))
 
-        1. Else Phantom#415
+        1. Else Phantom#416
 
   4. Case (% has type sliceAccessExpressionIR)
 
@@ -9841,7 +9847,7 @@ def $typedExpressionIR_as_typedLvalueIR((expressionIR # (( typeIR _ctk ))))
 
             1. Return ?(((typedLvalueIR_base [ typedExpressionIR_hi : typedExpressionIR_lo ]) # (( typeIR ))))
 
-        1. Else Phantom#416
+        1. Else Phantom#417
 
   5. Case (% has type parenthesizedExpressionIR)
 
@@ -9855,9 +9861,9 @@ def $typedExpressionIR_as_typedLvalueIR((expressionIR # (( typeIR _ctk ))))
 
             1. Return ?(((( typedLvalueIR' )) # (( typeIR ))))
 
-        1. Else Phantom#417
+        1. Else Phantom#418
 
-1. Else Phantom#418
+1. Else Phantom#419
 
 syntax emptyStatementIR = emptyStatement
 
@@ -10001,7 +10007,7 @@ def $flatten_objectInitializerOptIR(objectInitializerOptIR)
 
     1. Return []
 
-  1. Else Phantom#419
+  1. Else Phantom#420
 
 2. If ((objectInitializerOptIR matches pattern (_))), then
 
@@ -10009,7 +10015,7 @@ def $flatten_objectInitializerOptIR(objectInitializerOptIR)
 
     1. Return objectDeclarationListIR
 
-2. Else Phantom#420
+2. Else Phantom#421
 
 syntax errorDeclarationIR = 
    | error{ nameListIR }
@@ -10308,13 +10314,13 @@ def $partition_parameterListIR((parameterIR)*, (nameIR)*, (nameIR')*)
 
                 1. Return (parameterIR_h :: (parameterIR_given)*, (parameterIR_default)*, (parameterIR_optional)*)
 
-              1. Else Phantom#421
+              1. Else Phantom#422
 
           2. If (nameIR_h is in (nameIR')*), then
 
             1. Return ((parameterIR_given)*, (parameterIR_default)*, parameterIR_h :: (parameterIR_optional)*)
 
-          2. Else Phantom#422
+          2. Else Phantom#423
 
 syntax callAlign = 
    | given parameterIR* default parameterIR*
@@ -10339,7 +10345,7 @@ def $align_parameterListIR_given(({ ((id : parameterIR))* }), (parameterIR')*, (
 
       1. Return []
 
-    1. Else Phantom#423
+    1. Else Phantom#424
 
   2. Case (% matches pattern _ :: _)
 
@@ -10377,7 +10383,7 @@ def $align_parameterListIR_given(({ ((id : parameterIR))* }), (parameterIR')*, (
 
                         1. Return parameterIR_match :: (parameterIR_aligned)*
 
-                  1. Else Phantom#424
+                  1. Else Phantom#425
 
             4. Case (% matches pattern `%=_`)
 
@@ -10393,9 +10399,9 @@ def $align_parameterListIR_given(({ ((id : parameterIR))* }), (parameterIR')*, (
 
                         1. Return parameterIR_match :: (parameterIR_aligned)*
 
-                  1. Else Phantom#425
+                  1. Else Phantom#426
 
-      1. Else Phantom#426
+      1. Else Phantom#427
 
 syntax callTargetKey = 
    | nameIR ( id?* )
@@ -10534,7 +10540,7 @@ def $find_overloadeds_named<V>(set<pair<callableId, V>>, (nameIR_f ( (id_arg)* )
 
   1. Return []
 
-1. Else Phantom#427
+1. Else Phantom#428
 
 2. (Let ({ (pair<callableId, V>)* }) be set<pair<callableId, V>>)
 
@@ -10546,7 +10552,7 @@ def $find_overloadeds_named<V>(set<pair<callableId, V>>, (nameIR_f ( (id_arg)* )
 
         1. Return $find_overloadeds_named<V>(({ ((callTargetId_t : V_t))* }), (nameIR_f ( (id_arg)* )), $get_parameterListIR)
 
-      1. Else Phantom#428
+      1. Else Phantom#429
 
       2. (Let callTargetMatch be $match_overloaded_named<V>((callTargetId_h : V_h), (nameIR_f ( (id_arg)* )), $get_parameterListIR))
 
@@ -10556,9 +10562,9 @@ def $find_overloadeds_named<V>(set<pair<callableId, V>>, (nameIR_f ( (id_arg)* )
 
             1. Return (callTargetId_h : V_h # (id_default)* # (id_optional)*) :: $find_overloadeds_named<V>(({ ((callTargetId_t : V_t))* }), (nameIR_f ( (id_arg)* )), $get_parameterListIR)
 
-        1. Else Phantom#429
+        1. Else Phantom#430
 
-  1. Else Phantom#430
+  1. Else Phantom#431
 
 def $find_overloadeds_unnamed<V>(set<pair<callableId, V>>, (nameIR_f ( nat )), $get_parameterListIR)
 
@@ -10566,7 +10572,7 @@ def $find_overloadeds_unnamed<V>(set<pair<callableId, V>>, (nameIR_f ( nat )), $
 
   1. Return []
 
-1. Else Phantom#431
+1. Else Phantom#432
 
 2. (Let ({ (pair<callableId, V>)* }) be set<pair<callableId, V>>)
 
@@ -10578,7 +10584,7 @@ def $find_overloadeds_unnamed<V>(set<pair<callableId, V>>, (nameIR_f ( nat )), $
 
         1. Return $find_overloadeds_unnamed<V>(({ ((callTargetId_t : V_t))* }), (nameIR_f ( nat )), $get_parameterListIR)
 
-      1. Else Phantom#432
+      1. Else Phantom#433
 
       2. (Let callTargetMatch be $match_overloaded_unnamed<V>((callTargetId_h : V_h), (nameIR_f ( nat )), $get_parameterListIR))
 
@@ -10588,9 +10594,9 @@ def $find_overloadeds_unnamed<V>(set<pair<callableId, V>>, (nameIR_f ( nat )), $
 
             1. Return (callTargetId_h : V_h # (id_default)* # (id_optional)*) :: $find_overloadeds_unnamed<V>(({ ((callTargetId_t : V_t))* }), (nameIR_f ( nat )), $get_parameterListIR)
 
-        1. Else Phantom#433
+        1. Else Phantom#434
 
-  1. Else Phantom#434
+  1. Else Phantom#435
 
 def $find_overloaded<V>(({ ((callableId : V))* }), (nameIR_f ( ((id_arg)?)* )), $get_parameterListIR)
 
@@ -10604,7 +10610,7 @@ def $find_overloaded<V>(({ ((callableId : V))* }), (nameIR_f ( ((id_arg)?)* )), 
 
         1. Return ?()
 
-      1. Else Phantom#435
+      1. Else Phantom#436
 
       2. (Let (callResolution<V>)* be $find_overloadeds_named<V>(({ ((callableId : V))* }), (nameIR_f ( (id_arg_inner)* )), $get_parameterListIR))
 
@@ -10614,11 +10620,11 @@ def $find_overloaded<V>(({ ((callableId : V))* }), (nameIR_f ( ((id_arg)?)* )), 
 
             1. Return ?((callableId_found : V_found # (id_default)* # (id_optional)*))
 
-        1. Else Phantom#436
+        1. Else Phantom#437
 
-  1. Else Phantom#437
+  1. Else Phantom#438
 
-1. Else Phantom#438
+1. Else Phantom#439
 
 2. If (((id_arg)? matches pattern ()))*, then
 
@@ -10626,7 +10632,7 @@ def $find_overloaded<V>(({ ((callableId : V))* }), (nameIR_f ( ((id_arg)?)* )), 
 
     1. Return ?()
 
-  1. Else Phantom#439
+  1. Else Phantom#440
 
   2. (Let (callResolution<V>)* be $find_overloadeds_unnamed<V>(({ ((callableId : V))* }), (nameIR_f ( |((id_arg)?)*| )), $get_parameterListIR))
 
@@ -10636,9 +10642,9 @@ def $find_overloaded<V>(({ ((callableId : V))* }), (nameIR_f ( ((id_arg)?)* )), 
 
         1. Return ?((callableId_found : V_found # (id_omitted)* # (id_optional)*))
 
-    1. Else Phantom#440
+    1. Else Phantom#441
 
-2. Else Phantom#441
+2. Else Phantom#442
 
 def $find_non_overloaded<V>(({ ((callableId : V))* }), nameIR_f)
 
@@ -10660,7 +10666,7 @@ def $find_non_overloadeds<V>(set<pair<callableId, V>>, nameIR_f)
 
   1. Return []
 
-1. Else Phantom#442
+1. Else Phantom#443
 
 2. (Let ({ (pair<callableId, V>)* }) be set<pair<callableId, V>>)
 
@@ -10684,7 +10690,7 @@ def $find_non_overloadeds<V>(set<pair<callableId, V>>, nameIR_f)
 
               1. Return ((callableId_t_found, V_t_found))*
 
-  1. Else Phantom#443
+  1. Else Phantom#444
 
 def $name_annotation(annotationList)
 
@@ -10728,13 +10734,13 @@ def $name_annotation_default(annotationList, nameIR)
 
       1. Return nameIR_found
 
-  1. Else Phantom#444
+  1. Else Phantom#445
 
 2. If (([] = $name_annotation(annotationList))), then
 
   1. Return nameIR
 
-2. Else Phantom#445
+2. Else Phantom#446
 
 def $find_name_annotation_opt(annotationList)
 
@@ -10792,7 +10798,7 @@ def $add_annotationList(annotationList, (annotation)?)
 
   1. Return annotationList
 
-1. Else Phantom#446
+1. Else Phantom#447
 
 2. Case analysis on annotationList
 
@@ -10804,7 +10810,7 @@ def $add_annotationList(annotationList, (annotation)?)
 
         1. Return (annotation' as annotationList)
 
-    1. Else Phantom#447
+    1. Else Phantom#448
 
   2. Case (% has type annotationListNonEmpty)
 
@@ -10816,7 +10822,7 @@ def $add_annotationList(annotationList, (annotation)?)
 
           1. Return ((annotationListNonEmpty annotation') as annotationList)
 
-      1. Else Phantom#448
+      1. Else Phantom#449
 
 def $subexpressions_of_typedExpressionIR(typedExpressionIR)
 
@@ -11105,7 +11111,7 @@ def $exit_t(TC)
 
       1. Return TC[local.frames = (typeFrame_t)*]
 
-  1. Else Phantom#449
+  1. Else Phantom#450
 
 def $add_var_t(cursor, TC, id, varTypeIR)
 
@@ -11129,9 +11135,9 @@ def $add_var_t(cursor, TC, id, varTypeIR)
 
                   1. Return TC'
 
-            1. Else Phantom#450
+            1. Else Phantom#451
 
-      1. Else Phantom#451
+      1. Else Phantom#452
 
   2. Case (% matches pattern `BLOCK`)
 
@@ -11147,9 +11153,9 @@ def $add_var_t(cursor, TC, id, varTypeIR)
 
               1. Return TC'
 
-        1. Else Phantom#452
+        1. Else Phantom#453
 
-      1. Else Phantom#453
+      1. Else Phantom#454
 
   3. Case (% matches pattern `LOCAL`)
 
@@ -11171,11 +11177,11 @@ def $add_var_t(cursor, TC, id, varTypeIR)
 
                     1. Return TC'
 
-            1. Else Phantom#454
+            1. Else Phantom#455
 
-          1. Else Phantom#455
+          1. Else Phantom#456
 
-      1. Else Phantom#456
+      1. Else Phantom#457
 
 def $add_vars_t(p, TC, (id)*, (varTypeIR)*)
 
@@ -11187,7 +11193,7 @@ def $add_vars_t(p, TC, (id)*, (varTypeIR)*)
 
       1. Return TC
 
-    1. Else Phantom#457
+    1. Else Phantom#458
 
   2. Case (% matches pattern _ :: _)
 
@@ -11203,7 +11209,7 @@ def $add_vars_t(p, TC, (id)*, (varTypeIR)*)
 
               1. Return TC''
 
-      1. Else Phantom#458
+      1. Else Phantom#459
 
 def $add_parameter_t(cursor, TC, (_annotationList direction typeIR id _parameterInitializerOptIR))
 
@@ -11267,7 +11273,7 @@ def $add_typeDef_t(cursor, TC, typeId, typeDefIR)
 
             1. Return TC'
 
-      1. Else Phantom#459
+      1. Else Phantom#460
 
   2. Case (% matches pattern `BLOCK`)
 
@@ -11281,7 +11287,7 @@ def $add_typeDef_t(cursor, TC, typeId, typeDefIR)
 
             1. Return TC'
 
-      1. Else Phantom#460
+      1. Else Phantom#461
 
   3. Case (% matches pattern `LOCAL`)
 
@@ -11295,7 +11301,7 @@ def $add_typeDef_t(cursor, TC, typeId, typeDefIR)
 
             1. Return TC'
 
-      1. Else Phantom#461
+      1. Else Phantom#462
 
 def $add_typeDefs_t(p, TC, (typeId)*, (typeDefIR)*)
 
@@ -11307,7 +11313,7 @@ def $add_typeDefs_t(p, TC, (typeId)*, (typeDefIR)*)
 
       1. Return TC
 
-    1. Else Phantom#462
+    1. Else Phantom#463
 
   2. Case (% matches pattern _ :: _)
 
@@ -11323,7 +11329,7 @@ def $add_typeDefs_t(p, TC, (typeId)*, (typeDefIR)*)
 
               1. Return TC''
 
-      1. Else Phantom#463
+      1. Else Phantom#464
 
 def $add_typeParameters_t(p, TC, (typeId)*)
 
@@ -11345,7 +11351,7 @@ def $add_callableDef_overload_t(cursor, TC, callableId, callableTypeDefIR)
 
             1. Return TC'
 
-      1. Else Phantom#464
+      1. Else Phantom#465
 
   2. Case (% matches pattern `BLOCK`)
 
@@ -11359,9 +11365,9 @@ def $add_callableDef_overload_t(cursor, TC, callableId, callableTypeDefIR)
 
             1. Return TC'
 
-      1. Else Phantom#465
+      1. Else Phantom#466
 
-1. Else Phantom#466
+1. Else Phantom#467
 
 def $add_callableDef_non_overload_t(cursor, TC, callableId, callableTypeDefIR)
 
@@ -11383,7 +11389,7 @@ def $add_callableDef_non_overload_t(cursor, TC, callableId, callableTypeDefIR)
 
                 1. Return TC'
 
-          1. Else Phantom#467
+          1. Else Phantom#468
 
   2. Case (% matches pattern `BLOCK`)
 
@@ -11401,9 +11407,9 @@ def $add_callableDef_non_overload_t(cursor, TC, callableId, callableTypeDefIR)
 
                 1. Return TC'
 
-          1. Else Phantom#468
+          1. Else Phantom#469
 
-1. Else Phantom#469
+1. Else Phantom#470
 
 def $add_constructorDef_t(TC, callableId, constructorTypeDefIR)
 
@@ -11417,7 +11423,7 @@ def $add_constructorDef_t(TC, callableId, constructorTypeDefIR)
 
         1. Return TC'
 
-  1. Else Phantom#470
+  1. Else Phantom#471
 
 def $add_constructorDef_non_overload_t(TC, callableId, constructorTypeDefIR)
 
@@ -11435,7 +11441,7 @@ def $add_constructorDef_non_overload_t(TC, callableId, constructorTypeDefIR)
 
             1. Return TC'
 
-      1. Else Phantom#471
+      1. Else Phantom#472
 
 def $add_constructorDefs_t(TC, (callableId)*, (constructorTypeDefIR)*)
 
@@ -11447,7 +11453,7 @@ def $add_constructorDefs_t(TC, (callableId)*, (constructorTypeDefIR)*)
 
       1. Return TC
 
-    1. Else Phantom#472
+    1. Else Phantom#473
 
   2. Case (% matches pattern _ :: _)
 
@@ -11463,7 +11469,7 @@ def $add_constructorDefs_t(TC, (callableId)*, (constructorTypeDefIR)*)
 
               1. Return TC''
 
-      1. Else Phantom#473
+      1. Else Phantom#474
 
 def $find_var_t(prefixedNameIR, p, TC)
 
@@ -11501,13 +11507,13 @@ def $find_var_t(prefixedNameIR, p, TC)
 
                   1. Return ?(varTypeIR')
 
-              1. Else Phantom#474
+              1. Else Phantom#475
 
             2. If ((?() = $find_map<id, varTypeIR>(typeFrame, id))), then
 
               1. Return $find_var_t((` id), (global), TC)
 
-            2. Else Phantom#475
+            2. Else Phantom#476
 
         3. Case (% matches pattern `LOCAL`)
 
@@ -11521,13 +11527,13 @@ def $find_var_t(prefixedNameIR, p, TC)
 
                   1. Return ?(varTypeIR')
 
-              1. Else Phantom#476
+              1. Else Phantom#477
 
             2. If ((?() = $find_maps<id, varTypeIR>((typeFrame)*, id))), then
 
               1. Return $find_var_t((` id), (block), TC)
 
-            2. Else Phantom#477
+            2. Else Phantom#478
 
 def $find_var_value_t(prefixedNameIR, p, TC)
 
@@ -11543,9 +11549,9 @@ def $find_var_value_t(prefixedNameIR, p, TC)
 
           1. Return value'
 
-      1. Else Phantom#478
+      1. Else Phantom#479
 
-  1. Else Phantom#479
+  1. Else Phantom#480
 
 def $find_typeDef_t(p, TC, prefixedNameIR)
 
@@ -11557,7 +11563,7 @@ def $find_typeDef_t(p, TC, prefixedNameIR)
 
       1. Return $find_map<typeId, typeDefIR>(typeDefEnv, typeId)
 
-1. Else Phantom#480
+1. Else Phantom#481
 
 2. Case analysis on p
 
@@ -11571,7 +11577,7 @@ def $find_typeDef_t(p, TC, prefixedNameIR)
 
           1. Return $find_map<typeId, typeDefIR>(typeDefEnv, typeId)
 
-    1. Else Phantom#481
+    1. Else Phantom#482
 
   2. Case (% matches pattern `BLOCK`)
 
@@ -11589,15 +11595,15 @@ def $find_typeDef_t(p, TC, prefixedNameIR)
 
                 1. Return ?(typeDefIR')
 
-            1. Else Phantom#482
+            1. Else Phantom#483
 
           2. If ((?() = $find_map<typeId, typeDefIR>(typeDefEnv, typeId))), then
 
             1. Return $find_typeDef_t((global), TC, (` typeId))
 
-          2. Else Phantom#483
+          2. Else Phantom#484
 
-    1. Else Phantom#484
+    1. Else Phantom#485
 
   3. Case (% matches pattern `LOCAL`)
 
@@ -11615,15 +11621,15 @@ def $find_typeDef_t(p, TC, prefixedNameIR)
 
                 1. Return ?(typeDefIR')
 
-            1. Else Phantom#485
+            1. Else Phantom#486
 
           2. If ((?() = $find_maps<typeId, typeDefIR>((typeDefEnv)*, typeId))), then
 
             1. Return $find_typeDef_t((block), TC, (` typeId))
 
-          2. Else Phantom#486
+          2. Else Phantom#487
 
-    1. Else Phantom#487
+    1. Else Phantom#488
 
 def $find_callableDef_overloaded_t(cursor, TC, prefixedNameIR, (argumentIR)*)
 
@@ -11671,15 +11677,15 @@ def $find_callableDef_overloaded_t(cursor, TC, prefixedNameIR, (argumentIR)*)
 
                   1. Return ?((callableId : callableTypeDefIR # (id_default)* # (id_optional)*))
 
-              1. Else Phantom#488
+              1. Else Phantom#489
 
             2. If ((?() = $find_overloaded<callableTypeDefIR>(callableTypeDefEnv, callTargetKey, $parameterListIR_of_callableTypeDefIR))), then
 
               1. Return $find_callableDef_overloaded_t((global), TC, (` nameIR), (argumentIR)*)
 
-            2. Else Phantom#489
+            2. Else Phantom#490
 
-    1. Else Phantom#490
+    1. Else Phantom#491
 
   3. Case (% matches pattern `LOCAL`)
 
@@ -11689,7 +11695,7 @@ def $find_callableDef_overloaded_t(cursor, TC, prefixedNameIR, (argumentIR)*)
 
         1. Return $find_callableDef_overloaded_t((block), TC, (` nameIR), (argumentIR)*)
 
-    1. Else Phantom#491
+    1. Else Phantom#492
 
 def $find_callableDef_non_overloaded_t(p, TC, prefixedNameIR)
 
@@ -11699,7 +11705,7 @@ def $find_callableDef_non_overloaded_t(p, TC, prefixedNameIR)
 
     1. Return $find_non_overloaded<callableTypeDefIR>(TC.global.callable, nameIR)
 
-1. Else Phantom#492
+1. Else Phantom#493
 
 2. Case analysis on p
 
@@ -11711,7 +11717,7 @@ def $find_callableDef_non_overloaded_t(p, TC, prefixedNameIR)
 
         1. Return $find_non_overloaded<callableTypeDefIR>(TC.global.callable, nameIR)
 
-    1. Else Phantom#493
+    1. Else Phantom#494
 
   2. Case (% matches pattern `BLOCK`)
 
@@ -11727,15 +11733,15 @@ def $find_callableDef_non_overloaded_t(p, TC, prefixedNameIR)
 
               1. Return ?((callableId, callableTypeDefIR))
 
-          1. Else Phantom#494
+          1. Else Phantom#495
 
         2. If ((?() = $find_non_overloaded<callableTypeDefIR>(TC.block.callable, nameIR))), then
 
           1. Return $find_callableDef_non_overloaded_t((global), TC, (` nameIR))
 
-        2. Else Phantom#495
+        2. Else Phantom#496
 
-    1. Else Phantom#496
+    1. Else Phantom#497
 
   3. Case (% matches pattern `LOCAL`)
 
@@ -11745,7 +11751,7 @@ def $find_callableDef_non_overloaded_t(p, TC, prefixedNameIR)
 
         1. Return $find_callableDef_non_overloaded_t((block), TC, (` nameIR))
 
-    1. Else Phantom#497
+    1. Else Phantom#498
 
 def $find_constructorDef_overloaded_t(TC, prefixedNameIR, (argumentIR)*)
 
@@ -11993,7 +11999,7 @@ def $find_table_priority_last(TBLC)
 
         1. Return (n)*[n_last]
 
-    1. Else Phantom#498
+    1. Else Phantom#499
 
 def $join_tableEntryState(tableEntryState, tableEntryState')
 
@@ -12021,7 +12027,7 @@ def $join_tableEntryState(tableEntryState, tableEntryState')
 
         1. Return (lpm n)
 
-      1. Else Phantom#499
+      1. Else Phantom#500
 
 def $tableEntry_lpm_prefix(value)
 
@@ -12041,7 +12047,7 @@ def $tableEntry_lpm_prefix'(value, n_prefix)
 
           1. Return n_prefix
 
-        1. Else Phantom#500
+        1. Else Phantom#501
 
         2. If ((_int has type nat)), then
 
@@ -12067,13 +12073,13 @@ def $tableEntry_lpm_prefix'(value, n_prefix)
 
                               1. Return $tableEntry_lpm_prefix'(value', (n_prefix + 1))
 
-                        1. Else Phantom#501
+                        1. Else Phantom#502
 
-                    1. Else Phantom#502
+                    1. Else Phantom#503
 
-                1. Else Phantom#503
+                1. Else Phantom#504
 
-            1. Else Phantom#504
+            1. Else Phantom#505
 
             2. If ((n_prefix = 0)), then
 
@@ -12091,19 +12097,19 @@ def $tableEntry_lpm_prefix'(value, n_prefix)
 
                           1. Return $tableEntry_lpm_prefix'(value', 0)
 
-                      1. Else Phantom#505
+                      1. Else Phantom#506
 
-                  1. Else Phantom#506
+                  1. Else Phantom#507
 
-              1. Else Phantom#507
+              1. Else Phantom#508
 
-            2. Else Phantom#508
+            2. Else Phantom#509
 
-        2. Else Phantom#509
+        2. Else Phantom#510
 
-    1. Else Phantom#510
+    1. Else Phantom#511
 
-1. Else Phantom#511
+1. Else Phantom#512
 
 relation Type_wf: B |- typeIR
 
@@ -12127,7 +12133,7 @@ relation Type_wf: B |- typeIR
 
           1. The relation holds
 
-        1. Else Phantom#512
+        1. Else Phantom#513
 
   3. Case (% has type typedefTypeIR)
 
@@ -12141,9 +12147,9 @@ relation Type_wf: B |- typeIR
 
             1. The relation holds
 
-          1. Else Phantom#513
+          1. Else Phantom#514
 
-        1. Else Phantom#514
+        1. Else Phantom#515
 
   4. Case (% has type newTypeIR)
 
@@ -12157,9 +12163,9 @@ relation Type_wf: B |- typeIR
 
             1. The relation holds
 
-          1. Else Phantom#515
+          1. Else Phantom#516
 
-        1. Else Phantom#516
+        1. Else Phantom#517
 
   5. Case (% has type listTypeIR)
 
@@ -12173,9 +12179,9 @@ relation Type_wf: B |- typeIR
 
             1. The relation holds
 
-          1. Else Phantom#517
+          1. Else Phantom#518
 
-        1. Else Phantom#518
+        1. Else Phantom#519
 
   6. Case (% has type tupleTypeIR)
 
@@ -12189,9 +12195,9 @@ relation Type_wf: B |- typeIR
 
             1. The relation holds
 
-          1. Else Phantom#519
+          1. Else Phantom#520
 
-        1. Else Phantom#520
+        1. Else Phantom#521
 
   7. Case (% has type headerStackTypeIR)
 
@@ -12205,9 +12211,9 @@ relation Type_wf: B |- typeIR
 
             1. The relation holds
 
-          1. Else Phantom#521
+          1. Else Phantom#522
 
-        1. Else Phantom#522
+        1. Else Phantom#523
 
   8. Case (% has type structTypeIR)
 
@@ -12223,11 +12229,11 @@ relation Type_wf: B |- typeIR
 
               1. The relation holds
 
-            1. Else Phantom#523
+            1. Else Phantom#524
 
-          1. Else Phantom#524
+          1. Else Phantom#525
 
-        1. Else Phantom#525
+        1. Else Phantom#526
 
   9. Case (% has type headerTypeIR)
 
@@ -12243,11 +12249,11 @@ relation Type_wf: B |- typeIR
 
               1. The relation holds
 
-            1. Else Phantom#526
+            1. Else Phantom#527
 
-          1. Else Phantom#527
+          1. Else Phantom#528
 
-        1. Else Phantom#528
+        1. Else Phantom#529
 
   10. Case (% has type headerUnionTypeIR)
 
@@ -12263,13 +12269,13 @@ relation Type_wf: B |- typeIR
 
               1. The relation holds
 
-            1. Else Phantom#529
+            1. Else Phantom#530
 
-          1. Else Phantom#530
+          1. Else Phantom#531
 
-        1. Else Phantom#531
+        1. Else Phantom#532
 
-1. Else Phantom#532
+1. Else Phantom#533
 
 2. Group enumTypeIR: B |- typeIR
 
@@ -12283,7 +12289,7 @@ relation Type_wf: B |- typeIR
 
           1. The relation holds
 
-        1. Else Phantom#533
+        1. Else Phantom#534
 
     2. Case (% has type serializableEnumTypeIR)
 
@@ -12297,13 +12303,13 @@ relation Type_wf: B |- typeIR
 
               1. The relation holds
 
-            1. Else Phantom#534
+            1. Else Phantom#535
 
-          1. Else Phantom#535
+          1. Else Phantom#536
 
-        1. Else Phantom#536
+        1. Else Phantom#537
 
-  1. Else Phantom#537
+  1. Else Phantom#538
 
 3. Case analysis on typeIR
 
@@ -12317,7 +12323,7 @@ relation Type_wf: B |- typeIR
 
           1. The relation holds
 
-        1. Else Phantom#538
+        1. Else Phantom#539
 
   2. Case (% has type parserObjectTypeIR)
 
@@ -12329,7 +12335,7 @@ relation Type_wf: B |- typeIR
 
           1. The relation holds
 
-        1. Else Phantom#539
+        1. Else Phantom#540
 
   3. Case (% has type controlObjectTypeIR)
 
@@ -12341,7 +12347,7 @@ relation Type_wf: B |- typeIR
 
           1. The relation holds
 
-        1. Else Phantom#540
+        1. Else Phantom#541
 
   4. Case (% has type packageObjectTypeIR)
 
@@ -12353,7 +12359,7 @@ relation Type_wf: B |- typeIR
 
           1. The relation holds
 
-        1. Else Phantom#541
+        1. Else Phantom#542
 
   5. Case (% has type tableObjectTypeIR)
 
@@ -12365,7 +12371,7 @@ relation Type_wf: B |- typeIR
 
           1. The relation holds
 
-        1. Else Phantom#542
+        1. Else Phantom#543
 
   6. Case (% has type defaultTypeIR)
 
@@ -12399,7 +12405,7 @@ relation Type_wf: B |- typeIR
 
                 1. The relation holds
 
-              1. Else Phantom#543
+              1. Else Phantom#544
 
           2. Case (% matches pattern `SEQ<%,...>`)
 
@@ -12409,7 +12415,7 @@ relation Type_wf: B |- typeIR
 
                 1. The relation holds
 
-              1. Else Phantom#544
+              1. Else Phantom#545
 
   9. Case (% has type recordTypeIR)
 
@@ -12429,9 +12435,9 @@ relation Type_wf: B |- typeIR
 
                   1. The relation holds
 
-                1. Else Phantom#545
+                1. Else Phantom#546
 
-              1. Else Phantom#546
+              1. Else Phantom#547
 
           2. Case (% matches pattern `RECORD{%,...}`)
 
@@ -12443,9 +12449,9 @@ relation Type_wf: B |- typeIR
 
                   1. The relation holds
 
-                1. Else Phantom#547
+                1. Else Phantom#548
 
-              1. Else Phantom#548
+              1. Else Phantom#549
 
   10. Case (% has type setTypeIR)
 
@@ -12459,11 +12465,11 @@ relation Type_wf: B |- typeIR
 
             1. The relation holds
 
-          1. Else Phantom#549
+          1. Else Phantom#550
 
-        1. Else Phantom#550
+        1. Else Phantom#551
 
-3. Else Phantom#551
+3. Else Phantom#552
 
 4. Group tableMetadataTypeIR: B |- typeIR
 
@@ -12477,7 +12483,7 @@ relation Type_wf: B |- typeIR
 
           1. The relation holds
 
-        1. Else Phantom#552
+        1. Else Phantom#553
 
     2. Case (% has type tableMetadataStructTypeIR)
 
@@ -12487,9 +12493,9 @@ relation Type_wf: B |- typeIR
 
           1. The relation holds
 
-        1. Else Phantom#553
+        1. Else Phantom#554
 
-  1. Else Phantom#554
+  1. Else Phantom#555
 
 relation TypeDef_wf: B |- typeDefIR
 
@@ -12509,9 +12515,9 @@ relation TypeDef_wf: B |- typeDefIR
 
               1. The relation holds
 
-            1. Else Phantom#555
+            1. Else Phantom#556
 
-      1. Else Phantom#556
+      1. Else Phantom#557
 
 relation ParameterType_wf: B |- (annotationList direction typeIR id (parameterInitializerIR)?)
 
@@ -12531,11 +12537,11 @@ relation ParameterType_wf: B |- (annotationList direction typeIR id (parameterIn
 
               1. The relation holds
 
-            1. Else Phantom#557
+            1. Else Phantom#558
 
-          1. Else Phantom#558
+          1. Else Phantom#559
 
-      1. Else Phantom#559
+      1. Else Phantom#560
 
     2. Case (% matches pattern (_))
 
@@ -12553,15 +12559,15 @@ relation ParameterType_wf: B |- (annotationList direction typeIR id (parameterIn
 
                   1. The relation holds
 
-                1. Else Phantom#560
+                1. Else Phantom#561
 
-              1. Else Phantom#561
+              1. Else Phantom#562
 
-            1. Else Phantom#562
+            1. Else Phantom#563
 
-          1. Else Phantom#563
+          1. Else Phantom#564
 
-      1. Else Phantom#564
+      1. Else Phantom#565
 
 relation ReturnType_wf: B |- typeIR_ret
 
@@ -12575,9 +12581,9 @@ relation ReturnType_wf: B |- typeIR_ret
 
         1. The relation holds
 
-      1. Else Phantom#565
+      1. Else Phantom#566
 
-  1. Else Phantom#566
+  1. Else Phantom#567
 
 relation CallableType_wf: B |- callableTypeIR
 
@@ -12601,13 +12607,13 @@ relation CallableType_wf: B |- callableTypeIR
 
                   1. The relation holds
 
-                1. Else Phantom#567
+                1. Else Phantom#568
 
-              1. Else Phantom#568
+              1. Else Phantom#569
 
-          1. Else Phantom#569
+          1. Else Phantom#570
 
-        1. Else Phantom#570
+        1. Else Phantom#571
 
   2. Case (% has type definedFunctionTypeIR)
 
@@ -12627,13 +12633,13 @@ relation CallableType_wf: B |- callableTypeIR
 
                   1. The relation holds
 
-                1. Else Phantom#571
+                1. Else Phantom#572
 
-              1. Else Phantom#572
+              1. Else Phantom#573
 
-          1. Else Phantom#573
+          1. Else Phantom#574
 
-        1. Else Phantom#574
+        1. Else Phantom#575
 
   3. Case (% has type externFunctionTypeIR)
 
@@ -12651,11 +12657,11 @@ relation CallableType_wf: B |- callableTypeIR
 
                 1. The relation holds
 
-              1. Else Phantom#575
+              1. Else Phantom#576
 
-            1. Else Phantom#576
+            1. Else Phantom#577
 
-        1. Else Phantom#577
+        1. Else Phantom#578
 
   4. Case (% has type builtinMethodTypeIR)
 
@@ -12671,11 +12677,11 @@ relation CallableType_wf: B |- callableTypeIR
 
               1. The relation holds
 
-            1. Else Phantom#578
+            1. Else Phantom#579
 
-          1. Else Phantom#579
+          1. Else Phantom#580
 
-        1. Else Phantom#580
+        1. Else Phantom#581
 
   5. Case (% has type externMethodTypeIR)
 
@@ -12699,11 +12705,11 @@ relation CallableType_wf: B |- callableTypeIR
 
                       1. The relation holds
 
-                    1. Else Phantom#581
+                    1. Else Phantom#582
 
-                  1. Else Phantom#582
+                  1. Else Phantom#583
 
-              1. Else Phantom#583
+              1. Else Phantom#584
 
           2. Case (% matches pattern `EXTERN_METHODABSTRACT%(%):%`)
 
@@ -12721,13 +12727,13 @@ relation CallableType_wf: B |- callableTypeIR
 
                         1. The relation holds
 
-                      1. Else Phantom#584
+                      1. Else Phantom#585
 
-                    1. Else Phantom#585
+                    1. Else Phantom#586
 
-                1. Else Phantom#586
+                1. Else Phantom#587
 
-              1. Else Phantom#587
+              1. Else Phantom#588
 
   6. Case (% has type parserApplyMethodTypeIR)
 
@@ -12745,11 +12751,11 @@ relation CallableType_wf: B |- callableTypeIR
 
                 1. The relation holds
 
-              1. Else Phantom#588
+              1. Else Phantom#589
 
-          1. Else Phantom#589
+          1. Else Phantom#590
 
-        1. Else Phantom#590
+        1. Else Phantom#591
 
   7. Case (% has type controlApplyMethodTypeIR)
 
@@ -12767,11 +12773,11 @@ relation CallableType_wf: B |- callableTypeIR
 
                 1. The relation holds
 
-              1. Else Phantom#591
+              1. Else Phantom#592
 
-          1. Else Phantom#592
+          1. Else Phantom#593
 
-        1. Else Phantom#593
+        1. Else Phantom#594
 
   8. Case (% has type tableApplyMethodTypeIR)
 
@@ -12799,9 +12805,9 @@ relation CallableTypeDef_wf: B |- callableTypeDefIR
 
               1. The relation holds
 
-            1. Else Phantom#594
+            1. Else Phantom#595
 
-      1. Else Phantom#595
+      1. Else Phantom#596
 
 relation ConstructorParameterType_wf: B |- constructorParameterIR
 
@@ -12815,9 +12821,9 @@ relation ConstructorParameterType_wf: B |- constructorParameterIR
 
         1. The relation holds
 
-      1. Else Phantom#596
+      1. Else Phantom#597
 
-    1. Else Phantom#597
+    1. Else Phantom#598
 
 relation ConstructorType_wf: B |- (constructor( (parameterIR)* ): typeIR_object)
 
@@ -12837,13 +12843,13 @@ relation ConstructorType_wf: B |- (constructor( (parameterIR)* ): typeIR_object)
 
               1. The relation holds
 
-            1. Else Phantom#598
+            1. Else Phantom#599
 
-        1. Else Phantom#599
+        1. Else Phantom#600
 
-    1. Else Phantom#600
+    1. Else Phantom#601
 
-  1. Else Phantom#601
+  1. Else Phantom#602
 
 2. Group parserObjectTypeIR: B |- (constructor( (parameterIR)* ): typeIR_object)
 
@@ -12863,15 +12869,15 @@ relation ConstructorType_wf: B |- (constructor( (parameterIR)* ): typeIR_object)
 
                 1. The relation holds
 
-              1. Else Phantom#602
+              1. Else Phantom#603
 
-          1. Else Phantom#603
+          1. Else Phantom#604
 
-      1. Else Phantom#604
+      1. Else Phantom#605
 
-    1. Else Phantom#605
+    1. Else Phantom#606
 
-  1. Else Phantom#606
+  1. Else Phantom#607
 
 3. Group controlObjectTypeIR: B |- (constructor( (parameterIR)* ): typeIR_object)
 
@@ -12891,15 +12897,15 @@ relation ConstructorType_wf: B |- (constructor( (parameterIR)* ): typeIR_object)
 
                 1. The relation holds
 
-              1. Else Phantom#607
+              1. Else Phantom#608
 
-          1. Else Phantom#608
+          1. Else Phantom#609
 
-      1. Else Phantom#609
+      1. Else Phantom#610
 
-    1. Else Phantom#610
+    1. Else Phantom#611
 
-  1. Else Phantom#611
+  1. Else Phantom#612
 
 4. If (((parameterIR)* matches pattern [])), then
 
@@ -12913,11 +12919,11 @@ relation ConstructorType_wf: B |- (constructor( (parameterIR)* ): typeIR_object)
 
           1. The relation holds
 
-        1. Else Phantom#612
+        1. Else Phantom#613
 
-    1. Else Phantom#613
+    1. Else Phantom#614
 
-4. Else Phantom#614
+4. Else Phantom#615
 
 5. Group packageObjectTypeIR: B |- (constructor( (parameterIR)* ): typeIR_object)
 
@@ -12935,13 +12941,13 @@ relation ConstructorType_wf: B |- (constructor( (parameterIR)* ): typeIR_object)
 
               1. The relation holds
 
-            1. Else Phantom#615
+            1. Else Phantom#616
 
-        1. Else Phantom#616
+        1. Else Phantom#617
 
-    1. Else Phantom#617
+    1. Else Phantom#618
 
-  1. Else Phantom#618
+  1. Else Phantom#619
 
 relation ConstructorTypeDef_wf: B |- constructorTypeDefIR
 
@@ -12961,11 +12967,11 @@ relation ConstructorTypeDef_wf: B |- constructorTypeDefIR
 
               1. The relation holds
 
-            1. Else Phantom#619
+            1. Else Phantom#620
 
-        1. Else Phantom#620
+        1. Else Phantom#621
 
-    1. Else Phantom#621
+    1. Else Phantom#622
 
 tbl def $nestable_typedef(typeIR'')
 =
@@ -13782,7 +13788,7 @@ def $directionless_trailing'(bool, (direction)*)
 
         1. Return $directionless_trailing'(false, (direction_t)*)
 
-      1. Else Phantom#622
+      1. Else Phantom#623
 
 2. Case analysis on bool
 
@@ -13796,9 +13802,9 @@ def $directionless_trailing'(bool, (direction)*)
 
           1. Return $directionless_trailing'(true, (direction_t)*)
 
-        1. Else Phantom#623
+        1. Else Phantom#624
 
-    1. Else Phantom#624
+    1. Else Phantom#625
 
   2. Case (% = false)
 
@@ -13810,9 +13816,9 @@ def $directionless_trailing'(bool, (direction)*)
 
           1. Return false
 
-        1. Else Phantom#625
+        1. Else Phantom#626
 
-    1. Else Phantom#626
+    1. Else Phantom#627
 
 tbl def $nestable_action(typeIR'')
 =
@@ -14219,7 +14225,7 @@ relation Expr_eval_lctk: p TC |- (expressionIR # expressionNoteIR) ~> %
 
         1. Result in: % % |- % ~> (stringLiteral as value)
 
-  1. Else Phantom#627
+  1. Else Phantom#628
 
 2. Case analysis on expressionIR
 
@@ -14265,7 +14271,7 @@ relation Expr_eval_lctk: p TC |- (expressionIR # expressionNoteIR) ~> %
 
               1. Result in: % % |- % ~> $bin_op(binop, value_l, value_r)
 
-        1. Else Phantom#628
+        1. Else Phantom#629
 
         2. Case analysis on binop
 
@@ -14285,7 +14291,7 @@ relation Expr_eval_lctk: p TC |- (expressionIR # expressionNoteIR) ~> %
 
                     1. Result in: % % |- % ~> value_r
 
-              1. Else Phantom#629
+              1. Else Phantom#630
 
           2. Case (% matches pattern `||`)
 
@@ -14303,9 +14309,9 @@ relation Expr_eval_lctk: p TC |- (expressionIR # expressionNoteIR) ~> %
 
                     1. Result in: % % |- % ~> value_r
 
-              1. Else Phantom#630
+              1. Else Phantom#631
 
-        2. Else Phantom#631
+        2. Else Phantom#632
 
   5. Case (% has type ternaryExpressionIR)
 
@@ -14329,7 +14335,7 @@ relation Expr_eval_lctk: p TC |- (expressionIR # expressionNoteIR) ~> %
 
                 1. Result in: % % |- % ~> value_false
 
-          1. Else Phantom#632
+          1. Else Phantom#633
 
   6. Case (% has type castExpressionIR)
 
@@ -14399,7 +14405,7 @@ relation Expr_eval_lctk: p TC |- (expressionIR # expressionNoteIR) ~> %
 
                 1. Result in: % % |- % ~> ((record{ ((value nameIR ;))* ,...}) as value)
 
-2. Else Phantom#633
+2. Else Phantom#634
 
 3. (Let (( typeIR ctk )) be expressionNoteIR)
 
@@ -14415,7 +14421,7 @@ relation Expr_eval_lctk: p TC |- (expressionIR # expressionNoteIR) ~> %
 
             1. Result in: % % |- % ~> value_error
 
-  1. Else Phantom#634
+  1. Else Phantom#635
 
 4. Case analysis on expressionIR
 
@@ -14453,7 +14459,7 @@ relation Expr_eval_lctk: p TC |- (expressionIR # expressionNoteIR) ~> %
 
                                   1. Result in: % % |- % ~> ((typeId . nameIR) as value)
 
-                                1. Else Phantom#635
+                                1. Else Phantom#636
 
                             2. Case (% has type serializableEnumTypeIR)
 
@@ -14467,13 +14473,13 @@ relation Expr_eval_lctk: p TC |- (expressionIR # expressionNoteIR) ~> %
 
                                       1. Result in: % % |- % ~> ((typeId . nameIR . value') as value)
 
-                                  1. Else Phantom#636
+                                  1. Else Phantom#637
 
-                          1. Else Phantom#637
+                          1. Else Phantom#638
 
-                    1. Else Phantom#638
+                    1. Else Phantom#639
 
-                1. Else Phantom#639
+                1. Else Phantom#640
 
         2. Case (% has type typedExpressionIR)
 
@@ -14493,9 +14499,9 @@ relation Expr_eval_lctk: p TC |- (expressionIR # expressionNoteIR) ~> %
 
                         1. Result in: % % |- % ~> ((d (n_size as int)) as value)
 
-                      1. Else Phantom#640
+                      1. Else Phantom#641
 
-                  1. Else Phantom#641
+                  1. Else Phantom#642
 
               2. (Expr_eval_lctk: p TC |- typedExpressionIR_base ~> value)
 
@@ -14515,7 +14521,7 @@ relation Expr_eval_lctk: p TC |- (expressionIR # expressionNoteIR) ~> %
 
                               1. Result in: % % |- % ~> value''
 
-                          1. Else Phantom#642
+                          1. Else Phantom#643
 
                   2. Case (% has type headerValue)
 
@@ -14531,7 +14537,7 @@ relation Expr_eval_lctk: p TC |- (expressionIR # expressionNoteIR) ~> %
 
                               1. Result in: % % |- % ~> value''
 
-                          1. Else Phantom#643
+                          1. Else Phantom#644
 
                   3. Case (% has type headerUnionValue)
 
@@ -14547,9 +14553,9 @@ relation Expr_eval_lctk: p TC |- (expressionIR # expressionNoteIR) ~> %
 
                               1. Result in: % % |- % ~> value''
 
-                          1. Else Phantom#644
+                          1. Else Phantom#645
 
-                1. Else Phantom#645
+                1. Else Phantom#646
 
   2. Case (% has type indexAccessExpressionIR)
 
@@ -14583,9 +14589,9 @@ relation Expr_eval_lctk: p TC |- (expressionIR # expressionNoteIR) ~> %
 
                                 1. Result in: % % |- % ~> value'
 
-                            1. Else Phantom#646
+                            1. Else Phantom#647
 
-                        1. Else Phantom#647
+                        1. Else Phantom#648
 
                   2. Case (% has type headerStackValue)
 
@@ -14603,13 +14609,13 @@ relation Expr_eval_lctk: p TC |- (expressionIR # expressionNoteIR) ~> %
 
                                 1. Result in: % % |- % ~> value'
 
-                            1. Else Phantom#648
+                            1. Else Phantom#649
 
-                        1. Else Phantom#649
+                        1. Else Phantom#650
 
-                1. Else Phantom#650
+                1. Else Phantom#651
 
-            1. Else Phantom#651
+            1. Else Phantom#652
 
   3. Case (% has type sliceAccessExpressionIR)
 
@@ -14681,17 +14687,17 @@ relation Expr_eval_lctk: p TC |- (expressionIR # expressionNoteIR) ~> %
 
                                                         1. Result in: % % |- % ~> (boolValue as value)
 
-                                                      1. Else Phantom#652
+                                                      1. Else Phantom#653
 
-                                                  1. Else Phantom#653
+                                                  1. Else Phantom#654
 
-                                      1. Else Phantom#654
+                                      1. Else Phantom#655
 
-                            1. Else Phantom#655
+                            1. Else Phantom#656
 
-                          1. Else Phantom#656
+                          1. Else Phantom#657
 
-                    1. Else Phantom#657
+                    1. Else Phantom#658
 
               2. Case (% matches pattern `%.%`)
 
@@ -14703,7 +14709,7 @@ relation Expr_eval_lctk: p TC |- (expressionIR # expressionNoteIR) ~> %
 
                       1. Result in: % % |- % ~> $sizeof(typeIR_base, nameIR)
 
-                    1. Else Phantom#658
+                    1. Else Phantom#659
 
               3. Case (% matches pattern `TYPE%.%`)
 
@@ -14725,7 +14731,7 @@ relation Expr_eval_lctk: p TC |- (expressionIR # expressionNoteIR) ~> %
 
                                 1. Result in: % % |- % ~> $sizeof(typeIR_base, nameIR)
 
-                              1. Else Phantom#659
+                              1. Else Phantom#660
 
                           2. Case false
 
@@ -14737,11 +14743,11 @@ relation Expr_eval_lctk: p TC |- (expressionIR # expressionNoteIR) ~> %
 
                                   1. Result in: % % |- % ~> $sizeof(typeIR_base, nameIR)
 
-                                1. Else Phantom#660
+                                1. Else Phantom#661
 
-                            1. Else Phantom#661
+                            1. Else Phantom#662
 
-                    1. Else Phantom#662
+                    1. Else Phantom#663
 
               4. Case (% matches pattern `(%)`)
 
@@ -14753,7 +14759,7 @@ relation Expr_eval_lctk: p TC |- (expressionIR # expressionNoteIR) ~> %
 
                       1. Result in: % % |- % ~> value
 
-      1. Else Phantom#663
+      1. Else Phantom#664
 
   5. Case (% has type parenthesizedExpressionIR)
 
@@ -14765,7 +14771,7 @@ relation Expr_eval_lctk: p TC |- (expressionIR # expressionNoteIR) ~> %
 
           1. Result in: % % |- % ~> value
 
-4. Else Phantom#664
+4. Else Phantom#665
 
 relation Argument_eval_lctk: p TC |- argumentIR ~> %
 
@@ -14791,7 +14797,7 @@ relation Argument_eval_lctk: p TC |- argumentIR ~> %
 
           1. Result in: % % |- % ~> value
 
-1. Else Phantom#665
+1. Else Phantom#666
 
 relation Type_ok: p TC |- typeOrVoid : % # %
 
@@ -14839,7 +14845,7 @@ relation Type_ok: p TC |- typeOrVoid : % # %
 
             1. Result in: % % |- % : ((int) as typeIR) # []
 
-      1. Else Phantom#666
+      1. Else Phantom#667
 
       2. Group fixedInt: p TC |- (baseType as typeOrVoid) : % # %
 
@@ -14857,9 +14863,9 @@ relation Type_ok: p TC |- typeOrVoid : % # %
 
                     1. Result in: % % |- % : ((int< n >) as typeIR) # []
 
-                  1. Else Phantom#667
+                  1. Else Phantom#668
 
-              1. Else Phantom#668
+              1. Else Phantom#669
 
           2. Case (% matches pattern `INT<(%)>`)
 
@@ -14885,15 +14891,15 @@ relation Type_ok: p TC |- typeOrVoid : % # %
 
                                 1. Result in: % % |- % : ((int< n >) as typeIR) # []
 
-                              1. Else Phantom#669
+                              1. Else Phantom#670
 
-                          1. Else Phantom#670
+                          1. Else Phantom#671
 
-                    1. Else Phantom#671
+                    1. Else Phantom#672
 
-                1. Else Phantom#672
+                1. Else Phantom#673
 
-        1. Else Phantom#673
+        1. Else Phantom#674
 
       3. Group fixedBit: p TC |- (baseType as typeOrVoid) : % # %
 
@@ -14913,7 +14919,7 @@ relation Type_ok: p TC |- typeOrVoid : % # %
 
                   1. Result in: % % |- % : ((bit< n >) as typeIR) # []
 
-              1. Else Phantom#674
+              1. Else Phantom#675
 
           3. Case (% matches pattern `BIT<(%)>`)
 
@@ -14937,13 +14943,13 @@ relation Type_ok: p TC |- typeOrVoid : % # %
 
                               1. Result in: % % |- % : ((bit< n >) as typeIR) # []
 
-                          1. Else Phantom#675
+                          1. Else Phantom#676
 
-                    1. Else Phantom#676
+                    1. Else Phantom#677
 
-                1. Else Phantom#677
+                1. Else Phantom#678
 
-        1. Else Phantom#678
+        1. Else Phantom#679
 
       4. Group variableBit: p TC |- (baseType as typeOrVoid) : % # %
 
@@ -14959,7 +14965,7 @@ relation Type_ok: p TC |- typeOrVoid : % # %
 
                   1. Result in: % % |- % : ((varbit< n >) as typeIR) # []
 
-              1. Else Phantom#679
+              1. Else Phantom#680
 
           2. Case (% matches pattern `VARBIT<(%)>`)
 
@@ -14983,15 +14989,15 @@ relation Type_ok: p TC |- typeOrVoid : % # %
 
                               1. Result in: % % |- % : ((varbit< n >) as typeIR) # []
 
-                          1. Else Phantom#680
+                          1. Else Phantom#681
 
-                    1. Else Phantom#681
+                    1. Else Phantom#682
 
-                1. Else Phantom#682
+                1. Else Phantom#683
 
-        1. Else Phantom#683
+        1. Else Phantom#684
 
-1. Else Phantom#684
+1. Else Phantom#685
 
 2. Group prefixedTypeName-identifier: p TC |- typeOrVoid : % # %
 
@@ -15031,9 +15037,9 @@ relation Type_ok: p TC |- typeOrVoid : % # %
 
                       1. Result in: % % |- % : typeIR # []
 
-            1. Else Phantom#685
+            1. Else Phantom#686
 
-  1. Else Phantom#686
+  1. Else Phantom#687
 
 3. Case analysis on typeOrVoid
 
@@ -15059,9 +15065,9 @@ relation Type_ok: p TC |- typeOrVoid : % # %
 
                       1. Result in: % % |- % : typeIR # (typeId_fresh)*
 
-                1. Else Phantom#687
+                1. Else Phantom#688
 
-            1. Else Phantom#688
+            1. Else Phantom#689
 
   2. Case (% has type headerStackType)
 
@@ -15091,13 +15097,13 @@ relation Type_ok: p TC |- typeOrVoid : % # %
 
                             1. Result in: % % |- % : ((typeIR_base [ n_size ]) as typeIR) # (typeId_fresh)*
 
-                          1. Else Phantom#689
+                          1. Else Phantom#690
 
-                      1. Else Phantom#690
+                      1. Else Phantom#691
 
-                1. Else Phantom#691
+                1. Else Phantom#692
 
-            1. Else Phantom#692
+            1. Else Phantom#693
 
   3. Case (% has type listType)
 
@@ -15119,7 +15125,7 @@ relation Type_ok: p TC |- typeOrVoid : % # %
 
           1. Result in: % % |- % : ((tuple< (typeIR_arg)* >) as typeIR) # (typeId_fresh)*
 
-3. Else Phantom#693
+3. Else Phantom#694
 
 relation TypeParameterListOpt_ok: p TC_0 |- typeParameterListOpt : % %
 
@@ -15157,7 +15163,7 @@ relation TypeArgument_ok: p TC |- typeArgument : % # %
 
           1. Result in: % % |- % : ((` typeId) as typeArgumentIR) # []
 
-1. Else Phantom#694
+1. Else Phantom#695
 
 2. If ((typeArgument has type realTypeArgument)), then
 
@@ -15179,9 +15185,9 @@ relation TypeArgument_ok: p TC |- typeArgument : % # %
 
             1. Result in: % % |- % : ((` typeId_impl) as typeArgumentIR) # [typeId_impl]
 
-    1. Else Phantom#695
+    1. Else Phantom#696
 
-2. Else Phantom#696
+2. Else Phantom#697
 
 relation TypeArguments_ok: p TC |- (typeArgument)* : % # %
 
@@ -15191,7 +15197,7 @@ relation TypeArguments_ok: p TC |- (typeArgument)* : % # %
 
     1. Result in: % % |- % : [] # []
 
-  1. Else Phantom#697
+  1. Else Phantom#698
 
   2. If (((typeArgument)* matches pattern _ :: _)), then
 
@@ -15205,7 +15211,7 @@ relation TypeArguments_ok: p TC |- (typeArgument)* : % # %
 
             1. Result in: % % |- % : typeArgumentIR_h :: (typeArgumentIR_t)* # (typeId_impl)*
 
-  2. Else Phantom#698
+  2. Else Phantom#699
 
 relation TypeArgumentList_ok: p TC |- typeArgumentList : % # %
 
@@ -15235,7 +15241,7 @@ relation Cast_expl: typeIR_a -> typeIR_b
 
           1. The relation holds
 
-        1. Else Phantom#699
+        1. Else Phantom#700
 
 relation Cast_expl_neq: typeIR -> typeIR'
 
@@ -15251,7 +15257,7 @@ relation Cast_expl_neq: typeIR -> typeIR'
 
           1. The relation holds
 
-      1. Else Phantom#700
+      1. Else Phantom#701
 
   2. Case (% has type intTypeIR)
 
@@ -15263,7 +15269,7 @@ relation Cast_expl_neq: typeIR -> typeIR'
 
           1. The relation holds
 
-        1. Else Phantom#701
+        1. Else Phantom#702
 
         2. Case analysis on typeIR'
 
@@ -15275,7 +15281,7 @@ relation Cast_expl_neq: typeIR -> typeIR'
 
             1. The relation holds
 
-        2. Else Phantom#702
+        2. Else Phantom#703
 
   3. Case (% has type fixedIntTypeIR)
 
@@ -15293,13 +15299,13 @@ relation Cast_expl_neq: typeIR -> typeIR'
 
             1. The relation holds
 
-        1. Else Phantom#703
+        1. Else Phantom#704
 
         2. If ((typeIR' has type fixedIntTypeIR)), then
 
           1. The relation holds
 
-        2. Else Phantom#704
+        2. Else Phantom#705
 
   4. Case (% has type fixedBitTypeIR)
 
@@ -15313,9 +15319,9 @@ relation Cast_expl_neq: typeIR -> typeIR'
 
             1. The relation holds
 
-          1. Else Phantom#705
+          1. Else Phantom#706
 
-        1. Else Phantom#706
+        1. Else Phantom#707
 
         2. Case analysis on typeIR'
 
@@ -15327,15 +15333,15 @@ relation Cast_expl_neq: typeIR -> typeIR'
 
             1. The relation holds
 
-        2. Else Phantom#707
+        2. Else Phantom#708
 
         3. If ((typeIR' has type fixedBitTypeIR)), then
 
           1. The relation holds
 
-        3. Else Phantom#708
+        3. Else Phantom#709
 
-1. Else Phantom#709
+1. Else Phantom#710
 
 2. Group newTypeIR: typeIR -> typeIR'
 
@@ -15347,9 +15353,9 @@ relation Cast_expl_neq: typeIR -> typeIR'
 
         1. The relation holds
 
-      1. Else Phantom#710
+      1. Else Phantom#711
 
-  1. Else Phantom#711
+  1. Else Phantom#712
 
   2. If ((typeIR' has type newTypeIR)), then
 
@@ -15359,9 +15365,9 @@ relation Cast_expl_neq: typeIR -> typeIR'
 
         1. The relation holds
 
-      1. Else Phantom#712
+      1. Else Phantom#713
 
-  2. Else Phantom#713
+  2. Else Phantom#714
 
 3. Group enumTypeIR-serializable: typeIR -> typeIR'
 
@@ -15373,9 +15379,9 @@ relation Cast_expl_neq: typeIR -> typeIR'
 
         1. The relation holds
 
-      1. Else Phantom#714
+      1. Else Phantom#715
 
-  1. Else Phantom#715
+  1. Else Phantom#716
 
   2. If ((typeIR' has type serializableEnumTypeIR)), then
 
@@ -15385,9 +15391,9 @@ relation Cast_expl_neq: typeIR -> typeIR'
 
         1. The relation holds
 
-      1. Else Phantom#716
+      1. Else Phantom#717
 
-  2. Else Phantom#717
+  2. Else Phantom#718
 
 4. Case analysis on typeIR
 
@@ -15401,7 +15407,7 @@ relation Cast_expl_neq: typeIR -> typeIR'
 
           1. The relation holds
 
-        1. Else Phantom#718
+        1. Else Phantom#719
 
   2. Case (% has type invalidHeaderTypeIR)
 
@@ -15419,7 +15425,7 @@ relation Cast_expl_neq: typeIR -> typeIR'
 
             1. The relation holds
 
-        1. Else Phantom#719
+        1. Else Phantom#720
 
   3. Case (% has type sequenceTypeIR)
 
@@ -15443,7 +15449,7 @@ relation Cast_expl_neq: typeIR -> typeIR'
 
                       1. The relation holds
 
-                    1. Else Phantom#720
+                    1. Else Phantom#721
 
                 2. Case (% has type tupleTypeIR)
 
@@ -15453,7 +15459,7 @@ relation Cast_expl_neq: typeIR -> typeIR'
 
                       1. The relation holds
 
-                    1. Else Phantom#721
+                    1. Else Phantom#722
 
                 3. Case (% has type headerStackTypeIR)
 
@@ -15465,9 +15471,9 @@ relation Cast_expl_neq: typeIR -> typeIR'
 
                         1. The relation holds
 
-                      1. Else Phantom#722
+                      1. Else Phantom#723
 
-                    1. Else Phantom#723
+                    1. Else Phantom#724
 
                 4. Case (% has type structTypeIR)
 
@@ -15477,7 +15483,7 @@ relation Cast_expl_neq: typeIR -> typeIR'
 
                       1. The relation holds
 
-                    1. Else Phantom#724
+                    1. Else Phantom#725
 
                 5. Case (% has type headerTypeIR)
 
@@ -15487,9 +15493,9 @@ relation Cast_expl_neq: typeIR -> typeIR'
 
                       1. The relation holds
 
-                    1. Else Phantom#725
+                    1. Else Phantom#726
 
-              1. Else Phantom#726
+              1. Else Phantom#727
 
         2. Case (% matches pattern `SEQ<%,...>`)
 
@@ -15513,11 +15519,11 @@ relation Cast_expl_neq: typeIR -> typeIR'
 
                             1. The relation holds
 
-                          1. Else Phantom#727
+                          1. Else Phantom#728
 
-                        1. Else Phantom#728
+                        1. Else Phantom#729
 
-                    1. Else Phantom#729
+                    1. Else Phantom#730
 
                 2. Case (% has type headerStackTypeIR)
 
@@ -15531,11 +15537,11 @@ relation Cast_expl_neq: typeIR -> typeIR'
 
                           1. The relation holds
 
-                        1. Else Phantom#730
+                        1. Else Phantom#731
 
-                      1. Else Phantom#731
+                      1. Else Phantom#732
 
-                    1. Else Phantom#732
+                    1. Else Phantom#733
 
                 3. Case (% has type structTypeIR)
 
@@ -15551,11 +15557,11 @@ relation Cast_expl_neq: typeIR -> typeIR'
 
                             1. The relation holds
 
-                          1. Else Phantom#733
+                          1. Else Phantom#734
 
-                        1. Else Phantom#734
+                        1. Else Phantom#735
 
-                    1. Else Phantom#735
+                    1. Else Phantom#736
 
                 4. Case (% has type headerTypeIR)
 
@@ -15571,13 +15577,13 @@ relation Cast_expl_neq: typeIR -> typeIR'
 
                             1. The relation holds
 
-                          1. Else Phantom#736
+                          1. Else Phantom#737
 
-                        1. Else Phantom#737
+                        1. Else Phantom#738
 
-                    1. Else Phantom#738
+                    1. Else Phantom#739
 
-              1. Else Phantom#739
+              1. Else Phantom#740
 
   4. Case (% has type recordTypeIR)
 
@@ -15615,13 +15621,13 @@ relation Cast_expl_neq: typeIR -> typeIR'
 
                                     1. The relation holds
 
-                                  1. Else Phantom#740
+                                  1. Else Phantom#741
 
-                              1. Else Phantom#741
+                              1. Else Phantom#742
 
-                        1. Else Phantom#742
+                        1. Else Phantom#743
 
-                    1. Else Phantom#743
+                    1. Else Phantom#744
 
                 2. Case (% has type headerTypeIR)
 
@@ -15645,15 +15651,15 @@ relation Cast_expl_neq: typeIR -> typeIR'
 
                                     1. The relation holds
 
-                                  1. Else Phantom#744
+                                  1. Else Phantom#745
 
-                              1. Else Phantom#745
+                              1. Else Phantom#746
 
-                        1. Else Phantom#746
+                        1. Else Phantom#747
 
-                    1. Else Phantom#747
+                    1. Else Phantom#748
 
-              1. Else Phantom#748
+              1. Else Phantom#749
 
         2. Case (% matches pattern `RECORD{%,...}`)
 
@@ -15695,17 +15701,17 @@ relation Cast_expl_neq: typeIR -> typeIR'
 
                                               1. The relation holds
 
-                                            1. Else Phantom#749
+                                            1. Else Phantom#750
 
-                                        1. Else Phantom#750
+                                        1. Else Phantom#751
 
-                                  1. Else Phantom#751
+                                  1. Else Phantom#752
 
-                              1. Else Phantom#752
+                              1. Else Phantom#753
 
-                        1. Else Phantom#753
+                        1. Else Phantom#754
 
-                    1. Else Phantom#754
+                    1. Else Phantom#755
 
                 2. Case (% has type headerTypeIR)
 
@@ -15739,21 +15745,21 @@ relation Cast_expl_neq: typeIR -> typeIR'
 
                                               1. The relation holds
 
-                                            1. Else Phantom#755
+                                            1. Else Phantom#756
 
-                                        1. Else Phantom#756
+                                        1. Else Phantom#757
 
-                                  1. Else Phantom#757
+                                  1. Else Phantom#758
 
-                              1. Else Phantom#758
+                              1. Else Phantom#759
 
-                        1. Else Phantom#759
+                        1. Else Phantom#760
 
-                    1. Else Phantom#760
+                    1. Else Phantom#761
 
-              1. Else Phantom#761
+              1. Else Phantom#762
 
-4. Else Phantom#762
+4. Else Phantom#763
 
 relation Cast_impl: typeIR_a -> typeIR_b
 
@@ -15773,7 +15779,7 @@ relation Cast_impl: typeIR_a -> typeIR_b
 
           1. The relation holds
 
-        1. Else Phantom#763
+        1. Else Phantom#764
 
 relation Cast_impl_neq: typeIR -> typeIR'
 
@@ -15795,7 +15801,7 @@ relation Cast_impl_neq: typeIR -> typeIR'
 
             1. The relation holds
 
-        1. Else Phantom#764
+        1. Else Phantom#765
 
   2. Case (% has type serializableEnumTypeIR)
 
@@ -15807,7 +15813,7 @@ relation Cast_impl_neq: typeIR -> typeIR'
 
           1. The relation holds
 
-        1. Else Phantom#765
+        1. Else Phantom#766
 
   3. Case (% has type defaultTypeIR)
 
@@ -15819,7 +15825,7 @@ relation Cast_impl_neq: typeIR -> typeIR'
 
           1. The relation holds
 
-        1. Else Phantom#766
+        1. Else Phantom#767
 
   4. Case (% has type invalidHeaderTypeIR)
 
@@ -15837,7 +15843,7 @@ relation Cast_impl_neq: typeIR -> typeIR'
 
             1. The relation holds
 
-        1. Else Phantom#767
+        1. Else Phantom#768
 
   5. Case (% has type sequenceTypeIR)
 
@@ -15861,7 +15867,7 @@ relation Cast_impl_neq: typeIR -> typeIR'
 
                       1. The relation holds
 
-                    1. Else Phantom#768
+                    1. Else Phantom#769
 
                 2. Case (% has type tupleTypeIR)
 
@@ -15871,7 +15877,7 @@ relation Cast_impl_neq: typeIR -> typeIR'
 
                       1. The relation holds
 
-                    1. Else Phantom#769
+                    1. Else Phantom#770
 
                 3. Case (% has type headerStackTypeIR)
 
@@ -15883,9 +15889,9 @@ relation Cast_impl_neq: typeIR -> typeIR'
 
                         1. The relation holds
 
-                      1. Else Phantom#770
+                      1. Else Phantom#771
 
-                    1. Else Phantom#771
+                    1. Else Phantom#772
 
                 4. Case (% has type structTypeIR)
 
@@ -15895,7 +15901,7 @@ relation Cast_impl_neq: typeIR -> typeIR'
 
                       1. The relation holds
 
-                    1. Else Phantom#772
+                    1. Else Phantom#773
 
                 5. Case (% has type headerTypeIR)
 
@@ -15905,7 +15911,7 @@ relation Cast_impl_neq: typeIR -> typeIR'
 
                       1. The relation holds
 
-                    1. Else Phantom#773
+                    1. Else Phantom#774
 
                 6. Case (% has type sequenceTypeIR)
 
@@ -15919,11 +15925,11 @@ relation Cast_impl_neq: typeIR -> typeIR'
 
                           1. The relation holds
 
-                        1. Else Phantom#774
+                        1. Else Phantom#775
 
-                    1. Else Phantom#775
+                    1. Else Phantom#776
 
-              1. Else Phantom#776
+              1. Else Phantom#777
 
         2. Case (% matches pattern `SEQ<%,...>`)
 
@@ -15947,11 +15953,11 @@ relation Cast_impl_neq: typeIR -> typeIR'
 
                             1. The relation holds
 
-                          1. Else Phantom#777
+                          1. Else Phantom#778
 
-                        1. Else Phantom#778
+                        1. Else Phantom#779
 
-                    1. Else Phantom#779
+                    1. Else Phantom#780
 
                 2. Case (% has type headerStackTypeIR)
 
@@ -15965,11 +15971,11 @@ relation Cast_impl_neq: typeIR -> typeIR'
 
                           1. The relation holds
 
-                        1. Else Phantom#780
+                        1. Else Phantom#781
 
-                      1. Else Phantom#781
+                      1. Else Phantom#782
 
-                    1. Else Phantom#782
+                    1. Else Phantom#783
 
                 3. Case (% has type structTypeIR)
 
@@ -15985,11 +15991,11 @@ relation Cast_impl_neq: typeIR -> typeIR'
 
                             1. The relation holds
 
-                          1. Else Phantom#783
+                          1. Else Phantom#784
 
-                        1. Else Phantom#784
+                        1. Else Phantom#785
 
-                    1. Else Phantom#785
+                    1. Else Phantom#786
 
                 4. Case (% has type headerTypeIR)
 
@@ -16005,13 +16011,13 @@ relation Cast_impl_neq: typeIR -> typeIR'
 
                             1. The relation holds
 
-                          1. Else Phantom#786
+                          1. Else Phantom#787
 
-                        1. Else Phantom#787
+                        1. Else Phantom#788
 
-                    1. Else Phantom#788
+                    1. Else Phantom#789
 
-              1. Else Phantom#789
+              1. Else Phantom#790
 
   6. Case (% has type recordTypeIR)
 
@@ -16049,13 +16055,13 @@ relation Cast_impl_neq: typeIR -> typeIR'
 
                                     1. The relation holds
 
-                                  1. Else Phantom#790
+                                  1. Else Phantom#791
 
-                              1. Else Phantom#791
+                              1. Else Phantom#792
 
-                        1. Else Phantom#792
+                        1. Else Phantom#793
 
-                    1. Else Phantom#793
+                    1. Else Phantom#794
 
                 2. Case (% has type headerTypeIR)
 
@@ -16079,15 +16085,15 @@ relation Cast_impl_neq: typeIR -> typeIR'
 
                                     1. The relation holds
 
-                                  1. Else Phantom#794
+                                  1. Else Phantom#795
 
-                              1. Else Phantom#795
+                              1. Else Phantom#796
 
-                        1. Else Phantom#796
+                        1. Else Phantom#797
 
-                    1. Else Phantom#797
+                    1. Else Phantom#798
 
-              1. Else Phantom#798
+              1. Else Phantom#799
 
         2. Case (% matches pattern `RECORD{%,...}`)
 
@@ -16129,17 +16135,17 @@ relation Cast_impl_neq: typeIR -> typeIR'
 
                                               1. The relation holds
 
-                                            1. Else Phantom#799
+                                            1. Else Phantom#800
 
-                                        1. Else Phantom#800
+                                        1. Else Phantom#801
 
-                                  1. Else Phantom#801
+                                  1. Else Phantom#802
 
-                              1. Else Phantom#802
+                              1. Else Phantom#803
 
-                        1. Else Phantom#803
+                        1. Else Phantom#804
 
-                    1. Else Phantom#804
+                    1. Else Phantom#805
 
                 2. Case (% has type headerTypeIR)
 
@@ -16173,21 +16179,21 @@ relation Cast_impl_neq: typeIR -> typeIR'
 
                                               1. The relation holds
 
-                                            1. Else Phantom#805
+                                            1. Else Phantom#806
 
-                                        1. Else Phantom#806
+                                        1. Else Phantom#807
 
-                                  1. Else Phantom#807
+                                  1. Else Phantom#808
 
-                              1. Else Phantom#808
+                              1. Else Phantom#809
 
-                        1. Else Phantom#809
+                        1. Else Phantom#810
 
-                    1. Else Phantom#810
+                    1. Else Phantom#811
 
-              1. Else Phantom#811
+              1. Else Phantom#812
 
-1. Else Phantom#812
+1. Else Phantom#813
 
 relation Expr_ok: p TC |- expression : %
 
@@ -16241,7 +16247,7 @@ relation Expr_ok: p TC |- expression : %
 
           1. Result in: % % |- % : ((stringLiteral as expressionIR) # expressionNoteIR)
 
-  1. Else Phantom#813
+  1. Else Phantom#814
 
 2. Group referenceExpression: p TC |- expression : %
 
@@ -16261,9 +16267,9 @@ relation Expr_ok: p TC |- expression : %
 
                 1. Result in: % % |- % : ((prefixedNameIR as expressionIR) # expressionNoteIR)
 
-          1. Else Phantom#814
+          1. Else Phantom#815
 
-  1. Else Phantom#815
+  1. Else Phantom#816
 
   2. If ((expression = ((this) as expression))), then
 
@@ -16279,9 +16285,9 @@ relation Expr_ok: p TC |- expression : %
 
               1. Result in: % % |- % : ((prefixedNameIR as expressionIR) # expressionNoteIR)
 
-        1. Else Phantom#816
+        1. Else Phantom#817
 
-  2. Else Phantom#817
+  2. Else Phantom#818
 
 3. Case analysis on expression
 
@@ -16321,7 +16327,7 @@ relation Expr_ok: p TC |- expression : %
 
                           1. Result in: % % |- % : ((((!) typedExpressionIR_reduced) as expressionIR) # expressionNoteIR)
 
-                1. Else Phantom#818
+                1. Else Phantom#819
 
         2. Case (% matches pattern `~`)
 
@@ -16343,9 +16349,9 @@ relation Expr_ok: p TC |- expression : %
 
                           1. Result in: % % |- % : ((((~) typedExpressionIR_reduced) as expressionIR) # expressionNoteIR)
 
-                1. Else Phantom#819
+                1. Else Phantom#820
 
-      1. Else Phantom#820
+      1. Else Phantom#821
 
       2. Group unaryExpression-uplusminus: p TC |- ((unop expression') as expression) : %
 
@@ -16367,9 +16373,9 @@ relation Expr_ok: p TC |- expression : %
 
                         1. Result in: % % |- % : (((unop typedExpressionIR_reduced) as expressionIR) # expressionNoteIR)
 
-              1. Else Phantom#821
+              1. Else Phantom#822
 
-        1. Else Phantom#822
+        1. Else Phantom#823
 
   3. Case (% has type binaryExpression)
 
@@ -16407,11 +16413,11 @@ relation Expr_ok: p TC |- expression : %
 
                                     1. Result in: % % |- % : (((typedExpressionIR_l_reduced binop typedExpressionIR_r_reduced) as expressionIR) # expressionNoteIR)
 
-                      1. Else Phantom#823
+                      1. Else Phantom#824
 
-                1. Else Phantom#824
+                1. Else Phantom#825
 
-        1. Else Phantom#825
+        1. Else Phantom#826
 
       2. Group binaryExpression-satplusminus: p TC |- ((expression_l binop expression_r) as expression) : %
 
@@ -16445,11 +16451,11 @@ relation Expr_ok: p TC |- expression : %
 
                                     1. Result in: % % |- % : (((typedExpressionIR_l_reduced binop typedExpressionIR_r_reduced) as expressionIR) # expressionNoteIR)
 
-                      1. Else Phantom#826
+                      1. Else Phantom#827
 
-                1. Else Phantom#827
+                1. Else Phantom#828
 
-        1. Else Phantom#828
+        1. Else Phantom#829
 
       3. Group binaryExpression-divmod: p TC |- ((expression_l binop expression_r) as expression) : %
 
@@ -16501,11 +16507,11 @@ relation Expr_ok: p TC |- expression : %
 
                                                       1. Result in: % % |- % : (((typedExpressionIR_l_reduced binop typedExpressionIR_r_reduced) as expressionIR) # expressionNoteIR)
 
-                                                1. Else Phantom#829
+                                                1. Else Phantom#830
 
-                                            1. Else Phantom#830
+                                            1. Else Phantom#831
 
-                                      1. Else Phantom#831
+                                      1. Else Phantom#832
 
                                   2. Case false
 
@@ -16515,11 +16521,11 @@ relation Expr_ok: p TC |- expression : %
 
                                         1. Result in: % % |- % : (((typedExpressionIR_l_reduced binop typedExpressionIR_r_reduced) as expressionIR) # expressionNoteIR)
 
-                      1. Else Phantom#832
+                      1. Else Phantom#833
 
-                1. Else Phantom#833
+                1. Else Phantom#834
 
-        1. Else Phantom#834
+        1. Else Phantom#835
 
       4. Group binaryExpression-shift: p TC |- ((expression_l binop expression_r) as expression) : %
 
@@ -16555,7 +16561,7 @@ relation Expr_ok: p TC |- expression : %
 
                                       1. Result in: % % |- % : (((typedExpressionIR_l_reduced binop typedExpressionIR_r_reduced) as expressionIR) # expressionNoteIR)
 
-                                1. Else Phantom#835
+                                1. Else Phantom#836
 
                               2. Case false
 
@@ -16577,15 +16583,15 @@ relation Expr_ok: p TC |- expression : %
 
                                                 1. Result in: % % |- % : (((typedExpressionIR_l_reduced binop typedExpressionIR_r_reduced) as expressionIR) # expressionNoteIR)
 
-                                          1. Else Phantom#836
+                                          1. Else Phantom#837
 
-                                    1. Else Phantom#837
+                                    1. Else Phantom#838
 
-                                1. Else Phantom#838
+                                1. Else Phantom#839
 
-                1. Else Phantom#839
+                1. Else Phantom#840
 
-        1. Else Phantom#840
+        1. Else Phantom#841
 
       5. Group binaryExpression-equality: p TC |- ((expression_l binop expression_r) as expression) : %
 
@@ -16615,11 +16621,11 @@ relation Expr_ok: p TC |- expression : %
 
                                 1. Result in: % % |- % : (((typedExpressionIR_l_cast binop typedExpressionIR_r_cast) as expressionIR) # expressionNoteIR)
 
-                          1. Else Phantom#841
+                          1. Else Phantom#842
 
-                1. Else Phantom#842
+                1. Else Phantom#843
 
-        1. Else Phantom#843
+        1. Else Phantom#844
 
       6. Group binaryExpression-comparison: p TC |- ((expression_l binop expression_r) as expression) : %
 
@@ -16653,11 +16659,11 @@ relation Expr_ok: p TC |- expression : %
 
                                     1. Result in: % % |- % : (((typedExpressionIR_l_reduced binop typedExpressionIR_r_reduced) as expressionIR) # expressionNoteIR)
 
-                      1. Else Phantom#844
+                      1. Else Phantom#845
 
-                1. Else Phantom#845
+                1. Else Phantom#846
 
-        1. Else Phantom#846
+        1. Else Phantom#847
 
       7. Group binaryExpression-bitwise: p TC |- ((expression_l binop expression_r) as expression) : %
 
@@ -16691,11 +16697,11 @@ relation Expr_ok: p TC |- expression : %
 
                                     1. Result in: % % |- % : (((typedExpressionIR_l_reduced binop typedExpressionIR_r_reduced) as expressionIR) # expressionNoteIR)
 
-                      1. Else Phantom#847
+                      1. Else Phantom#848
 
-                1. Else Phantom#848
+                1. Else Phantom#849
 
-        1. Else Phantom#849
+        1. Else Phantom#850
 
       8. If ((binop matches pattern `++`)), then
 
@@ -16727,9 +16733,9 @@ relation Expr_ok: p TC |- expression : %
 
                                   1. Result in: % % |- % : (((typedExpressionIR_l_reduced (++) typedExpressionIR_r_reduced) as expressionIR) # expressionNoteIR)
 
-                1. Else Phantom#850
+                1. Else Phantom#851
 
-      8. Else Phantom#851
+      8. Else Phantom#852
 
       9. Group binaryExpression-logical: p TC |- ((expression_l binop expression_r) as expression) : %
 
@@ -16763,11 +16769,11 @@ relation Expr_ok: p TC |- expression : %
 
                                     1. Result in: % % |- % : (((typedExpressionIR_l_reduced binop typedExpressionIR_r_reduced) as expressionIR) # expressionNoteIR)
 
-                      1. Else Phantom#852
+                      1. Else Phantom#853
 
-                1. Else Phantom#853
+                1. Else Phantom#854
 
-        1. Else Phantom#854
+        1. Else Phantom#855
 
   4. Case (% has type ternaryExpression)
 
@@ -16807,11 +16813,11 @@ relation Expr_ok: p TC |- expression : %
 
                                       1. Result in: % % |- % : (((typedExpressionIR_cond ? typedExpressionIR_true_cast : typedExpressionIR_false_cast) as expressionIR) # expressionNoteIR)
 
-                                1. Else Phantom#855
+                                1. Else Phantom#856
 
-                      1. Else Phantom#856
+                      1. Else Phantom#857
 
-              1. Else Phantom#857
+              1. Else Phantom#858
 
   5. Case (% has type castExpression)
 
@@ -16837,11 +16843,11 @@ relation Expr_ok: p TC |- expression : %
 
                         1. Result in: % % |- % : (((( typeIR_t ) typedExpressionIR) as expressionIR) # expressionNoteIR)
 
-                    1. Else Phantom#858
+                    1. Else Phantom#859
 
-            1. Else Phantom#859
+            1. Else Phantom#860
 
-          1. Else Phantom#860
+          1. Else Phantom#861
 
   6. Case (% has type invalidHeaderExpression)
 
@@ -16915,11 +16921,11 @@ relation Expr_ok: p TC |- expression : %
 
                                               1. Result in: % % |- % : (((seq{ (typedExpressionIR_e_h)* ,...}) as expressionIR) # expressionNoteIR)
 
-                                1. Else Phantom#861
+                                1. Else Phantom#862
 
-                          1. Else Phantom#862
+                          1. Else Phantom#863
 
-                      1. Else Phantom#863
+                      1. Else Phantom#864
 
         2. Case (% has type recordElementExpression)
 
@@ -17033,7 +17039,7 @@ relation Expr_ok: p TC |- expression : %
 
                 1. Result in: % % |- % : (((error. nameIR) as expressionIR) # expressionNoteIR)
 
-            1. Else Phantom#864
+            1. Else Phantom#865
 
   9. Case (% has type memberAccessExpression)
 
@@ -17075,7 +17081,7 @@ relation Expr_ok: p TC |- expression : %
 
                                         1. Result in: % % |- % : ((((type prefixedNameIR_base) . nameIR) as expressionIR) # expressionNoteIR)
 
-                                    1. Else Phantom#865
+                                    1. Else Phantom#866
 
                               2. Case (% has type serializableEnumTypeIR)
 
@@ -17089,13 +17095,13 @@ relation Expr_ok: p TC |- expression : %
 
                                         1. Result in: % % |- % : ((((type prefixedNameIR_base) . nameIR) as expressionIR) # expressionNoteIR)
 
-                                    1. Else Phantom#866
+                                    1. Else Phantom#867
 
-                            1. Else Phantom#867
+                            1. Else Phantom#868
 
-                      1. Else Phantom#868
+                      1. Else Phantom#869
 
-                  1. Else Phantom#869
+                  1. Else Phantom#870
 
         2. Case (% has type expression)
 
@@ -17119,7 +17125,7 @@ relation Expr_ok: p TC |- expression : %
 
                             1. Result in: % % |- % : ((((typedExpressionIR_base as memberAccessBaseIR) . "size") as expressionIR) # expressionNoteIR)
 
-                        1. Else Phantom#870
+                        1. Else Phantom#871
 
                         2. If (("lastIndex" = $name(member))), then
 
@@ -17129,9 +17135,9 @@ relation Expr_ok: p TC |- expression : %
 
                               1. Result in: % % |- % : ((((typedExpressionIR_base as memberAccessBaseIR) . "lastIndex") as expressionIR) # expressionNoteIR)
 
-                          1. Else Phantom#871
+                          1. Else Phantom#872
 
-                        2. Else Phantom#872
+                        2. Else Phantom#873
 
                         3. If (("last" = $name(member))), then
 
@@ -17141,9 +17147,9 @@ relation Expr_ok: p TC |- expression : %
 
                               1. Result in: % % |- % : ((((typedExpressionIR_base as memberAccessBaseIR) . "last") as expressionIR) # expressionNoteIR)
 
-                          1. Else Phantom#873
+                          1. Else Phantom#874
 
-                        3. Else Phantom#874
+                        3. Else Phantom#875
 
                         4. If (("next" = $name(member))), then
 
@@ -17153,11 +17159,11 @@ relation Expr_ok: p TC |- expression : %
 
                               1. Result in: % % |- % : ((((typedExpressionIR_base as memberAccessBaseIR) . "next") as expressionIR) # expressionNoteIR)
 
-                          1. Else Phantom#875
+                          1. Else Phantom#876
 
-                        4. Else Phantom#876
+                        4. Else Phantom#877
 
-                    1. Else Phantom#877
+                    1. Else Phantom#878
 
                   2. (Let ctk_base be $ctk_of_typedExpressionIR(typedExpressionIR_base))
 
@@ -17181,7 +17187,7 @@ relation Expr_ok: p TC |- expression : %
 
                                       1. Result in: % % |- % : ((((typedExpressionIR_base as memberAccessBaseIR) . nameIR) as expressionIR) # expressionNoteIR)
 
-                                1. Else Phantom#878
+                                1. Else Phantom#879
 
                         2. Case (% has type headerTypeIR)
 
@@ -17199,7 +17205,7 @@ relation Expr_ok: p TC |- expression : %
 
                                       1. Result in: % % |- % : ((((typedExpressionIR_base as memberAccessBaseIR) . nameIR) as expressionIR) # expressionNoteIR)
 
-                                1. Else Phantom#879
+                                1. Else Phantom#880
 
                         3. Case (% has type headerUnionTypeIR)
 
@@ -17217,9 +17223,9 @@ relation Expr_ok: p TC |- expression : %
 
                                       1. Result in: % % |- % : ((((typedExpressionIR_base as memberAccessBaseIR) . nameIR) as expressionIR) # expressionNoteIR)
 
-                                1. Else Phantom#880
+                                1. Else Phantom#881
 
-                      1. Else Phantom#881
+                      1. Else Phantom#882
 
                   3. (Let typeIR be $unroll_typeIR(typeIR_base))
 
@@ -17249,9 +17255,9 @@ relation Expr_ok: p TC |- expression : %
 
                                 1. Result in: % % |- % : ((((typedExpressionIR_base as memberAccessBaseIR) . nameIR) as expressionIR) # expressionNoteIR)
 
-                          1. Else Phantom#882
+                          1. Else Phantom#883
 
-                    1. Else Phantom#883
+                    1. Else Phantom#884
 
   10. Case (% has type indexAccessExpression)
 
@@ -17305,13 +17311,13 @@ relation Expr_ok: p TC |- expression : %
 
                                                     1. Result in: % % |- % : (((typedExpressionIR_base [ typedExpressionIR_index_reduced ]) as expressionIR) # expressionNoteIR)
 
-                                                1. Else Phantom#884
+                                                1. Else Phantom#885
 
-                                            1. Else Phantom#885
+                                            1. Else Phantom#886
 
-                                      1. Else Phantom#886
+                                      1. Else Phantom#887
 
-                                  1. Else Phantom#887
+                                  1. Else Phantom#888
 
                               2. Case (% has type headerStackTypeIR)
 
@@ -17339,11 +17345,11 @@ relation Expr_ok: p TC |- expression : %
 
                                                       1. Result in: % % |- % : (((typedExpressionIR_base [ typedExpressionIR_index_reduced ]) as expressionIR) # expressionNoteIR)
 
-                                                  1. Else Phantom#888
+                                                  1. Else Phantom#889
 
-                                              1. Else Phantom#889
+                                              1. Else Phantom#890
 
-                                        1. Else Phantom#890
+                                        1. Else Phantom#891
 
                                     2. Case false
 
@@ -17353,9 +17359,9 @@ relation Expr_ok: p TC |- expression : %
 
                                           1. Result in: % % |- % : (((typedExpressionIR_base [ typedExpressionIR_index_reduced ]) as expressionIR) # expressionNoteIR)
 
-                            1. Else Phantom#891
+                            1. Else Phantom#892
 
-                      1. Else Phantom#892
+                      1. Else Phantom#893
 
   11. Case (% has type sliceAccessExpression)
 
@@ -17441,27 +17447,27 @@ relation Expr_ok: p TC |- expression : %
 
                                                                                     1. Result in: % % |- % : (((typedExpressionIR_base [ typedExpressionIR_hi_reduced : typedExpressionIR_lo_reduced ]) as expressionIR) # expressionNoteIR)
 
-                                                                            1. Else Phantom#893
+                                                                            1. Else Phantom#894
 
-                                                                        1. Else Phantom#894
+                                                                        1. Else Phantom#895
 
-                                                                    1. Else Phantom#895
+                                                                    1. Else Phantom#896
 
-                                                              1. Else Phantom#896
+                                                              1. Else Phantom#897
 
-                                                          1. Else Phantom#897
+                                                          1. Else Phantom#898
 
-                                                      1. Else Phantom#898
+                                                      1. Else Phantom#899
 
-                                                1. Else Phantom#899
+                                                1. Else Phantom#900
 
-                                            1. Else Phantom#900
+                                            1. Else Phantom#901
 
-                                1. Else Phantom#901
+                                1. Else Phantom#902
 
-                          1. Else Phantom#902
+                          1. Else Phantom#903
 
-                1. Else Phantom#903
+                1. Else Phantom#904
 
   12. Case (% has type callExpression)
 
@@ -17507,7 +17513,7 @@ relation Expr_ok: p TC |- expression : %
 
                                             1. Result in: % % |- % : ((literalExpressionIR as expressionIR) # expressionNoteIR)
 
-                                        1. Else Phantom#904
+                                        1. Else Phantom#905
 
                                 2. Case false
 
@@ -17517,9 +17523,9 @@ relation Expr_ok: p TC |- expression : %
 
                                       1. Result in: % % |- % : ((callExpressionIR as expressionIR) # expressionNoteIR)
 
-                          1. Else Phantom#905
+                          1. Else Phantom#906
 
-              1. Else Phantom#906
+              1. Else Phantom#907
 
           2. Case (% matches pattern `%<%>(%)`)
 
@@ -17549,7 +17555,7 @@ relation Expr_ok: p TC |- expression : %
 
                                     1. Result in: % % |- % : ((callExpressionIR as expressionIR) # expressionNoteIR)
 
-                            1. Else Phantom#907
+                            1. Else Phantom#908
 
       2. If ((callExpression matches pattern `%(%)`)), then
 
@@ -17581,7 +17587,7 @@ relation Expr_ok: p TC |- expression : %
 
                                   1. Result in: % % |- % : ((callExpressionIR as expressionIR) # expressionNoteIR)
 
-                            1. Else Phantom#908
+                            1. Else Phantom#909
 
               2. Case (% has type specializedType)
 
@@ -17609,11 +17615,11 @@ relation Expr_ok: p TC |- expression : %
 
                                       1. Result in: % % |- % : ((callExpressionIR as expressionIR) # expressionNoteIR)
 
-                                1. Else Phantom#909
+                                1. Else Phantom#910
 
-            1. Else Phantom#910
+            1. Else Phantom#911
 
-      2. Else Phantom#911
+      2. Else Phantom#912
 
   13. Case (% has type parenthesizedExpression)
 
@@ -17631,7 +17637,7 @@ relation Expr_ok: p TC |- expression : %
 
                 1. Result in: % % |- % : (((( typedExpressionIR )) as expressionIR) # expressionNoteIR)
 
-3. Else Phantom#912
+3. Else Phantom#913
 
 relation Argument_ok: p TC |- argument : %
 
@@ -17711,13 +17717,13 @@ relation Lvalue_ok: p TC |- lvalue : %
 
                       1. Result in: % % |- % : ((prefixedNameIR as lvalueIR) # (( typeIR )))
 
-                    1. Else Phantom#913
+                    1. Else Phantom#914
 
-                  1. Else Phantom#914
+                  1. Else Phantom#915
 
-                1. Else Phantom#915
+                1. Else Phantom#916
 
-            1. Else Phantom#916
+            1. Else Phantom#917
 
   2. Case (% matches pattern `%.%`)
 
@@ -17747,9 +17753,9 @@ relation Lvalue_ok: p TC |- lvalue : %
 
                             1. Result in: % % |- % : typedLvalueIR
 
-                        1. Else Phantom#917
+                        1. Else Phantom#918
 
-                      1. Else Phantom#918
+                      1. Else Phantom#919
 
                 2. Case (% has type structTypeIR)
 
@@ -17767,7 +17773,7 @@ relation Lvalue_ok: p TC |- lvalue : %
 
                               1. Result in: % % |- % : typedLvalueIR
 
-                        1. Else Phantom#919
+                        1. Else Phantom#920
 
                 3. Case (% has type headerTypeIR)
 
@@ -17785,7 +17791,7 @@ relation Lvalue_ok: p TC |- lvalue : %
 
                               1. Result in: % % |- % : typedLvalueIR
 
-                        1. Else Phantom#920
+                        1. Else Phantom#921
 
                 4. Case (% has type headerUnionTypeIR)
 
@@ -17803,9 +17809,9 @@ relation Lvalue_ok: p TC |- lvalue : %
 
                               1. Result in: % % |- % : typedLvalueIR
 
-                        1. Else Phantom#921
+                        1. Else Phantom#922
 
-              1. Else Phantom#922
+              1. Else Phantom#923
 
   3. Case (% matches pattern `%[%]`)
 
@@ -17855,11 +17861,11 @@ relation Lvalue_ok: p TC |- lvalue : %
 
                                                 1. Result in: % % |- % : typedLvalueIR
 
-                                            1. Else Phantom#923
+                                            1. Else Phantom#924
 
-                                        1. Else Phantom#924
+                                        1. Else Phantom#925
 
-                                  1. Else Phantom#925
+                                  1. Else Phantom#926
 
                               2. Case false
 
@@ -17867,9 +17873,9 @@ relation Lvalue_ok: p TC |- lvalue : %
 
                                   1. Result in: % % |- % : typedLvalueIR
 
-                        1. Else Phantom#926
+                        1. Else Phantom#927
 
-              1. Else Phantom#927
+              1. Else Phantom#928
 
   4. Case (% matches pattern `%[%:%]`)
 
@@ -17945,27 +17951,27 @@ relation Lvalue_ok: p TC |- lvalue : %
 
                                                                           1. Result in: % % |- % : typedLvalueIR
 
-                                                                  1. Else Phantom#928
+                                                                  1. Else Phantom#929
 
-                                                              1. Else Phantom#929
+                                                              1. Else Phantom#930
 
-                                                          1. Else Phantom#930
+                                                          1. Else Phantom#931
 
-                                                    1. Else Phantom#931
+                                                    1. Else Phantom#932
 
-                                                1. Else Phantom#932
+                                                1. Else Phantom#933
 
-                                            1. Else Phantom#933
+                                            1. Else Phantom#934
 
-                                      1. Else Phantom#934
+                                      1. Else Phantom#935
 
-                                  1. Else Phantom#935
+                                  1. Else Phantom#936
 
-                          1. Else Phantom#936
+                          1. Else Phantom#937
 
-                    1. Else Phantom#937
+                    1. Else Phantom#938
 
-            1. Else Phantom#938
+            1. Else Phantom#939
 
   5. Case (% matches pattern `(%)`)
 
@@ -17981,7 +17987,7 @@ relation Lvalue_ok: p TC |- lvalue : %
 
               1. Result in: % % |- % : typedLvalueIR
 
-1. Else Phantom#939
+1. Else Phantom#940
 
 syntax loopctxt = 
    | loop
@@ -18021,7 +18027,7 @@ relation Stmt_ok: p TC f l |- statement : % % %
 
                       1. Result in: % % % % |- % : TC f ((typedLvalueIR (=) typedExpressionIR_cast ;) as statementIR)
 
-                  1. Else Phantom#940
+                  1. Else Phantom#941
 
   3. Case (% has type callStatement)
 
@@ -18059,7 +18065,7 @@ relation Stmt_ok: p TC f l |- statement : % % %
 
                                     1. Result in: % % % % |- % : TC f (emptyStatementIR as statementIR)
 
-                                1. Else Phantom#941
+                                1. Else Phantom#942
 
                         2. Case false
 
@@ -18141,25 +18147,25 @@ relation Stmt_ok: p TC f l |- statement : % % %
 
                                                       1. Result in: % % % % |- % : TC f (directApplicationStatementIR as statementIR)
 
-                                                  1. Else Phantom#942
+                                                  1. Else Phantom#943
 
-                                                1. Else Phantom#943
+                                                1. Else Phantom#944
 
-                                              1. Else Phantom#944
+                                              1. Else Phantom#945
 
-                                            1. Else Phantom#945
+                                            1. Else Phantom#946
 
-                                        1. Else Phantom#946
+                                        1. Else Phantom#947
 
-                                  1. Else Phantom#947
+                                  1. Else Phantom#948
 
-                        1. Else Phantom#948
+                        1. Else Phantom#949
 
-                  1. Else Phantom#949
+                  1. Else Phantom#950
 
-              1. Else Phantom#950
+              1. Else Phantom#951
 
-          1. Else Phantom#951
+          1. Else Phantom#952
 
   5. Case (% has type exitStatement)
 
@@ -18191,7 +18197,7 @@ relation Stmt_ok: p TC f l |- statement : % % %
 
                       1. Result in: % % % % |- % : TC f ((if( typedExpressionIR_cond ) statementIR_then) as statementIR)
 
-                  1. Else Phantom#952
+                  1. Else Phantom#953
 
           2. Case (% matches pattern `IF(%)%ELSE%`)
 
@@ -18211,9 +18217,9 @@ relation Stmt_ok: p TC f l |- statement : % % %
 
                           1. Result in: % % % % |- % : TC f_post ((if( typedExpressionIR_cond ) statementIR_then else statementIR_else) as statementIR)
 
-                  1. Else Phantom#953
+                  1. Else Phantom#954
 
-1. Else Phantom#954
+1. Else Phantom#955
 
 2. If ((p matches pattern `LOCAL`)), then
 
@@ -18233,7 +18239,7 @@ relation Stmt_ok: p TC f l |- statement : % % %
 
                 1. Result in: % % % % |- % : TC (ret) ((return;) as statementIR)
 
-              1. Else Phantom#955
+              1. Else Phantom#956
 
             2. Case (% matches pattern `RETURN%;`)
 
@@ -18257,9 +18263,9 @@ relation Stmt_ok: p TC f l |- statement : % % %
 
                                 1. Result in: % % % % |- % : TC (ret) ((return typedExpressionIR_cast ;) as statementIR)
 
-                            1. Else Phantom#956
+                            1. Else Phantom#957
 
-                      1. Else Phantom#957
+                      1. Else Phantom#958
 
     2. Case (% has type blockStatement)
 
@@ -18305,9 +18311,9 @@ relation Stmt_ok: p TC f l |- statement : % % %
 
                                 1. Result in: % % % % |- % : TC f_post (forStatementIR as statementIR)
 
-                      1. Else Phantom#958
+                      1. Else Phantom#959
 
-        1. Else Phantom#959
+        1. Else Phantom#960
 
         2. Group forStatement-in: (local) TC f l |- (forStatement as statement) : % % %
 
@@ -18341,11 +18347,11 @@ relation Stmt_ok: p TC f l |- statement : % % %
 
                                       1. Result in: % % % % |- % : TC f_post (forStatementIR as statementIR)
 
-                      1. Else Phantom#960
+                      1. Else Phantom#961
 
-                    1. Else Phantom#961
+                    1. Else Phantom#962
 
-                  1. Else Phantom#962
+                  1. Else Phantom#963
 
             2. Case (% matches pattern `%FOR(%%%IN%)%`)
 
@@ -18359,9 +18365,9 @@ relation Stmt_ok: p TC f l |- statement : % % %
 
                       1. Result in: % % % % |- % : TC f_post (forStatementIR as statementIR)
 
-                  1. Else Phantom#963
+                  1. Else Phantom#964
 
-          1. Else Phantom#964
+          1. Else Phantom#965
 
     4. Case (% has type switchStatement)
 
@@ -18393,13 +18399,13 @@ relation Stmt_ok: p TC f l |- statement : % % %
 
                                 1. Result in: % % % % |- % : TC f_post (switchStatementIR as statementIR)
 
-                            1. Else Phantom#965
+                            1. Else Phantom#966
 
-                          1. Else Phantom#966
+                          1. Else Phantom#967
 
-                  1. Else Phantom#967
+                  1. Else Phantom#968
 
-          1. Else Phantom#968
+          1. Else Phantom#969
 
         2. Group switchStatement-general: (local) TC f l |- ((switch( expression_switch ){ switchCaseList }) as statement) : % % %
 
@@ -18421,15 +18427,15 @@ relation Stmt_ok: p TC f l |- statement : % % %
 
                           1. Result in: % % % % |- % : TC f_post (switchStatementIR as statementIR)
 
-                      1. Else Phantom#969
+                      1. Else Phantom#970
 
-                    1. Else Phantom#970
+                    1. Else Phantom#971
 
-                1. Else Phantom#971
+                1. Else Phantom#972
 
-          1. Else Phantom#972
+          1. Else Phantom#973
 
-  1. Else Phantom#973
+  1. Else Phantom#974
 
   2. If ((l matches pattern `LOOP`)), then
 
@@ -18451,11 +18457,11 @@ relation Stmt_ok: p TC f l |- statement : % % %
 
             1. Result in: % % % % |- % : TC f (continueStatement as statementIR)
 
-    1. Else Phantom#974
+    1. Else Phantom#975
 
-  2. Else Phantom#975
+  2. Else Phantom#976
 
-2. Else Phantom#976
+2. Else Phantom#977
 
 relation BlockElementStmt_ok: TC_0 f l |- blockElementStatement : % % %
 
@@ -18529,7 +18535,7 @@ relation Parameter_ok: p TC_0 |- (annotationList direction type name initializer
 
                   1. Result in: % % |- % : TC_1 parameterIR # (typeId_fresh)*
 
-          1. Else Phantom#977
+          1. Else Phantom#978
 
     2. Case (% has type initializer)
 
@@ -18565,7 +18571,7 @@ relation Parameter_ok: p TC_0 |- (annotationList direction type name initializer
 
                                     1. Result in: % % |- % : TC_1 parameterIR # (typeId_fresh)*
 
-                        1. Else Phantom#978
+                        1. Else Phantom#979
 
                     2. Case (% matches pattern `LCTK`)
 
@@ -18587,11 +18593,11 @@ relation Parameter_ok: p TC_0 |- (annotationList direction type name initializer
 
                                       1. Result in: % % |- % : TC_1 parameterIR # (typeId_fresh)*
 
-                        1. Else Phantom#979
+                        1. Else Phantom#980
 
-                  1. Else Phantom#980
+                  1. Else Phantom#981
 
-            1. Else Phantom#981
+            1. Else Phantom#982
 
 relation ParameterList_ok: p TC_0 |- parameterList : % % # %
 
@@ -18687,11 +18693,11 @@ relation ExternMethod_ok: TC_0 typeId_extern |- externMethodPrototype : %
 
                               1. Result in: % % |- % : externMethodPrototypeIR
 
-                          1. Else Phantom#982
+                          1. Else Phantom#983
 
-                  1. Else Phantom#983
+                  1. Else Phantom#984
 
-            1. Else Phantom#984
+            1. Else Phantom#985
 
     2. Case (% matches pattern `%ABSTRACT%;`)
 
@@ -18721,11 +18727,11 @@ relation ExternMethod_ok: TC_0 typeId_extern |- externMethodPrototype : %
 
                               1. Result in: % % |- % : externMethodPrototypeIR
 
-                          1. Else Phantom#985
+                          1. Else Phantom#986
 
-                  1. Else Phantom#986
+                  1. Else Phantom#987
 
-            1. Else Phantom#987
+            1. Else Phantom#988
 
 relation ExternConstructor_ok: TC_0 typeId_extern |- (annotationList typeIdentifier ( parameterList );) : %
 
@@ -18761,15 +18767,15 @@ relation ExternConstructor_ok: TC_0 typeId_extern |- (annotationList typeIdentif
 
                               1. Result in: % % |- % : externConstructorPrototypeIR
 
-                          1. Else Phantom#988
+                          1. Else Phantom#989
 
-                    1. Else Phantom#989
+                    1. Else Phantom#990
 
-              1. Else Phantom#990
+              1. Else Phantom#991
 
-          1. Else Phantom#991
+          1. Else Phantom#992
 
-    1. Else Phantom#992
+    1. Else Phantom#993
 
 relation ParserSelect_ok: TC_0 (nameIR_state)* |- (select( expressionList_key ){ selectCaseList }) : %
 
@@ -18793,7 +18799,7 @@ relation ParserSelect_ok: TC_0 (nameIR_state)* |- (select( expressionList_key ){
 
                   1. Result in: % % |- % : selectExpressionIR
 
-          1. Else Phantom#993
+          1. Else Phantom#994
 
 relation ParserTransition_ok: TC_0 (nameIR_state)* |- transitionStatement : %
 
@@ -18823,7 +18829,7 @@ relation ParserTransition_ok: TC_0 (nameIR_state)* |- transitionStatement : %
 
                     1. Result in: % % |- % : transitionStatementIR
 
-                1. Else Phantom#994
+                1. Else Phantom#995
 
           2. Case (% has type selectExpression)
 
@@ -18875,11 +18881,11 @@ relation ParserStmt_ok: TC_0 |- parserStatement : % %
 
                   1. Result in: % |- % : TC_0 (emptyStatementIR as parserStatementIR)
 
-              1. Else Phantom#995
+              1. Else Phantom#996
 
-            1. Else Phantom#996
+            1. Else Phantom#997
 
-          1. Else Phantom#997
+          1. Else Phantom#998
 
   4. Case (% has type assignmentStatement)
 
@@ -18897,9 +18903,9 @@ relation ParserStmt_ok: TC_0 |- parserStatement : % %
 
                 1. Result in: % |- % : TC_1 (assignmentStatementIR as parserStatementIR)
 
-            1. Else Phantom#998
+            1. Else Phantom#999
 
-          1. Else Phantom#999
+          1. Else Phantom#1000
 
   5. Case (% has type callStatement)
 
@@ -18917,9 +18923,9 @@ relation ParserStmt_ok: TC_0 |- parserStatement : % %
 
                 1. Result in: % |- % : TC_1 (callStatementIR as parserStatementIR)
 
-            1. Else Phantom#1000
+            1. Else Phantom#1001
 
-          1. Else Phantom#1001
+          1. Else Phantom#1002
 
   6. Case (% has type directApplicationStatement)
 
@@ -18937,9 +18943,9 @@ relation ParserStmt_ok: TC_0 |- parserStatement : % %
 
                 1. Result in: % |- % : TC_1 (directApplicationStatementIR as parserStatementIR)
 
-            1. Else Phantom#1002
+            1. Else Phantom#1003
 
-          1. Else Phantom#1003
+          1. Else Phantom#1004
 
   7. Case (% has type parserBlockStatement)
 
@@ -18979,7 +18985,7 @@ relation ParserStmt_ok: TC_0 |- parserStatement : % %
 
                       1. Result in: % |- % : TC_0 ((if( typedExpressionIR_cond ) parserStatementIR_then) as parserStatementIR)
 
-                  1. Else Phantom#1004
+                  1. Else Phantom#1005
 
           2. Case (% matches pattern `IF(%)%ELSE%`)
 
@@ -18997,7 +19003,7 @@ relation ParserStmt_ok: TC_0 |- parserStatement : % %
 
                         1. Result in: % |- % : TC_0 ((if( typedExpressionIR_cond ) parserStatementIR_then else parserStatementIR_else) as parserStatementIR)
 
-                  1. Else Phantom#1005
+                  1. Else Phantom#1006
 
 relation ParserStmtList_ok: TC_0 |- parserStatementList : % %
 
@@ -19053,11 +19059,11 @@ relation ParserStateList_ok: TC |- parserStateList : %
 
                   1. Result in: % |- % : (parserStateIR)*
 
-            1. Else Phantom#1006
+            1. Else Phantom#1007
 
-          1. Else Phantom#1007
+          1. Else Phantom#1008
 
-        1. Else Phantom#1008
+        1. Else Phantom#1009
 
 relation ParserLocalDecl_ok: TC_0 |- parserLocalDeclaration : % %
 
@@ -19119,11 +19125,11 @@ relation ParserLocalDecl_ok: TC_0 |- parserLocalDeclaration : % %
 
                           1. Result in: % |- % : TC_1 (valueSetDeclarationIR as parserLocalDeclarationIR)
 
-                1. Else Phantom#1009
+                1. Else Phantom#1010
 
-            1. Else Phantom#1010
+            1. Else Phantom#1011
 
-          1. Else Phantom#1011
+          1. Else Phantom#1012
 
 relation ParserLocalDeclList_ok: TC_0 |- parserLocalDeclarationList : % %
 
@@ -19163,11 +19169,11 @@ relation TableKey_ok: TC TBLC_0 |- (expression : name_matchkind annotationList ;
 
                         1. Result in: % % |- % : TBLC_2 tableKeyIR
 
-                1. Else Phantom#1012
+                1. Else Phantom#1013
 
-              1. Else Phantom#1013
+              1. Else Phantom#1014
 
-      1. Else Phantom#1014
+      1. Else Phantom#1015
 
 relation TableKeys_ok: TC tableContext |- (tableKey)* : % %
 
@@ -19177,7 +19183,7 @@ relation TableKeys_ok: TC tableContext |- (tableKey)* : % %
 
     1. Result in: % % |- % : tableContext []
 
-  1. Else Phantom#1015
+  1. Else Phantom#1016
 
   2. If (((tableKey)* matches pattern _ :: _)), then
 
@@ -19189,7 +19195,7 @@ relation TableKeys_ok: TC tableContext |- (tableKey)* : % %
 
           1. Result in: % % |- % : TBLC_2 tableKeyIR_h :: (tableKeyIR_t)*
 
-  2. Else Phantom#1016
+  2. Else Phantom#1017
 
 relation Call_action_partial_ok: TC |- (parameterIR)* @ (argumentIR)* : % , % @ %
 
@@ -19207,9 +19213,9 @@ relation Call_action_partial_ok: TC |- (parameterIR)* @ (argumentIR)* : % , % @ 
 
             1. Result in: % |- % @ % : (parameterIR_data)* , (parameterIR_control)* @ (argumentIR_cast)*
 
-        1. Else Phantom#1017
+        1. Else Phantom#1018
 
-    1. Else Phantom#1018
+    1. Else Phantom#1019
 
 relation TableAction_ok: TC TBLC_0 |- (annotationList tableActionReference ;) : % %
 
@@ -19247,11 +19253,11 @@ relation TableAction_ok: TC TBLC_0 |- (annotationList tableActionReference ;) : 
 
                                 1. Result in: % % |- % : TBLC_1 tableActionIR
 
-                          1. Else Phantom#1019
+                          1. Else Phantom#1020
 
-                1. Else Phantom#1020
+                1. Else Phantom#1021
 
-            1. Else Phantom#1021
+            1. Else Phantom#1022
 
     2. Case (% matches pattern `%(%)`)
 
@@ -19283,9 +19289,9 @@ relation TableAction_ok: TC TBLC_0 |- (annotationList tableActionReference ;) : 
 
                                 1. Result in: % % |- % : TBLC_1 tableActionIR
 
-                1. Else Phantom#1022
+                1. Else Phantom#1023
 
-            1. Else Phantom#1023
+            1. Else Phantom#1024
 
 relation TableActions_ok: TC tableContext |- (tableAction)* : % %
 
@@ -19295,7 +19301,7 @@ relation TableActions_ok: TC tableContext |- (tableAction)* : % %
 
     1. Result in: % % |- % : tableContext []
 
-  1. Else Phantom#1024
+  1. Else Phantom#1025
 
   2. If (((tableAction)* matches pattern _ :: _)), then
 
@@ -19307,7 +19313,7 @@ relation TableActions_ok: TC tableContext |- (tableAction)* : % %
 
           1. Result in: % % |- % : TBLC_2 tableActionIR_h :: (tableActionIR_t)*
 
-  2. Else Phantom#1025
+  2. Else Phantom#1026
 
 relation Call_action_default_ok: TC |- (parameterIR)* @ (argumentIR)* : % , % @ %
 
@@ -19323,7 +19329,7 @@ relation Call_action_default_ok: TC |- (parameterIR)* @ (argumentIR)* : % , % @ 
 
           1. Result in: % |- % @ % : (parameterIR_data)* , (parameterIR_control)* @ (argumentIR_cast)*
 
-      1. Else Phantom#1026
+      1. Else Phantom#1027
 
 relation TableDefaultAction_ok: TC TBLC |- (= expression) : %
 
@@ -19341,7 +19347,7 @@ relation TableDefaultAction_ok: TC TBLC |- (= expression) : %
 
             1. Result in: % % |- % : (prefixedNameIR ?() ( [] ))
 
-          1. Else Phantom#1027
+          1. Else Phantom#1028
 
     2. Case (% has type callExpression)
 
@@ -19375,15 +19381,15 @@ relation TableDefaultAction_ok: TC TBLC |- (= expression) : %
 
                                   1. Result in: % % |- % : (prefixedNameIR ?() ( (argumentIR_cast)* ))
 
-                                1. Else Phantom#1028
+                                1. Else Phantom#1029
 
-                    1. Else Phantom#1029
+                    1. Else Phantom#1030
 
-            1. Else Phantom#1030
+            1. Else Phantom#1031
 
-        1. Else Phantom#1031
+        1. Else Phantom#1032
 
-  1. Else Phantom#1032
+  1. Else Phantom#1033
 
 relation TableEntry_keyset_ok: TC TBLC |- keysetExpression : % %
 
@@ -19403,11 +19409,11 @@ relation TableEntry_keyset_ok: TC TBLC |- keysetExpression : % %
 
               1. Result in: % % |- % : TBLS (simpleKeysetExpressionIR' as keysetExpressionIR)
 
-          1. Else Phantom#1033
+          1. Else Phantom#1034
 
-      1. Else Phantom#1034
+      1. Else Phantom#1035
 
-1. Else Phantom#1035
+1. Else Phantom#1036
 
 2. Group mask: TC TBLC |- keysetExpression : % %
 
@@ -19431,11 +19437,11 @@ relation TableEntry_keyset_ok: TC TBLC |- keysetExpression : % %
 
                     1. Result in: % % |- % : TBLS (simpleKeysetExpressionIR' as keysetExpressionIR)
 
-                1. Else Phantom#1036
+                1. Else Phantom#1037
 
-            1. Else Phantom#1037
+            1. Else Phantom#1038
 
-        1. Else Phantom#1038
+        1. Else Phantom#1039
 
     2. Case (% has type tupleKeysetExpression)
 
@@ -19455,11 +19461,11 @@ relation TableEntry_keyset_ok: TC TBLC |- keysetExpression : % %
 
                     1. Result in: % % |- % : TBLS ((( [simpleKeysetExpressionIR'] )) as keysetExpressionIR)
 
-                1. Else Phantom#1039
+                1. Else Phantom#1040
 
-            1. Else Phantom#1040
+            1. Else Phantom#1041
 
-        1. Else Phantom#1041
+        1. Else Phantom#1042
 
 3. Group range: TC TBLC |- keysetExpression : % %
 
@@ -19483,11 +19489,11 @@ relation TableEntry_keyset_ok: TC TBLC |- keysetExpression : % %
 
                     1. Result in: % % |- % : TBLS (simpleKeysetExpressionIR' as keysetExpressionIR)
 
-                1. Else Phantom#1042
+                1. Else Phantom#1043
 
-            1. Else Phantom#1043
+            1. Else Phantom#1044
 
-        1. Else Phantom#1044
+        1. Else Phantom#1045
 
     2. Case (% has type tupleKeysetExpression)
 
@@ -19507,11 +19513,11 @@ relation TableEntry_keyset_ok: TC TBLC |- keysetExpression : % %
 
                     1. Result in: % % |- % : TBLS ((( [simpleKeysetExpressionIR'] )) as keysetExpressionIR)
 
-                1. Else Phantom#1045
+                1. Else Phantom#1046
 
-            1. Else Phantom#1046
+            1. Else Phantom#1047
 
-        1. Else Phantom#1047
+        1. Else Phantom#1048
 
 4. Group default: TC TBLC |- keysetExpression : % %
 
@@ -19529,7 +19535,7 @@ relation TableEntry_keyset_ok: TC TBLC |- keysetExpression : % %
 
               1. Result in: % % |- % : TBLS ((default) as keysetExpressionIR)
 
-        1. Else Phantom#1048
+        1. Else Phantom#1049
 
       2. If ((((TBLC.mode = (nopri)) \/ (TBLC.mode = (pri))) \/ (TBLC.mode = (prilpm)))), then
 
@@ -19537,7 +19543,7 @@ relation TableEntry_keyset_ok: TC TBLC |- keysetExpression : % %
 
           1. Result in: % % |- % : TBLS ((default) as keysetExpressionIR)
 
-      2. Else Phantom#1049
+      2. Else Phantom#1050
 
     2. Case (% = (((default)) as keysetExpression))
 
@@ -19551,7 +19557,7 @@ relation TableEntry_keyset_ok: TC TBLC |- keysetExpression : % %
 
               1. Result in: % % |- % : TBLS ((( [(default)] )) as keysetExpressionIR)
 
-        1. Else Phantom#1050
+        1. Else Phantom#1051
 
       2. If ((((TBLC.mode = (nopri)) \/ (TBLC.mode = (pri))) \/ (TBLC.mode = (prilpm)))), then
 
@@ -19559,9 +19565,9 @@ relation TableEntry_keyset_ok: TC TBLC |- keysetExpression : % %
 
           1. Result in: % % |- % : TBLS ((( [(default)] )) as keysetExpressionIR)
 
-      2. Else Phantom#1051
+      2. Else Phantom#1052
 
-  1. Else Phantom#1052
+  1. Else Phantom#1053
 
 5. Group dontcare: TC TBLC |- keysetExpression : % %
 
@@ -19577,7 +19583,7 @@ relation TableEntry_keyset_ok: TC TBLC |- keysetExpression : % %
 
             1. Result in: % % |- % : TBLS ((_) as keysetExpressionIR)
 
-        1. Else Phantom#1053
+        1. Else Phantom#1054
 
       2. If ((((TBLC.mode = (nopri)) \/ (TBLC.mode = (pri))) \/ (TBLC.mode = (prilpm)))), then
 
@@ -19585,7 +19591,7 @@ relation TableEntry_keyset_ok: TC TBLC |- keysetExpression : % %
 
           1. Result in: % % |- % : TBLS ((_) as keysetExpressionIR)
 
-      2. Else Phantom#1054
+      2. Else Phantom#1055
 
     2. Case (% = (((_)) as keysetExpression))
 
@@ -19597,7 +19603,7 @@ relation TableEntry_keyset_ok: TC TBLC |- keysetExpression : % %
 
             1. Result in: % % |- % : TBLS ((( [(_)] )) as keysetExpressionIR)
 
-        1. Else Phantom#1055
+        1. Else Phantom#1056
 
       2. If ((((TBLC.mode = (nopri)) \/ (TBLC.mode = (pri))) \/ (TBLC.mode = (prilpm)))), then
 
@@ -19605,9 +19611,9 @@ relation TableEntry_keyset_ok: TC TBLC |- keysetExpression : % %
 
           1. Result in: % % |- % : TBLS ((( [(_)] )) as keysetExpressionIR)
 
-      2. Else Phantom#1056
+      2. Else Phantom#1057
 
-  1. Else Phantom#1057
+  1. Else Phantom#1058
 
 6. If ((keysetExpression has type tupleKeysetExpression)), then
 
@@ -19629,11 +19635,11 @@ relation TableEntry_keyset_ok: TC TBLC |- keysetExpression : % %
 
                   1. Result in: % % |- % : TBLS ((( (simpleKeysetExpressionIR)* )) as keysetExpressionIR)
 
-              1. Else Phantom#1058
+              1. Else Phantom#1059
 
-    1. Else Phantom#1059
+    1. Else Phantom#1060
 
-6. Else Phantom#1060
+6. Else Phantom#1061
 
 relation TableEntry_action_ok: TC TBLC |- tableActionReference : %
 
@@ -19651,7 +19657,7 @@ relation TableEntry_action_ok: TC TBLC |- tableActionReference : %
 
             1. Result in: % % |- % : (prefixedNameIR ?() ( [] ))
 
-          1. Else Phantom#1061
+          1. Else Phantom#1062
 
     2. Case (% matches pattern `%(%)`)
 
@@ -19677,9 +19683,9 @@ relation TableEntry_action_ok: TC TBLC |- tableActionReference : %
 
                           1. Result in: % % |- % : (prefixedNameIR ?() ( (argumentIR_cast)* ))
 
-                        1. Else Phantom#1062
+                        1. Else Phantom#1063
 
-            1. Else Phantom#1063
+            1. Else Phantom#1064
 
 relation TableEntry_priority_ok: TC tableContext TBLS |- (tableEntryPriority)? : % %
 
@@ -19693,7 +19699,7 @@ relation TableEntry_priority_ok: TC tableContext TBLS |- (tableEntryPriority)? :
 
         1. Result in: % % % |- % : tableContext ?()
 
-      1. Else Phantom#1064
+      1. Else Phantom#1065
 
       2. (Let matchMode be tableContext.mode)
 
@@ -19705,9 +19711,9 @@ relation TableEntry_priority_ok: TC tableContext TBLS |- (tableEntryPriority)? :
 
               1. Result in: % % % |- % : tableContext ?((priority= (d (n_prefix as int)) :))
 
-          1. Else Phantom#1065
+          1. Else Phantom#1066
 
-        1. Else Phantom#1066
+        1. Else Phantom#1067
 
       3. If (((tableContext.mode = (pri)) \/ (tableContext.mode = (prilpm)))), then
 
@@ -19731,7 +19737,7 @@ relation TableEntry_priority_ok: TC tableContext TBLS |- (tableEntryPriority)? :
 
                           1. Result in: % % % |- % : TBLC_1 ?((priority= (d (n as int)) :))
 
-                    1. Else Phantom#1067
+                    1. Else Phantom#1068
 
           2. Case (% =/= [])
 
@@ -19751,9 +19757,9 @@ relation TableEntry_priority_ok: TC tableContext TBLS |- (tableEntryPriority)? :
 
                           1. Result in: % % % |- % : TBLC_1 ?((priority= (d (n as int)) :))
 
-                    1. Else Phantom#1068
+                    1. Else Phantom#1069
 
-      3. Else Phantom#1069
+      3. Else Phantom#1070
 
   2. Case (% matches pattern (_))
 
@@ -19787,7 +19793,7 @@ relation TableEntry_priority_ok: TC tableContext TBLS |- (tableEntryPriority)? :
 
                                 1. Result in: % % % |- % : TBLC_2 ?((priority= integerLiteral :))
 
-                        1. Else Phantom#1070
+                        1. Else Phantom#1071
 
                     2. Case (% =/= [])
 
@@ -19803,13 +19809,13 @@ relation TableEntry_priority_ok: TC tableContext TBLS |- (tableEntryPriority)? :
 
                                 1. Result in: % % % |- % : TBLC_1 ?((priority= integerLiteral :))
 
-                          1. Else Phantom#1071
+                          1. Else Phantom#1072
 
-                      1. Else Phantom#1072
+                      1. Else Phantom#1073
 
-                1. Else Phantom#1073
+                1. Else Phantom#1074
 
-              1. Else Phantom#1074
+              1. Else Phantom#1075
 
         2. Case (% matches pattern `PRIORITY=(%):`)
 
@@ -19847,11 +19853,11 @@ relation TableEntry_priority_ok: TC tableContext TBLS |- (tableEntryPriority)? :
 
                                           1. Result in: % % % |- % : TBLC_2 ?((priority= (d (n as int)) :))
 
-                                  1. Else Phantom#1075
+                                  1. Else Phantom#1076
 
-                            1. Else Phantom#1076
+                            1. Else Phantom#1077
 
-                        1. Else Phantom#1077
+                        1. Else Phantom#1078
 
                     2. Case (% =/= [])
 
@@ -19877,17 +19883,17 @@ relation TableEntry_priority_ok: TC tableContext TBLS |- (tableEntryPriority)? :
 
                                           1. Result in: % % % |- % : TBLC_1 ?((priority= (d (n as int)) :))
 
-                                    1. Else Phantom#1078
+                                    1. Else Phantom#1079
 
-                              1. Else Phantom#1079
+                              1. Else Phantom#1080
 
-                          1. Else Phantom#1080
+                          1. Else Phantom#1081
 
-                      1. Else Phantom#1081
+                      1. Else Phantom#1082
 
-                1. Else Phantom#1082
+                1. Else Phantom#1083
 
-              1. Else Phantom#1083
+              1. Else Phantom#1084
 
 relation TableEntry_ok: TC TBLC_0 |- tableEntry : % %
 
@@ -19935,7 +19941,7 @@ relation TableEntries_ok: TC tableContext |- (tableEntry)* : % %
 
     1. Result in: % % |- % : tableContext []
 
-  1. Else Phantom#1084
+  1. Else Phantom#1085
 
   2. If (((tableEntry)* matches pattern _ :: _)), then
 
@@ -19947,7 +19953,7 @@ relation TableEntries_ok: TC tableContext |- (tableEntry)* : % %
 
           1. Result in: % % |- % : TBLC_2 tableEntryIR_h :: (tableEntryIR_t)*
 
-  2. Else Phantom#1085
+  2. Else Phantom#1086
 
 relation TableProperty_ok: TC TBLC_0 |- tableProperty : % %
 
@@ -19997,7 +20003,7 @@ relation TableProperty_ok: TC TBLC_0 |- tableProperty : % %
 
                     1. Result in: % % |- % : TBLC_3 ((annotationList constOptIR entries={ (tableEntryIR)* }) as tablePropertyIR)
 
-          1. Else Phantom#1086
+          1. Else Phantom#1087
 
   4. Case (% matches pattern `%%%%;`)
 
@@ -20015,7 +20021,7 @@ relation TableProperty_ok: TC TBLC_0 |- tableProperty : % %
 
                 1. Result in: % % |- % : TBLC_0 tablePropertyIR
 
-        1. Else Phantom#1087
+        1. Else Phantom#1088
 
     2. (Let (annotationList constOpt tableCustomName (= expression) ;) be tableProperty)
 
@@ -20045,13 +20051,13 @@ relation TableProperty_ok: TC TBLC_0 |- tableProperty : % %
 
                               1. Result in: % % |- % : TBLC_1 tablePropertyIR
 
-                    1. Else Phantom#1088
+                    1. Else Phantom#1089
 
-                1. Else Phantom#1089
+                1. Else Phantom#1090
 
-              1. Else Phantom#1090
+              1. Else Phantom#1091
 
-        1. Else Phantom#1091
+        1. Else Phantom#1092
 
         2. If (("priority_delta" = $tableCustomName(tableCustomName))), then
 
@@ -20087,17 +20093,17 @@ relation TableProperty_ok: TC TBLC_0 |- tableProperty : % %
 
                                         1. Result in: % % |- % : TBLC_1 tablePropertyIR
 
-                                1. Else Phantom#1092
+                                1. Else Phantom#1093
 
-                            1. Else Phantom#1093
+                            1. Else Phantom#1094
 
-                      1. Else Phantom#1094
+                      1. Else Phantom#1095
 
-                  1. Else Phantom#1095
+                  1. Else Phantom#1096
 
-              1. Else Phantom#1096
+              1. Else Phantom#1097
 
-        2. Else Phantom#1097
+        2. Else Phantom#1098
 
       2. Group size-and-others: TC TBLC_0 |- (annotationList constOpt tableCustomName (= expression) ;) : % %
 
@@ -20117,9 +20123,9 @@ relation TableProperty_ok: TC TBLC_0 |- tableProperty : % %
 
                       1. Result in: % % |- % : TBLC_0 tablePropertyIR
 
-                1. Else Phantom#1098
+                1. Else Phantom#1099
 
-        1. Else Phantom#1099
+        1. Else Phantom#1100
 
         2. (Let nameIR be $tableCustomName(tableCustomName))
 
@@ -20133,7 +20139,7 @@ relation TableProperty_ok: TC TBLC_0 |- tableProperty : % %
 
                   1. Result in: % % |- % : TBLC_0 tablePropertyIR
 
-          1. Else Phantom#1100
+          1. Else Phantom#1101
 
 relation TableProperties_ok: TC tableContext |- (tableProperty)* : % %
 
@@ -20143,7 +20149,7 @@ relation TableProperties_ok: TC tableContext |- (tableProperty)* : % %
 
     1. Result in: % % |- % : tableContext []
 
-  1. Else Phantom#1101
+  1. Else Phantom#1102
 
   2. If (((tableProperty)* matches pattern _ :: _)), then
 
@@ -20155,7 +20161,7 @@ relation TableProperties_ok: TC tableContext |- (tableProperty)* : % %
 
           1. Result in: % % |- % : TBLC_2 tablePropertyIR_h :: (tablePropertyIR_t)*
 
-  2. Else Phantom#1102
+  2. Else Phantom#1103
 
 relation Table_ok: TC |- (tableProperty)* : % %
 
@@ -20187,11 +20193,11 @@ relation Table_ok: TC |- (tableProperty)* : % %
 
               1. Result in: % |- % : TBLC_1 (tablePropertyIR)*
 
-      1. Else Phantom#1103
+      1. Else Phantom#1104
 
-    1. Else Phantom#1104
+    1. Else Phantom#1105
 
-  1. Else Phantom#1105
+  1. Else Phantom#1106
 
 relation TableType_ok: TC_0 TBLC |- name : % %
 
@@ -20323,11 +20329,11 @@ relation VarDecl_ok: p TC_0 |- (annotationList type name initializerOpt ;) : % %
 
                     1. Result in: % % |- % : TC_1 variableDeclarationIR
 
-            1. Else Phantom#1106
+            1. Else Phantom#1107
 
-          1. Else Phantom#1107
+          1. Else Phantom#1108
 
-        1. Else Phantom#1108
+        1. Else Phantom#1109
 
     2. Case (% has type initializer)
 
@@ -20357,13 +20363,13 @@ relation VarDecl_ok: p TC_0 |- (annotationList type name initializerOpt ;) : % %
 
                               1. Result in: % % |- % : TC_1 variableDeclarationIR
 
-                    1. Else Phantom#1109
+                    1. Else Phantom#1110
 
-              1. Else Phantom#1110
+              1. Else Phantom#1111
 
-            1. Else Phantom#1111
+            1. Else Phantom#1112
 
-          1. Else Phantom#1112
+          1. Else Phantom#1113
 
 relation ConstDecl_ok: p TC_0 |- (annotationList const type name (= expression_value) ;) : % %
 
@@ -20395,13 +20401,13 @@ relation ConstDecl_ok: p TC_0 |- (annotationList const type name (= expression_v
 
                           1. Result in: % % |- % : TC_1 constantDeclarationIR
 
-              1. Else Phantom#1113
+              1. Else Phantom#1114
 
-          1. Else Phantom#1114
+          1. Else Phantom#1115
 
-      1. Else Phantom#1115
+      1. Else Phantom#1116
 
-    1. Else Phantom#1116
+    1. Else Phantom#1117
 
 relation InstDecl_ok: p TC_0 |- instantiation : % %
 
@@ -20431,7 +20437,7 @@ relation InstDecl_ok: p TC_0 |- instantiation : % %
 
                 1. Result in: % % |- % : TC_1 instantiationIR
 
-        1. Else Phantom#1117
+        1. Else Phantom#1118
 
     2. Case (% matches pattern `%%(%)%%;`)
 
@@ -20455,7 +20461,7 @@ relation InstDecl_ok: p TC_0 |- instantiation : % %
 
                 1. Result in: % % |- % : TC_1 instantiationIR
 
-        1. Else Phantom#1118
+        1. Else Phantom#1119
 
 relation FuncDecl_ok: p TC_0 |- (annotationList (typeOrVoid name typeParameterListOpt ( parameterList )) blockStatement) : % %
 
@@ -20489,11 +20495,11 @@ relation FuncDecl_ok: p TC_0 |- (annotationList (typeOrVoid name typeParameterLi
 
                             1. Result in: % % |- % : TC_4 functionDeclarationIR
 
-                      1. Else Phantom#1119
+                      1. Else Phantom#1120
 
-              1. Else Phantom#1120
+              1. Else Phantom#1121
 
-      1. Else Phantom#1121
+      1. Else Phantom#1122
 
 relation ActionDecl_ok: p TC_0 |- (annotationList action name ( parameterList ) blockStatement) : % %
 
@@ -20521,9 +20527,9 @@ relation ActionDecl_ok: p TC_0 |- (annotationList action name ( parameterList ) 
 
                       1. Result in: % % |- % : TC_3 actionDeclarationIR
 
-                1. Else Phantom#1122
+                1. Else Phantom#1123
 
-      1. Else Phantom#1123
+      1. Else Phantom#1124
 
 relation Decl_ok: TC_0 |- declaration : % %
 
@@ -20591,7 +20597,7 @@ relation Decl_ok: TC_0 |- declaration : % %
 
                       1. Result in: % |- % : TC_1 ((error{ (nameIR)* }) as declarationIR)
 
-            1. Else Phantom#1124
+            1. Else Phantom#1125
 
   6. Case (% has type matchKindDeclaration)
 
@@ -20613,7 +20619,7 @@ relation Decl_ok: TC_0 |- declaration : % %
 
                     1. Result in: % |- % : TC_1 ((match_kind{ (nameIR)* }) as declarationIR)
 
-            1. Else Phantom#1125
+            1. Else Phantom#1126
 
   7. Case (% has type externFunctionDeclaration)
 
@@ -20643,9 +20649,9 @@ relation Decl_ok: TC_0 |- declaration : % %
 
                             1. Result in: % |- % : TC_4 (externFunctionDeclarationIR as declarationIR)
 
-                      1. Else Phantom#1126
+                      1. Else Phantom#1127
 
-              1. Else Phantom#1127
+              1. Else Phantom#1128
 
   8. Case (% has type externObjectDeclaration)
 
@@ -20693,7 +20699,7 @@ relation Decl_ok: TC_0 |- declaration : % %
 
                                               1. Result in: % |- % : TC_6 (externObjectDeclarationIR as declarationIR)
 
-                    1. Else Phantom#1128
+                    1. Else Phantom#1129
 
   9. Case (% has type parserDeclaration)
 
@@ -20741,15 +20747,15 @@ relation Decl_ok: TC_0 |- declaration : % %
 
                                               1. Result in: % |- % : TC_6 (parserDeclarationIR as declarationIR)
 
-                                        1. Else Phantom#1129
+                                        1. Else Phantom#1130
 
-                            1. Else Phantom#1130
+                            1. Else Phantom#1131
 
-                  1. Else Phantom#1131
+                  1. Else Phantom#1132
 
-              1. Else Phantom#1132
+              1. Else Phantom#1133
 
-          1. Else Phantom#1133
+          1. Else Phantom#1134
 
   10. Case (% has type controlDeclaration)
 
@@ -20797,15 +20803,15 @@ relation Decl_ok: TC_0 |- declaration : % %
 
                                               1. Result in: % |- % : TC_6 (controlDeclarationIR as declarationIR)
 
-                                        1. Else Phantom#1134
+                                        1. Else Phantom#1135
 
-                            1. Else Phantom#1135
+                            1. Else Phantom#1136
 
-                  1. Else Phantom#1136
+                  1. Else Phantom#1137
 
-              1. Else Phantom#1137
+              1. Else Phantom#1138
 
-          1. Else Phantom#1138
+          1. Else Phantom#1139
 
   11. Case (% has type enumTypeDeclaration)
 
@@ -20843,7 +20849,7 @@ relation Decl_ok: TC_0 |- declaration : % %
 
                                     1. Result in: % |- % : TC_2 (enumTypeDeclarationIR as declarationIR)
 
-                      1. Else Phantom#1139
+                      1. Else Phantom#1140
 
         2. Case (% matches pattern `%ENUM%%{%%}`)
 
@@ -20881,11 +20887,11 @@ relation Decl_ok: TC_0 |- declaration : % %
 
                                           1. Result in: % |- % : TC_3 (enumTypeDeclarationIR as declarationIR)
 
-                                    1. Else Phantom#1140
+                                    1. Else Phantom#1141
 
-                    1. Else Phantom#1141
+                    1. Else Phantom#1142
 
-                  1. Else Phantom#1142
+                  1. Else Phantom#1143
 
   12. Case (% has type structTypeDeclaration)
 
@@ -20915,9 +20921,9 @@ relation Decl_ok: TC_0 |- declaration : % %
 
                             1. Result in: % |- % : TC_2 (structTypeDeclarationIR as declarationIR)
 
-                      1. Else Phantom#1143
+                      1. Else Phantom#1144
 
-              1. Else Phantom#1144
+              1. Else Phantom#1145
 
   13. Case (% has type headerTypeDeclaration)
 
@@ -20947,9 +20953,9 @@ relation Decl_ok: TC_0 |- declaration : % %
 
                             1. Result in: % |- % : TC_2 (headerTypeDeclarationIR as declarationIR)
 
-                      1. Else Phantom#1145
+                      1. Else Phantom#1146
 
-              1. Else Phantom#1146
+              1. Else Phantom#1147
 
   14. Case (% has type headerUnionTypeDeclaration)
 
@@ -20979,9 +20985,9 @@ relation Decl_ok: TC_0 |- declaration : % %
 
                             1. Result in: % |- % : TC_2 (headerUnionTypeDeclarationIR as declarationIR)
 
-                      1. Else Phantom#1147
+                      1. Else Phantom#1148
 
-              1. Else Phantom#1148
+              1. Else Phantom#1149
 
   15. Case (% has type typedefDeclaration)
 
@@ -21021,11 +21027,11 @@ relation Decl_ok: TC_0 |- declaration : % %
 
                                       1. Result in: % |- % : TC_1 (typedefDeclarationIR as declarationIR)
 
-                                1. Else Phantom#1149
+                                1. Else Phantom#1150
 
-                          1. Else Phantom#1150
+                          1. Else Phantom#1151
 
-                        1. Else Phantom#1151
+                        1. Else Phantom#1152
 
                 2. Case (% has type derivedTypeDeclaration)
 
@@ -21067,7 +21073,7 @@ relation Decl_ok: TC_0 |- declaration : % %
 
                                                       1. Result in: % |- % : TC_1 (typedefDeclarationIR as declarationIR)
 
-                                                1. Else Phantom#1152
+                                                1. Else Phantom#1153
 
                                         2. Case false
 
@@ -21087,15 +21093,15 @@ relation Decl_ok: TC_0 |- declaration : % %
 
                                                         1. Result in: % |- % : TC_1 (typedefDeclarationIR as declarationIR)
 
-                                                  1. Else Phantom#1153
+                                                  1. Else Phantom#1154
 
-                                          1. Else Phantom#1154
+                                          1. Else Phantom#1155
 
-                                  1. Else Phantom#1155
+                                  1. Else Phantom#1156
 
-                            1. Else Phantom#1156
+                            1. Else Phantom#1157
 
-                      1. Else Phantom#1157
+                      1. Else Phantom#1158
 
         2. Case (% matches pattern `%TYPE%%;`)
 
@@ -21123,11 +21129,11 @@ relation Decl_ok: TC_0 |- declaration : % %
 
                                 1. Result in: % |- % : TC_1 (typedefDeclarationIR as declarationIR)
 
-                          1. Else Phantom#1158
+                          1. Else Phantom#1159
 
-                    1. Else Phantom#1159
+                    1. Else Phantom#1160
 
-                  1. Else Phantom#1160
+                  1. Else Phantom#1161
 
   16. Case (% has type parserTypeDeclaration)
 
@@ -21153,7 +21159,7 @@ relation Decl_ok: TC_0 |- declaration : % %
 
                         1. Result in: % |- % : TC_4 (parserTypeDeclarationIR as declarationIR)
 
-                  1. Else Phantom#1161
+                  1. Else Phantom#1162
 
   17. Case (% has type controlTypeDeclaration)
 
@@ -21179,7 +21185,7 @@ relation Decl_ok: TC_0 |- declaration : % %
 
                         1. Result in: % |- % : TC_4 (controlTypeDeclarationIR as declarationIR)
 
-                  1. Else Phantom#1162
+                  1. Else Phantom#1163
 
   18. Case (% has type packageTypeDeclaration)
 
@@ -21219,9 +21225,9 @@ relation Decl_ok: TC_0 |- declaration : % %
 
                                       1. Result in: % |- % : TC_5 (packageTypeDeclarationIR as declarationIR)
 
-                                1. Else Phantom#1163
+                                1. Else Phantom#1164
 
-                      1. Else Phantom#1164
+                      1. Else Phantom#1165
 
 relation Decls_ok: typingContext |- (declaration)* : % %
 
@@ -21231,7 +21237,7 @@ relation Decls_ok: typingContext |- (declaration)* : % %
 
     1. Result in: % |- % : typingContext []
 
-  1. Else Phantom#1165
+  1. Else Phantom#1166
 
   2. If (((declaration)* matches pattern _ :: _)), then
 
@@ -21243,7 +21249,7 @@ relation Decls_ok: typingContext |- (declaration)* : % %
 
           1. Result in: % |- % : TC_2 declarationIR_h :: (declarationIR_t)*
 
-  2. Else Phantom#1166
+  2. Else Phantom#1167
 
 relation Program_ok: |- p4program : %
 
@@ -21275,9 +21281,9 @@ relation Call_convention_expr_ok: p TC actctxt |- (annotationList direction type
 
           1. Result in: % % % |- % @ % : typedExpressionIR_arg_cast
 
-      1. Else Phantom#1167
+      1. Else Phantom#1168
 
-1. Else Phantom#1168
+1. Else Phantom#1169
 
 2. Group out-inout: p TC actctxt |- (annotationList direction typeIR_param id parameterInitializerOptIR) @ typedExpressionIR_arg : %
 
@@ -21291,11 +21297,11 @@ relation Call_convention_expr_ok: p TC actctxt |- (annotationList direction type
 
           1. Result in: % % % |- % @ % : typedExpressionIR_arg
 
-        1. Else Phantom#1169
+        1. Else Phantom#1170
 
-      1. Else Phantom#1170
+      1. Else Phantom#1171
 
-  1. Else Phantom#1171
+  1. Else Phantom#1172
 
 3. If ((direction matches pattern ``EMPTY`)), then
 
@@ -21313,7 +21319,7 @@ relation Call_convention_expr_ok: p TC actctxt |- (annotationList direction type
 
               1. Result in: % % % |- % @ % : typedExpressionIR_arg_cast
 
-          1. Else Phantom#1172
+          1. Else Phantom#1173
 
       2. Case (% matches pattern `NOACTION`)
 
@@ -21327,11 +21333,11 @@ relation Call_convention_expr_ok: p TC actctxt |- (annotationList direction type
 
                 1. Result in: % % % |- % @ % : typedExpressionIR_arg_cast
 
-              1. Else Phantom#1173
+              1. Else Phantom#1174
 
-          1. Else Phantom#1174
+          1. Else Phantom#1175
 
-3. Else Phantom#1175
+3. Else Phantom#1176
 
 relation Call_convention_argument_ok: p TC actctxt |- parameterIR @ argumentIR : %
 
@@ -21369,7 +21375,7 @@ relation Call_convention_argument_ok: p TC actctxt |- parameterIR @ argumentIR :
 
             1. Result in: % % % |- % @ % : (nameIR =_)
 
-          1. Else Phantom#1176
+          1. Else Phantom#1177
 
   4. Case (% matches pattern `_`)
 
@@ -21381,7 +21387,7 @@ relation Call_convention_argument_ok: p TC actctxt |- parameterIR @ argumentIR :
 
           1. Result in: % % % |- % @ % : (_)
 
-        1. Else Phantom#1177
+        1. Else Phantom#1178
 
 relation Call_convention_ok: p TC actctxt |- (parameterIR)* @ (argumentIR)* : %
 
@@ -21393,9 +21399,9 @@ relation Call_convention_ok: p TC actctxt |- (parameterIR)* @ (argumentIR)* : %
 
       1. Result in: % % % |- % @ % : []
 
-    1. Else Phantom#1178
+    1. Else Phantom#1179
 
-  1. Else Phantom#1179
+  1. Else Phantom#1180
 
   2. If (((parameterIR)* matches pattern _ :: _)), then
 
@@ -21411,9 +21417,9 @@ relation Call_convention_ok: p TC actctxt |- (parameterIR)* @ (argumentIR)* : %
 
               1. Result in: % % % |- % @ % : argumentIR_h_cast :: (argumentIR_t_cast)*
 
-      1. Else Phantom#1180
+      1. Else Phantom#1181
 
-  2. Else Phantom#1181
+  2. Else Phantom#1182
 
 def $is_static_callableTypeIR(callableTypeIR)
 
@@ -21501,13 +21507,13 @@ relation CallableTarget_ok: p TC |- callableTarget : %
 
           1. Result in: % % |- % : (( callableTargetIR ))
 
-  1. Else Phantom#1182
+  1. Else Phantom#1183
 
   2. If ((callableTarget = ((this) as callableTarget))), then
 
     1. Result in: % % |- % : ((` "this") as callableTargetIR)
 
-  2. Else Phantom#1183
+  2. Else Phantom#1184
 
 relation CallableTarget_lvalue_ok: p TC |- lvalue : %
 
@@ -21545,13 +21551,13 @@ relation CallableType_ok: p TC |- callableTargetIR < (typeArgumentIR)* >( (argum
 
                       1. Result in: % % |- % < % >( % ): (actionTypeIR as callableTypeIR) <# [] >(# (id_default)* # (id_optional)* )
 
-                    1. Else Phantom#1184
+                    1. Else Phantom#1185
 
-                1. Else Phantom#1185
+                1. Else Phantom#1186
 
-            1. Else Phantom#1186
+            1. Else Phantom#1187
 
-      1. Else Phantom#1187
+      1. Else Phantom#1188
 
       2. Group functionTypeIR: p TC |- (prefixedNameIR as callableTargetIR) < (typeArgumentIR)* >( (argumentIR)* ): % <# % >(# % # % )
 
@@ -21577,13 +21583,13 @@ relation CallableType_ok: p TC |- callableTargetIR < (typeArgumentIR)* >( (argum
 
                             1. Result in: % % |- % < % >( % ): (functionTypeIR as callableTypeIR) <# (typeId_impl)* >(# (id_default)* # (id_optional)* )
 
-                          1. Else Phantom#1188
+                          1. Else Phantom#1189
 
-                    1. Else Phantom#1189
+                    1. Else Phantom#1190
 
-              1. Else Phantom#1190
+              1. Else Phantom#1191
 
-          1. Else Phantom#1191
+          1. Else Phantom#1192
 
   2. Case (% matches pattern `%.%`)
 
@@ -21611,9 +21617,9 @@ relation CallableType_ok: p TC |- callableTargetIR < (typeArgumentIR)* >( (argum
 
                           1. Result in: % % |- % < % >( % ): (methodTypeIR as callableTypeIR) <# [] >(# [] # [] )
 
-                      1. Else Phantom#1192
+                      1. Else Phantom#1193
 
-                    1. Else Phantom#1193
+                    1. Else Phantom#1194
 
               2. Case (% is in ["isValid"])
 
@@ -21635,7 +21641,7 @@ relation CallableType_ok: p TC |- callableTargetIR < (typeArgumentIR)* >( (argum
 
                           1. Result in: % % |- % < % >( % ): (methodTypeIR as callableTypeIR) <# [] >(# [] # [] )
 
-                    1. Else Phantom#1194
+                    1. Else Phantom#1195
 
               3. Case (% is in ["setValid", "setInvalid"])
 
@@ -21649,11 +21655,11 @@ relation CallableType_ok: p TC |- callableTargetIR < (typeArgumentIR)* >( (argum
 
                         1. Result in: % % |- % < % >( % ): (methodTypeIR as callableTypeIR) <# [] >(# [] # [] )
 
-                    1. Else Phantom#1195
+                    1. Else Phantom#1196
 
-            1. Else Phantom#1196
+            1. Else Phantom#1197
 
-          1. Else Phantom#1197
+          1. Else Phantom#1198
 
           2. If (((argumentIR)* matches pattern [ _/1 ])), then
 
@@ -21671,13 +21677,13 @@ relation CallableType_ok: p TC |- callableTargetIR < (typeArgumentIR)* >( (argum
 
                         1. Result in: % % |- % < % >( % ): (methodTypeIR as callableTypeIR) <# [] >(# [] # [] )
 
-                  1. Else Phantom#1198
+                  1. Else Phantom#1199
 
-            1. Else Phantom#1199
+            1. Else Phantom#1200
 
-          2. Else Phantom#1200
+          2. Else Phantom#1201
 
-      1. Else Phantom#1201
+      1. Else Phantom#1202
 
       2. Group externMethodTypeIR: p TC |- (typedExpressionIR_base . nameIR) < (typeArgumentIR)* >( (argumentIR)* ): % <# % >(# % # % )
 
@@ -21709,13 +21715,13 @@ relation CallableType_ok: p TC |- callableTargetIR < (typeArgumentIR)* >( (argum
 
                                   1. Result in: % % |- % < % >( % ): (externMethodTypeIR as callableTypeIR) <# (typeId_impl)* >(# (id_default)* # (id_optional)* )
 
-                                1. Else Phantom#1202
+                                1. Else Phantom#1203
 
-                          1. Else Phantom#1203
+                          1. Else Phantom#1204
 
-                    1. Else Phantom#1204
+                    1. Else Phantom#1205
 
-            1. Else Phantom#1205
+            1. Else Phantom#1206
 
       3. If ((nameIR = "apply")), then
 
@@ -21747,9 +21753,9 @@ relation CallableType_ok: p TC |- callableTargetIR < (typeArgumentIR)* >( (argum
 
                                   1. Result in: % % |- % < % >( % ): (parserApplyMethodTypeIR as callableTypeIR) <# [] >(# (id_default)* # (id_optional)* )
 
-                              1. Else Phantom#1206
+                              1. Else Phantom#1207
 
-                1. Else Phantom#1207
+                1. Else Phantom#1208
 
           2. Group controlApplyMethodTypeIR: p TC |- (typedExpressionIR_base . "apply") < [] >( (argumentIR)* ): % <# % >(# % # % )
 
@@ -21777,9 +21783,9 @@ relation CallableType_ok: p TC |- callableTargetIR < (typeArgumentIR)* >( (argum
 
                                   1. Result in: % % |- % < % >( % ): (controlApplyMethodTypeIR as callableTypeIR) <# [] >(# (id_default)* # (id_optional)* )
 
-                              1. Else Phantom#1208
+                              1. Else Phantom#1209
 
-                1. Else Phantom#1209
+                1. Else Phantom#1210
 
           3. If (((argumentIR)* matches pattern [])), then
 
@@ -21797,13 +21803,13 @@ relation CallableType_ok: p TC |- callableTargetIR < (typeArgumentIR)* >( (argum
 
                         1. Result in: % % |- % < % >( % ): (tableApplyMethodTypeIR as callableTypeIR) <# [] >(# [] # [] )
 
-                  1. Else Phantom#1210
+                  1. Else Phantom#1211
 
-          3. Else Phantom#1211
+          3. Else Phantom#1212
 
-        1. Else Phantom#1212
+        1. Else Phantom#1213
 
-      3. Else Phantom#1213
+      3. Else Phantom#1214
 
   3. Case (% matches pattern `(%)`)
 
@@ -21815,7 +21821,7 @@ relation CallableType_ok: p TC |- callableTargetIR < (typeArgumentIR)* >( (argum
 
           1. Result in: % % |- % < % >( % ): callableTypeIR <# (typeId_inserted)* >(# (id_default)* # (id_optional)* )
 
-1. Else Phantom#1214
+1. Else Phantom#1215
 
 relation Call_ok: p TC |- callableTypeIR < (typeArgumentIR)* # (typeId)* >( (argumentIR)* # (id_default)* # (id_optional)* ): % < % >( % )
 
@@ -21841,11 +21847,11 @@ relation Call_ok: p TC |- callableTypeIR < (typeArgumentIR)* # (typeId)* >( (arg
 
                     1. Result in: % % |- % < % # % >( % # % # % ): ((void) as typeIR) < [] >( (argumentIR_cast)* )
 
-                1. Else Phantom#1215
+                1. Else Phantom#1216
 
-        1. Else Phantom#1216
+        1. Else Phantom#1217
 
-      1. Else Phantom#1217
+      1. Else Phantom#1218
 
   2. Case (% has type definedFunctionTypeIR)
 
@@ -21881,11 +21887,11 @@ relation Call_ok: p TC |- callableTypeIR < (typeArgumentIR)* # (typeId)* >( (arg
 
                                   1. Result in: % % |- % < % # % >( % # % # % ): typeIR_ret_inferred < (typeArgumentIR_inferred)* >( (argumentIR_cast)* )
 
-                              1. Else Phantom#1218
+                              1. Else Phantom#1219
 
-                            1. Else Phantom#1219
+                            1. Else Phantom#1220
 
-                1. Else Phantom#1220
+                1. Else Phantom#1221
 
   3. Case (% has type externFunctionTypeIR)
 
@@ -21921,11 +21927,11 @@ relation Call_ok: p TC |- callableTypeIR < (typeArgumentIR)* # (typeId)* >( (arg
 
                                   1. Result in: % % |- % < % # % >( % # % # % ): typeIR_ret_inferred < (typeArgumentIR_inferred)* >( (argumentIR_cast)* )
 
-                              1. Else Phantom#1221
+                              1. Else Phantom#1222
 
-                            1. Else Phantom#1222
+                            1. Else Phantom#1223
 
-                1. Else Phantom#1223
+                1. Else Phantom#1224
 
   4. Case (% has type builtinMethodTypeIR)
 
@@ -21945,9 +21951,9 @@ relation Call_ok: p TC |- callableTypeIR < (typeArgumentIR)* # (typeId)* >( (arg
 
                   1. Result in: % % |- % < % # % >( % # % # % ): typeIR_ret < (typeArgumentIR)* >( (argumentIR_cast)* )
 
-              1. Else Phantom#1224
+              1. Else Phantom#1225
 
-      1. Else Phantom#1225
+      1. Else Phantom#1226
 
   5. Case (% has type externMethodTypeIR)
 
@@ -21985,13 +21991,13 @@ relation Call_ok: p TC |- callableTypeIR < (typeArgumentIR)* # (typeId)* >( (arg
 
                                     1. Result in: % % |- % < % # % >( % # % # % ): typeIR_ret_inferred < (typeArgumentIR_inferred)* >( (argumentIR_cast)* )
 
-                                1. Else Phantom#1226
+                                1. Else Phantom#1227
 
-                              1. Else Phantom#1227
+                              1. Else Phantom#1228
 
-                  1. Else Phantom#1228
+                  1. Else Phantom#1229
 
-        1. Else Phantom#1229
+        1. Else Phantom#1230
 
       2. Group externMethodTypeIR-abstract: p TC |- (externMethodTypeIR as callableTypeIR) < (typeArgumentIR)* # (typeId)* >( (argumentIR)* # (id_default)* # (id_optional)* ): % < % >( % )
 
@@ -22025,13 +22031,13 @@ relation Call_ok: p TC |- callableTypeIR < (typeArgumentIR)* # (typeId)* >( (arg
 
                                     1. Result in: % % |- % < % # % >( % # % # % ): typeIR_ret_inferred < (typeArgumentIR_inferred)* >( (argumentIR_cast)* )
 
-                                1. Else Phantom#1230
+                                1. Else Phantom#1231
 
-                              1. Else Phantom#1231
+                              1. Else Phantom#1232
 
-                  1. Else Phantom#1232
+                  1. Else Phantom#1233
 
-        1. Else Phantom#1233
+        1. Else Phantom#1234
 
   6. Case (% has type parserApplyMethodTypeIR)
 
@@ -22053,11 +22059,11 @@ relation Call_ok: p TC |- callableTypeIR < (typeArgumentIR)* # (typeId)* >( (arg
 
                     1. Result in: % % |- % < % # % >( % # % # % ): ((void) as typeIR) < [] >( (argumentIR_cast)* )
 
-                1. Else Phantom#1234
+                1. Else Phantom#1235
 
-        1. Else Phantom#1235
+        1. Else Phantom#1236
 
-      1. Else Phantom#1236
+      1. Else Phantom#1237
 
   7. Case (% has type controlApplyMethodTypeIR)
 
@@ -22079,11 +22085,11 @@ relation Call_ok: p TC |- callableTypeIR < (typeArgumentIR)* # (typeId)* >( (arg
 
                     1. Result in: % % |- % < % # % >( % # % # % ): ((void) as typeIR) < [] >( (argumentIR_cast)* )
 
-                1. Else Phantom#1237
+                1. Else Phantom#1238
 
-        1. Else Phantom#1238
+        1. Else Phantom#1239
 
-      1. Else Phantom#1239
+      1. Else Phantom#1240
 
   8. Case (% has type tableApplyMethodTypeIR)
 
@@ -22107,17 +22113,17 @@ relation Call_ok: p TC |- callableTypeIR < (typeArgumentIR)* # (typeId)* >( (arg
 
                       1. Result in: % % |- % < % # % >( % # % # % ): (tableMetadataStructTypeIR as typeIR) < [] >( [] )
 
-                    1. Else Phantom#1240
+                    1. Else Phantom#1241
 
-              1. Else Phantom#1241
+              1. Else Phantom#1242
 
-            1. Else Phantom#1242
+            1. Else Phantom#1243
 
-          1. Else Phantom#1243
+          1. Else Phantom#1244
 
-        1. Else Phantom#1244
+        1. Else Phantom#1245
 
-      1. Else Phantom#1245
+      1. Else Phantom#1246
 
 relation ConstructorType_ok: p TC |- (prefixedNameIR < (typeArgumentIR)* >) ( (argumentIR)* ): % <# % >(# % # % )
 
@@ -22139,11 +22145,11 @@ relation ConstructorType_ok: p TC |- (prefixedNameIR < (typeArgumentIR)* >) ( (a
 
                 1. Result in: % % |- % ( % ): constructorTypeIR <# (typeId_impl)* >(# (id_default)* # (id_optional)* )
 
-              1. Else Phantom#1246
+              1. Else Phantom#1247
 
-      1. Else Phantom#1247
+      1. Else Phantom#1248
 
-  1. Else Phantom#1248
+  1. Else Phantom#1249
 
   2. (Let (typeDefIR)? be $find_typeDef_t(p, TC, prefixedNameIR))
 
@@ -22167,13 +22173,13 @@ relation ConstructorType_ok: p TC |- (prefixedNameIR < (typeArgumentIR)* >) ( (a
 
                       1. Result in: % % |- % ( % ): constructorTypeIR <# (typeId_impl)* >(# (id_default)* # (id_optional)* )
 
-                    1. Else Phantom#1249
+                    1. Else Phantom#1250
 
-            1. Else Phantom#1250
+            1. Else Phantom#1251
 
-        1. Else Phantom#1251
+        1. Else Phantom#1252
 
-    1. Else Phantom#1252
+    1. Else Phantom#1253
 
   3. If (((typeArgumentIR)* = [])), then
 
@@ -22203,15 +22209,15 @@ relation ConstructorType_ok: p TC |- (prefixedNameIR < (typeArgumentIR)* >) ( (a
 
                             1. Result in: % % |- % ( % ): constructorTypeIR <# (typeId_impl)* >(# (id_default)* # (id_optional)* )
 
-                          1. Else Phantom#1253
+                          1. Else Phantom#1254
 
-                  1. Else Phantom#1254
+                  1. Else Phantom#1255
 
-          1. Else Phantom#1255
+          1. Else Phantom#1256
 
-      1. Else Phantom#1256
+      1. Else Phantom#1257
 
-  3. Else Phantom#1257
+  3. Else Phantom#1258
 
 syntax instctxt = 
    | named
@@ -22255,15 +22261,15 @@ relation Inst_ok: cursor TC instctxt |- constructorTypeIR < (typeArgumentIR)* # 
 
                                   1. Result in: % % % |- % < % # % >( % # % # % ): typeIR_object_inferred < (typeArgumentIR_inferred)* >( (argumentIR_cast)* )
 
-                              1. Else Phantom#1258
+                              1. Else Phantom#1259
 
-                            1. Else Phantom#1259
+                            1. Else Phantom#1260
 
-                1. Else Phantom#1260
+                1. Else Phantom#1261
 
-        1. Else Phantom#1261
+        1. Else Phantom#1262
 
-1. Else Phantom#1262
+1. Else Phantom#1263
 
 2. Group non-package: cursor TC instctxt |- constructorTypeIR < (typeArgumentIR)* # (typeId_infer)* >( (argumentIR)* # (id_default)* # (id_optional)* ): % < % >( % )
 
@@ -22299,13 +22305,13 @@ relation Inst_ok: cursor TC instctxt |- constructorTypeIR < (typeArgumentIR)* # 
 
                                 1. Result in: % % % |- % < % # % >( % # % # % ): typeIR_object_inferred < (typeArgumentIR_inferred)* >( (argumentIR_cast)* )
 
-                            1. Else Phantom#1263
+                            1. Else Phantom#1264
 
-                          1. Else Phantom#1264
+                          1. Else Phantom#1265
 
-              1. Else Phantom#1265
+              1. Else Phantom#1266
 
-      1. Else Phantom#1266
+      1. Else Phantom#1267
 
 def $reduce_serenum(typedExpressionIR)
 
@@ -22975,7 +22981,7 @@ def $result_concat(typeIR, typeIR')
 
             1. Return ((int< (w_a + w_b) >) as typeIR)
 
-      1. Else Phantom#1267
+      1. Else Phantom#1268
 
   2. Case (% has type fixedBitTypeIR)
 
@@ -22995,7 +23001,7 @@ def $result_concat(typeIR, typeIR')
 
             1. Return ((bit< (w_a + w_b) >) as typeIR)
 
-      1. Else Phantom#1268
+      1. Else Phantom#1269
 
   3. Case (% has type typedefTypeIR)
 
@@ -23003,7 +23009,7 @@ def $result_concat(typeIR, typeIR')
 
       1. Return $result_concat(typeIR_l, typeIR')
 
-1. Else Phantom#1269
+1. Else Phantom#1270
 
 2. If ((typeIR' has type typedefTypeIR)), then
 
@@ -23013,9 +23019,9 @@ def $result_concat(typeIR, typeIR')
 
       1. Return $result_concat(typeIR, typeIR_r)
 
-    1. Else Phantom#1270
+    1. Else Phantom#1271
 
-2. Else Phantom#1271
+2. Else Phantom#1272
 
 tbl def $compat_logical(typeIR'', typeIR''')
 =
@@ -23245,7 +23251,7 @@ relation ParameterList_ok_inner: p typingContext |- (parameter)* : % % # %
 
     1. Result in: % % |- % : typingContext [] # []
 
-  1. Else Phantom#1272
+  1. Else Phantom#1273
 
   2. If (((parameter)* matches pattern _ :: _)), then
 
@@ -23261,7 +23267,7 @@ relation ParameterList_ok_inner: p typingContext |- (parameter)* : % % # %
 
               1. Result in: % % |- % : TC_2 (parameterIR)* # (typeId_fresh)*
 
-  2. Else Phantom#1273
+  2. Else Phantom#1274
 
 relation ForUpdateStmt_ok: TC |- forUpdateStatement : %
 
@@ -23281,7 +23287,7 @@ relation ForUpdateStmt_ok: TC |- forUpdateStatement : %
 
               1. Result in: % |- % : (callableTargetIR < (typeArgumentIR)* >( (argumentIR)* ))
 
-          1. Else Phantom#1274
+          1. Else Phantom#1275
 
     2. Case (% matches pattern `%<%>(%)`)
 
@@ -23295,7 +23301,7 @@ relation ForUpdateStmt_ok: TC |- forUpdateStatement : %
 
               1. Result in: % |- % : (callableTargetIR < (typeArgumentIR)* >( (argumentIR)* ))
 
-          1. Else Phantom#1275
+          1. Else Phantom#1276
 
     3. Case (% matches pattern `%%%`)
 
@@ -23311,9 +23317,9 @@ relation ForUpdateStmt_ok: TC |- forUpdateStatement : %
 
                 1. Result in: % |- % : (typedLvalueIR assignop typedExpressionIR)
 
-              1. Else Phantom#1276
+              1. Else Phantom#1277
 
-          1. Else Phantom#1277
+          1. Else Phantom#1278
 
 relation ForUpdateStmtList_ok: TC |- forUpdateStatementList : %
 
@@ -23353,11 +23359,11 @@ relation ForInitStmt_ok: typingContext |- forInitStatement : % %
 
                         1. Result in: % |- % : TC_1 (annotationList typeIR nameIR ?())
 
-                  1. Else Phantom#1278
+                  1. Else Phantom#1279
 
-                1. Else Phantom#1279
+                1. Else Phantom#1280
 
-              1. Else Phantom#1280
+              1. Else Phantom#1281
 
           2. Case (% has type initializer)
 
@@ -23385,13 +23391,13 @@ relation ForInitStmt_ok: typingContext |- forInitStatement : % %
 
                                   1. Result in: % |- % : TC_1 (annotationList typeIR nameIR ?((= typedExpressionIR_init_cast)))
 
-                          1. Else Phantom#1281
+                          1. Else Phantom#1282
 
-                    1. Else Phantom#1282
+                    1. Else Phantom#1283
 
-                  1. Else Phantom#1283
+                  1. Else Phantom#1284
 
-                1. Else Phantom#1284
+                1. Else Phantom#1285
 
     2. Case (% has type forUpdateStatement)
 
@@ -23409,7 +23415,7 @@ relation ForInitStmts_ok: typingContext |- (forInitStatement)* : % %
 
     1. Result in: % |- % : typingContext []
 
-  1. Else Phantom#1285
+  1. Else Phantom#1286
 
   2. If (((forInitStatement)* matches pattern _ :: _)), then
 
@@ -23421,7 +23427,7 @@ relation ForInitStmts_ok: typingContext |- (forInitStatement)* : % %
 
           1. Result in: % |- % : TC_2 forInitStatementIR_h :: (forInitStatementIR_t)*
 
-  2. Else Phantom#1286
+  2. Else Phantom#1287
 
 relation ForInitStmtList_ok: TC_0 |- forInitStatementList : % %
 
@@ -23459,7 +23465,7 @@ relation ForCollectionExpr_ok: TC typeIR_var |- forCollectionExpression : %
 
                       1. Result in: % % |- % : (typedExpressionIR as forCollectionExpressionIR)
 
-                    1. Else Phantom#1287
+                    1. Else Phantom#1288
 
                 2. Case (% has type headerStackTypeIR)
 
@@ -23469,9 +23475,9 @@ relation ForCollectionExpr_ok: TC typeIR_var |- forCollectionExpression : %
 
                       1. Result in: % % |- % : (typedExpressionIR as forCollectionExpressionIR)
 
-                    1. Else Phantom#1288
+                    1. Else Phantom#1289
 
-              1. Else Phantom#1289
+              1. Else Phantom#1290
 
     2. Case (% matches pattern `%..%`)
 
@@ -23501,11 +23507,11 @@ relation ForCollectionExpr_ok: TC typeIR_var |- forCollectionExpression : %
 
                               1. Result in: % % |- % : (typedExpressionIR_l_casted .. typedExpressionIR_r_casted)
 
-                            1. Else Phantom#1290
+                            1. Else Phantom#1291
 
-                    1. Else Phantom#1291
+                    1. Else Phantom#1292
 
-              1. Else Phantom#1292
+              1. Else Phantom#1293
 
 tbl def $compat_range(typeIR'', typeIR''')
 =
@@ -23628,15 +23634,15 @@ relation SwitchLabel_table_ok: TC typeId_table |- switchLabel : %
 
                                 1. Result in: % % |- % : (typedExpressionIR_label as switchLabelIR)
 
-                            1. Else Phantom#1293
+                            1. Else Phantom#1294
 
-                        1. Else Phantom#1294
+                        1. Else Phantom#1295
 
-                    1. Else Phantom#1295
+                    1. Else Phantom#1296
 
-          1. Else Phantom#1296
+          1. Else Phantom#1297
 
-  1. Else Phantom#1297
+  1. Else Phantom#1298
 
 relation SwitchCase_table_ok: TC f l typeId_table |- switchCase : % % # %
 
@@ -23674,7 +23680,7 @@ relation SwitchCases_table_ok: TC f l typeId_table |- (switchCase)* : % % # %
 
     1. Result in: % % % % |- % : f [] # []
 
-  1. Else Phantom#1298
+  1. Else Phantom#1299
 
   2. If (((switchCase)* matches pattern _ :: _)), then
 
@@ -23686,7 +23692,7 @@ relation SwitchCases_table_ok: TC f l typeId_table |- (switchCase)* : % % # %
 
           1. Result in: % % % % |- % : f_t switchCaseIR_h :: (switchCaseIR_t)* # switchLabel_h :: (switchLabel_t)*
 
-  2. Else Phantom#1299
+  2. Else Phantom#1300
 
 relation SwitchCaseList_table_ok: TC f l typeId_table |- switchCaseList : % % # %
 
@@ -23728,9 +23734,9 @@ relation SwitchLabel_general_ok: TC typeIR |- switchLabel : %
 
                       1. Result in: % % |- % : (typedExpressionIR_label_cast as switchLabelIR)
 
-                    1. Else Phantom#1300
+                    1. Else Phantom#1301
 
-              1. Else Phantom#1301
+              1. Else Phantom#1302
 
 relation SwitchCase_general_ok: TC f l typeIR_switch |- switchCase : % % # %
 
@@ -23768,7 +23774,7 @@ relation SwitchCases_general_ok: TC f l typeIR_switch |- (switchCase)* : % % # %
 
     1. Result in: % % % % |- % : f [] # []
 
-  1. Else Phantom#1302
+  1. Else Phantom#1303
 
   2. If (((switchCase)* matches pattern _ :: _)), then
 
@@ -23780,7 +23786,7 @@ relation SwitchCases_general_ok: TC f l typeIR_switch |- (switchCase)* : % % # %
 
           1. Result in: % % % % |- % : f_t switchCaseIR_h :: (switchCaseIR_t)* # switchLabel_h :: (switchLabel_t)*
 
-  2. Else Phantom#1303
+  2. Else Phantom#1304
 
 relation SwitchCaseList_general_ok: TC f l typeIR_switch |- switchCaseList : % % # %
 
@@ -23841,7 +23847,7 @@ relation BlockElementStmts_ok: typingContext flow l |- (blockElementStatement)* 
 
     1. Result in: % % % |- % : typingContext flow []
 
-  1. Else Phantom#1304
+  1. Else Phantom#1305
 
   2. If (((blockElementStatement)* matches pattern _ :: _)), then
 
@@ -23853,7 +23859,7 @@ relation BlockElementStmts_ok: typingContext flow l |- (blockElementStatement)* 
 
           1. Result in: % % % |- % : TC_2 f_2 blockElementStatementIR_h :: (blockElementStatementIR_t)*
 
-  2. Else Phantom#1305
+  2. Else Phantom#1306
 
 relation InstDecl_non_objectInitializer_ok: p TC_0 |- annotationList prefixedTypeName < typeArgumentList >( argumentList ) name ;: % %
 
@@ -23907,7 +23913,7 @@ relation ObjectDecl_ok: p TC_0 typeFrame externMethodTypeDefEnv |- objectDeclara
 
                     1. Result in: % % % % |- % : typeFrame_init externMethodTypeDefEnv (instantiationIR as objectDeclarationIR)
 
-              1. Else Phantom#1306
+              1. Else Phantom#1307
 
     2. Case (% has type functionDeclaration)
 
@@ -23945,11 +23951,11 @@ relation ObjectDecl_ok: p TC_0 typeFrame externMethodTypeDefEnv |- objectDeclara
 
                                       1. Result in: % % % % |- % : typeFrame externMethodTypeDefEnv_init (functionDeclarationIR as objectDeclarationIR)
 
-                                1. Else Phantom#1307
+                                1. Else Phantom#1308
 
-                        1. Else Phantom#1308
+                        1. Else Phantom#1309
 
-                  1. Else Phantom#1309
+                  1. Else Phantom#1310
 
 relation ObjectDecls_ok: p TC typeFrame externMethodTypeDefEnv |- (objectDeclaration)* : % % %
 
@@ -23959,7 +23965,7 @@ relation ObjectDecls_ok: p TC typeFrame externMethodTypeDefEnv |- (objectDeclara
 
     1. Result in: % % % % |- % : typeFrame externMethodTypeDefEnv []
 
-  1. Else Phantom#1310
+  1. Else Phantom#1311
 
   2. If (((objectDeclaration)* matches pattern _ :: _)), then
 
@@ -23971,7 +23977,7 @@ relation ObjectDecls_ok: p TC typeFrame externMethodTypeDefEnv |- (objectDeclara
 
           1. Result in: % % % % |- % : typeFrame_2 externMethodTypeDefEnv_2 objectDeclarationIR_h :: (objectDeclarationIR_t)*
 
-  2. Else Phantom#1311
+  2. Else Phantom#1312
 
 relation ObjectDeclList_ok: p TC |- objectDeclarationList : % % %
 
@@ -23989,7 +23995,7 @@ def $subst_externMethodTypeDefEnv(externMethodTypeDefEnv_extern, set<pair<callab
 
   1. Return externMethodTypeDefEnv_extern
 
-1. Else Phantom#1312
+1. Else Phantom#1313
 
 2. (Let ({ (pair<callableId, externMethodTypeDefIR>)* }) be set<pair<callableId, externMethodTypeDefIR>>)
 
@@ -24017,13 +24023,13 @@ def $subst_externMethodTypeDefEnv(externMethodTypeDefEnv_extern, set<pair<callab
 
                         1. Return $subst_externMethodTypeDefEnv(externMethodTypeDefEnv_extern_subst, ({ ((callableId_init_t : externMethodTypeDefIR_init_t))* }))
 
-                    1. Else Phantom#1313
+                    1. Else Phantom#1314
 
-              1. Else Phantom#1314
+              1. Else Phantom#1315
 
-          1. Else Phantom#1315
+          1. Else Phantom#1316
 
-  1. Else Phantom#1316
+  1. Else Phantom#1317
 
 relation InstDecl_objectInitializer_ok: p TC_0 |- annotationList prefixedTypeName < typeArgumentList >( argumentList ) name ={ objectDeclarationList };: % %
 
@@ -24069,9 +24075,9 @@ relation InstDecl_objectInitializer_ok: p TC_0 |- annotationList prefixedTypeNam
 
                                         1. Result in: % % |- % % < % >( % ) % ={ % };: TC_2 instantiationIR
 
-                              1. Else Phantom#1317
+                              1. Else Phantom#1318
 
-                  1. Else Phantom#1318
+                  1. Else Phantom#1319
 
 def $split_externConstructorOrMethodPrototypeList(externConstructorOrMethodPrototypeList)
 
@@ -24091,9 +24097,9 @@ def $split_externConstructorOrMethodPrototypeList(externConstructorOrMethodProto
 
               1. Return ((externConstructorPrototype)*, (externMethodPrototype)*)
 
-          1. Else Phantom#1319
+          1. Else Phantom#1320
 
-    1. Else Phantom#1320
+    1. Else Phantom#1321
 
 def $constructorTypeDef_of_externConstructorPrototypeIR(typeParameterListIR_expl, typeIR, (_annotationList nameIR <, typeParameterListIR_impl >( (parameterIR)* );))
 
@@ -24125,9 +24131,9 @@ relation Enum_serializable_field_ok: TC_0 nameIR_enum typeIR |- (name = expressi
 
                     1. Result in: % % % |- % : TC_1 (nameIR = value)
 
-          1. Else Phantom#1321
+          1. Else Phantom#1322
 
-      1. Else Phantom#1322
+      1. Else Phantom#1323
 
 relation Enum_serializable_fields_ok: typingContext nameIR_enum typeIR |- (namedExpression)* : % %
 
@@ -24137,7 +24143,7 @@ relation Enum_serializable_fields_ok: typingContext nameIR_enum typeIR |- (named
 
     1. Result in: % % % |- % : typingContext []
 
-  1. Else Phantom#1323
+  1. Else Phantom#1324
 
   2. If (((namedExpression)* matches pattern _ :: _)), then
 
@@ -24151,7 +24157,7 @@ relation Enum_serializable_fields_ok: typingContext nameIR_enum typeIR |- (named
 
             1. Result in: % % % |- % : TC_2 (namedValueIR)*
 
-  2. Else Phantom#1324
+  2. Else Phantom#1325
 
 relation Enum_serializable_fieldList_ok: TC_0 nameIR_enum typeIR |- namedExpressionList : % %
 
@@ -24199,7 +24205,7 @@ relation SelectCase_keyset_simple_ok: TC typeIR_key |- simpleKeysetExpression : 
 
                             1. Result in: % % |- % : (typedExpressionIR_cast as simpleKeysetExpressionIR)
 
-                      1. Else Phantom#1325
+                      1. Else Phantom#1326
 
                 2. Case false
 
@@ -24211,7 +24217,7 @@ relation SelectCase_keyset_simple_ok: TC typeIR_key |- simpleKeysetExpression : 
 
                         1. Result in: % % |- % : (typedExpressionIR_cast as simpleKeysetExpressionIR)
 
-                  1. Else Phantom#1326
+                  1. Else Phantom#1327
 
   2. Case (% matches pattern `%&&&%`)
 
@@ -24251,13 +24257,13 @@ relation SelectCase_keyset_simple_ok: TC typeIR_key |- simpleKeysetExpression : 
 
                                       1. Result in: % % |- % : (typedExpressionIR_l_casted &&& typedExpressionIR_r_casted)
 
-                                  1. Else Phantom#1327
+                                  1. Else Phantom#1328
 
-                            1. Else Phantom#1328
+                            1. Else Phantom#1329
 
-                    1. Else Phantom#1329
+                    1. Else Phantom#1330
 
-              1. Else Phantom#1330
+              1. Else Phantom#1331
 
   3. Case (% matches pattern `%..%`)
 
@@ -24299,15 +24305,15 @@ relation SelectCase_keyset_simple_ok: TC typeIR_key |- simpleKeysetExpression : 
 
                                         1. Result in: % % |- % : (typedExpressionIR_l_casted .. typedExpressionIR_r_casted)
 
-                                    1. Else Phantom#1331
+                                    1. Else Phantom#1332
 
-                              1. Else Phantom#1332
+                              1. Else Phantom#1333
 
-                          1. Else Phantom#1333
+                          1. Else Phantom#1334
 
-                    1. Else Phantom#1334
+                    1. Else Phantom#1335
 
-              1. Else Phantom#1335
+              1. Else Phantom#1336
 
   4. Case (% matches pattern `DEFAULT`)
 
@@ -24396,7 +24402,7 @@ relation SelectCase_keyset_ok: TC (typeIR)* |- keysetExpression : %
 
             1. Result in: % % |- % : (simpleKeysetExpressionIR as keysetExpressionIR)
 
-      1. Else Phantom#1336
+      1. Else Phantom#1337
 
       2. If ((keysetExpression has type simpleKeysetExpression)), then
 
@@ -24420,9 +24426,9 @@ relation SelectCase_keyset_ok: TC (typeIR)* |- keysetExpression : %
 
                   1. Result in: % % |- % : (simpleKeysetExpressionIR as keysetExpressionIR)
 
-          1. Else Phantom#1337
+          1. Else Phantom#1338
 
-      2. Else Phantom#1338
+      2. Else Phantom#1339
 
       3. Case analysis on keysetExpression
 
@@ -24438,9 +24444,9 @@ relation SelectCase_keyset_ok: TC (typeIR)* |- keysetExpression : %
 
             1. Result in: % % |- % : (simpleKeysetExpressionIR as keysetExpressionIR)
 
-      3. Else Phantom#1339
+      3. Else Phantom#1340
 
-  1. Else Phantom#1340
+  1. Else Phantom#1341
 
   2. If ((keysetExpression has type expression)), then
 
@@ -24454,9 +24460,9 @@ relation SelectCase_keyset_ok: TC (typeIR)* |- keysetExpression : %
 
             1. Result in: % % |- % : (simpleKeysetExpressionIR as keysetExpressionIR)
 
-      1. Else Phantom#1341
+      1. Else Phantom#1342
 
-  2. Else Phantom#1342
+  2. Else Phantom#1343
 
   3. If (((typeIR)* = [])), then
 
@@ -24464,9 +24470,9 @@ relation SelectCase_keyset_ok: TC (typeIR)* |- keysetExpression : %
 
       1. Result in: % % |- % : ((default) as keysetExpressionIR)
 
-    1. Else Phantom#1343
+    1. Else Phantom#1344
 
-  3. Else Phantom#1344
+  3. Else Phantom#1345
 
   4. Case analysis on keysetExpression
 
@@ -24478,7 +24484,7 @@ relation SelectCase_keyset_ok: TC (typeIR)* |- keysetExpression : %
 
           1. Result in: % % |- % : (simpleKeysetExpressionIR as keysetExpressionIR)
 
-      1. Else Phantom#1345
+      1. Else Phantom#1346
 
     2. Case (% = ((_) as keysetExpression))
 
@@ -24488,9 +24494,9 @@ relation SelectCase_keyset_ok: TC (typeIR)* |- keysetExpression : %
 
           1. Result in: % % |- % : (simpleKeysetExpressionIR as keysetExpressionIR)
 
-      1. Else Phantom#1346
+      1. Else Phantom#1347
 
-  4. Else Phantom#1347
+  4. Else Phantom#1348
 
 2. If ((keysetExpression has type tupleKeysetExpression)), then
 
@@ -24532,9 +24538,9 @@ relation SelectCase_keyset_ok: TC (typeIR)* |- keysetExpression : %
 
                 1. Result in: % % |- % : ((( [simpleKeysetExpressionIR] )) as keysetExpressionIR)
 
-          1. Else Phantom#1348
+          1. Else Phantom#1349
 
-      1. Else Phantom#1349
+      1. Else Phantom#1350
 
       2. Case analysis on tupleKeysetExpression
 
@@ -24546,7 +24552,7 @@ relation SelectCase_keyset_ok: TC (typeIR)* |- keysetExpression : %
 
               1. Result in: % % |- % : ((( [simpleKeysetExpressionIR] )) as keysetExpressionIR)
 
-          1. Else Phantom#1350
+          1. Else Phantom#1351
 
         2. Case (% matches pattern `(_)`)
 
@@ -24556,7 +24562,7 @@ relation SelectCase_keyset_ok: TC (typeIR)* |- keysetExpression : %
 
               1. Result in: % % |- % : ((( [simpleKeysetExpressionIR] )) as keysetExpressionIR)
 
-          1. Else Phantom#1351
+          1. Else Phantom#1352
 
         3. Case (% matches pattern `(%,%)`)
 
@@ -24572,11 +24578,11 @@ relation SelectCase_keyset_ok: TC (typeIR)* |- keysetExpression : %
 
                     1. Result in: % % |- % : ((( (simpleKeysetExpressionIR)* )) as keysetExpressionIR)
 
-                1. Else Phantom#1352
+                1. Else Phantom#1353
 
-      2. Else Phantom#1353
+      2. Else Phantom#1354
 
-2. Else Phantom#1354
+2. Else Phantom#1355
 
 relation SelectCase_ok: TC (nameIR_state)* (typeIR_key)* |- (keysetExpression : name ;) : %
 
@@ -24590,7 +24596,7 @@ relation SelectCase_ok: TC (nameIR_state)* (typeIR_key)* |- (keysetExpression : 
 
         1. Result in: % % % |- % : (keysetExpressionIR : nameIR ;)
 
-      1. Else Phantom#1355
+      1. Else Phantom#1356
 
 relation ParserStmts_ok: typingContext |- (parserStatement)* : % %
 
@@ -24600,7 +24606,7 @@ relation ParserStmts_ok: typingContext |- (parserStatement)* : % %
 
     1. Result in: % |- % : typingContext []
 
-  1. Else Phantom#1356
+  1. Else Phantom#1357
 
   2. If (((parserStatement)* matches pattern _ :: _)), then
 
@@ -24612,7 +24618,7 @@ relation ParserStmts_ok: typingContext |- (parserStatement)* : % %
 
           1. Result in: % |- % : TC_2 parserStatementIR_h :: (parserStatementIR_t)*
 
-  2. Else Phantom#1357
+  2. Else Phantom#1358
 
 relation ParserLocalDecls_ok: typingContext |- (parserLocalDeclaration)* : % %
 
@@ -24622,7 +24628,7 @@ relation ParserLocalDecls_ok: typingContext |- (parserLocalDeclaration)* : % %
 
     1. Result in: % |- % : typingContext []
 
-  1. Else Phantom#1358
+  1. Else Phantom#1359
 
   2. If (((parserLocalDeclaration)* matches pattern _ :: _)), then
 
@@ -24634,7 +24640,7 @@ relation ParserLocalDecls_ok: typingContext |- (parserLocalDeclaration)* : % %
 
           1. Result in: % |- % : TC_2 parserLocalDeclarationIR_h :: (parserLocalDeclarationIR_t)*
 
-  2. Else Phantom#1359
+  2. Else Phantom#1360
 
 tbl def $compat_table_exact_optional_key(typeIR'')
 =
@@ -24834,9 +24840,9 @@ relation TableEntry_keyset_simple_ok: TC TBLC |- (typeIR_key : text) @ simpleKey
 
                               1. Result in: % % |- % @ % : (lpm n) (typedExpressionIR_set as simpleKeysetExpressionIR)
 
-                        1. Else Phantom#1360
+                        1. Else Phantom#1361
 
-              1. Else Phantom#1361
+              1. Else Phantom#1362
 
           2. Case (% =/= "lpm")
 
@@ -24868,13 +24874,13 @@ relation TableEntry_keyset_simple_ok: TC TBLC |- (typeIR_key : text) @ simpleKey
 
                                       1. Result in: % % |- % @ % : (non_lpm) (typedExpressionIR_set as simpleKeysetExpressionIR)
 
-                                1. Else Phantom#1362
+                                1. Else Phantom#1363
 
-                        1. Else Phantom#1363
+                        1. Else Phantom#1364
 
-                    1. Else Phantom#1364
+                    1. Else Phantom#1365
 
-                1. Else Phantom#1365
+                1. Else Phantom#1366
 
               2. Case false
 
@@ -24892,7 +24898,7 @@ relation TableEntry_keyset_simple_ok: TC TBLC |- (typeIR_key : text) @ simpleKey
 
                             1. Result in: % % |- % @ % : (non_lpm) (typedExpressionIR_set as simpleKeysetExpressionIR)
 
-                      1. Else Phantom#1366
+                      1. Else Phantom#1367
 
   2. Case (% matches pattern `%&&&%`)
 
@@ -24952,19 +24958,19 @@ relation TableEntry_keyset_simple_ok: TC TBLC |- (typeIR_key : text) @ simpleKey
 
                                                           1. Result in: % % |- % @ % : (lpm n_prefix) (typedExpressionIR_l_reduced &&& typedExpressionIR_r_reduced)
 
-                                                    1. Else Phantom#1367
+                                                    1. Else Phantom#1368
 
-                                              1. Else Phantom#1368
+                                              1. Else Phantom#1369
 
-                                          1. Else Phantom#1369
+                                          1. Else Phantom#1370
 
-                                    1. Else Phantom#1370
+                                    1. Else Phantom#1371
 
-                              1. Else Phantom#1371
+                              1. Else Phantom#1372
 
-                        1. Else Phantom#1372
+                        1. Else Phantom#1373
 
-              1. Else Phantom#1373
+              1. Else Phantom#1374
 
           2. Case (% = "ternary")
 
@@ -24992,13 +24998,13 @@ relation TableEntry_keyset_simple_ok: TC TBLC |- (typeIR_key : text) @ simpleKey
 
                                   1. Result in: % % |- % @ % : (non_lpm) (typedExpressionIR_l_reduced &&& typedExpressionIR_r_reduced)
 
-                              1. Else Phantom#1374
+                              1. Else Phantom#1375
 
-                        1. Else Phantom#1375
+                        1. Else Phantom#1376
 
-                  1. Else Phantom#1376
+                  1. Else Phantom#1377
 
-        1. Else Phantom#1377
+        1. Else Phantom#1378
 
   3. Case (% matches pattern `DEFAULT`)
 
@@ -25016,7 +25022,7 @@ relation TableEntry_keyset_simple_ok: TC TBLC |- (typeIR_key : text) @ simpleKey
 
                 1. Result in: % % |- % @ % : (lpm n) (default)
 
-            1. Else Phantom#1378
+            1. Else Phantom#1379
 
         2. Case (% =/= "lpm")
 
@@ -25024,7 +25030,7 @@ relation TableEntry_keyset_simple_ok: TC TBLC |- (typeIR_key : text) @ simpleKey
 
             1. Result in: % % |- % @ % : (non_lpm) (default)
 
-          1. Else Phantom#1379
+          1. Else Phantom#1380
 
   4. Case (% matches pattern `_`)
 
@@ -25040,7 +25046,7 @@ relation TableEntry_keyset_simple_ok: TC TBLC |- (typeIR_key : text) @ simpleKey
 
               1. Result in: % % |- % @ % : (lpm 0) (_)
 
-            1. Else Phantom#1380
+            1. Else Phantom#1381
 
         2. Case (% =/= "lpm")
 
@@ -25048,9 +25054,9 @@ relation TableEntry_keyset_simple_ok: TC TBLC |- (typeIR_key : text) @ simpleKey
 
             1. Result in: % % |- % @ % : (non_lpm) (_)
 
-          1. Else Phantom#1381
+          1. Else Phantom#1382
 
-1. Else Phantom#1382
+1. Else Phantom#1383
 
 2. If ((text = "range")), then
 
@@ -25084,15 +25090,15 @@ relation TableEntry_keyset_simple_ok: TC TBLC |- (typeIR_key : text) @ simpleKey
 
                               1. Result in: % % |- % @ % : (non_lpm) (typedExpressionIR_l_reduced .. typedExpressionIR_r_reduced)
 
-                          1. Else Phantom#1383
+                          1. Else Phantom#1384
 
-                    1. Else Phantom#1384
+                    1. Else Phantom#1385
 
-              1. Else Phantom#1385
+              1. Else Phantom#1386
 
-  1. Else Phantom#1386
+  1. Else Phantom#1387
 
-2. Else Phantom#1387
+2. Else Phantom#1388
 
 def $is_singleton_list_expression(expression)
 
@@ -25120,9 +25126,9 @@ relation TableEntry_keysets_simple_ok: TC TBLC tableEntryState |- (matchKey)* @ 
 
       1. Result in: % % % |- % @ % : tableEntryState []
 
-    1. Else Phantom#1388
+    1. Else Phantom#1389
 
-  1. Else Phantom#1389
+  1. Else Phantom#1390
 
   2. If (((matchKey)* matches pattern _ :: _)), then
 
@@ -25140,9 +25146,9 @@ relation TableEntry_keysets_simple_ok: TC TBLC tableEntryState |- (matchKey)* @ 
 
                 1. Result in: % % % |- % @ % : TBLS_3 simpleKeysetExpressionIR_h :: (simpleKeysetExpressionIR_t)*
 
-      1. Else Phantom#1390
+      1. Else Phantom#1391
 
-  2. Else Phantom#1391
+  2. Else Phantom#1392
 
 def $is_tableKeysProperty(tableProperty)
 
@@ -25230,7 +25236,7 @@ relation ControlLocalDecls_ok: typingContext |- (controlLocalDeclaration)* : % %
 
     1. Result in: % |- % : typingContext []
 
-  1. Else Phantom#1392
+  1. Else Phantom#1393
 
   2. If (((controlLocalDeclaration)* matches pattern _ :: _)), then
 
@@ -25242,7 +25248,7 @@ relation ControlLocalDecls_ok: typingContext |- (controlLocalDeclaration)* : % %
 
           1. Result in: % |- % : TC_2 controlLocalDeclarationIR_h :: (controlLocalDeclarationIR_t)*
 
-  2. Else Phantom#1393
+  2. Else Phantom#1394
 
 relation Expr_lvalue_ok: p TC |- (expressionIR # (( typeIR ctk )))
 
@@ -25266,11 +25272,11 @@ relation Expr_lvalue_ok: p TC |- (expressionIR # (( typeIR ctk )))
 
                   1. The relation holds
 
-                1. Else Phantom#1394
+                1. Else Phantom#1395
 
-              1. Else Phantom#1395
+              1. Else Phantom#1396
 
-          1. Else Phantom#1396
+          1. Else Phantom#1397
 
   2. Case (% has type memberAccessExpressionIR)
 
@@ -25298,17 +25304,17 @@ relation Expr_lvalue_ok: p TC |- (expressionIR # (( typeIR ctk )))
 
                           1. The relation holds
 
-                        1. Else Phantom#1397
+                        1. Else Phantom#1398
 
-                      1. Else Phantom#1398
+                      1. Else Phantom#1399
 
                     2. Case false
 
                       1. The relation holds
 
-            1. Else Phantom#1399
+            1. Else Phantom#1400
 
-      1. Else Phantom#1400
+      1. Else Phantom#1401
 
   3. Case (% has type indexAccessExpressionIR)
 
@@ -25320,7 +25326,7 @@ relation Expr_lvalue_ok: p TC |- (expressionIR # (( typeIR ctk )))
 
           1. The relation holds
 
-        1. Else Phantom#1401
+        1. Else Phantom#1402
 
   4. Case (% has type sliceAccessExpressionIR)
 
@@ -25332,9 +25338,9 @@ relation Expr_lvalue_ok: p TC |- (expressionIR # (( typeIR ctk )))
 
           1. The relation holds
 
-        1. Else Phantom#1402
+        1. Else Phantom#1403
 
-1. Else Phantom#1403
+1. Else Phantom#1404
 
 syntax infer = 
    | knownas typeIR
@@ -25354,7 +25360,7 @@ def $infer((typeId)*, (parameterIR)*, (argumentIR)*)
 
   1. Return $empty_map<typeId, typeIR>
 
-1. Else Phantom#1404
+1. Else Phantom#1405
 
 2. If (((typeId)* =/= [])), then
 
@@ -25370,7 +25376,7 @@ def $infer((typeId)*, (parameterIR)*, (argumentIR)*)
 
             1. Return inference_resolved
 
-2. Else Phantom#1405
+2. Else Phantom#1406
 
 def $infer'(constraint, parameterIR, argumentIR)
 
@@ -25612,7 +25618,7 @@ def $merge_constraint(constraint_pre, constraint_post)
 
       1. Return $merge_constraint'(constraint_pre, constraint_post, (typeId_pre)*, ({ [] }))
 
-    1. Else Phantom#1406
+    1. Else Phantom#1407
 
 def $merge_constraint'(constraint_pre, constraint_post, (typeId)*, constraint)
 
@@ -25634,7 +25640,7 @@ def $merge_constraint'(constraint_pre, constraint_post, (typeId)*, constraint)
 
             1. Return $merge_constraint'(constraint_pre, constraint_post, (typeId_t)*, constraint_updated)
 
-        1. Else Phantom#1407
+        1. Else Phantom#1408
 
         2. (Let (infer)? be $find_map<typeId, infer>(constraint_post, typeId_h))
 
@@ -25650,11 +25656,11 @@ def $merge_constraint'(constraint_pre, constraint_post, (typeId)*, constraint)
 
                     1. Return $merge_constraint'(constraint_pre, constraint_post, (typeId_t)*, constraint_updated)
 
-              1. Else Phantom#1408
+              1. Else Phantom#1409
 
-          1. Else Phantom#1409
+          1. Else Phantom#1410
 
-      1. Else Phantom#1410
+      1. Else Phantom#1411
 
       2. (Let (infer)? be $find_map<typeId, infer>(constraint_pre, typeId_h))
 
@@ -25672,7 +25678,7 @@ def $merge_constraint'(constraint_pre, constraint_post, (typeId)*, constraint)
 
                     1. Return $merge_constraint'(constraint_pre, constraint_post, (typeId_t)*, constraint_updated)
 
-                1. Else Phantom#1411
+                1. Else Phantom#1412
 
                 2. (Let (infer'')? be $find_map<typeId, infer>(constraint_post, typeId_h))
 
@@ -25698,15 +25704,15 @@ def $merge_constraint'(constraint_pre, constraint_post, (typeId)*, constraint)
 
                                 1. Return $merge_constraint'(constraint_pre, constraint_post, (typeId_t)*, constraint_updated)
 
-                            1. Else Phantom#1412
+                            1. Else Phantom#1413
 
-                      1. Else Phantom#1413
+                      1. Else Phantom#1414
 
-                  1. Else Phantom#1414
+                  1. Else Phantom#1415
 
-            1. Else Phantom#1415
+            1. Else Phantom#1416
 
-        1. Else Phantom#1416
+        1. Else Phantom#1417
 
 def $merge_constraints(constraint_pre, (constraint)*)
 
@@ -25734,7 +25740,7 @@ def $resolve_constraint(({ ((typeId : infer))* }))
 
     1. Return ({ ((typeId : typeIR))* })
 
-1. Else Phantom#1417
+1. Else Phantom#1418
 
 def $resolve_type_alias(typeIR)
 
@@ -25758,7 +25764,7 @@ def $resolve_type_alias(typeIR)
 
       1. Return (nameIR_alias, (typeIR_arg)*)
 
-1. Else Phantom#1418
+1. Else Phantom#1419
 
 def $instantiable_extern(cursor, TC, instctxt)
 
@@ -25878,7 +25884,7 @@ def $instantiable(p, TC, instctxt, typeIR)
 
       1. Return $instantiable_table(p, TC, instctxt)
 
-  1. Else Phantom#1419
+  1. Else Phantom#1420
 
 def $callable_action(cursor, TC)
 
@@ -26212,7 +26218,7 @@ def $parameterListIR_of_externMethodDef(externMethodDef)
 
     1. Return parameterListIR
 
-1. Else Phantom#1420
+1. Else Phantom#1421
 
 def $parameterListIR_of_parserApplyMethodDef((parser_apply( parameterListIR ){ _parserLocalDeclarationListIR ; _stateEnv }))
 
@@ -26401,7 +26407,7 @@ def $find_store(store, objectId)
 
       1. Return object'
 
-  1. Else Phantom#1421
+  1. Else Phantom#1422
 
 syntax globalInstLayer = {constructor constructorDefEnv, type typeDefEnv, callable callableDefEnv, frame frame}
 
@@ -26437,7 +26443,7 @@ def $exit_i(IC)
 
       1. Return IC[local.frames = (frame_t)*]
 
-  1. Else Phantom#1422
+  1. Else Phantom#1423
 
 def $enter_path_i(IC, id)
 
@@ -26477,7 +26483,7 @@ def $add_var_i(cursor, IC, id, value)
 
         1. Return IC[global.frame = frame]
 
-    1. Else Phantom#1423
+    1. Else Phantom#1424
 
   2. Case (% matches pattern `BLOCK`)
 
@@ -26487,7 +26493,7 @@ def $add_var_i(cursor, IC, id, value)
 
         1. Return IC[block.frame = frame]
 
-    1. Else Phantom#1424
+    1. Else Phantom#1425
 
   3. Case (% matches pattern `LOCAL`)
 
@@ -26503,9 +26509,9 @@ def $add_var_i(cursor, IC, id, value)
 
               1. Return IC[local.frames = frame_h' :: (frame_t)*]
 
-          1. Else Phantom#1425
+          1. Else Phantom#1426
 
-      1. Else Phantom#1426
+      1. Else Phantom#1427
 
 def $add_vars_i(p, IC, (id)*, (value)*)
 
@@ -26517,7 +26523,7 @@ def $add_vars_i(p, IC, (id)*, (value)*)
 
       1. Return IC
 
-    1. Else Phantom#1427
+    1. Else Phantom#1428
 
   2. Case (% matches pattern _ :: _)
 
@@ -26533,7 +26539,7 @@ def $add_vars_i(p, IC, (id)*, (value)*)
 
               1. Return IC''
 
-      1. Else Phantom#1428
+      1. Else Phantom#1429
 
 def $add_typeDef_i(cursor, IC, typeId, typeDefIR)
 
@@ -26543,7 +26549,7 @@ def $add_typeDef_i(cursor, IC, typeId, typeDefIR)
 
     1. Return IC[global.type = typeDefEnv]
 
-1. Else Phantom#1429
+1. Else Phantom#1430
 
 def $add_parserState_i(IC, nameIR, parserStateIR)
 
@@ -26553,7 +26559,7 @@ def $add_parserState_i(IC, nameIR, parserStateIR)
 
     1. Return IC[block.state = stateEnv]
 
-1. Else Phantom#1430
+1. Else Phantom#1431
 
 def $add_type_i(cursor, IC, typeId, typeIR)
 
@@ -26571,7 +26577,7 @@ def $add_type_i(cursor, IC, typeId, typeIR)
 
       1. Return IC[local.type = theta]
 
-1. Else Phantom#1431
+1. Else Phantom#1432
 
 def $add_types_i(p, IC, (typeId)*, (typeIR)*)
 
@@ -26583,7 +26589,7 @@ def $add_types_i(p, IC, (typeId)*, (typeIR)*)
 
       1. Return IC
 
-    1. Else Phantom#1432
+    1. Else Phantom#1433
 
   2. Case (% matches pattern _ :: _)
 
@@ -26597,7 +26603,7 @@ def $add_types_i(p, IC, (typeId)*, (typeIR)*)
 
             1. Return $add_types_i(p, IC', (typeId_t)*, (typeIR_t)*)
 
-      1. Else Phantom#1433
+      1. Else Phantom#1434
 
 def $add_callableDef_overload_i(cursor, IC, callableId, callableDef)
 
@@ -26611,7 +26617,7 @@ def $add_callableDef_overload_i(cursor, IC, callableId, callableDef)
 
         1. Return IC[global.callable = callableDefEnv]
 
-    1. Else Phantom#1434
+    1. Else Phantom#1435
 
   2. Case (% matches pattern `BLOCK`)
 
@@ -26621,9 +26627,9 @@ def $add_callableDef_overload_i(cursor, IC, callableId, callableDef)
 
         1. Return IC[block.callable = callableDefEnv]
 
-    1. Else Phantom#1435
+    1. Else Phantom#1436
 
-1. Else Phantom#1436
+1. Else Phantom#1437
 
 def $add_callableDef_non_overload_i(cursor, IC, callableId, callableDef)
 
@@ -26641,7 +26647,7 @@ def $add_callableDef_non_overload_i(cursor, IC, callableId, callableDef)
 
             1. Return IC[global.callable = callableDefEnv]
 
-        1. Else Phantom#1437
+        1. Else Phantom#1438
 
   2. Case (% matches pattern `BLOCK`)
 
@@ -26655,9 +26661,9 @@ def $add_callableDef_non_overload_i(cursor, IC, callableId, callableDef)
 
             1. Return IC[block.callable = callableDefEnv]
 
-        1. Else Phantom#1438
+        1. Else Phantom#1439
 
-1. Else Phantom#1439
+1. Else Phantom#1440
 
 def $find_callableDef_non_overload_i(p, IC, prefixedNameIR)
 
@@ -26669,7 +26675,7 @@ def $find_callableDef_non_overload_i(p, IC, prefixedNameIR)
 
       1. Return ?()
 
-    1. Else Phantom#1440
+    1. Else Phantom#1441
 
     2. (Let ((callableId, callableDef))? be $find_non_overloaded<callableDef>(IC.global.callable, nameIR))
 
@@ -26679,9 +26685,9 @@ def $find_callableDef_non_overload_i(p, IC, prefixedNameIR)
 
           1. Return ?(((global), callableId, callableDef))
 
-      1. Else Phantom#1441
+      1. Else Phantom#1442
 
-1. Else Phantom#1442
+1. Else Phantom#1443
 
 2. Case analysis on p
 
@@ -26693,7 +26699,7 @@ def $find_callableDef_non_overload_i(p, IC, prefixedNameIR)
 
         1. Return $find_callableDef_non_overload_i((global), IC, (. nameIR))
 
-    1. Else Phantom#1443
+    1. Else Phantom#1444
 
   2. Case (% matches pattern `BLOCK`)
 
@@ -26709,15 +26715,15 @@ def $find_callableDef_non_overload_i(p, IC, prefixedNameIR)
 
               1. Return ?(((block), callableId, callableDef))
 
-          1. Else Phantom#1444
+          1. Else Phantom#1445
 
         2. If ((?() = $find_non_overloaded<callableDef>(IC.block.callable, nameIR))), then
 
           1. Return $find_callableDef_non_overload_i((global), IC, (` nameIR))
 
-        2. Else Phantom#1445
+        2. Else Phantom#1446
 
-    1. Else Phantom#1446
+    1. Else Phantom#1447
 
   3. Case (% matches pattern `LOCAL`)
 
@@ -26727,7 +26733,7 @@ def $find_callableDef_non_overload_i(p, IC, prefixedNameIR)
 
         1. Return $find_callableDef_non_overload_i((block), IC, (` nameIR))
 
-    1. Else Phantom#1447
+    1. Else Phantom#1448
 
 def $add_constructorDef_i(IC, callableId, constructorDef)
 
@@ -26745,7 +26751,7 @@ def $add_constructorDefs_i(IC, (callableId)*, (constructorDef)*)
 
       1. Return IC
 
-    1. Else Phantom#1448
+    1. Else Phantom#1449
 
   2. Case (% matches pattern _ :: _)
 
@@ -26761,7 +26767,7 @@ def $add_constructorDefs_i(IC, (callableId)*, (constructorDef)*)
 
               1. Return IC''
 
-      1. Else Phantom#1449
+      1. Else Phantom#1450
 
 def $find_var_i(prefixedNameIR, p, IC)
 
@@ -26779,7 +26785,7 @@ def $find_var_i(prefixedNameIR, p, IC)
 
             1. Return value'
 
-        1. Else Phantom#1450
+        1. Else Phantom#1451
 
   2. Case (% matches pattern ``%`)
 
@@ -26797,7 +26803,7 @@ def $find_var_i(prefixedNameIR, p, IC)
 
                 1. Return value'
 
-            1. Else Phantom#1451
+            1. Else Phantom#1452
 
         2. Case (% matches pattern `BLOCK`)
 
@@ -26809,13 +26815,13 @@ def $find_var_i(prefixedNameIR, p, IC)
 
                 1. Return value'
 
-            1. Else Phantom#1452
+            1. Else Phantom#1453
 
           2. If ((?() = $find_map<id, value>(IC.block.frame, id))), then
 
             1. Return $find_var_i((` id), (global), IC)
 
-          2. Else Phantom#1453
+          2. Else Phantom#1454
 
         3. Case (% matches pattern `LOCAL`)
 
@@ -26827,13 +26833,13 @@ def $find_var_i(prefixedNameIR, p, IC)
 
                 1. Return value'
 
-            1. Else Phantom#1454
+            1. Else Phantom#1455
 
           2. If ((?() = $find_maps<id, value>(IC.local.frames, id))), then
 
             1. Return $find_var_i((` id), (block), IC)
 
-          2. Else Phantom#1455
+          2. Else Phantom#1456
 
 def $find_typeDef_i(_cursor, IC, prefixedNameIR)
 
@@ -26925,7 +26931,7 @@ relation Expr_inst: p IC STO |- (expressionIR # expressionNoteIR) : % %
 
         1. Result in: % % % |- % : STO (stringLiteral as value)
 
-  1. Else Phantom#1456
+  1. Else Phantom#1457
 
 2. Case analysis on expressionIR
 
@@ -26971,7 +26977,7 @@ relation Expr_inst: p IC STO |- (expressionIR # expressionNoteIR) : % %
 
               1. Result in: % % % |- % : STO_2 $bin_op(binop, value_l, value_r)
 
-        1. Else Phantom#1457
+        1. Else Phantom#1458
 
         2. Case analysis on binop
 
@@ -26991,7 +26997,7 @@ relation Expr_inst: p IC STO |- (expressionIR # expressionNoteIR) : % %
 
                     1. Result in: % % % |- % : STO_2 value_r
 
-              1. Else Phantom#1458
+              1. Else Phantom#1459
 
           2. Case (% matches pattern `||`)
 
@@ -27009,9 +27015,9 @@ relation Expr_inst: p IC STO |- (expressionIR # expressionNoteIR) : % %
 
                     1. Result in: % % % |- % : STO_2 value_r
 
-              1. Else Phantom#1459
+              1. Else Phantom#1460
 
-        2. Else Phantom#1460
+        2. Else Phantom#1461
 
   5. Case (% has type ternaryExpressionIR)
 
@@ -27035,7 +27041,7 @@ relation Expr_inst: p IC STO |- (expressionIR # expressionNoteIR) : % %
 
                 1. Result in: % % % |- % : STO_2 value_false
 
-          1. Else Phantom#1461
+          1. Else Phantom#1462
 
   6. Case (% has type castExpressionIR)
 
@@ -27155,11 +27161,11 @@ relation Expr_inst: p IC STO |- (expressionIR # expressionNoteIR) : % %
 
                                 1. Result in: % % % |- % : STO ((typeId . nameIR . value') as value)
 
-                            1. Else Phantom#1462
+                            1. Else Phantom#1463
 
-                    1. Else Phantom#1463
+                    1. Else Phantom#1464
 
-                1. Else Phantom#1464
+                1. Else Phantom#1465
 
         2. Case (% has type typedExpressionIR)
 
@@ -27179,9 +27185,9 @@ relation Expr_inst: p IC STO |- (expressionIR # expressionNoteIR) : % %
 
                         1. Result in: % % % |- % : STO ((d (n_size as int)) as value)
 
-                      1. Else Phantom#1465
+                      1. Else Phantom#1466
 
-                  1. Else Phantom#1466
+                  1. Else Phantom#1467
 
               2. (Expr_inst: p IC STO |- typedExpressionIR_base : STO_1 value)
 
@@ -27201,7 +27207,7 @@ relation Expr_inst: p IC STO |- (expressionIR # expressionNoteIR) : % %
 
                               1. Result in: % % % |- % : STO_1 value''
 
-                          1. Else Phantom#1467
+                          1. Else Phantom#1468
 
                   2. Case (% has type headerValue)
 
@@ -27217,7 +27223,7 @@ relation Expr_inst: p IC STO |- (expressionIR # expressionNoteIR) : % %
 
                               1. Result in: % % % |- % : STO_1 value''
 
-                          1. Else Phantom#1468
+                          1. Else Phantom#1469
 
                   3. Case (% has type headerUnionValue)
 
@@ -27233,9 +27239,9 @@ relation Expr_inst: p IC STO |- (expressionIR # expressionNoteIR) : % %
 
                               1. Result in: % % % |- % : STO_1 value''
 
-                          1. Else Phantom#1469
+                          1. Else Phantom#1470
 
-                1. Else Phantom#1470
+                1. Else Phantom#1471
 
   12. Case (% has type indexAccessExpressionIR)
 
@@ -27269,9 +27275,9 @@ relation Expr_inst: p IC STO |- (expressionIR # expressionNoteIR) : % %
 
                                 1. Result in: % % % |- % : STO_2 value'
 
-                            1. Else Phantom#1471
+                            1. Else Phantom#1472
 
-                        1. Else Phantom#1472
+                        1. Else Phantom#1473
 
                   2. Case (% has type headerStackValue)
 
@@ -27289,13 +27295,13 @@ relation Expr_inst: p IC STO |- (expressionIR # expressionNoteIR) : % %
 
                                 1. Result in: % % % |- % : STO_2 value'
 
-                            1. Else Phantom#1473
+                            1. Else Phantom#1474
 
-                        1. Else Phantom#1474
+                        1. Else Phantom#1475
 
-                1. Else Phantom#1475
+                1. Else Phantom#1476
 
-            1. Else Phantom#1476
+            1. Else Phantom#1477
 
   13. Case (% has type sliceAccessExpressionIR)
 
@@ -27351,7 +27357,7 @@ relation Expr_inst: p IC STO |- (expressionIR # expressionNoteIR) : % %
 
                         1. Result in: % % % |- % : STO $sizeof(typeIR_base, nameIR)
 
-                      1. Else Phantom#1477
+                      1. Else Phantom#1478
 
                 2. Case (% matches pattern `TYPE%.%`)
 
@@ -27373,7 +27379,7 @@ relation Expr_inst: p IC STO |- (expressionIR # expressionNoteIR) : % %
 
                                   1. Result in: % % % |- % : STO $sizeof(typeIR_base, nameIR)
 
-                                1. Else Phantom#1478
+                                1. Else Phantom#1479
 
                             2. Case false
 
@@ -27385,13 +27391,13 @@ relation Expr_inst: p IC STO |- (expressionIR # expressionNoteIR) : % %
 
                                     1. Result in: % % % |- % : STO $sizeof(typeIR_base, nameIR)
 
-                                  1. Else Phantom#1479
+                                  1. Else Phantom#1480
 
-                              1. Else Phantom#1480
+                              1. Else Phantom#1481
 
-                      1. Else Phantom#1481
+                      1. Else Phantom#1482
 
-              1. Else Phantom#1482
+              1. Else Phantom#1483
 
             2. If ((callableTargetIR matches pattern `(%)`)), then
 
@@ -27403,7 +27409,7 @@ relation Expr_inst: p IC STO |- (expressionIR # expressionNoteIR) : % %
 
                     1. Result in: % % % |- % : STO_1 value
 
-            2. Else Phantom#1483
+            2. Else Phantom#1484
 
   15. Case (% has type parenthesizedExpressionIR)
 
@@ -27415,7 +27421,7 @@ relation Expr_inst: p IC STO |- (expressionIR # expressionNoteIR) : % %
 
           1. Result in: % % % |- % : STO_1 value
 
-2. Else Phantom#1484
+2. Else Phantom#1485
 
 relation Exprs_inst: p IC store |- (typedExpressionIR)* : % %
 
@@ -27425,7 +27431,7 @@ relation Exprs_inst: p IC store |- (typedExpressionIR)* : % %
 
     1. Result in: % % % |- % : store []
 
-  1. Else Phantom#1485
+  1. Else Phantom#1486
 
   2. If (((typedExpressionIR)* matches pattern _ :: _)), then
 
@@ -27437,7 +27443,7 @@ relation Exprs_inst: p IC store |- (typedExpressionIR)* : % %
 
           1. Result in: % % % |- % : STO_2 value_h :: (value_t)*
 
-  2. Else Phantom#1486
+  2. Else Phantom#1487
 
 relation Argument_inst: p IC STO_0 |- argumentIR : % %
 
@@ -27463,7 +27469,7 @@ relation Argument_inst: p IC STO_0 |- argumentIR : % %
 
           1. Result in: % % % |- % : STO_1 value
 
-1. Else Phantom#1487
+1. Else Phantom#1488
 
 relation DirectApplicationStmt_inst: p IC STO_0 |- (constructorTargetIR .apply( argumentListIR );) : % % %
 
@@ -27589,7 +27595,7 @@ relation Stmt_inst: p IC STO |- statementIR : % % %
 
                 1. Result in: % % % |- % : IC STO_1 (forStatementIR' as statementIR)
 
-      1. Else Phantom#1488
+      1. Else Phantom#1489
 
       2. Group forStatementIR-in: p IC STO |- (forStatementIR as statementIR) : % % %
 
@@ -27617,9 +27623,9 @@ relation Stmt_inst: p IC STO |- statementIR : % % %
 
                     1. Result in: % % % |- % : IC STO_1 (forStatementIR' as statementIR)
 
-              1. Else Phantom#1489
+              1. Else Phantom#1490
 
-        1. Else Phantom#1490
+        1. Else Phantom#1491
 
   8. Case (% has type breakStatementIR)
 
@@ -27647,7 +27653,7 @@ relation Stmt_inst: p IC STO |- statementIR : % % %
 
           1. Result in: % % % |- % : IC STO_1 ((switch( typedExpressionIR ){ switchCaseListIR_inst }) as statementIR)
 
-1. Else Phantom#1491
+1. Else Phantom#1492
 
 2. If ((p matches pattern `LOCAL`)), then
 
@@ -27675,9 +27681,9 @@ relation Stmt_inst: p IC STO |- statementIR : % % %
 
                 1. Result in: % % % |- % : IC_3 STO_1 ((annotationList { blockElementStatementListIR_inst }) as statementIR)
 
-  1. Else Phantom#1492
+  1. Else Phantom#1493
 
-2. Else Phantom#1493
+2. Else Phantom#1494
 
 relation BlockElementStmt_inst: instContext store |- blockElementStatementIR : % % %
 
@@ -27715,7 +27721,7 @@ relation BlockElementStmtList_inst: instContext store |- (blockElementStatementI
 
     1. Result in: % % |- % : instContext store []
 
-  1. Else Phantom#1494
+  1. Else Phantom#1495
 
   2. If (((blockElementStatementIR)* matches pattern _ :: _)), then
 
@@ -27727,7 +27733,7 @@ relation BlockElementStmtList_inst: instContext store |- (blockElementStatementI
 
           1. Result in: % % |- % : IC_2 STO_2 blockElementStatementIR_h_inst :: (blockElementStatementIR_t_inst)*
 
-  2. Else Phantom#1495
+  2. Else Phantom#1496
 
 relation Block_inst: IC_0 STO_0 |- (annotationList { blockElementStatementListIR }) : % % %
 
@@ -27777,7 +27783,7 @@ relation ExternMethods_inst: instContext |- (externMethodPrototypeIR)* : %
 
     1. Result in: % |- % : instContext
 
-  1. Else Phantom#1496
+  1. Else Phantom#1497
 
   2. If (((externMethodPrototypeIR)* matches pattern _ :: _)), then
 
@@ -27789,7 +27795,7 @@ relation ExternMethods_inst: instContext |- (externMethodPrototypeIR)* : %
 
           1. Result in: % |- % : IC_2
 
-  2. Else Phantom#1497
+  2. Else Phantom#1498
 
 relation ParserStmt_inst: IC_0 STO |- parserStatementIR : % % %
 
@@ -27827,7 +27833,7 @@ relation ParserStmt_inst: IC_0 STO |- parserStatementIR : % % %
 
               1. Result in: % % |- % : IC_1 STO_1 (emptyStatementIR_inst as parserStatementIR)
 
-          1. Else Phantom#1498
+          1. Else Phantom#1499
 
   4. Case (% has type assignmentStatementIR)
 
@@ -27843,7 +27849,7 @@ relation ParserStmt_inst: IC_0 STO |- parserStatementIR : % % %
 
               1. Result in: % % |- % : IC_1 STO_1 (assignmentStatementIR_inst as parserStatementIR)
 
-          1. Else Phantom#1499
+          1. Else Phantom#1500
 
   5. Case (% has type callStatementIR)
 
@@ -27859,7 +27865,7 @@ relation ParserStmt_inst: IC_0 STO |- parserStatementIR : % % %
 
               1. Result in: % % |- % : IC_1 STO_1 (callStatementIR_inst as parserStatementIR)
 
-          1. Else Phantom#1500
+          1. Else Phantom#1501
 
   6. Case (% has type directApplicationStatementIR)
 
@@ -27919,7 +27925,7 @@ relation ParserStmts_inst: instContext store |- (parserStatementIR)* : % % %
 
     1. Result in: % % |- % : instContext store []
 
-  1. Else Phantom#1501
+  1. Else Phantom#1502
 
   2. If (((parserStatementIR)* matches pattern _ :: _)), then
 
@@ -27931,7 +27937,7 @@ relation ParserStmts_inst: instContext store |- (parserStatementIR)* : % % %
 
           1. Result in: % % |- % : IC_2 STO_2 parserStatementIR_h_inst :: (parserStatementIR_t_inst)*
 
-  2. Else Phantom#1502
+  2. Else Phantom#1503
 
 relation ParserState_inst: IC_0 STO_0 |- parserStateIR : % %
 
@@ -27955,7 +27961,7 @@ relation ParserStates_inst: instContext store |- (parserStateIR)* : % %
 
     1. Result in: % % |- % : instContext store
 
-  1. Else Phantom#1503
+  1. Else Phantom#1504
 
   2. If (((parserStateIR)* matches pattern _ :: _)), then
 
@@ -27967,7 +27973,7 @@ relation ParserStates_inst: instContext store |- (parserStateIR)* : % %
 
           1. Result in: % % |- % : IC_2 STO_2
 
-  2. Else Phantom#1504
+  2. Else Phantom#1505
 
 relation ParserLocalDecl_inst: IC_0 STO |- parserLocalDeclarationIR : % % %
 
@@ -28033,9 +28039,9 @@ relation ParserLocalDecl_inst: IC_0 STO |- parserLocalDeclarationIR : % % %
 
                                 1. Result in: % % |- % : IC_0 STO_2 (constantDeclarationIR as parserLocalDeclarationIR)
 
-                1. Else Phantom#1505
+                1. Else Phantom#1506
 
-          1. Else Phantom#1506
+          1. Else Phantom#1507
 
 relation ParserLocalDecls_inst: instContext store |- (parserLocalDeclarationIR)* : % % %
 
@@ -28045,7 +28051,7 @@ relation ParserLocalDecls_inst: instContext store |- (parserLocalDeclarationIR)*
 
     1. Result in: % % |- % : instContext store []
 
-  1. Else Phantom#1507
+  1. Else Phantom#1508
 
   2. If (((parserLocalDeclarationIR)* matches pattern _ :: _)), then
 
@@ -28057,7 +28063,7 @@ relation ParserLocalDecls_inst: instContext store |- (parserLocalDeclarationIR)*
 
           1. Result in: % % |- % : IC_2 STO_2 parserLocalDeclarationIR_h_inst :: (parserLocalDeclarationIR_t_inst)*
 
-  2. Else Phantom#1508
+  2. Else Phantom#1509
 
 relation TableAction_inst: IC STO |- (annotationList tableActionReferenceIR #( parameterListIR , parameterListIR_control );) : % %
 
@@ -28105,7 +28111,7 @@ relation TableAction_inst: IC STO |- (annotationList tableActionReferenceIR #( p
 
                                 1. Result in: % % |- % : STO tableActionIR
 
-                  1. Else Phantom#1509
+                  1. Else Phantom#1510
 
                 2. If (([] = $name_annotation(annotationList_actionDef))), then
 
@@ -28117,11 +28123,11 @@ relation TableAction_inst: IC STO |- (annotationList tableActionReferenceIR #( p
 
                         1. Result in: % % |- % : STO tableActionIR
 
-                2. Else Phantom#1510
+                2. Else Phantom#1511
 
-          1. Else Phantom#1511
+          1. Else Phantom#1512
 
-      1. Else Phantom#1512
+      1. Else Phantom#1513
 
 relation TableActions_inst: IC store |- (tableActionIR)* : % %
 
@@ -28131,7 +28137,7 @@ relation TableActions_inst: IC store |- (tableActionIR)* : % %
 
     1. Result in: % % |- % : store []
 
-  1. Else Phantom#1513
+  1. Else Phantom#1514
 
   2. If (((tableActionIR)* matches pattern _ :: _)), then
 
@@ -28143,7 +28149,7 @@ relation TableActions_inst: IC store |- (tableActionIR)* : % %
 
           1. Result in: % % |- % : STO_1 tableActionIR_h_inst :: (tableActionIR_t_inst)*
 
-  2. Else Phantom#1514
+  2. Else Phantom#1515
 
 relation TableProperty_inst: IC STO |- tablePropertyIR : % %
 
@@ -28221,7 +28227,7 @@ relation TableProperties_inst: IC store |- (tablePropertyIR)* : % %
 
     1. Result in: % % |- % : store []
 
-  1. Else Phantom#1515
+  1. Else Phantom#1516
 
   2. If (((tablePropertyIR)* matches pattern _ :: _)), then
 
@@ -28233,7 +28239,7 @@ relation TableProperties_inst: IC store |- (tablePropertyIR)* : % %
 
           1. Result in: % % |- % : STO_2 tablePropertyIR_h_inst :: (tablePropertyIR_t_inst)*
 
-  2. Else Phantom#1516
+  2. Else Phantom#1517
 
 relation ControlLocalDecl_inst: IC_0 STO |- controlLocalDeclarationIR : % % %
 
@@ -28313,7 +28319,7 @@ relation ControlLocalDecl_inst: IC_0 STO |- controlLocalDeclarationIR : % % %
 
                                     1. Result in: % % |- % : IC_1 STO_2 ?((constantDeclarationIR as controlLocalDeclarationIR))
 
-                              1. Else Phantom#1517
+                              1. Else Phantom#1518
 
                               2. (Let (nameIR')* be $name_annotation(annotationList))
 
@@ -28331,9 +28337,9 @@ relation ControlLocalDecl_inst: IC_0 STO |- controlLocalDeclarationIR : % % %
 
                                             1. Result in: % % |- % : IC_1 STO_3 ?((constantDeclarationIR as controlLocalDeclarationIR))
 
-                                1. Else Phantom#1518
+                                1. Else Phantom#1519
 
-                  1. Else Phantom#1519
+                  1. Else Phantom#1520
 
 relation ControlLocalDecls_inst: instContext store |- (controlLocalDeclarationIR)* : % % %
 
@@ -28343,7 +28349,7 @@ relation ControlLocalDecls_inst: instContext store |- (controlLocalDeclarationIR
 
     1. Result in: % % |- % : instContext store []
 
-  1. Else Phantom#1520
+  1. Else Phantom#1521
 
   2. If (((controlLocalDeclarationIR)* matches pattern _ :: _)), then
 
@@ -28367,7 +28373,7 @@ relation ControlLocalDecls_inst: instContext store |- (controlLocalDeclarationIR
 
                 1. Result in: % % |- % : IC_2 STO_2 controlLocalDeclarationIR_h_inst :: (controlLocalDeclarationIR_t_inst)*
 
-  2. Else Phantom#1521
+  2. Else Phantom#1522
 
 relation ConstDecl_inst: p IC_0 |- (annotationList const typeIR nameIR (=`value value) ;) : %
 
@@ -28415,7 +28421,7 @@ relation InstDecl_inst: p IC_0 STO_0 |- (annotationList typeIR constructorTarget
 
                                   1. Result in: % % % |- % : IC_1 STO_3 constantDeclarationIR
 
-          1. Else Phantom#1522
+          1. Else Phantom#1523
 
       2. (Let nameIR' be $name_annotation_default(annotationList, nameIR))
 
@@ -28435,7 +28441,7 @@ relation InstDecl_inst: p IC_0 STO_0 |- (annotationList typeIR constructorTarget
 
                       1. Result in: % % % |- % : IC_1 STO_2 constantDeclarationIR
 
-            1. Else Phantom#1523
+            1. Else Phantom#1524
 
 relation FuncDecl_inst: p IC_0 |- (annotationList (typeIR nameIR < typeParameterListIR_expl , typeParameterListIR_impl >( parameterListIR )) blockStatementIR) : %
 
@@ -28779,11 +28785,11 @@ relation Decl_inst: IC_0 STO |- declarationIR : % %
 
                                               1. Result in: % % |- % : IC_1 STO
 
-                                      1. Else Phantom#1524
+                                      1. Else Phantom#1525
 
-                              1. Else Phantom#1525
+                              1. Else Phantom#1526
 
-                        1. Else Phantom#1526
+                        1. Else Phantom#1527
 
         2. Case (% matches pattern `%TYPE%%;`)
 
@@ -28849,7 +28855,7 @@ relation Decls_inst: instContext store |- (declarationIR)* : % %
 
     1. Result in: % % |- % : instContext store
 
-  1. Else Phantom#1527
+  1. Else Phantom#1528
 
   2. If (((declarationIR)* matches pattern _ :: _)), then
 
@@ -28861,7 +28867,7 @@ relation Decls_inst: instContext store |- (declarationIR)* : % %
 
           1. Result in: % % |- % : IC_2 STO_2
 
-  2. Else Phantom#1528
+  2. Else Phantom#1529
 
 relation Program_inst: |- p4program : % %
 
@@ -28899,9 +28905,9 @@ relation Copy_in_inst: store p_caller IC_caller (argumentIR)* @ p_callee instCon
 
       1. Result in: % % % % @ % % % ~> store instContext
 
-    1. Else Phantom#1529
+    1. Else Phantom#1530
 
-  1. Else Phantom#1530
+  1. Else Phantom#1531
 
   2. If (((argumentIR)* matches pattern _ :: _)), then
 
@@ -28917,9 +28923,9 @@ relation Copy_in_inst: store p_caller IC_caller (argumentIR)* @ p_callee instCon
 
               1. Result in: % % % % @ % % % ~> STO_2 IC_callee_2
 
-      1. Else Phantom#1531
+      1. Else Phantom#1532
 
-  2. Else Phantom#1532
+  2. Else Phantom#1533
 
 relation Copy_in_argument_inst_default: store p_caller IC_caller @ p_callee IC_callee_0 parameterIR ~> % %
 
@@ -28953,7 +28959,7 @@ relation Copy_in_argument_inst_default: store p_caller IC_caller @ p_callee IC_c
 
                 1. Result in: % % % @ % % % ~> store IC_callee_1
 
-    1. Else Phantom#1533
+    1. Else Phantom#1534
 
 relation Copy_in_inst_default: store p_caller IC_caller @ p_callee instContext (parameterIR)* ~> % %
 
@@ -28963,7 +28969,7 @@ relation Copy_in_inst_default: store p_caller IC_caller @ p_callee instContext (
 
     1. Result in: % % % @ % % % ~> store instContext
 
-  1. Else Phantom#1534
+  1. Else Phantom#1535
 
   2. If (((parameterIR)* matches pattern _ :: _)), then
 
@@ -28975,7 +28981,7 @@ relation Copy_in_inst_default: store p_caller IC_caller @ p_callee instContext (
 
           1. Result in: % % % @ % % % ~> STO_2 IC_callee_2
 
-  2. Else Phantom#1535
+  2. Else Phantom#1536
 
 relation Constructor_inst: p IC |- prefixedNameIR < (typeArgumentIR)* >( (argumentIR)* ): % < % >(# % # % )
 
@@ -28991,9 +28997,9 @@ relation Constructor_inst: p IC |- prefixedNameIR < (typeArgumentIR)* >( (argume
 
           1. Result in: % % |- % < % >( % ): constructorDef < (typeArgumentIR)* >(# (id_default)* # (id_optional)* )
 
-      1. Else Phantom#1536
+      1. Else Phantom#1537
 
-  1. Else Phantom#1537
+  1. Else Phantom#1538
 
   2. (Let (typeDefIR)? be $find_typeDef_i(p, IC, prefixedNameIR))
 
@@ -29011,11 +29017,11 @@ relation Constructor_inst: p IC |- prefixedNameIR < (typeArgumentIR)* >( (argume
 
                 1. Result in: % % |- % < % >( % ): constructorDef < (typeArgumentIR)* >(# (id_default)* # (id_optional)* )
 
-            1. Else Phantom#1538
+            1. Else Phantom#1539
 
-        1. Else Phantom#1539
+        1. Else Phantom#1540
 
-    1. Else Phantom#1540
+    1. Else Phantom#1541
 
   3. If (((typeArgumentIR)* = [])), then
 
@@ -29039,13 +29045,13 @@ relation Constructor_inst: p IC |- prefixedNameIR < (typeArgumentIR)* >( (argume
 
                       1. Result in: % % |- % < % >( % ): constructorDef < (typeArgumentIR')* >(# (id_default)* # (id_optional)* )
 
-                  1. Else Phantom#1541
+                  1. Else Phantom#1542
 
-          1. Else Phantom#1542
+          1. Else Phantom#1543
 
-      1. Else Phantom#1543
+      1. Else Phantom#1544
 
-  3. Else Phantom#1544
+  3. Else Phantom#1545
 
 relation Constructor_call: p IC STO_0 |- constructorDef < (typeArgumentIR)* >( (argumentIR)* # (id_default)* # (id_optional)* ): % %
 
@@ -29103,9 +29109,9 @@ relation Constructor_call: p IC STO_0 |- constructorDef < (typeArgumentIR)* >( (
 
                                                     1. Result in: % % % |- % < % >( % # % # % ): STO_2 object_extern
 
-                                      1. Else Phantom#1545
+                                      1. Else Phantom#1546
 
-                              1. Else Phantom#1546
+                              1. Else Phantom#1547
 
   2. Case (% has type parserObjectConstructorDef)
 
@@ -29183,7 +29189,7 @@ relation Constructor_call: p IC STO_0 |- constructorDef < (typeArgumentIR)* >( (
 
                                         1. Result in: % % % |- % < % >( % # % # % ): STO_4 object_control
 
-                                  1. Else Phantom#1547
+                                  1. Else Phantom#1548
 
   4. Case (% has type packageObjectConstructorDef)
 
@@ -29233,7 +29239,7 @@ relation SwitchCase_inst: p IC store |- switchCaseIR : % %
 
               1. Result in: % % % |- % : STO_1 (switchLabelIR : blockStatementIR_inst)
 
-          1. Else Phantom#1548
+          1. Else Phantom#1549
 
     2. Case (% matches pattern `%:`)
 
@@ -29249,7 +29255,7 @@ relation SwitchCases_inst: p IC store |- (switchCaseIR)* : % %
 
     1. Result in: % % % |- % : store []
 
-  1. Else Phantom#1549
+  1. Else Phantom#1550
 
   2. If (((switchCaseIR)* matches pattern _ :: _)), then
 
@@ -29261,7 +29267,7 @@ relation SwitchCases_inst: p IC store |- (switchCaseIR)* : % %
 
           1. Result in: % % % |- % : STO_2 switchCaseIR_h' :: (switchCaseIR_t')*
 
-  2. Else Phantom#1550
+  2. Else Phantom#1551
 
 def $merge_frames(frame, ({ ((id : value))* }))
 
@@ -29273,7 +29279,7 @@ def $merge_externMethodDefEnvs(externMethodDefEnv, set<pair<callableId, callable
 
   1. Return externMethodDefEnv
 
-1. Else Phantom#1551
+1. Else Phantom#1552
 
 2. (Let ({ (pair<callableId, callableDef>)* }) be set<pair<callableId, callableDef>>)
 
@@ -29291,9 +29297,9 @@ def $merge_externMethodDefEnvs(externMethodDefEnv, set<pair<callableId, callable
 
               1. Return $merge_externMethodDefEnvs(externMethodDefEnv_post, ({ ((callableId_t : callableDef_t))* }))
 
-      1. Else Phantom#1552
+      1. Else Phantom#1553
 
-  1. Else Phantom#1553
+  1. Else Phantom#1554
 
 relation ObjectDecl_inst: IC_0 store |- objectDeclarationIR : % %
 
@@ -29325,7 +29331,7 @@ relation ObjectDecls_inst: instContext store |- (objectDeclarationIR)* : % %
 
     1. Result in: % % |- % : instContext store
 
-  1. Else Phantom#1554
+  1. Else Phantom#1555
 
   2. If (((objectDeclarationIR)* matches pattern _ :: _)), then
 
@@ -29337,7 +29343,7 @@ relation ObjectDecls_inst: instContext store |- (objectDeclarationIR)* : % %
 
           1. Result in: % % |- % : IC_2 STO_2
 
-  2. Else Phantom#1555
+  2. Else Phantom#1556
 
 def $callableId_of_externMethodPrototypeIR(externMethodPrototypeIR)
 
@@ -29403,15 +29409,15 @@ def $init_table((tablePropertyIR)*)
 
                                 1. Return TBL
 
-                          1. Else Phantom#1556
+                          1. Else Phantom#1557
 
-                  1. Else Phantom#1557
+                  1. Else Phantom#1558
 
-              1. Else Phantom#1558
+              1. Else Phantom#1559
 
-        1. Else Phantom#1559
+        1. Else Phantom#1560
 
-    1. Else Phantom#1560
+    1. Else Phantom#1561
 
 def $init_tableKeys((tablePropertyIR)*)
 
@@ -29427,15 +29433,15 @@ def $init_tableKeys((tablePropertyIR)*)
 
           1. Return tableKeysPropertyIR'
 
-      1. Else Phantom#1561
+      1. Else Phantom#1562
 
-  1. Else Phantom#1562
+  1. Else Phantom#1563
 
 2. If (([] = $filter_<tablePropertyIR>((tablePropertyIR)*, ((tablePropertyIR has type tableKeysPropertyIR))*))), then
 
   1. Return (key={ [] })
 
-2. Else Phantom#1563
+2. Else Phantom#1564
 
 def $init_tableEntries((tablePropertyIR)*)
 
@@ -29451,15 +29457,15 @@ def $init_tableEntries((tablePropertyIR)*)
 
           1. Return tableEntriesPropertyIR'
 
-      1. Else Phantom#1564
+      1. Else Phantom#1565
 
-  1. Else Phantom#1565
+  1. Else Phantom#1566
 
 2. If (([] = $filter_<tablePropertyIR>((tablePropertyIR)*, ((tablePropertyIR has type tableEntriesPropertyIR))*))), then
 
   1. Return ((`empty) ?() entries={ [] })
 
-2. Else Phantom#1566
+2. Else Phantom#1567
 
 syntax globalEvalLayer = globalInstLayer
 
@@ -29483,7 +29489,7 @@ def $exit_e(EC)
 
       1. Return EC[local.frames = (frame_t)*]
 
-  1. Else Phantom#1567
+  1. Else Phantom#1568
 
 def $inherit_e(cursor, EC)
 
@@ -29557,7 +29563,7 @@ def $add_var_e(cursor, EC, prefixedNameIR, value)
 
           1. Return EC[block.frame = frame]
 
-    1. Else Phantom#1568
+    1. Else Phantom#1569
 
   3. Case (% matches pattern `LOCAL`)
 
@@ -29575,9 +29581,9 @@ def $add_var_e(cursor, EC, prefixedNameIR, value)
 
                 1. Return EC[local.frames = frame_h' :: (frame_t)*]
 
-          1. Else Phantom#1569
+          1. Else Phantom#1570
 
-    1. Else Phantom#1570
+    1. Else Phantom#1571
 
 def $add_vars_e(p, EC, (prefixedNameIR)*, (value)*)
 
@@ -29589,7 +29595,7 @@ def $add_vars_e(p, EC, (prefixedNameIR)*, (value)*)
 
       1. Return EC
 
-    1. Else Phantom#1571
+    1. Else Phantom#1572
 
   2. Case (% matches pattern _ :: _)
 
@@ -29605,7 +29611,7 @@ def $add_vars_e(p, EC, (prefixedNameIR)*, (value)*)
 
               1. Return EC''
 
-      1. Else Phantom#1572
+      1. Else Phantom#1573
 
 def $update_var_e(p, EC, prefixedNameIR, value)
 
@@ -29617,7 +29623,7 @@ def $update_var_e(p, EC, prefixedNameIR, value)
 
       1. Return EC[global.frame = frame]
 
-1. Else Phantom#1573
+1. Else Phantom#1574
 
 2. Case analysis on p
 
@@ -29635,9 +29641,9 @@ def $update_var_e(p, EC, prefixedNameIR, value)
 
               1. Return EC[global.frame = frame']
 
-          1. Else Phantom#1574
+          1. Else Phantom#1575
 
-    1. Else Phantom#1575
+    1. Else Phantom#1576
 
   2. Case (% matches pattern `BLOCK`)
 
@@ -29659,7 +29665,7 @@ def $update_var_e(p, EC, prefixedNameIR, value)
 
               1. Return $update_var_e((global), EC, (` id), value)
 
-    1. Else Phantom#1576
+    1. Else Phantom#1577
 
   3. Case (% matches pattern `LOCAL`)
 
@@ -29671,7 +29677,7 @@ def $update_var_e(p, EC, prefixedNameIR, value)
 
           1. Return $update_var_e((block), EC, (` id), value)
 
-        1. Else Phantom#1577
+        1. Else Phantom#1578
 
         2. (Let (frame)* be EC.local.frames)
 
@@ -29695,9 +29701,9 @@ def $update_var_e(p, EC, prefixedNameIR, value)
 
                       1. Return EC_pop'[local.frames = frame_h :: EC_pop'.local.frames]
 
-          1. Else Phantom#1578
+          1. Else Phantom#1579
 
-    1. Else Phantom#1579
+    1. Else Phantom#1580
 
 def $find_var_e(prefixedNameIR, p, EC)
 
@@ -29715,7 +29721,7 @@ def $find_var_e(prefixedNameIR, p, EC)
 
             1. Return value'
 
-        1. Else Phantom#1580
+        1. Else Phantom#1581
 
   2. Case (% matches pattern ``%`)
 
@@ -29733,7 +29739,7 @@ def $find_var_e(prefixedNameIR, p, EC)
 
                 1. Return value'
 
-            1. Else Phantom#1581
+            1. Else Phantom#1582
 
         2. Case (% matches pattern `BLOCK`)
 
@@ -29745,13 +29751,13 @@ def $find_var_e(prefixedNameIR, p, EC)
 
                 1. Return value'
 
-            1. Else Phantom#1582
+            1. Else Phantom#1583
 
           2. If ((?() = $find_map<id, value>(EC.block.frame, id))), then
 
             1. Return $find_var_e((` id), (global), EC)
 
-          2. Else Phantom#1583
+          2. Else Phantom#1584
 
         3. Case (% matches pattern `LOCAL`)
 
@@ -29763,13 +29769,13 @@ def $find_var_e(prefixedNameIR, p, EC)
 
                 1. Return value'
 
-            1. Else Phantom#1584
+            1. Else Phantom#1585
 
           2. If ((?() = $find_maps<id, value>(EC.local.frames, id))), then
 
             1. Return $find_var_e((` id), (block), EC)
 
-          2. Else Phantom#1585
+          2. Else Phantom#1586
 
 def $find_typeDef_e(_cursor, EC, prefixedNameIR)
 
@@ -29805,15 +29811,15 @@ def $find_type_e(cursor, EC, nameIR)
 
           1. Return ?(typeIR')
 
-      1. Else Phantom#1586
+      1. Else Phantom#1587
 
     2. If ((?() = $find_map<typeId, typeIR>(EC.local.type, nameIR))), then
 
       1. Return $find_type_e((block), EC, nameIR)
 
-    2. Else Phantom#1587
+    2. Else Phantom#1588
 
-1. Else Phantom#1588
+1. Else Phantom#1589
 
 def $find_callableDef_overloaded_e(cursor, EC, prefixedNameIR, (argumentIR)*)
 
@@ -29837,13 +29843,13 @@ def $find_callableDef_overloaded_e(cursor, EC, prefixedNameIR, (argumentIR)*)
 
                   1. Return ?((callableId : ((global), callableDef) # (id_default)* # (id_optional)*))
 
-              1. Else Phantom#1589
+              1. Else Phantom#1590
 
             2. If ((?() = $find_overloaded<callableDef>(EC.global.callable, callTargetKey, $parameterListIR_of_callableDef))), then
 
               1. Return ?()
 
-            2. Else Phantom#1590
+            2. Else Phantom#1591
 
       2. Case (% matches pattern `.%`)
 
@@ -29859,13 +29865,13 @@ def $find_callableDef_overloaded_e(cursor, EC, prefixedNameIR, (argumentIR)*)
 
                   1. Return ?((callableId : ((global), callableDef) # (id_default)* # (id_optional)*))
 
-              1. Else Phantom#1591
+              1. Else Phantom#1592
 
             2. If ((?() = $find_overloaded<callableDef>(EC.global.callable, callTargetKey, $parameterListIR_of_callableDef))), then
 
               1. Return ?()
 
-            2. Else Phantom#1592
+            2. Else Phantom#1593
 
   2. Case (% matches pattern `BLOCK`)
 
@@ -29883,15 +29889,15 @@ def $find_callableDef_overloaded_e(cursor, EC, prefixedNameIR, (argumentIR)*)
 
                 1. Return ?((callableId : ((block), callableDef) # (id_default)* # (id_optional)*))
 
-            1. Else Phantom#1593
+            1. Else Phantom#1594
 
           2. If ((?() = $find_overloaded<callableDef>(EC.block.callable, callTargetKey, $parameterListIR_of_callableDef))), then
 
             1. Return $find_callableDef_overloaded_e((global), EC, (` nameIR), (argumentIR)*)
 
-          2. Else Phantom#1594
+          2. Else Phantom#1595
 
-    1. Else Phantom#1595
+    1. Else Phantom#1596
 
   3. Case (% matches pattern `LOCAL`)
 
@@ -29901,7 +29907,7 @@ def $find_callableDef_overloaded_e(cursor, EC, prefixedNameIR, (argumentIR)*)
 
         1. Return $find_callableDef_overloaded_e((block), EC, (` nameIR), (argumentIR)*)
 
-    1. Else Phantom#1596
+    1. Else Phantom#1597
 
 def $find_constructorDef_e(EC, prefixedNameIR, (argumentIR)*)
 
@@ -30033,7 +30039,7 @@ def $update_object_qualified_e(ARCH_0, objectId, object)
 
     1. Return ARCH_1
 
-1. Else Phantom#1597
+1. Else Phantom#1598
 
 def $update_object_unqualified_e(ARCH_0, id, object)
 
@@ -30055,9 +30061,9 @@ def $update_object_unqualified_e(ARCH_0, id, object)
 
                 1. Return ARCH_1
 
-          1. Else Phantom#1598
+          1. Else Phantom#1599
 
-      1. Else Phantom#1599
+      1. Else Phantom#1600
 
 def $update_objectState_e(ARCH_0, objectId, objectState)
 
@@ -30145,7 +30151,7 @@ relation Expr_eval: p EC ARCH |- (expressionIR # expressionNoteIR) : % % %
 
           1. Result in: % % % |- % : EC ARCH expressionResult
 
-  1. Else Phantom#1600
+  1. Else Phantom#1601
 
 2. Case analysis on expressionIR
 
@@ -30225,9 +30231,9 @@ relation Expr_eval: p EC ARCH |- (expressionIR # expressionNoteIR) : % % %
 
                         1. Result in: % % % |- % : EC_1 ARCH_1 expressionResult
 
-                  1. Else Phantom#1601
+                  1. Else Phantom#1602
 
-        1. Else Phantom#1602
+        1. Else Phantom#1603
 
         2. Case analysis on binop
 
@@ -30241,7 +30247,7 @@ relation Expr_eval: p EC ARCH |- (expressionIR # expressionNoteIR) : % % %
 
                   1. Result in: % % % |- % : EC_1 ARCH_1 (abortResult as expressionResult)
 
-              1. Else Phantom#1603
+              1. Else Phantom#1604
 
               2. Case analysis on expressionResult
 
@@ -30257,7 +30263,7 @@ relation Expr_eval: p EC ARCH |- (expressionIR # expressionNoteIR) : % % %
 
                     1. Result in: % % % |- % : EC_2 ARCH_2 expressionResult_r
 
-              2. Else Phantom#1604
+              2. Else Phantom#1605
 
           2. Case (% matches pattern `||`)
 
@@ -30269,7 +30275,7 @@ relation Expr_eval: p EC ARCH |- (expressionIR # expressionNoteIR) : % % %
 
                   1. Result in: % % % |- % : EC_1 ARCH_1 (abortResult as expressionResult)
 
-              1. Else Phantom#1605
+              1. Else Phantom#1606
 
               2. Case analysis on expressionResult
 
@@ -30285,9 +30291,9 @@ relation Expr_eval: p EC ARCH |- (expressionIR # expressionNoteIR) : % % %
 
                     1. Result in: % % % |- % : EC_2 ARCH_2 expressionResult_r
 
-              2. Else Phantom#1606
+              2. Else Phantom#1607
 
-        2. Else Phantom#1607
+        2. Else Phantom#1608
 
   5. Case (% has type ternaryExpressionIR)
 
@@ -30303,7 +30309,7 @@ relation Expr_eval: p EC ARCH |- (expressionIR # expressionNoteIR) : % % %
 
               1. Result in: % % % |- % : EC_1 ARCH_1 (abortResult as expressionResult)
 
-          1. Else Phantom#1608
+          1. Else Phantom#1609
 
           2. Case analysis on expressionResult
 
@@ -30319,7 +30325,7 @@ relation Expr_eval: p EC ARCH |- (expressionIR # expressionNoteIR) : % % %
 
                 1. Result in: % % % |- % : EC_2 ARCH_2 expressionResult_false
 
-          2. Else Phantom#1609
+          2. Else Phantom#1610
 
   6. Case (% has type castExpressionIR)
 
@@ -30515,11 +30521,11 @@ relation Expr_eval: p EC ARCH |- (expressionIR # expressionNoteIR) : % % %
 
                                   1. Result in: % % % |- % : EC ARCH expressionResult
 
-                            1. Else Phantom#1610
+                            1. Else Phantom#1611
 
-                    1. Else Phantom#1611
+                    1. Else Phantom#1612
 
-                1. Else Phantom#1612
+                1. Else Phantom#1613
 
         2. Case (% has type typedExpressionIR)
 
@@ -30583,7 +30589,7 @@ relation Expr_eval: p EC ARCH |- (expressionIR # expressionNoteIR) : % % %
 
                                                   1. Result in: % % % |- % : EC_1 ARCH_1 expressionResult'
 
-                                          1. Else Phantom#1613
+                                          1. Else Phantom#1614
 
                                 3. Case (% = "lastIndex")
 
@@ -30599,9 +30605,9 @@ relation Expr_eval: p EC ARCH |- (expressionIR # expressionNoteIR) : % % %
 
                                             1. Result in: % % % |- % : EC_1 ARCH_1 expressionResult'
 
-                                    1. Else Phantom#1614
+                                    1. Else Phantom#1615
 
-                              1. Else Phantom#1615
+                              1. Else Phantom#1616
 
                         2. Case (% has type structValue)
 
@@ -30619,7 +30625,7 @@ relation Expr_eval: p EC ARCH |- (expressionIR # expressionNoteIR) : % % %
 
                                       1. Result in: % % % |- % : EC_1 ARCH_1 expressionResult'
 
-                                1. Else Phantom#1616
+                                1. Else Phantom#1617
 
                         3. Case (% has type headerValue)
 
@@ -30637,7 +30643,7 @@ relation Expr_eval: p EC ARCH |- (expressionIR # expressionNoteIR) : % % %
 
                                       1. Result in: % % % |- % : EC_1 ARCH_1 expressionResult'
 
-                                1. Else Phantom#1617
+                                1. Else Phantom#1618
 
                         4. Case (% has type headerUnionValue)
 
@@ -30655,9 +30661,9 @@ relation Expr_eval: p EC ARCH |- (expressionIR # expressionNoteIR) : % % %
 
                                       1. Result in: % % % |- % : EC_1 ARCH_1 expressionResult'
 
-                                1. Else Phantom#1618
+                                1. Else Phantom#1619
 
-                      1. Else Phantom#1619
+                      1. Else Phantom#1620
 
               2. (Expr_eval: p EC ARCH |- typedExpressionIR_base : EC_1 ARCH_1 expressionResult)
 
@@ -30691,11 +30697,11 @@ relation Expr_eval: p EC ARCH |- (expressionIR # expressionNoteIR) : % % %
 
                                 1. Result in: % % % |- % : EC_1 ARCH_1 expressionResult'
 
-                          1. Else Phantom#1620
+                          1. Else Phantom#1621
 
-                    1. Else Phantom#1621
+                    1. Else Phantom#1622
 
-                1. Else Phantom#1622
+                1. Else Phantom#1623
 
   12. Case (% has type indexAccessExpressionIR)
 
@@ -30743,9 +30749,9 @@ relation Expr_eval: p EC ARCH |- (expressionIR # expressionNoteIR) : % % %
 
                                         1. Result in: % % % |- % : EC_1 ARCH_1 expressionResult
 
-                                  1. Else Phantom#1623
+                                  1. Else Phantom#1624
 
-                          1. Else Phantom#1624
+                          1. Else Phantom#1625
 
                       2. Case (% has type headerStackValue)
 
@@ -30771,13 +30777,13 @@ relation Expr_eval: p EC ARCH |- (expressionIR # expressionNoteIR) : % % %
 
                                             1. Result in: % % % |- % : EC_1 ARCH_1 expressionResult
 
-                                      1. Else Phantom#1625
+                                      1. Else Phantom#1626
 
-                          1. Else Phantom#1626
+                          1. Else Phantom#1627
 
-                    1. Else Phantom#1627
+                    1. Else Phantom#1628
 
-                1. Else Phantom#1628
+                1. Else Phantom#1629
 
   13. Case (% has type sliceAccessExpressionIR)
 
@@ -30807,7 +30813,7 @@ relation Expr_eval: p EC ARCH |- (expressionIR # expressionNoteIR) : % % %
 
                       1. Result in: % % % |- % : EC_1 ARCH_1 expressionResult
 
-                1. Else Phantom#1629
+                1. Else Phantom#1630
 
   14. Case (% has type callExpressionIR)
 
@@ -30853,9 +30859,9 @@ relation Expr_eval: p EC ARCH |- (expressionIR # expressionNoteIR) : % % %
 
                                 1. Result in: % % % |- % : EC_2 ARCH_2 ((` value') as expressionResult)
 
-                            1. Else Phantom#1630
+                            1. Else Phantom#1631
 
-      1. Else Phantom#1631
+      1. Else Phantom#1632
 
   15. Case (% has type parenthesizedExpressionIR)
 
@@ -30867,7 +30873,7 @@ relation Expr_eval: p EC ARCH |- (expressionIR # expressionNoteIR) : % % %
 
           1. Result in: % % % |- % : EC_1 ARCH_1 expressionResult
 
-2. Else Phantom#1632
+2. Else Phantom#1633
 
 syntax expressionListResult = 
    | ` value*
@@ -30882,7 +30888,7 @@ relation Exprs_eval: p evalContext arch |- (typedExpressionIR)* : % % %
 
     1. Result in: % % % |- % : evalContext arch ((` []) as expressionListResult)
 
-  1. Else Phantom#1633
+  1. Else Phantom#1634
 
   2. If (((typedExpressionIR)* matches pattern _ :: _)), then
 
@@ -30918,7 +30924,7 @@ relation Exprs_eval: p evalContext arch |- (typedExpressionIR)* : % % %
 
                       1. Result in: % % % |- % : EC_2 ARCH_2 ((` value_h :: (value_t)*) as expressionListResult)
 
-  2. Else Phantom#1634
+  2. Else Phantom#1635
 
 syntax keysetExpressionResult = 
    | ` setValue*
@@ -30959,7 +30965,7 @@ relation Argument_eval: p EC_0 ARCH_0 |- argumentIR : % % %
 
           1. Result in: % % % |- % : EC_1 ARCH_1 expressionResult
 
-1. Else Phantom#1635
+1. Else Phantom#1636
 
 syntax storageReferenceResult = 
    | ` storageReference?
@@ -30986,7 +30992,7 @@ relation Argument_eval_lvalue: p EC_0 ARCH_0 |- argumentIR : % % %
 
                 1. Result in: % % % |- % : EC_1 ARCH_1 storageReferenceResult
 
-          1. Else Phantom#1636
+          1. Else Phantom#1637
 
   2. Case (% matches pattern `%=%`)
 
@@ -31004,7 +31010,7 @@ relation Argument_eval_lvalue: p EC_0 ARCH_0 |- argumentIR : % % %
 
                 1. Result in: % % % |- % : EC_1 ARCH_1 storageReferenceResult
 
-          1. Else Phantom#1637
+          1. Else Phantom#1638
 
   3. Case (% matches pattern `%=_`)
 
@@ -31074,7 +31080,7 @@ relation Lvalue_eval: p EC ARCH |- (lvalueIR # lvalueNoteIR) : % % %
 
                                     1. Result in: % % % |- % : EC_1 ARCH_1 (rejectTransitionResult as storageReferenceResult)
 
-                                1. Else Phantom#1638
+                                1. Else Phantom#1639
 
                                 2. If ((n_idx < n_size)), then
 
@@ -31082,9 +31088,9 @@ relation Lvalue_eval: p EC ARCH |- (lvalueIR # lvalueNoteIR) : % % %
 
                                     1. Result in: % % % |- % : EC_1 ARCH_1 storageReferenceResult'
 
-                                2. Else Phantom#1639
+                                2. Else Phantom#1640
 
-                              1. Else Phantom#1640
+                              1. Else Phantom#1641
 
                         2. Case false
 
@@ -31092,7 +31098,7 @@ relation Lvalue_eval: p EC ARCH |- (lvalueIR # lvalueNoteIR) : % % %
 
                             1. Result in: % % % |- % : EC_1 ARCH_1 storageReferenceResult'
 
-                1. Else Phantom#1641
+                1. Else Phantom#1642
 
   3. Case (% matches pattern `%[%]`)
 
@@ -31140,9 +31146,9 @@ relation Lvalue_eval: p EC ARCH |- (lvalueIR # lvalueNoteIR) : % % %
 
                                   1. Result in: % % % |- % : EC_2 ARCH_2 storageReferenceResult'
 
-                            1. Else Phantom#1642
+                            1. Else Phantom#1643
 
-                1. Else Phantom#1643
+                1. Else Phantom#1644
 
   4. Case (% matches pattern `%[%:%]`)
 
@@ -31190,9 +31196,9 @@ relation Lvalue_eval: p EC ARCH |- (lvalueIR # lvalueNoteIR) : % % %
 
                                   1. Result in: % % % |- % : EC_1 ARCH_1 storageReferenceResult'
 
-                            1. Else Phantom#1644
+                            1. Else Phantom#1645
 
-                1. Else Phantom#1645
+                1. Else Phantom#1646
 
   5. Case (% matches pattern `(%)`)
 
@@ -31250,11 +31256,11 @@ relation Lvalue_read: p EC ARCH |- storageReference : %
 
                                 1. Result in: % % % |- % : value'
 
-                            1. Else Phantom#1646
+                            1. Else Phantom#1647
 
-                      1. Else Phantom#1647
+                      1. Else Phantom#1648
 
-                  1. Else Phantom#1648
+                  1. Else Phantom#1649
 
             2. Case (% has type headerStackValue)
 
@@ -31270,9 +31276,9 @@ relation Lvalue_read: p EC ARCH |- storageReference : %
 
                         1. Result in: % % % |- % : value
 
-                    1. Else Phantom#1649
+                    1. Else Phantom#1650
 
-                  1. Else Phantom#1650
+                  1. Else Phantom#1651
 
             3. Case (% has type structValue)
 
@@ -31288,7 +31294,7 @@ relation Lvalue_read: p EC ARCH |- storageReference : %
 
                         1. Result in: % % % |- % : value'
 
-                    1. Else Phantom#1651
+                    1. Else Phantom#1652
 
             4. Case (% has type headerValue)
 
@@ -31304,7 +31310,7 @@ relation Lvalue_read: p EC ARCH |- storageReference : %
 
                         1. Result in: % % % |- % : value'
 
-                    1. Else Phantom#1652
+                    1. Else Phantom#1653
 
             5. Case (% has type headerUnionValue)
 
@@ -31320,9 +31326,9 @@ relation Lvalue_read: p EC ARCH |- storageReference : %
 
                         1. Result in: % % % |- % : value'
 
-                    1. Else Phantom#1653
+                    1. Else Phantom#1654
 
-          1. Else Phantom#1654
+          1. Else Phantom#1655
 
   3. Case (% matches pattern `%[%]`)
 
@@ -31358,7 +31364,7 @@ relation Lvalue_read: p EC ARCH |- storageReference : %
 
                                   1. Result in: % % % |- % : value''
 
-                            1. Else Phantom#1655
+                            1. Else Phantom#1656
 
                           2. Case false
 
@@ -31372,11 +31378,11 @@ relation Lvalue_read: p EC ARCH |- storageReference : %
 
                                     1. Result in: % % % |- % : value'''
 
-                              1. Else Phantom#1656
+                              1. Else Phantom#1657
 
-              1. Else Phantom#1657
+              1. Else Phantom#1658
 
-      1. Else Phantom#1658
+      1. Else Phantom#1659
 
   4. Case (% matches pattern `%[%:%]`)
 
@@ -31430,7 +31436,7 @@ relation Lvalue_write: p EC_0 ARCH |- storageReference -> value : %
 
                           1. Result in: % % % |- % -> % : EC_1
 
-                  1. Else Phantom#1659
+                  1. Else Phantom#1660
 
             2. Case (% has type structValue)
 
@@ -31506,13 +31512,13 @@ relation Lvalue_write: p EC_0 ARCH |- storageReference -> value : %
 
                                                 1. Result in: % % % |- % -> % : EC_1
 
-                                1. Else Phantom#1660
+                                1. Else Phantom#1661
 
-                          1. Else Phantom#1661
+                          1. Else Phantom#1662
 
-                      1. Else Phantom#1662
+                      1. Else Phantom#1663
 
-          1. Else Phantom#1663
+          1. Else Phantom#1664
 
   3. Case (% matches pattern `%[%]`)
 
@@ -31552,15 +31558,15 @@ relation Lvalue_write: p EC_0 ARCH |- storageReference -> value : %
 
                                       1. Result in: % % % |- % -> % : EC_1
 
-                            1. Else Phantom#1664
+                            1. Else Phantom#1665
 
                           2. Case false
 
                             1. Result in: % % % |- % -> % : EC_0
 
-              1. Else Phantom#1665
+              1. Else Phantom#1666
 
-      1. Else Phantom#1666
+      1. Else Phantom#1667
 
   4. Case (% matches pattern `%[%:%]`)
 
@@ -31653,7 +31659,7 @@ relation Stmt_eval: p EC ARCH |- statementIR : % % %
 
                               1. Result in: % % % |- % : EC_3 ARCH_2 ((`empty) as statementResult)
 
-                1. Else Phantom#1667
+                1. Else Phantom#1668
 
   3. Case (% has type callStatementIR)
 
@@ -31731,7 +31737,7 @@ relation Stmt_eval: p EC ARCH |- statementIR : % % %
 
                     1. Result in: % % % |- % : EC_cond ARCH_cond (abortResult as statementResult)
 
-                1. Else Phantom#1668
+                1. Else Phantom#1669
 
                 2. Case analysis on expressionResult
 
@@ -31745,7 +31751,7 @@ relation Stmt_eval: p EC ARCH |- statementIR : % % %
 
                     1. Result in: % % % |- % : EC_cond ARCH_cond ((`empty) as statementResult)
 
-                2. Else Phantom#1669
+                2. Else Phantom#1670
 
           2. Case (% matches pattern `IF(%)%ELSE%`)
 
@@ -31759,7 +31765,7 @@ relation Stmt_eval: p EC ARCH |- statementIR : % % %
 
                     1. Result in: % % % |- % : EC_cond ARCH_cond (abortResult as statementResult)
 
-                1. Else Phantom#1670
+                1. Else Phantom#1671
 
                 2. Case analysis on expressionResult
 
@@ -31775,9 +31781,9 @@ relation Stmt_eval: p EC ARCH |- statementIR : % % %
 
                       1. Result in: % % % |- % : EC_else ARCH_else statementResult
 
-                2. Else Phantom#1671
+                2. Else Phantom#1672
 
-1. Else Phantom#1672
+1. Else Phantom#1673
 
 2. If ((p matches pattern `LOCAL`)), then
 
@@ -31849,9 +31855,9 @@ relation Stmt_eval: p EC ARCH |- statementIR : % % %
 
                             1. Result in: % % % |- % : EC_4 ARCH_2 statementResult'
 
-                  1. Else Phantom#1673
+                  1. Else Phantom#1674
 
-        1. Else Phantom#1674
+        1. Else Phantom#1675
 
         2. Group forStatementIR-in: (local) EC ARCH |- (forStatementIR as statementIR) : % % %
 
@@ -31899,7 +31905,7 @@ relation Stmt_eval: p EC ARCH |- statementIR : % % %
 
                   1. Result in: % % % |- % : EC_1 ARCH_1 statementResult
 
-          1. Else Phantom#1675
+          1. Else Phantom#1676
 
     3. Case (% has type breakStatement)
 
@@ -31953,9 +31959,9 @@ relation Stmt_eval: p EC ARCH |- statementIR : % % %
 
                         1. Result in: % % % |- % : EC_2 ARCH_2 statementResult
 
-  1. Else Phantom#1676
+  1. Else Phantom#1677
 
-2. Else Phantom#1677
+2. Else Phantom#1678
 
 relation BlockElementStmt_eval: EC_0 arch |- blockElementStatementIR : % % %
 
@@ -31995,7 +32001,7 @@ relation BlockElementStmtList_eval: evalContext arch |- (blockElementStatementIR
 
     1. Result in: % % |- % : evalContext arch ((`empty) as statementResult)
 
-  1. Else Phantom#1678
+  1. Else Phantom#1679
 
   2. If (((blockElementStatementIR)* matches pattern _ :: _)), then
 
@@ -32007,7 +32013,7 @@ relation BlockElementStmtList_eval: evalContext arch |- (blockElementStatementIR
 
           1. Result in: % % |- % : EC_1 ARCH_1 statementResult
 
-        1. Else Phantom#1679
+        1. Else Phantom#1680
 
         2. If ((statementResult has type continueEmptyResult)), then
 
@@ -32017,9 +32023,9 @@ relation BlockElementStmtList_eval: evalContext arch |- (blockElementStatementIR
 
               1. Result in: % % |- % : EC_2 ARCH_2 statementResult'
 
-        2. Else Phantom#1680
+        2. Else Phantom#1681
 
-  2. Else Phantom#1681
+  2. Else Phantom#1682
 
 relation Block_eval: EC_0 ARCH_0 |- (annotationList { blockElementStatementListIR }) : % % %
 
@@ -32069,7 +32075,7 @@ relation ParserStmt_eval: EC_0 ARCH |- parserStatementIR : % % %
 
                 1. Result in: % % |- % : EC_1 ARCH_1 ((`empty) as parserStatementResult)
 
-          1. Else Phantom#1682
+          1. Else Phantom#1683
 
   3. Case (% has type emptyStatementIR)
 
@@ -32085,7 +32091,7 @@ relation ParserStmt_eval: EC_0 ARCH |- parserStatementIR : % % %
 
               1. Result in: % % |- % : EC_1 ARCH_1 ((`empty) as parserStatementResult)
 
-          1. Else Phantom#1683
+          1. Else Phantom#1684
 
   4. Case (% has type assignmentStatementIR)
 
@@ -32109,7 +32115,7 @@ relation ParserStmt_eval: EC_0 ARCH |- parserStatementIR : % % %
 
                 1. Result in: % % |- % : EC_1 ARCH_1 ((`empty) as parserStatementResult)
 
-          1. Else Phantom#1684
+          1. Else Phantom#1685
 
   5. Case (% has type callStatementIR)
 
@@ -32133,7 +32139,7 @@ relation ParserStmt_eval: EC_0 ARCH |- parserStatementIR : % % %
 
                 1. Result in: % % |- % : EC_1 ARCH_1 ((`empty) as parserStatementResult)
 
-          1. Else Phantom#1685
+          1. Else Phantom#1686
 
   6. Case (% has type parserBlockStatementIR)
 
@@ -32169,7 +32175,7 @@ relation ParserStmt_eval: EC_0 ARCH |- parserStatementIR : % % %
 
                     1. Result in: % % |- % : EC_cond ARCH_cond (rejectTransitionResult as parserStatementResult)
 
-                1. Else Phantom#1686
+                1. Else Phantom#1687
 
                 2. Case analysis on expressionResult
 
@@ -32183,7 +32189,7 @@ relation ParserStmt_eval: EC_0 ARCH |- parserStatementIR : % % %
 
                     1. Result in: % % |- % : EC_cond ARCH_cond ((`empty) as parserStatementResult)
 
-                2. Else Phantom#1687
+                2. Else Phantom#1688
 
           2. Case (% matches pattern `IF(%)%ELSE%`)
 
@@ -32205,9 +32211,9 @@ relation ParserStmt_eval: EC_0 ARCH |- parserStatementIR : % % %
 
                       1. Result in: % % |- % : EC_else ARCH_else parserStatementResult
 
-                1. Else Phantom#1688
+                1. Else Phantom#1689
 
-1. Else Phantom#1689
+1. Else Phantom#1690
 
 relation ParserStmts_eval: evalContext arch |- (parserStatementIR)* : % % %
 
@@ -32217,7 +32223,7 @@ relation ParserStmts_eval: evalContext arch |- (parserStatementIR)* : % % %
 
     1. Result in: % % |- % : evalContext arch ((`empty) as parserStatementResult)
 
-  1. Else Phantom#1690
+  1. Else Phantom#1691
 
   2. If (((parserStatementIR)* matches pattern _ :: _)), then
 
@@ -32241,7 +32247,7 @@ relation ParserStmts_eval: evalContext arch |- (parserStatementIR)* : % % %
 
                 1. Result in: % % |- % : EC_2 ARCH_2 parserStatementResult'
 
-  2. Else Phantom#1691
+  2. Else Phantom#1692
 
 syntax transitionResult = 
    | accept
@@ -32288,7 +32294,7 @@ relation ParserSelect_eval: EC_0 ARCH_0 |- selectExpressionIR : % % %
 
                         1. Result in: % % |- % : EC_2 ARCH_2 (rejectTransitionResult as transitionResult)
 
-                    1. Else Phantom#1692
+                    1. Else Phantom#1693
 
                     2. If (((nameIR_state)? matches pattern (_))), then
 
@@ -32298,9 +32304,9 @@ relation ParserSelect_eval: EC_0 ARCH_0 |- selectExpressionIR : % % %
 
                           1. Result in: % % |- % : EC_3 ARCH_3 transitionResult
 
-                    2. Else Phantom#1693
+                    2. Else Phantom#1694
 
-      1. Else Phantom#1694
+      1. Else Phantom#1695
 
 relation ParserTransition_eval: evalContext arch |- (transition stateExpressionIR) : % % %
 
@@ -32324,13 +32330,13 @@ relation ParserTransition_eval: evalContext arch |- (transition stateExpressionI
 
               1. Result in: % % |- % : evalContext arch ((reject errorValue) as transitionResult)
 
-        1. Else Phantom#1695
+        1. Else Phantom#1696
 
         2. If (((nameIR =/= "accept") /\ (nameIR =/= "reject"))), then
 
           1. Result in: % % |- % : evalContext arch ((state nameIR) as transitionResult)
 
-        2. Else Phantom#1696
+        2. Else Phantom#1697
 
     2. Case (% has type selectExpressionIR)
 
@@ -32398,7 +32404,7 @@ relation ParserState_trans: EC_0 ARCH_0 |-transition nameIR : % % %
 
                   1. Result in: % % |-transition % : EC_2 ARCH_2 transitionResult'
 
-    1. Else Phantom#1697
+    1. Else Phantom#1698
 
 syntax parserDeclarationResult = parserStatementResult
 
@@ -32438,9 +32444,9 @@ relation ParserLocalDecl_eval: EC_0 ARCH |- parserLocalDeclarationIR : % % %
 
                 1. Result in: % % |- % : EC_1 ARCH_1 ((`empty) as parserDeclarationResult)
 
-          1. Else Phantom#1698
+          1. Else Phantom#1699
 
-1. Else Phantom#1699
+1. Else Phantom#1700
 
 relation ParserLocalDecls_eval: evalContext arch |- (parserLocalDeclarationIR)* : % % %
 
@@ -32450,7 +32456,7 @@ relation ParserLocalDecls_eval: evalContext arch |- (parserLocalDeclarationIR)* 
 
     1. Result in: % % |- % : evalContext arch ((`empty) as parserDeclarationResult)
 
-  1. Else Phantom#1700
+  1. Else Phantom#1701
 
   2. If (((parserLocalDeclarationIR)* matches pattern _ :: _)), then
 
@@ -32472,7 +32478,7 @@ relation ParserLocalDecls_eval: evalContext arch |- (parserLocalDeclarationIR)* 
 
               1. Result in: % % |- % : EC_2 ARCH_2 parserStatementResult
 
-  2. Else Phantom#1701
+  2. Else Phantom#1702
 
 syntax tableResult = 
    | exit
@@ -32540,7 +32546,7 @@ relation Table_eval: EC_0 ARCH_0 |- typeId TBL : % % %
 
                                         1. Result in: % % |- % % : EC_3 ARCH_3 ((return ?((tableMetadataStructValue as value))) as tableResult)
 
-                          1. Else Phantom#1702
+                          1. Else Phantom#1703
 
 syntax controlBodyResult = 
    | exit
@@ -32566,13 +32572,13 @@ relation ControlBody_eval: EC_0 ARCH_0 |- controlBodyIR : % % %
 
           1. Result in: % % |- % : EC_1 ARCH_1 ((exit) as controlBodyResult)
 
-    1. Else Phantom#1703
+    1. Else Phantom#1704
 
     2. If ((statementResult = ((return ?()) as statementResult))), then
 
       1. Result in: % % |- % : EC_1 ARCH_1 ((return ?()) as controlBodyResult)
 
-    2. Else Phantom#1704
+    2. Else Phantom#1705
 
 syntax controlLocalDeclarationResult = 
    | `empty
@@ -32614,9 +32620,9 @@ relation ControlLocalDecl_eval: EC_0 ARCH |- controlLocalDeclarationIR : % % %
 
                 1. Result in: % % |- % : EC_1 ARCH_1 ((`empty) as controlLocalDeclarationResult)
 
-          1. Else Phantom#1705
+          1. Else Phantom#1706
 
-1. Else Phantom#1706
+1. Else Phantom#1707
 
 relation ControlLocalDecls_eval: evalContext arch |- (controlLocalDeclarationIR)* : % % %
 
@@ -32626,7 +32632,7 @@ relation ControlLocalDecls_eval: evalContext arch |- (controlLocalDeclarationIR)
 
     1. Result in: % % |- % : evalContext arch ((`empty) as controlLocalDeclarationResult)
 
-  1. Else Phantom#1707
+  1. Else Phantom#1708
 
   2. If (((controlLocalDeclarationIR)* matches pattern _ :: _)), then
 
@@ -32650,7 +32656,7 @@ relation ControlLocalDecls_eval: evalContext arch |- (controlLocalDeclarationIR)
 
                 1. Result in: % % |- % : EC_2 ARCH_2 controlLocalDeclarationResult'
 
-  2. Else Phantom#1708
+  2. Else Phantom#1709
 
 syntax declarationResult = 
    | `empty
@@ -32734,9 +32740,9 @@ relation Callee_eval: p EC ARCH |- callableTargetIR <_>( argumentListIR ): % % %
 
                       1. Result in: % % % |- % <_>( % ): EC ARCH ((` (actionCallee as callee)) as calleeResult)
 
-              1. Else Phantom#1709
+              1. Else Phantom#1710
 
-          1. Else Phantom#1710
+          1. Else Phantom#1711
 
       2. Group externFunctionCallee: p EC ARCH |- (referenceExpressionIR as callableTargetIR) <_>( argumentListIR ): % % %
 
@@ -32756,9 +32762,9 @@ relation Callee_eval: p EC ARCH |- callableTargetIR <_>( argumentListIR ): % % %
 
                       1. Result in: % % % |- % <_>( % ): EC ARCH ((` (externFunctionCallee as callee)) as calleeResult)
 
-              1. Else Phantom#1711
+              1. Else Phantom#1712
 
-          1. Else Phantom#1712
+          1. Else Phantom#1713
 
       3. Group definedFunctionCallee: p EC ARCH |- (referenceExpressionIR as callableTargetIR) <_>( argumentListIR ): % % %
 
@@ -32778,9 +32784,9 @@ relation Callee_eval: p EC ARCH |- callableTargetIR <_>( argumentListIR ): % % %
 
                       1. Result in: % % % |- % <_>( % ): EC ARCH ((` (definedFunctionCallee as callee)) as calleeResult)
 
-              1. Else Phantom#1713
+              1. Else Phantom#1714
 
-          1. Else Phantom#1714
+          1. Else Phantom#1715
 
   2. Case (% matches pattern `%.%`)
 
@@ -32802,9 +32808,9 @@ relation Callee_eval: p EC ARCH |- callableTargetIR <_>( argumentListIR ): % % %
 
                     1. Result in: % % % |- % <_>( % ): EC_1 ARCH_1 (abortResult as calleeResult)
 
-                1. Else Phantom#1715
+                1. Else Phantom#1716
 
-          1. Else Phantom#1716
+          1. Else Phantom#1717
 
         2. Case analysis on nameIR
 
@@ -32834,13 +32840,13 @@ relation Callee_eval: p EC ARCH |- callableTargetIR <_>( argumentListIR ): % % %
 
                                   1. Result in: % % % |- % <_>( % ): EC_1 ARCH_1 ((` (builtinMethodCallee as callee)) as calleeResult)
 
-                          1. Else Phantom#1717
+                          1. Else Phantom#1718
 
-                      1. Else Phantom#1718
+                      1. Else Phantom#1719
 
-                1. Else Phantom#1719
+                1. Else Phantom#1720
 
-            1. Else Phantom#1720
+            1. Else Phantom#1721
 
           2. Case (% = "pop_front")
 
@@ -32868,13 +32874,13 @@ relation Callee_eval: p EC ARCH |- callableTargetIR <_>( argumentListIR ): % % %
 
                                   1. Result in: % % % |- % <_>( % ): EC_1 ARCH_1 ((` (builtinMethodCallee as callee)) as calleeResult)
 
-                          1. Else Phantom#1721
+                          1. Else Phantom#1722
 
-                      1. Else Phantom#1722
+                      1. Else Phantom#1723
 
-                1. Else Phantom#1723
+                1. Else Phantom#1724
 
-            1. Else Phantom#1724
+            1. Else Phantom#1725
 
           3. Case (% = "isValid")
 
@@ -32900,13 +32906,13 @@ relation Callee_eval: p EC ARCH |- callableTargetIR <_>( argumentListIR ): % % %
 
                                 1. Result in: % % % |- % <_>( % ): EC_1 ARCH_1 ((` (builtinMethodCallee as callee)) as calleeResult)
 
-                          1. Else Phantom#1725
+                          1. Else Phantom#1726
 
-                      1. Else Phantom#1726
+                      1. Else Phantom#1727
 
-                1. Else Phantom#1727
+                1. Else Phantom#1728
 
-            1. Else Phantom#1728
+            1. Else Phantom#1729
 
           4. Case (% = "setValid")
 
@@ -32932,13 +32938,13 @@ relation Callee_eval: p EC ARCH |- callableTargetIR <_>( argumentListIR ): % % %
 
                                 1. Result in: % % % |- % <_>( % ): EC_1 ARCH_1 ((` (builtinMethodCallee as callee)) as calleeResult)
 
-                          1. Else Phantom#1729
+                          1. Else Phantom#1730
 
-                      1. Else Phantom#1730
+                      1. Else Phantom#1731
 
-                1. Else Phantom#1731
+                1. Else Phantom#1732
 
-            1. Else Phantom#1732
+            1. Else Phantom#1733
 
           5. Case (% = "setInvalid")
 
@@ -32964,15 +32970,15 @@ relation Callee_eval: p EC ARCH |- callableTargetIR <_>( argumentListIR ): % % %
 
                                 1. Result in: % % % |- % <_>( % ): EC_1 ARCH_1 ((` (builtinMethodCallee as callee)) as calleeResult)
 
-                          1. Else Phantom#1733
+                          1. Else Phantom#1734
 
-                      1. Else Phantom#1734
+                      1. Else Phantom#1735
 
-                1. Else Phantom#1735
+                1. Else Phantom#1736
 
-            1. Else Phantom#1736
+            1. Else Phantom#1737
 
-        2. Else Phantom#1737
+        2. Else Phantom#1738
 
       2. Group externMethodCallee: p EC ARCH |- (typedExpressionIR . nameIR) <_>( argumentListIR ): % % %
 
@@ -33034,21 +33040,21 @@ relation Callee_eval: p EC ARCH |- callableTargetIR <_>( argumentListIR ): % % %
 
                                                           1. Result in: % % % |- % <_>( % ): EC_1 ARCH_1 ((` (externMethodCallee as callee)) as calleeResult)
 
-                                                      1. Else Phantom#1738
+                                                      1. Else Phantom#1739
 
-                                                  1. Else Phantom#1739
+                                                  1. Else Phantom#1740
 
-                                              1. Else Phantom#1740
+                                              1. Else Phantom#1741
 
-                                      1. Else Phantom#1741
+                                      1. Else Phantom#1742
 
-                                  1. Else Phantom#1742
+                                  1. Else Phantom#1743
 
-                            1. Else Phantom#1743
+                            1. Else Phantom#1744
 
-                      1. Else Phantom#1744
+                      1. Else Phantom#1745
 
-          1. Else Phantom#1745
+          1. Else Phantom#1746
 
       3. If ((nameIR = "apply")), then
 
@@ -33110,17 +33116,17 @@ relation Callee_eval: p EC ARCH |- callableTargetIR <_>( argumentListIR ): % % %
 
                                                           1. Result in: % % % |- % <_>( % ): EC_1 ARCH_1 ((` (parserApplyMethodCallee as callee)) as calleeResult)
 
-                                                    1. Else Phantom#1746
+                                                    1. Else Phantom#1747
 
-                                        1. Else Phantom#1747
+                                        1. Else Phantom#1748
 
-                                    1. Else Phantom#1748
+                                    1. Else Phantom#1749
 
-                              1. Else Phantom#1749
+                              1. Else Phantom#1750
 
-                        1. Else Phantom#1750
+                        1. Else Phantom#1751
 
-            1. Else Phantom#1751
+            1. Else Phantom#1752
 
         2. Group controlApplyMethodCallee: p EC ARCH |- (typedExpressionIR . "apply") <_>( argumentListIR ): % % %
 
@@ -33180,21 +33186,21 @@ relation Callee_eval: p EC ARCH |- callableTargetIR <_>( argumentListIR ): % % %
 
                                                           1. Result in: % % % |- % <_>( % ): EC_1 ARCH_1 ((` (controlApplyMethodCallee as callee)) as calleeResult)
 
-                                                    1. Else Phantom#1752
+                                                    1. Else Phantom#1753
 
-                                        1. Else Phantom#1753
+                                        1. Else Phantom#1754
 
-                                    1. Else Phantom#1754
+                                    1. Else Phantom#1755
 
-                              1. Else Phantom#1755
+                              1. Else Phantom#1756
 
-                        1. Else Phantom#1756
+                        1. Else Phantom#1757
 
-            1. Else Phantom#1757
+            1. Else Phantom#1758
 
-      3. Else Phantom#1758
+      3. Else Phantom#1759
 
-1. Else Phantom#1759
+1. Else Phantom#1760
 
 2. (Let (argumentIR)* be argumentListIR)
 
@@ -33252,21 +33258,21 @@ relation Callee_eval: p EC ARCH |- callableTargetIR <_>( argumentListIR ): % % %
 
                                                 1. Result in: % % % |- % <_>( % ): EC_1 ARCH_1 ((` (tableApplyMethodCallee as callee)) as calleeResult)
 
-                                          1. Else Phantom#1760
+                                          1. Else Phantom#1761
 
-                                      1. Else Phantom#1761
+                                      1. Else Phantom#1762
 
-                                1. Else Phantom#1762
+                                1. Else Phantom#1763
 
-                          1. Else Phantom#1763
+                          1. Else Phantom#1764
 
-              1. Else Phantom#1764
+              1. Else Phantom#1765
 
-        1. Else Phantom#1765
+        1. Else Phantom#1766
 
-      1. Else Phantom#1766
+      1. Else Phantom#1767
 
-  1. Else Phantom#1767
+  1. Else Phantom#1768
 
 syntax copyInArgumentResult = 
    | ` storageReference?
@@ -33297,7 +33303,7 @@ relation Copy_in_argument: ARCH_0 |- p_caller EC_caller_0 (annotationList direct
 
               1. Result in: % |- % % % @ % % % ~> ARCH_1 EC_caller_1 EC_callee_1 # ((` ?()) as copyInArgumentResult)
 
-  1. Else Phantom#1768
+  1. Else Phantom#1769
 
 2. Case analysis on direction
 
@@ -33329,7 +33335,7 @@ relation Copy_in_argument: ARCH_0 |- p_caller EC_caller_0 (annotationList direct
 
                       1. Result in: % |- % % % @ % % % ~> ARCH_1 EC_caller_1 EC_callee_1 # ((` ?(storageReference')) as copyInArgumentResult)
 
-              1. Else Phantom#1769
+              1. Else Phantom#1770
 
   2. Case (% matches pattern `OUT`)
 
@@ -33357,7 +33363,7 @@ relation Copy_in_argument: ARCH_0 |- p_caller EC_caller_0 (annotationList direct
 
                     1. Result in: % |- % % % @ % % % ~> ARCH_1 EC_caller_1 EC_callee_1 # ((` (storageReference)?) as copyInArgumentResult)
 
-2. Else Phantom#1770
+2. Else Phantom#1771
 
 syntax copyInResult = 
    | ` storageReference?*
@@ -33376,9 +33382,9 @@ relation Copy_in: p_shared arch |- p_caller evalContext (parameterIR)* @ p_calle
 
         1. Result in: % % |- % % % @ % % % ~> arch evalContext EC_callee_1 # ((` []) as copyInResult)
 
-    1. Else Phantom#1771
+    1. Else Phantom#1772
 
-  1. Else Phantom#1772
+  1. Else Phantom#1773
 
   2. If (((parameterIR)* matches pattern _ :: _)), then
 
@@ -33424,11 +33430,11 @@ relation Copy_in: p_shared arch |- p_caller evalContext (parameterIR)* @ p_calle
 
                                 1. Result in: % % |- % % % @ % % % ~> ARCH_2 EC_caller_2 EC_callee_2 # ((` ((storageReference')?)*) as copyInResult)
 
-                          1. Else Phantom#1773
+                          1. Else Phantom#1774
 
-      1. Else Phantom#1774
+      1. Else Phantom#1775
 
-  2. Else Phantom#1775
+  2. Else Phantom#1776
 
 relation Copy_in_default: (parameterIR)* @ p_callee EC_callee_0 ~> %
 
@@ -33448,9 +33454,9 @@ relation Copy_in_default: (parameterIR)* @ p_callee EC_callee_0 ~> %
 
               1. Result in: % @ % % ~> EC_callee_1
 
-        1. Else Phantom#1776
+        1. Else Phantom#1777
 
-    1. Else Phantom#1777
+    1. Else Phantom#1778
 
 relation Copy_out_argument: ARCH |- p_caller EC_caller_0 (annotationList direction typeIR nameIR parameterInitializerOptIR) @ p_callee EC_callee (storageReference)? ~> %
 
@@ -33462,9 +33468,9 @@ relation Copy_out_argument: ARCH |- p_caller EC_caller_0 (annotationList directi
 
       1. Result in: % |- % % % @ % % % ~> EC_caller_0
 
-    1. Else Phantom#1778
+    1. Else Phantom#1779
 
-1. Else Phantom#1779
+1. Else Phantom#1780
 
 2. Group out-inout: ARCH |- p_caller EC_caller_0 (annotationList direction typeIR nameIR parameterInitializerOptIR) @ p_callee EC_callee (storageReference)? ~> %
 
@@ -33476,7 +33482,7 @@ relation Copy_out_argument: ARCH |- p_caller EC_caller_0 (annotationList directi
 
         1. Result in: % |- % % % @ % % % ~> EC_caller_0
 
-      1. Else Phantom#1780
+      1. Else Phantom#1781
 
     2. Case (% matches pattern (_))
 
@@ -33490,7 +33496,7 @@ relation Copy_out_argument: ARCH |- p_caller EC_caller_0 (annotationList directi
 
               1. Result in: % |- % % % @ % % % ~> EC_caller_1
 
-        1. Else Phantom#1781
+        1. Else Phantom#1782
 
 relation Copy_out: p_shared ARCH |- p_caller EC_caller_0 parameterListIR @ p_callee EC_callee ((storageReference)?)* ~> %
 
@@ -33548,7 +33554,7 @@ relation Call_eval: p EC_0 ARCH_0 |- callee @< typeArgumentListIR >( argumentLis
 
                                     1. Result in: % % % |- % @< % >( % ): EC_2 ARCH_2 ((exit) as callResult)
 
-                              1. Else Phantom#1782
+                              1. Else Phantom#1783
 
                               2. If ((actionResult = ((return ?()) as actionResult))), then
 
@@ -33556,11 +33562,11 @@ relation Call_eval: p EC_0 ARCH_0 |- callee @< typeArgumentListIR >( argumentLis
 
                                   1. Result in: % % % |- % @< % >( % ): EC_2 ARCH_2 ((return ?()) as callResult)
 
-                              2. Else Phantom#1783
+                              2. Else Phantom#1784
 
-                    1. Else Phantom#1784
+                    1. Else Phantom#1785
 
-        1. Else Phantom#1785
+        1. Else Phantom#1786
 
     2. Case (% has type definedFunctionCallee)
 
@@ -33600,7 +33606,7 @@ relation Call_eval: p EC_0 ARCH_0 |- callee @< typeArgumentListIR >( argumentLis
 
                                   1. Result in: % % % |- % @< % >( % ): EC_2 ARCH_2 (definedFunctionResult as callResult)
 
-  1. Else Phantom#1786
+  1. Else Phantom#1787
 
   2. (Let (argumentIR)* be argumentListIR)
 
@@ -33644,7 +33650,7 @@ relation Call_eval: p EC_0 ARCH_0 |- callee @< typeArgumentListIR >( argumentLis
 
                                     1. Result in: % % % |- % @< % >( % ): EC_2 ARCH_2 callResult
 
-    1. Else Phantom#1787
+    1. Else Phantom#1788
 
   3. If ((callee has type builtinMethodCallee)), then
 
@@ -33724,9 +33730,9 @@ relation Call_eval: p EC_0 ARCH_0 |- callee @< typeArgumentListIR >( argumentLis
 
                                                                         1. Result in: % % % |- % @< % >( % ): EC_2 ARCH_1 ((return ?()) as callResult)
 
-                                                          1. Else Phantom#1788
+                                                          1. Else Phantom#1789
 
-                                                  1. Else Phantom#1789
+                                                  1. Else Phantom#1790
 
                                                   2. If ((n_count >= n_size)), then
 
@@ -33740,17 +33746,17 @@ relation Call_eval: p EC_0 ARCH_0 |- callee @< typeArgumentListIR >( argumentLis
 
                                                             1. Result in: % % % |- % @< % >( % ): EC_2 ARCH_1 ((return ?()) as callResult)
 
-                                                  2. Else Phantom#1790
+                                                  2. Else Phantom#1791
 
-                                              1. Else Phantom#1791
+                                              1. Else Phantom#1792
 
-                                        1. Else Phantom#1792
+                                        1. Else Phantom#1793
 
-                          1. Else Phantom#1793
+                          1. Else Phantom#1794
 
-                      1. Else Phantom#1794
+                      1. Else Phantom#1795
 
-                    1. Else Phantom#1795
+                    1. Else Phantom#1796
 
                   2. Case (% = "pop_front")
 
@@ -33812,9 +33818,9 @@ relation Call_eval: p EC_0 ARCH_0 |- callee @< typeArgumentListIR >( argumentLis
 
                                                                       1. Result in: % % % |- % @< % >( % ): EC_2 ARCH_1 ((return ?()) as callResult)
 
-                                                      1. Else Phantom#1796
+                                                      1. Else Phantom#1797
 
-                                                  1. Else Phantom#1797
+                                                  1. Else Phantom#1798
 
                                                   2. If ((n_count >= n_size)), then
 
@@ -33832,23 +33838,23 @@ relation Call_eval: p EC_0 ARCH_0 |- callee @< typeArgumentListIR >( argumentLis
 
                                                                 1. Result in: % % % |- % @< % >( % ): EC_2 ARCH_1 ((return ?()) as callResult)
 
-                                                        1. Else Phantom#1798
+                                                        1. Else Phantom#1799
 
-                                                  2. Else Phantom#1799
+                                                  2. Else Phantom#1800
 
-                                              1. Else Phantom#1800
+                                              1. Else Phantom#1801
 
-                                        1. Else Phantom#1801
+                                        1. Else Phantom#1802
 
-                          1. Else Phantom#1802
+                          1. Else Phantom#1803
 
-                      1. Else Phantom#1803
+                      1. Else Phantom#1804
 
-                    1. Else Phantom#1804
+                    1. Else Phantom#1805
 
-                1. Else Phantom#1805
+                1. Else Phantom#1806
 
-          1. Else Phantom#1806
+          1. Else Phantom#1807
 
           2. If ((argumentListIR = [])), then
 
@@ -33890,11 +33896,11 @@ relation Call_eval: p EC_0 ARCH_0 |- callee @< typeArgumentListIR >( argumentLis
 
                                       1. Result in: % % % |- % @< % >( % ): EC_0 ARCH_0 (returnResult as callResult)
 
-                        1. Else Phantom#1807
+                        1. Else Phantom#1808
 
-                    1. Else Phantom#1808
+                    1. Else Phantom#1809
 
-                  1. Else Phantom#1809
+                  1. Else Phantom#1810
 
                 2. Case (% = "setValid")
 
@@ -33918,11 +33924,11 @@ relation Call_eval: p EC_0 ARCH_0 |- callee @< typeArgumentListIR >( argumentLis
 
                                     1. Result in: % % % |- % @< % >( % ): EC_1 ARCH_0 (returnResult as callResult)
 
-                        1. Else Phantom#1810
+                        1. Else Phantom#1811
 
-                    1. Else Phantom#1811
+                    1. Else Phantom#1812
 
-                  1. Else Phantom#1812
+                  1. Else Phantom#1813
 
                 3. Case (% = "setInvalid")
 
@@ -33946,19 +33952,19 @@ relation Call_eval: p EC_0 ARCH_0 |- callee @< typeArgumentListIR >( argumentLis
 
                                     1. Result in: % % % |- % @< % >( % ): EC_1 ARCH_0 (returnResult as callResult)
 
-                        1. Else Phantom#1813
+                        1. Else Phantom#1814
 
-                    1. Else Phantom#1814
+                    1. Else Phantom#1815
 
-                  1. Else Phantom#1815
+                  1. Else Phantom#1816
 
-              1. Else Phantom#1816
+              1. Else Phantom#1817
 
-          2. Else Phantom#1817
+          2. Else Phantom#1818
 
-      1. Else Phantom#1818
+      1. Else Phantom#1819
 
-  3. Else Phantom#1819
+  3. Else Phantom#1820
 
   4. (Let (argumentIR)* be argumentListIR)
 
@@ -34008,9 +34014,9 @@ relation Call_eval: p EC_0 ARCH_0 |- callee @< typeArgumentListIR >( argumentLis
 
                                           1. Result in: % % % |- % @< % >( % ): EC_2 ARCH_2 callResult
 
-            1. Else Phantom#1820
+            1. Else Phantom#1821
 
-    1. Else Phantom#1821
+    1. Else Phantom#1822
 
 2. Case analysis on callee
 
@@ -34080,9 +34086,9 @@ relation Call_eval: p EC_0 ARCH_0 |- callee @< typeArgumentListIR >( argumentLis
 
                                             1. Result in: % % % |- % @< % >( % ): EC_2 ARCH_3 ((return ?()) as callResult)
 
-                                    1. Else Phantom#1822
+                                    1. Else Phantom#1823
 
-                    1. Else Phantom#1823
+                    1. Else Phantom#1824
 
   2. Case (% has type controlApplyMethodCallee)
 
@@ -34144,7 +34150,7 @@ relation Call_eval: p EC_0 ARCH_0 |- callee @< typeArgumentListIR >( argumentLis
 
                                               1. Result in: % % % |- % @< % >( % ): EC_2 ARCH_3 ((exit) as callResult)
 
-                                        1. Else Phantom#1824
+                                        1. Else Phantom#1825
 
                                         2. If ((controlBodyResult = ((return ?()) as controlBodyResult))), then
 
@@ -34152,9 +34158,9 @@ relation Call_eval: p EC_0 ARCH_0 |- callee @< typeArgumentListIR >( argumentLis
 
                                             1. Result in: % % % |- % @< % >( % ): EC_2 ARCH_3 ((return ?()) as callResult)
 
-                                        2. Else Phantom#1825
+                                        2. Else Phantom#1826
 
-                      1. Else Phantom#1826
+                      1. Else Phantom#1827
 
   3. Case (% has type tableApplyMethodCallee)
 
@@ -34194,9 +34200,9 @@ relation Call_eval: p EC_0 ARCH_0 |- callee @< typeArgumentListIR >( argumentLis
 
                               1. Result in: % % % |- % @< % >( % ): EC_1 ARCH_1 (returnResult as callResult)
 
-                1. Else Phantom#1827
+                1. Else Phantom#1828
 
-2. Else Phantom#1828
+2. Else Phantom#1829
 
 extern relation ExternFunctionCall_eval: evalContext arch |- nameIR ( (nameIR')* ): % % %
 
@@ -34212,7 +34218,7 @@ def $match_keysets((setValue)*, (value)*)
 
       1. Return true
 
-    1. Else Phantom#1829
+    1. Else Phantom#1830
 
   2. Case (% matches pattern [ _/1 ])
 
@@ -34226,9 +34232,9 @@ def $match_keysets((setValue)*, (value)*)
 
             1. Return $match_keyset(setValue', value_key)
 
-          1. Else Phantom#1830
+          1. Else Phantom#1831
 
-      1. Else Phantom#1831
+      1. Else Phantom#1832
 
   3. Case (% matches pattern _ :: _)
 
@@ -34252,19 +34258,19 @@ def $match_keysets((setValue)*, (value)*)
 
                   1. Return false
 
-            1. Else Phantom#1832
+            1. Else Phantom#1833
 
-          1. Else Phantom#1833
+          1. Else Phantom#1834
 
-      1. Else Phantom#1834
+      1. Else Phantom#1835
 
-1. Else Phantom#1835
+1. Else Phantom#1836
 
 2. If (((setValue)* = [(set{...})])), then
 
   1. Return true
 
-2. Else Phantom#1836
+2. Else Phantom#1837
 
 def $match_keyset(setValue, value_key)
 
@@ -34353,11 +34359,11 @@ relation Expr_eval_keyset_simple: EC_0 ARCH_0 |- simpleKeysetExpressionIR : % % 
 
                                   1. Result in: % % |- % : EC_1 ARCH_1 ((` setValue) as simpleKeysetExpressionResult)
 
-                            1. Else Phantom#1837
+                            1. Else Phantom#1838
 
-                        1. Else Phantom#1838
+                        1. Else Phantom#1839
 
-                1. Else Phantom#1839
+                1. Else Phantom#1840
 
   2. Case (% matches pattern `%&&&%`)
 
@@ -34435,7 +34441,7 @@ relation Expr_eval_keyset_simple: EC_0 ARCH_0 |- simpleKeysetExpressionIR : % % 
 
                           1. Result in: % % |- % : EC_2 ARCH_2 ((` setValue) as simpleKeysetExpressionResult)
 
-1. Else Phantom#1840
+1. Else Phantom#1841
 
 2. Group default-any: EC_0 ARCH_0 |- simpleKeysetExpressionIR : % % %
 
@@ -34445,7 +34451,7 @@ relation Expr_eval_keyset_simple: EC_0 ARCH_0 |- simpleKeysetExpressionIR : % % 
 
       1. Result in: % % |- % : EC_0 ARCH_0 ((` setValue) as simpleKeysetExpressionResult)
 
-  1. Else Phantom#1841
+  1. Else Phantom#1842
 
 relation Exprs_eval_keyset_simple: evalContext arch |- (simpleKeysetExpressionIR)* : % % %
 
@@ -34455,7 +34461,7 @@ relation Exprs_eval_keyset_simple: evalContext arch |- (simpleKeysetExpressionIR
 
     1. Result in: % % |- % : evalContext arch ((` []) as keysetExpressionResult)
 
-  1. Else Phantom#1842
+  1. Else Phantom#1843
 
   2. If (((simpleKeysetExpressionIR)* matches pattern _ :: _)), then
 
@@ -34493,7 +34499,7 @@ relation Exprs_eval_keyset_simple: evalContext arch |- (simpleKeysetExpressionIR
 
                         1. Result in: % % |- % : EC_2 ARCH_2 keysetExpressionResult'
 
-  2. Else Phantom#1843
+  2. Else Phantom#1844
 
 relation ForUpdateStmt_eval: EC_0 ARCH_0 |- forUpdateStatementIR : % % %
 
@@ -34525,7 +34531,7 @@ relation ForUpdateStmts_eval: evalContext arch |- (forUpdateStatementIR)* : % % 
 
     1. Result in: % % |- % : evalContext arch ((`empty) as statementResult)
 
-  1. Else Phantom#1844
+  1. Else Phantom#1845
 
   2. If (((forUpdateStatementIR)* matches pattern _ :: _)), then
 
@@ -34549,9 +34555,9 @@ relation ForUpdateStmts_eval: evalContext arch |- (forUpdateStatementIR)* : % % 
 
                 1. Result in: % % |- % : EC_2 ARCH_2 statementResult'
 
-        1. Else Phantom#1845
+        1. Else Phantom#1846
 
-  2. Else Phantom#1846
+  2. Else Phantom#1847
 
 relation ForInitStmt_eval: EC_0 arch |- forInitStatementIR : % % %
 
@@ -34573,7 +34579,7 @@ relation ForInitStmt_eval: EC_0 arch |- forInitStatementIR : % % %
 
                 1. Result in: % % |- % : EC_1 arch ((`empty) as statementResult)
 
-        1. Else Phantom#1847
+        1. Else Phantom#1848
 
       2. (Let (annotationList typeIR nameIR initializerOptIR) be forInitStatementIR)
 
@@ -34599,7 +34605,7 @@ relation ForInitStmt_eval: EC_0 arch |- forInitStatementIR : % % %
 
                       1. Result in: % % |- % : EC_2 ARCH_1 ((`empty) as statementResult)
 
-        1. Else Phantom#1848
+        1. Else Phantom#1849
 
     2. Case (% has type forUpdateStatementIR)
 
@@ -34617,7 +34623,7 @@ relation ForInitStmts_eval: evalContext arch |- (forInitStatementIR)* : % % %
 
     1. Result in: % % |- % : evalContext arch ((`empty) as statementResult)
 
-  1. Else Phantom#1849
+  1. Else Phantom#1850
 
   2. If (((forInitStatementIR)* matches pattern _ :: _)), then
 
@@ -34641,9 +34647,9 @@ relation ForInitStmts_eval: evalContext arch |- (forInitStatementIR)* : % % %
 
                 1. Result in: % % |- % : EC_2 ARCH_2 statementResult'
 
-        1. Else Phantom#1850
+        1. Else Phantom#1851
 
-  2. Else Phantom#1851
+  2. Else Phantom#1852
 
 relation ForThreeClauseStmt_eval: EC_0 ARCH_0 |- typedExpressionIR statementIR forUpdateStatementListIR : % % %
 
@@ -34657,7 +34663,7 @@ relation ForThreeClauseStmt_eval: EC_0 ARCH_0 |- typedExpressionIR statementIR f
 
         1. Result in: % % |- % % % : EC_1 ARCH_1 (abortResult as statementResult)
 
-    1. Else Phantom#1852
+    1. Else Phantom#1853
 
     2. Case analysis on expressionResult
 
@@ -34689,7 +34695,7 @@ relation ForThreeClauseStmt_eval: EC_0 ARCH_0 |- typedExpressionIR statementIR f
 
                 1. Result in: % % |- % % % : EC_2 ARCH_2 ((`empty) as statementResult)
 
-          1. Else Phantom#1853
+          1. Else Phantom#1854
 
           2. If (((statementResult = ((`empty) as statementResult)) \/ (statementResult = ((continue) as statementResult)))), then
 
@@ -34711,11 +34717,11 @@ relation ForThreeClauseStmt_eval: EC_0 ARCH_0 |- typedExpressionIR statementIR f
 
                       1. Result in: % % |- % % % : EC_4 ARCH_4 statementResult''
 
-              1. Else Phantom#1854
+              1. Else Phantom#1855
 
-          2. Else Phantom#1855
+          2. Else Phantom#1856
 
-    2. Else Phantom#1856
+    2. Else Phantom#1857
 
 relation ForCollectionExpr_eval: EC_0 ARCH_0 |- forCollectionExpressionIR : % % %
 
@@ -34759,7 +34765,7 @@ relation ForCollectionExpr_eval: EC_0 ARCH_0 |- forCollectionExpressionIR : % % 
 
                         1. Result in: % % |- % : EC_1 ARCH_1 ((` (value')*) as expressionListResult)
 
-                1. Else Phantom#1857
+                1. Else Phantom#1858
 
   2. Case (% matches pattern `%..%`)
 
@@ -34815,21 +34821,21 @@ def $values_of_setValue((set< typeIR >), setValue)
 
           1. Return value_l :: $values_of_setValue((set< typeIR >), (set{ value_l_inc .. value_r }))
 
-    1. Else Phantom#1858
+    1. Else Phantom#1859
 
     2. If ($bin_eq(value_l, value_r)), then
 
       1. Return [value_l]
 
-    2. Else Phantom#1859
+    2. Else Phantom#1860
 
     3. If ($bin_gt(value_l, value_r)), then
 
       1. Return []
 
-    3. Else Phantom#1860
+    3. Else Phantom#1861
 
-1. Else Phantom#1861
+1. Else Phantom#1862
 
 relation ForInStmt_eval: evalContext arch |- nameIR (value)* statementIR : % % %
 
@@ -34839,7 +34845,7 @@ relation ForInStmt_eval: evalContext arch |- nameIR (value)* statementIR : % % %
 
     1. Result in: % % |- % % % : evalContext arch ((`empty) as statementResult)
 
-  1. Else Phantom#1862
+  1. Else Phantom#1863
 
   2. If (((value)* matches pattern _ :: _)), then
 
@@ -34869,7 +34875,7 @@ relation ForInStmt_eval: evalContext arch |- nameIR (value)* statementIR : % % %
 
                 1. Result in: % % |- % % % : EC_2 ARCH_1 ((`empty) as statementResult)
 
-          1. Else Phantom#1863
+          1. Else Phantom#1864
 
           2. If (((statementResult = ((`empty) as statementResult)) \/ (statementResult = ((continue) as statementResult)))), then
 
@@ -34877,9 +34883,9 @@ relation ForInStmt_eval: evalContext arch |- nameIR (value)* statementIR : % % %
 
               1. Result in: % % |- % % % : EC_3 ARCH_2 statementResult'
 
-          2. Else Phantom#1864
+          2. Else Phantom#1865
 
-  2. Else Phantom#1865
+  2. Else Phantom#1866
 
 relation Switch_table_eval: EC_0 ARCH_0 |-switch( id_enum ){ (switchCaseIR)* }: % % %
 
@@ -34937,7 +34943,7 @@ relation SwitchCases_table_eval: id |- (switchCaseIR)* : %
 
     1. Result in: % |- % : ?()
 
-  1. Else Phantom#1866
+  1. Else Phantom#1867
 
   2. If (((switchCaseIR)* matches pattern _ :: _)), then
 
@@ -34981,9 +34987,9 @@ relation SwitchCases_table_eval: id |- (switchCaseIR)* : %
 
                           1. Result in: % |- % : ?(blockStatementIR)
 
-                      1. Else Phantom#1867
+                      1. Else Phantom#1868
 
-                  1. Else Phantom#1868
+                  1. Else Phantom#1869
 
               2. Case false
 
@@ -34991,7 +34997,7 @@ relation SwitchCases_table_eval: id |- (switchCaseIR)* : %
 
                   1. Result in: % |- % : (blockStatementIR)?
 
-  2. Else Phantom#1869
+  2. Else Phantom#1870
 
 def $is_non_fallthrough_switchCaseIR(switchCaseIR)
 
@@ -35045,7 +35051,7 @@ relation SwitchLabel_general_eval: cursor EC_0 ARCH_0 |- switchLabelIR : % % %
 
             1. Result in: % % % |- % : EC_1 ARCH_1 expressionResult
 
-1. Else Phantom#1870
+1. Else Phantom#1871
 
 def $match_switchLabelIR_general(value, value')
 
@@ -35069,7 +35075,7 @@ relation SwitchCases_general_eval: cursor EC_0 ARCH_0 value |- (switchCaseIR)* :
 
       1. Result in: % % % % |- % : EC_0 ARCH_0 ?()
 
-    1. Else Phantom#1871
+    1. Else Phantom#1872
 
     2. If (((switchCaseIR)* matches pattern _ :: _)), then
 
@@ -35099,7 +35105,7 @@ relation SwitchCases_general_eval: cursor EC_0 ARCH_0 value |- (switchCaseIR)* :
 
                           1. Result in: % % % % |- % : EC_2 ARCH_2 (blockStatementIR)?
 
-                1. Else Phantom#1872
+                1. Else Phantom#1873
 
           2. Case (% matches pattern `%:`)
 
@@ -35127,9 +35133,9 @@ relation SwitchCases_general_eval: cursor EC_0 ARCH_0 value |- (switchCaseIR)* :
 
                                   1. Result in: % % % % |- % : EC_1 ARCH_1 ?(blockStatementIR)
 
-                              1. Else Phantom#1873
+                              1. Else Phantom#1874
 
-                          1. Else Phantom#1874
+                          1. Else Phantom#1875
 
                       2. Case false
 
@@ -35137,11 +35143,11 @@ relation SwitchCases_general_eval: cursor EC_0 ARCH_0 value |- (switchCaseIR)* :
 
                           1. Result in: % % % % |- % : EC_2 ARCH_2 (blockStatementIR)?
 
-                1. Else Phantom#1875
+                1. Else Phantom#1876
 
-    2. Else Phantom#1876
+    2. Else Phantom#1877
 
-1. Else Phantom#1877
+1. Else Phantom#1878
 
 syntax selectCaseMatchResult = 
    | ` nameIR?
@@ -35175,7 +35181,7 @@ relation SelectCase_match: EC_0 ARCH_0 (value_key)* |- (keysetExpressionIR : nam
 
               1. Result in: % % % |- % : EC_1 ARCH_1 ((` ?(nameIR)) as selectCaseMatchResult)
 
-    1. Else Phantom#1878
+    1. Else Phantom#1879
 
 relation SelectCases_match: evalContext arch (value_key)* |- (selectCaseIR)* : % % %
 
@@ -35185,7 +35191,7 @@ relation SelectCases_match: evalContext arch (value_key)* |- (selectCaseIR)* : %
 
     1. Result in: % % % |- % : evalContext arch ((` ?()) as selectCaseMatchResult)
 
-  1. Else Phantom#1879
+  1. Else Phantom#1880
 
   2. If (((selectCaseIR)* matches pattern _ :: _)), then
 
@@ -35211,7 +35217,7 @@ relation SelectCases_match: evalContext arch (value_key)* |- (selectCaseIR)* : %
 
                   1. Result in: % % % |- % : EC_1 ARCH_1 ((` ?(nameIR_state)) as selectCaseMatchResult)
 
-              1. Else Phantom#1880
+              1. Else Phantom#1881
 
         2. If ((selectCaseMatchResult = ((` ?()) as selectCaseMatchResult))), then
 
@@ -35219,9 +35225,9 @@ relation SelectCases_match: evalContext arch (value_key)* |- (selectCaseIR)* : %
 
             1. Result in: % % % |- % : EC_2 ARCH_2 selectCaseMatchResult'
 
-        2. Else Phantom#1881
+        2. Else Phantom#1882
 
-  2. Else Phantom#1882
+  2. Else Phantom#1883
 
 syntax tableKeyValue = 
    | value : nameIR
@@ -35252,7 +35258,7 @@ relation TableKey_eval: EC_0 ARCH_0 |- (typedExpressionIR # nameIR' : nameIR ann
 
             1. Result in: % % |- % : EC_1 ARCH_1 ((` tableKeyValue) as tableKeyResult)
 
-    1. Else Phantom#1883
+    1. Else Phantom#1884
 
 syntax tableKeysResult = 
    | ` tableKeyValue*
@@ -35266,7 +35272,7 @@ relation TableKeys_eval: evalContext arch |- (tableKeyIR)* : % % %
 
     1. Result in: % % |- % : evalContext arch ((` []) as tableKeysResult)
 
-  1. Else Phantom#1884
+  1. Else Phantom#1885
 
   2. If (((tableKeyIR)* matches pattern _ :: _)), then
 
@@ -35304,7 +35310,7 @@ relation TableKeys_eval: evalContext arch |- (tableKeyIR)* : % % %
 
                         1. Result in: % % |- % : EC_2 ARCH_2 ((` (tableKeyValue)*) as tableKeysResult)
 
-  2. Else Phantom#1885
+  2. Else Phantom#1886
 
 def $get_tableEntryPriority((tableEntryPriorityIR)?)
 
@@ -35326,7 +35332,7 @@ def $get_tableEntryPriority((tableEntryPriorityIR)?)
 
             1. Return ?(n)
 
-        1. Else Phantom#1886
+        1. Else Phantom#1887
 
 syntax tableMatch = 
    | nat? : tableActionReferenceIR
@@ -35371,7 +35377,7 @@ relation TableMatch_eval: EC_0 ARCH_0 |- (tableKeyValue)* @ tableEntryIR : % % %
 
                       1. Result in: % % |- % @ % : EC_1 ARCH_1 ((` ?(tableMatch)) as tableMatchResult)
 
-        1. Else Phantom#1887
+        1. Else Phantom#1888
 
 syntax tableMatchesResult = 
    | ` tableMatch*
@@ -35385,7 +35391,7 @@ relation TableMatches_eval: evalContext arch |- (tableKeyValue)* @ (tableEntryIR
 
     1. Result in: % % |- % @ % : evalContext arch ((` []) as tableMatchesResult)
 
-  1. Else Phantom#1888
+  1. Else Phantom#1889
 
   2. If (((tableEntryIR)* matches pattern _ :: _)), then
 
@@ -35423,7 +35429,7 @@ relation TableMatches_eval: evalContext arch |- (tableKeyValue)* @ (tableEntryIR
 
                         1. Result in: % % |- % @ % : EC_2 ARCH_2 ((` (tableMatch)*) as tableMatchesResult)
 
-  2. Else Phantom#1889
+  2. Else Phantom#1890
 
 def $largest_priority_wins(TBL)
 
@@ -35445,17 +35451,17 @@ def $largest_priority_wins(TBL)
 
                 1. Return b
 
-            1. Else Phantom#1890
+            1. Else Phantom#1891
 
-        1. Else Phantom#1891
+        1. Else Phantom#1892
 
-    1. Else Phantom#1892
+    1. Else Phantom#1893
 
   2. If (([] = $filter_<tableCustomPropertyIR>((tableCustomPropertyIR)*, ($is_largest_priority_wins(tableCustomPropertyIR))*))), then
 
     1. Return true
 
-  2. Else Phantom#1893
+  2. Else Phantom#1894
 
 def $is_largest_priority_wins(tableCustomPropertyIR)
 
@@ -35489,7 +35495,7 @@ def $select_action(TBL, (tableMatch)*)
 
         1. Return tableActionReferenceIR
 
-1. Else Phantom#1894
+1. Else Phantom#1895
 
 2. If ((|(tableMatch)*| > 1)), then
 
@@ -35513,7 +35519,7 @@ def $select_action(TBL, (tableMatch)*)
 
                     1. Return tableActionReferenceIR_h
 
-                1. Else Phantom#1895
+                1. Else Phantom#1896
 
             2. Case false
 
@@ -35523,11 +35529,11 @@ def $select_action(TBL, (tableMatch)*)
 
                   1. Return tableActionReferenceIR_h
 
-              1. Else Phantom#1896
+              1. Else Phantom#1897
 
-    1. Else Phantom#1897
+    1. Else Phantom#1898
 
-2. Else Phantom#1898
+2. Else Phantom#1899
 
 relation Copy_out_inner: ARCH |- p_caller evalContext (parameterIR)* @ p_callee EC_callee ((storageReference)?)* ~> %
 
@@ -35539,9 +35545,9 @@ relation Copy_out_inner: ARCH |- p_caller evalContext (parameterIR)* @ p_callee 
 
       1. Result in: % |- % % % @ % % % ~> evalContext
 
-    1. Else Phantom#1899
+    1. Else Phantom#1900
 
-  1. Else Phantom#1900
+  1. Else Phantom#1901
 
   2. If (((parameterIR)* matches pattern _ :: _)), then
 
@@ -35559,9 +35565,9 @@ relation Copy_out_inner: ARCH |- p_caller evalContext (parameterIR)* @ p_callee 
 
                 1. Result in: % |- % % % @ % % % ~> EC_caller_2
 
-        1. Else Phantom#1901
+        1. Else Phantom#1902
 
-  2. Else Phantom#1902
+  2. Else Phantom#1903
 
 syntax actionResult = 
    | exit
@@ -35587,13 +35593,13 @@ relation ActionBody_eval: EC_0 ARCH_0 |- blockStatementIR : % % %
 
           1. Result in: % % |- % : EC_1 ARCH_1 ((exit) as actionResult)
 
-    1. Else Phantom#1903
+    1. Else Phantom#1904
 
     2. If ((statementResult = ((return ?()) as statementResult))), then
 
       1. Result in: % % |- % : EC_1 ARCH_1 ((return ?()) as actionResult)
 
-    2. Else Phantom#1904
+    2. Else Phantom#1905
 
 syntax definedFunctionResult = 
    | exit
@@ -35625,7 +35631,7 @@ relation DefinedFunctionBody_eval: EC_0 ARCH_0 |- blockStatementIR : % % %
 
           1. Result in: % % |- % : EC_1 ARCH_1 (returnResult as definedFunctionResult)
 
-    1. Else Phantom#1905
+    1. Else Phantom#1906
 
 def $isValid_fieldValue((value id ;))
 
@@ -35667,11 +35673,11 @@ relation Extern_init: EC ARCH_0 |- nameIR_extern nameIR : %
 
                       1. Result in: % % |- % % : ARCH_2
 
-          1. Else Phantom#1906
+          1. Else Phantom#1907
 
-        1. Else Phantom#1907
+        1. Else Phantom#1908
 
-      1. Else Phantom#1908
+      1. Else Phantom#1909
 
 relation Program_init: |- p4program : % %
 
@@ -35847,7 +35853,7 @@ def $tableObject_create_entry_priority(tableEntryPriorityInterface)
 
     1. Return ?()
 
-  1. Else Phantom#1909
+  1. Else Phantom#1910
 
 2. If ((tableEntryPriorityInterface matches pattern (_))), then
 
@@ -35859,9 +35865,9 @@ def $tableObject_create_entry_priority(tableEntryPriorityInterface)
 
         1. Return ?((priority= (d (n_priority as int)) :))
 
-    1. Else Phantom#1910
+    1. Else Phantom#1911
 
-2. Else Phantom#1911
+2. Else Phantom#1912
 
 def $needs_priority_tableKeysPropertyIR((key={ (tableKeyIR)* }))
 
@@ -35903,11 +35909,11 @@ def $tableObject_create_entry_key(EC, (nameIR_key, text, typeIR), (tableKeyInter
 
                               1. Return simpleKeysetExpressionIR
 
-                      1. Else Phantom#1912
+                      1. Else Phantom#1913
 
-            1. Else Phantom#1913
+            1. Else Phantom#1914
 
-      1. Else Phantom#1914
+      1. Else Phantom#1915
 
   2. Case (% = "ternary")
 
@@ -35951,9 +35957,9 @@ def $tableObject_create_entry_key(EC, (nameIR_key, text, typeIR), (tableKeyInter
 
                                           1. Return simpleKeysetExpressionIR
 
-                                    1. Else Phantom#1915
+                                    1. Else Phantom#1916
 
-                        1. Else Phantom#1916
+                        1. Else Phantom#1917
 
             2. Case (% matches pattern ``BIN%`)
 
@@ -35987,13 +35993,13 @@ def $tableObject_create_entry_key(EC, (nameIR_key, text, typeIR), (tableKeyInter
 
                                           1. Return simpleKeysetExpressionIR
 
-                                    1. Else Phantom#1917
+                                    1. Else Phantom#1918
 
-                        1. Else Phantom#1918
+                        1. Else Phantom#1919
 
-          1. Else Phantom#1919
+          1. Else Phantom#1920
 
-      1. Else Phantom#1920
+      1. Else Phantom#1921
 
   3. Case (% = "lpm")
 
@@ -36041,11 +36047,11 @@ def $tableObject_create_entry_key(EC, (nameIR_key, text, typeIR), (tableKeyInter
 
                                               1. Return simpleKeysetExpressionIR
 
-                                        1. Else Phantom#1921
+                                        1. Else Phantom#1922
 
-                            1. Else Phantom#1922
+                            1. Else Phantom#1923
 
-                  1. Else Phantom#1923
+                  1. Else Phantom#1924
 
             2. Case (% matches pattern ``BIN%`)
 
@@ -36083,11 +36089,11 @@ def $tableObject_create_entry_key(EC, (nameIR_key, text, typeIR), (tableKeyInter
 
                                               1. Return simpleKeysetExpressionIR
 
-                                        1. Else Phantom#1924
+                                        1. Else Phantom#1925
 
-                            1. Else Phantom#1925
+                            1. Else Phantom#1926
 
-                  1. Else Phantom#1926
+                  1. Else Phantom#1927
 
             3. Case (% matches pattern `%`SLASH%`)
 
@@ -36127,17 +36133,17 @@ def $tableObject_create_entry_key(EC, (nameIR_key, text, typeIR), (tableKeyInter
 
                                                 1. Return simpleKeysetExpressionIR
 
-                                          1. Else Phantom#1927
+                                          1. Else Phantom#1928
 
-                                  1. Else Phantom#1928
+                                  1. Else Phantom#1929
 
-                        1. Else Phantom#1929
+                        1. Else Phantom#1930
 
-                    1. Else Phantom#1930
+                    1. Else Phantom#1931
 
-          1. Else Phantom#1931
+          1. Else Phantom#1932
 
-      1. Else Phantom#1932
+      1. Else Phantom#1933
 
   4. Case (% = "optional")
 
@@ -36181,17 +36187,17 @@ def $tableObject_create_entry_key(EC, (nameIR_key, text, typeIR), (tableKeyInter
 
                                           1. Return simpleKeysetExpressionIR
 
-                                    1. Else Phantom#1933
+                                    1. Else Phantom#1934
 
-                        1. Else Phantom#1934
+                        1. Else Phantom#1935
 
-              1. Else Phantom#1935
+              1. Else Phantom#1936
 
-          1. Else Phantom#1936
+          1. Else Phantom#1937
 
-      1. Else Phantom#1937
+      1. Else Phantom#1938
 
-1. Else Phantom#1938
+1. Else Phantom#1939
 
 def $tableObject_create_entry_keys(evalContext, ((nameIR, nameIR, typeIR))*, tableKeysetInterface)
 
@@ -36199,7 +36205,7 @@ def $tableObject_create_entry_keys(evalContext, ((nameIR, nameIR, typeIR))*, tab
 
   1. Return []
 
-1. Else Phantom#1939
+1. Else Phantom#1940
 
 2. (Let (tableKeyInterface)* be tableKeysetInterface)
 
@@ -36211,7 +36217,7 @@ def $tableObject_create_entry_keys(evalContext, ((nameIR, nameIR, typeIR))*, tab
 
         1. Return simpleKeysetExpressionIR_h :: $tableObject_create_entry_keys(evalContext, ((nameIR_key_t, nameIR_matchKind_t, typeIR_t))*, (tableKeyInterface)*)
 
-  1. Else Phantom#1940
+  1. Else Phantom#1941
 
 def $interface_of_tableKeyIR((typedExpressionIR # nameIR_key : nameIR_matchKind annotationList ;))
 
@@ -36231,7 +36237,7 @@ def $tableObject_create_entry_keyset(EC, (key={ (tableKeyIR)* }), (tableKeyInter
 
         1. Return ((( (simpleKeysetExpressionIR)* )) as keysetExpressionIR)
 
-    1. Else Phantom#1941
+    1. Else Phantom#1942
 
 def $alias_to_original_lookup_map((parameterIR)*)
 
@@ -36269,9 +36275,9 @@ def $align_tableActionArgumentInterfaces((parameterIR)*, ((nameIR_arg, i_arg))*)
 
               1. Return (i_aligned)*
 
-          1. Else Phantom#1942
+          1. Else Phantom#1943
 
-    1. Else Phantom#1943
+    1. Else Phantom#1944
 
 def $align_tableActionArgumentInterfaces'(({ ((id_arg : i_arg))* }), (_annotationList _direction _typeIR nameIR_param _parameterInitializerOptIR))
 
@@ -36297,7 +36303,7 @@ def $find_tableActionIR_qualified((tableActionIR)*, nameIR)
 
             1. Return $find_tableActionIR_qualified((tableActionIR_t)*, nameIR)
 
-          1. Else Phantom#1944
+          1. Else Phantom#1945
 
           2. If ((?(nameIR) = controlPlaneNameIR)), then
 
@@ -36305,7 +36311,7 @@ def $find_tableActionIR_qualified((tableActionIR)*, nameIR)
 
               1. Return ?((nameIR_action, tableActionIR_h))
 
-          2. Else Phantom#1945
+          2. Else Phantom#1946
 
 def $find_tableActionIR_unqualified((tableActionIR)*, nameIR)
 
@@ -36315,13 +36321,13 @@ def $find_tableActionIR_unqualified((tableActionIR)*, nameIR)
 
     1. Return ?()
 
-  1. Else Phantom#1946
+  1. Else Phantom#1947
 
   2. If ((|(nameIR_split)*| = 1)), then
 
     1. Return $find_tableActionIR_unqualified'((tableActionIR)*, (nameIR_split)*[0])
 
-  2. Else Phantom#1947
+  2. Else Phantom#1948
 
 def $find_tableActionIR_unqualified'((tableActionIR)*, nameIR)
 
@@ -36355,7 +36361,7 @@ def $find_tableActionIR_unqualified'((tableActionIR)*, nameIR)
 
                         1. Return $find_tableActionIR_unqualified'((tableActionIR_t)*, nameIR)
 
-                      1. Else Phantom#1948
+                      1. Else Phantom#1949
 
                       2. If ((nameIR = nameIR_unqualified)), then
 
@@ -36363,11 +36369,11 @@ def $find_tableActionIR_unqualified'((tableActionIR)*, nameIR)
 
                           1. Return ?((nameIR_action, tableActionIR_h))
 
-                      2. Else Phantom#1949
+                      2. Else Phantom#1950
 
-                  1. Else Phantom#1950
+                  1. Else Phantom#1951
 
-          1. Else Phantom#1951
+          1. Else Phantom#1952
 
 def $tableObject_create_entry_action(EC, (actions={ (tableActionIR)* }), (nameIR_action_update, (tableActionArgumentInterface_update)*))
 
@@ -36395,9 +36401,9 @@ def $tableObject_create_entry_action(EC, (actions={ (tableActionIR)* }), (nameIR
 
                       1. Return ((` nameIR_found) controlPlaneNameIR ( (argumentIR)* ))
 
-                1. Else Phantom#1952
+                1. Else Phantom#1953
 
-  1. Else Phantom#1953
+  1. Else Phantom#1954
 
 2. If ((?() = $find_tableActionIR_qualified((tableActionIR)*, nameIR_action_update))), then
 
@@ -36425,11 +36431,11 @@ def $tableObject_create_entry_action(EC, (actions={ (tableActionIR)* }), (nameIR
 
                         1. Return ((` nameIR_found) controlPlaneNameIR ( (argumentIR)* ))
 
-                  1. Else Phantom#1954
+                  1. Else Phantom#1955
 
-    1. Else Phantom#1955
+    1. Else Phantom#1956
 
-2. Else Phantom#1956
+2. Else Phantom#1957
 
 def $tableObject_add_entry(EC, (table typeId { frame TBL }), tableEntryPriorityInterface, tableKeysetInterface, tableActionInterface)
 
@@ -36451,7 +36457,7 @@ def $tableObject_add_entry(EC, (table typeId { frame TBL }), tableEntryPriorityI
 
                 1. Return (table typeId { frame TBL_updated })
 
-  1. Else Phantom#1957
+  1. Else Phantom#1958
 
 def $tableObject_add_default_action(EC, (table typeId { frame TBL }), tableActionInterface)
 
@@ -36467,7 +36473,7 @@ def $tableObject_add_default_action(EC, (table typeId { frame TBL }), tableActio
 
           1. Return (table typeId { frame TBL_updated })
 
-  1. Else Phantom#1958
+  1. Else Phantom#1959
 
 relation V1Model_init: |- p4program : % %
 
@@ -36505,9 +36511,9 @@ relation V1Model_init_packet_in: EC_0 ARCH_0 |- objectState_packet_in : % %
 
                       1. Result in: % % |- % : EC_1 ARCH_2
 
-            1. Else Phantom#1959
+            1. Else Phantom#1960
 
-        1. Else Phantom#1960
+        1. Else Phantom#1961
 
 relation V1Model_init_packet_out: EC_0 ARCH_0 |- objectState_packet_out : % %
 
@@ -36535,9 +36541,9 @@ relation V1Model_init_packet_out: EC_0 ARCH_0 |- objectState_packet_out : % %
 
                       1. Result in: % % |- % : EC_1 ARCH_2
 
-            1. Else Phantom#1961
+            1. Else Phantom#1962
 
-        1. Else Phantom#1962
+        1. Else Phantom#1963
 
 relation V1Model_init_globals: EC_0 ARCH |- i_port : %
 
@@ -36587,15 +36593,15 @@ relation V1Model_init_globals: EC_0 ARCH |- i_port : %
 
                                             1. Result in: % % |- % : EC_4
 
-                              1. Else Phantom#1963
+                              1. Else Phantom#1964
 
-                    1. Else Phantom#1964
+                    1. Else Phantom#1965
 
-              1. Else Phantom#1965
+              1. Else Phantom#1966
 
-        1. Else Phantom#1966
+        1. Else Phantom#1967
 
-    1. Else Phantom#1967
+    1. Else Phantom#1968
 
 def $V1Model_setup_packet_in_argument(EC)
 
@@ -36611,7 +36617,7 @@ def $V1Model_setup_packet_in_argument(EC)
 
           1. Return argumentIR_packet_in
 
-  1. Else Phantom#1968
+  1. Else Phantom#1969
 
 def $V1Model_setup_packet_out_argument(EC)
 
@@ -36627,7 +36633,7 @@ def $V1Model_setup_packet_out_argument(EC)
 
           1. Return argumentIR_packet_out
 
-  1. Else Phantom#1969
+  1. Else Phantom#1970
 
 def $V1Model_setup_hdr_argument(ARCH)
 
@@ -36651,11 +36657,11 @@ def $V1Model_setup_hdr_argument(ARCH)
 
                   1. Return argumentIR_hdr
 
-            1. Else Phantom#1970
+            1. Else Phantom#1971
 
-      1. Else Phantom#1971
+      1. Else Phantom#1972
 
-  1. Else Phantom#1972
+  1. Else Phantom#1973
 
 def $V1Model_setup_meta_argument(ARCH)
 
@@ -36679,11 +36685,11 @@ def $V1Model_setup_meta_argument(ARCH)
 
                   1. Return argumentIR_meta
 
-            1. Else Phantom#1973
+            1. Else Phantom#1974
 
-      1. Else Phantom#1974
+      1. Else Phantom#1975
 
-  1. Else Phantom#1975
+  1. Else Phantom#1976
 
 def $V1Model_setup_standard_metadata_argument(EC)
 
@@ -36699,7 +36705,7 @@ def $V1Model_setup_standard_metadata_argument(EC)
 
           1. Return argumentIR_standard_metadata
 
-  1. Else Phantom#1976
+  1. Else Phantom#1977
 
 def $V1Model_setup_main_callee(EC, ARCH)
 
@@ -36737,15 +36743,15 @@ def $V1Model_setup_main_callee(EC, ARCH)
 
                                 1. Return typedExpressionIR_main
 
-                        1. Else Phantom#1977
+                        1. Else Phantom#1978
 
-                  1. Else Phantom#1978
+                  1. Else Phantom#1979
 
-            1. Else Phantom#1979
+            1. Else Phantom#1980
 
-        1. Else Phantom#1980
+        1. Else Phantom#1981
 
-  1. Else Phantom#1981
+  1. Else Phantom#1982
 
 def $V1Model_setup_parser_callee(EC, ARCH, typedExpressionIR_main)
 
@@ -36783,15 +36789,15 @@ def $V1Model_setup_parser_callee(EC, ARCH, typedExpressionIR_main)
 
                                 1. Return typedExpressionIR_parser
 
-                        1. Else Phantom#1982
+                        1. Else Phantom#1983
 
-                  1. Else Phantom#1983
+                  1. Else Phantom#1984
 
-            1. Else Phantom#1984
+            1. Else Phantom#1985
 
-        1. Else Phantom#1985
+        1. Else Phantom#1986
 
-  1. Else Phantom#1986
+  1. Else Phantom#1987
 
 def $V1Model_setup_verify_callee(EC, ARCH, typedExpressionIR_main)
 
@@ -36829,15 +36835,15 @@ def $V1Model_setup_verify_callee(EC, ARCH, typedExpressionIR_main)
 
                                 1. Return typedExpressionIR_verify
 
-                        1. Else Phantom#1987
+                        1. Else Phantom#1988
 
-                  1. Else Phantom#1988
+                  1. Else Phantom#1989
 
-            1. Else Phantom#1989
+            1. Else Phantom#1990
 
-        1. Else Phantom#1990
+        1. Else Phantom#1991
 
-  1. Else Phantom#1991
+  1. Else Phantom#1992
 
 def $V1Model_setup_ingress_callee(EC, ARCH, typedExpressionIR_main)
 
@@ -36875,15 +36881,15 @@ def $V1Model_setup_ingress_callee(EC, ARCH, typedExpressionIR_main)
 
                                 1. Return typedExpressionIR_ingress
 
-                        1. Else Phantom#1992
+                        1. Else Phantom#1993
 
-                  1. Else Phantom#1993
+                  1. Else Phantom#1994
 
-            1. Else Phantom#1994
+            1. Else Phantom#1995
 
-        1. Else Phantom#1995
+        1. Else Phantom#1996
 
-  1. Else Phantom#1996
+  1. Else Phantom#1997
 
 def $V1Model_setup_egress_callee(EC, ARCH, typedExpressionIR_main)
 
@@ -36921,15 +36927,15 @@ def $V1Model_setup_egress_callee(EC, ARCH, typedExpressionIR_main)
 
                                 1. Return typedExpressionIR_egress
 
-                        1. Else Phantom#1997
+                        1. Else Phantom#1998
 
-                  1. Else Phantom#1998
+                  1. Else Phantom#1999
 
-            1. Else Phantom#1999
+            1. Else Phantom#2000
 
-        1. Else Phantom#2000
+        1. Else Phantom#2001
 
-  1. Else Phantom#2001
+  1. Else Phantom#2002
 
 def $V1Model_setup_check_callee(EC, ARCH, typedExpressionIR_main)
 
@@ -36967,15 +36973,15 @@ def $V1Model_setup_check_callee(EC, ARCH, typedExpressionIR_main)
 
                                 1. Return typedExpressionIR_check
 
-                        1. Else Phantom#2002
+                        1. Else Phantom#2003
 
-                  1. Else Phantom#2003
+                  1. Else Phantom#2004
 
-            1. Else Phantom#2004
+            1. Else Phantom#2005
 
-        1. Else Phantom#2005
+        1. Else Phantom#2006
 
-  1. Else Phantom#2006
+  1. Else Phantom#2007
 
 def $V1Model_setup_deparse_callee(EC, ARCH, typedExpressionIR_main)
 
@@ -37007,13 +37013,13 @@ def $V1Model_setup_deparse_callee(EC, ARCH, typedExpressionIR_main)
 
                           1. Return typedExpressionIR_deparse
 
-                  1. Else Phantom#2007
+                  1. Else Phantom#2008
 
-            1. Else Phantom#2008
+            1. Else Phantom#2009
 
-        1. Else Phantom#2009
+        1. Else Phantom#2010
 
-  1. Else Phantom#2010
+  1. Else Phantom#2011
 
 relation V1Model_parser: EC_0 ARCH_0 |- % % %
 
@@ -37051,7 +37057,7 @@ relation V1Model_parser: EC_0 ARCH_0 |- % % %
 
                           1. Result in: % % |- EC_1 ARCH_1 (rejectTransitionResult as transitionResult)
 
-                    1. Else Phantom#2011
+                    1. Else Phantom#2012
 
 relation V1Model_verify: EC_0 ARCH_0 |- % % %
 
@@ -37085,7 +37091,7 @@ relation V1Model_verify: EC_0 ARCH_0 |- % % %
 
                       1. Result in: % % |- EC_1 ARCH_1 ((exit) as callResult)
 
-                1. Else Phantom#2012
+                1. Else Phantom#2013
 
 relation V1Model_ingress: EC_0 ARCH_0 |- % % %
 
@@ -37121,7 +37127,7 @@ relation V1Model_ingress: EC_0 ARCH_0 |- % % %
 
                         1. Result in: % % |- EC_1 ARCH_1 ((return ?()) as callResult)
 
-                  1. Else Phantom#2013
+                  1. Else Phantom#2014
 
 relation V1Model_egress: EC_0 ARCH_0 |- % % %
 
@@ -37157,7 +37163,7 @@ relation V1Model_egress: EC_0 ARCH_0 |- % % %
 
                         1. Result in: % % |- EC_1 ARCH_1 ((exit) as callResult)
 
-                  1. Else Phantom#2014
+                  1. Else Phantom#2015
 
 relation V1Model_check: EC_0 ARCH_0 |- % % %
 
@@ -37191,7 +37197,7 @@ relation V1Model_check: EC_0 ARCH_0 |- % % %
 
                       1. Result in: % % |- EC_1 ARCH_1 ((exit) as callResult)
 
-                1. Else Phantom#2015
+                1. Else Phantom#2016
 
 relation V1Model_deparse: EC_0 ARCH_0 |- % % %
 
@@ -37225,7 +37231,7 @@ relation V1Model_deparse: EC_0 ARCH_0 |- % % %
 
                       1. Result in: % % |- EC_1 ARCH_1 ((exit) as callResult)
 
-                1. Else Phantom#2016
+                1. Else Phantom#2017
 
 def $field_list_annotation_index(annotationList)
 
@@ -37347,13 +37353,13 @@ def $V1Model_meta_fields_of_index(ARCH, integerLiteral_index)
 
                       1. Return (nameIR_field)*
 
-                1. Else Phantom#2017
+                1. Else Phantom#2018
 
-            1. Else Phantom#2018
+            1. Else Phantom#2019
 
-      1. Else Phantom#2019
+      1. Else Phantom#2020
 
-  1. Else Phantom#2020
+  1. Else Phantom#2021
 
 relation V1Model_copy_meta_fields: EC_capture EC_0 ARCH |- (nameIR)* : %
 
@@ -37363,7 +37369,7 @@ relation V1Model_copy_meta_fields: EC_capture EC_0 ARCH |- (nameIR)* : %
 
     1. Result in: % % % |- % : EC_0
 
-  1. Else Phantom#2021
+  1. Else Phantom#2022
 
   2. If (((nameIR)* matches pattern _ :: _)), then
 
@@ -37379,7 +37385,7 @@ relation V1Model_copy_meta_fields: EC_capture EC_0 ARCH |- (nameIR)* : %
 
               1. Result in: % % % |- % : EC_2
 
-  2. Else Phantom#2022
+  2. Else Phantom#2023
 
 relation V1Model_setup_preserved_meta_fields: EC_0 ARCH |- integerLiteral_index : %
 
@@ -37409,11 +37415,11 @@ relation V1Model_setup_preserved_meta_fields: EC_0 ARCH |- integerLiteral_index 
 
                         1. Result in: % % |- % : EC_2
 
-              1. Else Phantom#2023
+              1. Else Phantom#2024
 
-        1. Else Phantom#2024
+        1. Else Phantom#2025
 
-    1. Else Phantom#2025
+    1. Else Phantom#2026
 
 relation EBPF_init: |- p4program : % %
 
@@ -37451,9 +37457,9 @@ relation EBPF_init_packet_in: EC_0 ARCH_0 |- objectState_packet_in : % %
 
                       1. Result in: % % |- % : EC_1 ARCH_2
 
-            1. Else Phantom#2026
+            1. Else Phantom#2027
 
-        1. Else Phantom#2027
+        1. Else Phantom#2028
 
 relation EBPF_init_globals: EC_0 ARCH |- %
 
@@ -37481,11 +37487,11 @@ relation EBPF_init_globals: EC_0 ARCH |- %
 
                       1. Result in: % % |- EC_2
 
-              1. Else Phantom#2028
+              1. Else Phantom#2029
 
-        1. Else Phantom#2029
+        1. Else Phantom#2030
 
-    1. Else Phantom#2030
+    1. Else Phantom#2031
 
 def $eBPF_setup_packet_in_argument(EC)
 
@@ -37501,7 +37507,7 @@ def $eBPF_setup_packet_in_argument(EC)
 
           1. Return argumentIR_packet_in
 
-  1. Else Phantom#2031
+  1. Else Phantom#2032
 
 def $eBPF_setup_headers_argument(ARCH)
 
@@ -37525,11 +37531,11 @@ def $eBPF_setup_headers_argument(ARCH)
 
                   1. Return argumentIR_headers
 
-            1. Else Phantom#2032
+            1. Else Phantom#2033
 
-      1. Else Phantom#2033
+      1. Else Phantom#2034
 
-  1. Else Phantom#2034
+  1. Else Phantom#2035
 
 def $eBPF_setup_main_callee(EC, ARCH)
 
@@ -37561,13 +37567,13 @@ def $eBPF_setup_main_callee(EC, ARCH)
 
                           1. Return typedExpressionIR_main
 
-                  1. Else Phantom#2035
+                  1. Else Phantom#2036
 
-            1. Else Phantom#2036
+            1. Else Phantom#2037
 
-        1. Else Phantom#2037
+        1. Else Phantom#2038
 
-  1. Else Phantom#2038
+  1. Else Phantom#2039
 
 def $eBPF_setup_parse_callee(EC, ARCH, typedExpressionIR_main)
 
@@ -37599,13 +37605,13 @@ def $eBPF_setup_parse_callee(EC, ARCH, typedExpressionIR_main)
 
                           1. Return typedExpressionIR_parse
 
-                  1. Else Phantom#2039
+                  1. Else Phantom#2040
 
-            1. Else Phantom#2040
+            1. Else Phantom#2041
 
-        1. Else Phantom#2041
+        1. Else Phantom#2042
 
-  1. Else Phantom#2042
+  1. Else Phantom#2043
 
 def $eBPF_setup_filter_callee(EC, ARCH, typedExpressionIR_main)
 
@@ -37637,13 +37643,13 @@ def $eBPF_setup_filter_callee(EC, ARCH, typedExpressionIR_main)
 
                           1. Return typedExpressionIR_filter
 
-                  1. Else Phantom#2043
+                  1. Else Phantom#2044
 
-            1. Else Phantom#2044
+            1. Else Phantom#2045
 
-        1. Else Phantom#2045
+        1. Else Phantom#2046
 
-  1. Else Phantom#2046
+  1. Else Phantom#2047
 
 relation EBPF_parse: EC_0 ARCH_0 |- % % %
 
@@ -37677,7 +37683,7 @@ relation EBPF_parse: EC_0 ARCH_0 |- % % %
 
                       1. Result in: % % |- EC_1 ARCH_1 (rejectTransitionResult as transitionResult)
 
-                1. Else Phantom#2047
+                1. Else Phantom#2048
 
 relation EBPF_filter: EC_0 ARCH_0 |- % % %
 
@@ -37711,7 +37717,7 @@ relation EBPF_filter: EC_0 ARCH_0 |- % % %
 
                       1. Result in: % % |- EC_1 ARCH_1 ((exit) as callResult)
 
-                1. Else Phantom#2048
+                1. Else Phantom#2049
 
 relation PSA_init: |- p4program : % %
 
@@ -37745,11 +37751,11 @@ def $PSA_setup_normal_meta_argument(ARCH)
 
                   1. Return argumentIR_normal_meta
 
-            1. Else Phantom#2049
+            1. Else Phantom#2050
 
-      1. Else Phantom#2050
+      1. Else Phantom#2051
 
-  1. Else Phantom#2051
+  1. Else Phantom#2052
 
 def $PSA_setup_clone_i2e_meta_argument(ARCH)
 
@@ -37773,11 +37779,11 @@ def $PSA_setup_clone_i2e_meta_argument(ARCH)
 
                   1. Return argumentIR_clone_i2e_meta
 
-            1. Else Phantom#2052
+            1. Else Phantom#2053
 
-      1. Else Phantom#2053
+      1. Else Phantom#2054
 
-  1. Else Phantom#2054
+  1. Else Phantom#2055
 
 def $PSA_setup_clone_e2e_meta_argument(ARCH)
 
@@ -37801,11 +37807,11 @@ def $PSA_setup_clone_e2e_meta_argument(ARCH)
 
                   1. Return argumentIR_clone_e2e_meta
 
-            1. Else Phantom#2055
+            1. Else Phantom#2056
 
-      1. Else Phantom#2056
+      1. Else Phantom#2057
 
-  1. Else Phantom#2057
+  1. Else Phantom#2058
 
 def $PSA_setup_resubmit_meta_argument(ARCH)
 
@@ -37829,11 +37835,11 @@ def $PSA_setup_resubmit_meta_argument(ARCH)
 
                   1. Return argumentIR_resubmit_meta
 
-            1. Else Phantom#2058
+            1. Else Phantom#2059
 
-      1. Else Phantom#2059
+      1. Else Phantom#2060
 
-  1. Else Phantom#2060
+  1. Else Phantom#2061
 
 def $PSA_setup_recirculate_meta_argument(ARCH)
 
@@ -37857,11 +37863,11 @@ def $PSA_setup_recirculate_meta_argument(ARCH)
 
                   1. Return argumentIR_recirculate_meta
 
-            1. Else Phantom#2061
+            1. Else Phantom#2062
 
-      1. Else Phantom#2062
+      1. Else Phantom#2063
 
-  1. Else Phantom#2063
+  1. Else Phantom#2064
 
 def $PSA_setup_main_callee(EC, ARCH)
 
@@ -37943,29 +37949,29 @@ def $PSA_setup_main_callee(EC, ARCH)
 
                                                                             1. Return typedExpressionIR_main
 
-                                                                  1. Else Phantom#2064
+                                                                  1. Else Phantom#2065
 
-                                                            1. Else Phantom#2065
+                                                            1. Else Phantom#2066
 
-                                                      1. Else Phantom#2066
+                                                      1. Else Phantom#2067
 
-                                                1. Else Phantom#2067
+                                                1. Else Phantom#2068
 
-                                          1. Else Phantom#2068
+                                          1. Else Phantom#2069
 
-                                    1. Else Phantom#2069
+                                    1. Else Phantom#2070
 
-                              1. Else Phantom#2070
+                              1. Else Phantom#2071
 
-                        1. Else Phantom#2071
+                        1. Else Phantom#2072
 
-                  1. Else Phantom#2072
+                  1. Else Phantom#2073
 
-            1. Else Phantom#2073
+            1. Else Phantom#2074
 
-        1. Else Phantom#2074
+        1. Else Phantom#2075
 
-  1. Else Phantom#2075
+  1. Else Phantom#2076
 
 relation PSA_ingress_init_packet_in: EC_0 ARCH_0 |- objectState_packet_in : % %
 
@@ -37993,9 +37999,9 @@ relation PSA_ingress_init_packet_in: EC_0 ARCH_0 |- objectState_packet_in : % %
 
                       1. Result in: % % |- % : EC_1 ARCH_2
 
-            1. Else Phantom#2076
+            1. Else Phantom#2077
 
-        1. Else Phantom#2077
+        1. Else Phantom#2078
 
 relation PSA_ingress_init_packet_out: EC_0 ARCH_0 |- objectState_packet_out : % %
 
@@ -38023,9 +38029,9 @@ relation PSA_ingress_init_packet_out: EC_0 ARCH_0 |- objectState_packet_out : % 
 
                       1. Result in: % % |- % : EC_1 ARCH_2
 
-            1. Else Phantom#2078
+            1. Else Phantom#2079
 
-        1. Else Phantom#2079
+        1. Else Phantom#2080
 
 relation PSA_ingress_init_parser_input_metadata: EC_0 ARCH |- i_port t_path : %
 
@@ -38213,27 +38219,27 @@ relation PSA_ingress_init_globals: EC_0 ARCH |- i_port : %
 
                                                                                             1. Result in: % % |- % : EC_10
 
-                                                                                1. Else Phantom#2080
+                                                                                1. Else Phantom#2081
 
-                                                                          1. Else Phantom#2081
+                                                                          1. Else Phantom#2082
 
-                                                                    1. Else Phantom#2082
+                                                                    1. Else Phantom#2083
 
-                                                              1. Else Phantom#2083
+                                                              1. Else Phantom#2084
 
-                                                  1. Else Phantom#2084
+                                                  1. Else Phantom#2085
 
-                                        1. Else Phantom#2085
+                                        1. Else Phantom#2086
 
-                              1. Else Phantom#2086
+                              1. Else Phantom#2087
 
-                    1. Else Phantom#2087
+                    1. Else Phantom#2088
 
-              1. Else Phantom#2088
+              1. Else Phantom#2089
 
-        1. Else Phantom#2089
+        1. Else Phantom#2090
 
-    1. Else Phantom#2090
+    1. Else Phantom#2091
 
 def $PSA_setup_ingress_packet_in_argument(EC)
 
@@ -38249,7 +38255,7 @@ def $PSA_setup_ingress_packet_in_argument(EC)
 
           1. Return argumentIR_packet_in
 
-  1. Else Phantom#2091
+  1. Else Phantom#2092
 
 def $PSA_setup_ingress_packet_out_argument(EC)
 
@@ -38265,7 +38271,7 @@ def $PSA_setup_ingress_packet_out_argument(EC)
 
           1. Return argumentIR_packet_out
 
-  1. Else Phantom#2092
+  1. Else Phantom#2093
 
 def $PSA_setup_ingress_hdr_argument(ARCH)
 
@@ -38289,11 +38295,11 @@ def $PSA_setup_ingress_hdr_argument(ARCH)
 
                   1. Return argumentIR_hdr
 
-            1. Else Phantom#2093
+            1. Else Phantom#2094
 
-      1. Else Phantom#2094
+      1. Else Phantom#2095
 
-  1. Else Phantom#2095
+  1. Else Phantom#2096
 
 def $PSA_setup_ingress_user_meta_argument(ARCH)
 
@@ -38317,11 +38323,11 @@ def $PSA_setup_ingress_user_meta_argument(ARCH)
 
                   1. Return argumentIR_user_meta
 
-            1. Else Phantom#2096
+            1. Else Phantom#2097
 
-      1. Else Phantom#2097
+      1. Else Phantom#2098
 
-  1. Else Phantom#2098
+  1. Else Phantom#2099
 
 def $PSA_setup_ingress_parser_input_metadata_argument(EC)
 
@@ -38337,7 +38343,7 @@ def $PSA_setup_ingress_parser_input_metadata_argument(EC)
 
           1. Return argumentIR_parser_input_metadata
 
-  1. Else Phantom#2099
+  1. Else Phantom#2100
 
 def $PSA_setup_ingress_input_metadata_argument(EC)
 
@@ -38353,7 +38359,7 @@ def $PSA_setup_ingress_input_metadata_argument(EC)
 
           1. Return argumentIR_input_metadata
 
-  1. Else Phantom#2100
+  1. Else Phantom#2101
 
 def $PSA_setup_ingress_output_metadata_argument(EC)
 
@@ -38369,7 +38375,7 @@ def $PSA_setup_ingress_output_metadata_argument(EC)
 
           1. Return argumentIR_output_metadata
 
-  1. Else Phantom#2101
+  1. Else Phantom#2102
 
 def $PSA_setup_ingress_pipeline_callee(EC, ARCH, typedExpressionIR_main)
 
@@ -38433,23 +38439,23 @@ def $PSA_setup_ingress_pipeline_callee(EC, ARCH, typedExpressionIR_main)
 
                                                           1. Return typedExpressionIR_ingress_pipeline
 
-                                                1. Else Phantom#2102
+                                                1. Else Phantom#2103
 
-                                          1. Else Phantom#2103
+                                          1. Else Phantom#2104
 
-                                    1. Else Phantom#2104
+                                    1. Else Phantom#2105
 
-                              1. Else Phantom#2105
+                              1. Else Phantom#2106
 
-                        1. Else Phantom#2106
+                        1. Else Phantom#2107
 
-                  1. Else Phantom#2107
+                  1. Else Phantom#2108
 
-            1. Else Phantom#2108
+            1. Else Phantom#2109
 
-        1. Else Phantom#2109
+        1. Else Phantom#2110
 
-  1. Else Phantom#2110
+  1. Else Phantom#2111
 
 def $PSA_setup_ingress_parser_callee(EC, ARCH, typedExpressionIR_ingress_pipeline)
 
@@ -38501,19 +38507,19 @@ def $PSA_setup_ingress_parser_callee(EC, ARCH, typedExpressionIR_ingress_pipelin
 
                                               1. Return typedExpressionIR_ingress_parser
 
-                                    1. Else Phantom#2111
+                                    1. Else Phantom#2112
 
-                              1. Else Phantom#2112
+                              1. Else Phantom#2113
 
-                        1. Else Phantom#2113
+                        1. Else Phantom#2114
 
-                  1. Else Phantom#2114
+                  1. Else Phantom#2115
 
-            1. Else Phantom#2115
+            1. Else Phantom#2116
 
-        1. Else Phantom#2116
+        1. Else Phantom#2117
 
-  1. Else Phantom#2117
+  1. Else Phantom#2118
 
 def $PSA_setup_ingress_callee(EC, ARCH, typedExpressionIR_ingress_pipeline)
 
@@ -38553,15 +38559,15 @@ def $PSA_setup_ingress_callee(EC, ARCH, typedExpressionIR_ingress_pipeline)
 
                                   1. Return typedExpressionIR_ingress
 
-                        1. Else Phantom#2118
+                        1. Else Phantom#2119
 
-                  1. Else Phantom#2119
+                  1. Else Phantom#2120
 
-            1. Else Phantom#2120
+            1. Else Phantom#2121
 
-        1. Else Phantom#2121
+        1. Else Phantom#2122
 
-  1. Else Phantom#2122
+  1. Else Phantom#2123
 
 def $PSA_setup_ingress_deparser_callee(EC, ARCH, typedExpressionIR_ingress_pipeline)
 
@@ -38619,21 +38625,21 @@ def $PSA_setup_ingress_deparser_callee(EC, ARCH, typedExpressionIR_ingress_pipel
 
                                                     1. Return typedExpressionIR_ingress_deparser
 
-                                          1. Else Phantom#2123
+                                          1. Else Phantom#2124
 
-                                    1. Else Phantom#2124
+                                    1. Else Phantom#2125
 
-                              1. Else Phantom#2125
+                              1. Else Phantom#2126
 
-                        1. Else Phantom#2126
+                        1. Else Phantom#2127
 
-                  1. Else Phantom#2127
+                  1. Else Phantom#2128
 
-            1. Else Phantom#2128
+            1. Else Phantom#2129
 
-        1. Else Phantom#2129
+        1. Else Phantom#2130
 
-  1. Else Phantom#2130
+  1. Else Phantom#2131
 
 relation PSA_ingress_parser: EC_0 ARCH_0 |- % % %
 
@@ -38677,7 +38683,7 @@ relation PSA_ingress_parser: EC_0 ARCH_0 |- % % %
 
                                 1. Result in: % % |- EC_1 ARCH_1 (rejectTransitionResult as transitionResult)
 
-                          1. Else Phantom#2131
+                          1. Else Phantom#2132
 
 relation PSA_ingress: EC_0 ARCH_0 |- % % %
 
@@ -38717,7 +38723,7 @@ relation PSA_ingress: EC_0 ARCH_0 |- % % %
 
                             1. Result in: % % |- EC_1 ARCH_1 ((return ?()) as callResult)
 
-                      1. Else Phantom#2132
+                      1. Else Phantom#2133
 
 relation PSA_ingress_deparser: EC_0 ARCH_0 |- % % %
 
@@ -38763,7 +38769,7 @@ relation PSA_ingress_deparser: EC_0 ARCH_0 |- % % %
 
                                   1. Result in: % % |- EC_1 ARCH_1 ((exit) as callResult)
 
-                            1. Else Phantom#2133
+                            1. Else Phantom#2134
 
 relation PSA_egress_init_packet_in: EC_0 ARCH_0 |- objectState_packet_in : % %
 
@@ -38791,9 +38797,9 @@ relation PSA_egress_init_packet_in: EC_0 ARCH_0 |- objectState_packet_in : % %
 
                       1. Result in: % % |- % : EC_1 ARCH_2
 
-            1. Else Phantom#2134
+            1. Else Phantom#2135
 
-        1. Else Phantom#2135
+        1. Else Phantom#2136
 
 relation PSA_egress_init_packet_out: EC_0 ARCH_0 |- objectState_packet_out : % %
 
@@ -38821,9 +38827,9 @@ relation PSA_egress_init_packet_out: EC_0 ARCH_0 |- objectState_packet_out : % %
 
                       1. Result in: % % |- % : EC_1 ARCH_2
 
-            1. Else Phantom#2136
+            1. Else Phantom#2137
 
-        1. Else Phantom#2137
+        1. Else Phantom#2138
 
 relation PSA_egress_init_parser_input_metadata: EC_0 ARCH |- i_port t_path : %
 
@@ -39015,25 +39021,25 @@ relation PSA_egress_init_globals: EC_0 ARCH |- i_port : %
 
                                                                                         1. Result in: % % |- % : EC_8
 
-                                                                                  1. Else Phantom#2138
+                                                                                  1. Else Phantom#2139
 
-                                                                        1. Else Phantom#2139
+                                                                        1. Else Phantom#2140
 
-                                                            1. Else Phantom#2140
+                                                            1. Else Phantom#2141
 
-                                                  1. Else Phantom#2141
+                                                  1. Else Phantom#2142
 
-                                        1. Else Phantom#2142
+                                        1. Else Phantom#2143
 
-                              1. Else Phantom#2143
+                              1. Else Phantom#2144
 
-                    1. Else Phantom#2144
+                    1. Else Phantom#2145
 
-              1. Else Phantom#2145
+              1. Else Phantom#2146
 
-        1. Else Phantom#2146
+        1. Else Phantom#2147
 
-    1. Else Phantom#2147
+    1. Else Phantom#2148
 
 def $PSA_setup_egress_packet_in_argument(EC)
 
@@ -39049,7 +39055,7 @@ def $PSA_setup_egress_packet_in_argument(EC)
 
           1. Return argumentIR_packet_in
 
-  1. Else Phantom#2148
+  1. Else Phantom#2149
 
 def $PSA_setup_egress_packet_out_argument(EC)
 
@@ -39065,7 +39071,7 @@ def $PSA_setup_egress_packet_out_argument(EC)
 
           1. Return argumentIR_packet_out
 
-  1. Else Phantom#2149
+  1. Else Phantom#2150
 
 def $PSA_setup_egress_hdr_argument(ARCH)
 
@@ -39089,11 +39095,11 @@ def $PSA_setup_egress_hdr_argument(ARCH)
 
                   1. Return argumentIR_hdr
 
-            1. Else Phantom#2150
+            1. Else Phantom#2151
 
-      1. Else Phantom#2151
+      1. Else Phantom#2152
 
-  1. Else Phantom#2152
+  1. Else Phantom#2153
 
 def $PSA_setup_egress_user_meta_argument(ARCH)
 
@@ -39117,11 +39123,11 @@ def $PSA_setup_egress_user_meta_argument(ARCH)
 
                   1. Return argumentIR_user_meta
 
-            1. Else Phantom#2153
+            1. Else Phantom#2154
 
-      1. Else Phantom#2154
+      1. Else Phantom#2155
 
-  1. Else Phantom#2155
+  1. Else Phantom#2156
 
 def $PSA_setup_egress_parser_input_metadata_argument(EC)
 
@@ -39137,7 +39143,7 @@ def $PSA_setup_egress_parser_input_metadata_argument(EC)
 
           1. Return argumentIR_parser_input_metadata
 
-  1. Else Phantom#2156
+  1. Else Phantom#2157
 
 def $PSA_setup_egress_input_metadata_argument(EC)
 
@@ -39153,7 +39159,7 @@ def $PSA_setup_egress_input_metadata_argument(EC)
 
           1. Return argumentIR_input_metadata
 
-  1. Else Phantom#2157
+  1. Else Phantom#2158
 
 def $PSA_setup_egress_output_metadata_argument(EC)
 
@@ -39169,7 +39175,7 @@ def $PSA_setup_egress_output_metadata_argument(EC)
 
           1. Return argumentIR_output_metadata
 
-  1. Else Phantom#2158
+  1. Else Phantom#2159
 
 def $PSA_setup_egress_deparser_input_metadata_argument(EC)
 
@@ -39185,7 +39191,7 @@ def $PSA_setup_egress_deparser_input_metadata_argument(EC)
 
           1. Return argumentIR_deparser_input_metadata
 
-  1. Else Phantom#2159
+  1. Else Phantom#2160
 
 def $PSA_setup_egress_pipeline_callee(EC, ARCH, typedExpressionIR_main)
 
@@ -39249,23 +39255,23 @@ def $PSA_setup_egress_pipeline_callee(EC, ARCH, typedExpressionIR_main)
 
                                                           1. Return typedExpressionIR_egress_pipeline
 
-                                                1. Else Phantom#2160
+                                                1. Else Phantom#2161
 
-                                          1. Else Phantom#2161
+                                          1. Else Phantom#2162
 
-                                    1. Else Phantom#2162
+                                    1. Else Phantom#2163
 
-                              1. Else Phantom#2163
+                              1. Else Phantom#2164
 
-                        1. Else Phantom#2164
+                        1. Else Phantom#2165
 
-                  1. Else Phantom#2165
+                  1. Else Phantom#2166
 
-            1. Else Phantom#2166
+            1. Else Phantom#2167
 
-        1. Else Phantom#2167
+        1. Else Phantom#2168
 
-  1. Else Phantom#2168
+  1. Else Phantom#2169
 
 def $PSA_setup_egress_parser_callee(EC, ARCH, typedExpressionIR_egress_pipeline)
 
@@ -39323,21 +39329,21 @@ def $PSA_setup_egress_parser_callee(EC, ARCH, typedExpressionIR_egress_pipeline)
 
                                                     1. Return typedExpressionIR_egress_parser
 
-                                          1. Else Phantom#2169
+                                          1. Else Phantom#2170
 
-                                    1. Else Phantom#2170
+                                    1. Else Phantom#2171
 
-                              1. Else Phantom#2171
+                              1. Else Phantom#2172
 
-                        1. Else Phantom#2172
+                        1. Else Phantom#2173
 
-                  1. Else Phantom#2173
+                  1. Else Phantom#2174
 
-            1. Else Phantom#2174
+            1. Else Phantom#2175
 
-        1. Else Phantom#2175
+        1. Else Phantom#2176
 
-  1. Else Phantom#2176
+  1. Else Phantom#2177
 
 def $PSA_setup_egress_callee(EC, ARCH, typedExpressionIR_egress_pipeline)
 
@@ -39377,15 +39383,15 @@ def $PSA_setup_egress_callee(EC, ARCH, typedExpressionIR_egress_pipeline)
 
                                   1. Return typedExpressionIR_egress
 
-                        1. Else Phantom#2177
+                        1. Else Phantom#2178
 
-                  1. Else Phantom#2178
+                  1. Else Phantom#2179
 
-            1. Else Phantom#2179
+            1. Else Phantom#2180
 
-        1. Else Phantom#2180
+        1. Else Phantom#2181
 
-  1. Else Phantom#2181
+  1. Else Phantom#2182
 
 def $PSA_setup_egress_deparser_callee(EC, ARCH, typedExpressionIR_egress_pipeline)
 
@@ -39437,19 +39443,19 @@ def $PSA_setup_egress_deparser_callee(EC, ARCH, typedExpressionIR_egress_pipelin
 
                                               1. Return typedExpressionIR_egress_deparser
 
-                                    1. Else Phantom#2182
+                                    1. Else Phantom#2183
 
-                              1. Else Phantom#2183
+                              1. Else Phantom#2184
 
-                        1. Else Phantom#2184
+                        1. Else Phantom#2185
 
-                  1. Else Phantom#2185
+                  1. Else Phantom#2186
 
-            1. Else Phantom#2186
+            1. Else Phantom#2187
 
-        1. Else Phantom#2187
+        1. Else Phantom#2188
 
-  1. Else Phantom#2188
+  1. Else Phantom#2189
 
 relation PSA_egress_parser: EC_0 ARCH_0 |- % % %
 
@@ -39495,7 +39501,7 @@ relation PSA_egress_parser: EC_0 ARCH_0 |- % % %
 
                                   1. Result in: % % |- EC_1 ARCH_1 (rejectTransitionResult as transitionResult)
 
-                            1. Else Phantom#2189
+                            1. Else Phantom#2190
 
 relation PSA_egress: EC_0 ARCH_0 |- % % %
 
@@ -39535,7 +39541,7 @@ relation PSA_egress: EC_0 ARCH_0 |- % % %
 
                             1. Result in: % % |- EC_1 ARCH_1 ((return ?()) as callResult)
 
-                      1. Else Phantom#2190
+                      1. Else Phantom#2191
 
 relation PSA_egress_deparser: EC_0 ARCH_0 |- % % %
 
@@ -39581,4 +39587,4 @@ relation PSA_egress_deparser: EC_0 ARCH_0 |- % % %
 
                                   1. Result in: % % |- EC_1 ARCH_1 ((exit) as callResult)
 
-                            1. Else Phantom#2191
+                            1. Else Phantom#2192

--- a/p4spec/test/lang/struct.expected
+++ b/p4spec/test/lang/struct.expected
@@ -26635,6 +26635,62 @@ def $add_callableDef_non_overload_i(cursor, IC, callableId, callableDef)
 
 1. Else Phantom#1438
 
+def $find_callableDef_non_overload_i(p, IC, prefixedNameIR)
+
+1. If ((prefixedNameIR matches pattern `.%`)), then
+
+  1. (Let (. nameIR) be prefixedNameIR)
+
+    1. Return $find_non_overloaded<callableDef>(IC.global.callable, nameIR)
+
+1. Else Phantom#1439
+
+2. Case analysis on p
+
+  1. Case (% matches pattern `GLOBAL`)
+
+    1. If ((prefixedNameIR matches pattern ``%`)), then
+
+      1. (Let (` nameIR) be prefixedNameIR)
+
+        1. Return $find_non_overloaded<callableDef>(IC.global.callable, nameIR)
+
+    1. Else Phantom#1440
+
+  2. Case (% matches pattern `BLOCK`)
+
+    1. If ((prefixedNameIR matches pattern ``%`)), then
+
+      1. (Let (` nameIR) be prefixedNameIR)
+
+        1. (Let ((callableId, callableDef))? be $find_non_overloaded<callableDef>(IC.block.callable, nameIR))
+
+          1. If ((((callableId, callableDef))? matches pattern (_))), then
+
+            1. (Let ?((callableId, callableDef)) be ((callableId, callableDef))?)
+
+              1. Return ?((callableId, callableDef))
+
+          1. Else Phantom#1441
+
+        2. If ((?() = $find_non_overloaded<callableDef>(IC.block.callable, nameIR))), then
+
+          1. Return $find_callableDef_non_overload_i((global), IC, (` nameIR))
+
+        2. Else Phantom#1442
+
+    1. Else Phantom#1443
+
+  3. Case (% matches pattern `LOCAL`)
+
+    1. If ((prefixedNameIR matches pattern ``%`)), then
+
+      1. (Let (` nameIR) be prefixedNameIR)
+
+        1. Return $find_callableDef_non_overload_i((block), IC, (` nameIR))
+
+    1. Else Phantom#1444
+
 def $add_constructorDef_i(IC, callableId, constructorDef)
 
 1. (Let constructorDefEnv be $add_map<callableId, constructorDef>(IC.global.constructor, callableId, constructorDef))
@@ -26651,7 +26707,7 @@ def $add_constructorDefs_i(IC, (callableId)*, (constructorDef)*)
 
       1. Return IC
 
-    1. Else Phantom#1439
+    1. Else Phantom#1445
 
   2. Case (% matches pattern _ :: _)
 
@@ -26667,7 +26723,7 @@ def $add_constructorDefs_i(IC, (callableId)*, (constructorDef)*)
 
               1. Return IC''
 
-      1. Else Phantom#1440
+      1. Else Phantom#1446
 
 def $find_var_i(prefixedNameIR, p, IC)
 
@@ -26685,7 +26741,7 @@ def $find_var_i(prefixedNameIR, p, IC)
 
             1. Return value'
 
-        1. Else Phantom#1441
+        1. Else Phantom#1447
 
   2. Case (% matches pattern ``%`)
 
@@ -26703,7 +26759,7 @@ def $find_var_i(prefixedNameIR, p, IC)
 
                 1. Return value'
 
-            1. Else Phantom#1442
+            1. Else Phantom#1448
 
         2. Case (% matches pattern `BLOCK`)
 
@@ -26715,13 +26771,13 @@ def $find_var_i(prefixedNameIR, p, IC)
 
                 1. Return value'
 
-            1. Else Phantom#1443
+            1. Else Phantom#1449
 
           2. If ((?() = $find_map<id, value>(IC.block.frame, id))), then
 
             1. Return $find_var_i((` id), (global), IC)
 
-          2. Else Phantom#1444
+          2. Else Phantom#1450
 
         3. Case (% matches pattern `LOCAL`)
 
@@ -26733,13 +26789,13 @@ def $find_var_i(prefixedNameIR, p, IC)
 
                 1. Return value'
 
-            1. Else Phantom#1445
+            1. Else Phantom#1451
 
           2. If ((?() = $find_maps<id, value>(IC.local.frames, id))), then
 
             1. Return $find_var_i((` id), (block), IC)
 
-          2. Else Phantom#1446
+          2. Else Phantom#1452
 
 def $find_typeDef_i(_cursor, IC, prefixedNameIR)
 
@@ -26831,7 +26887,7 @@ relation Expr_inst: p IC STO |- (expressionIR # expressionNoteIR) : % %
 
         1. Result in: % % % |- % : STO (stringLiteral as value)
 
-  1. Else Phantom#1447
+  1. Else Phantom#1453
 
 2. Case analysis on expressionIR
 
@@ -26877,7 +26933,7 @@ relation Expr_inst: p IC STO |- (expressionIR # expressionNoteIR) : % %
 
               1. Result in: % % % |- % : STO_2 $bin_op(binop, value_l, value_r)
 
-        1. Else Phantom#1448
+        1. Else Phantom#1454
 
         2. Case analysis on binop
 
@@ -26897,7 +26953,7 @@ relation Expr_inst: p IC STO |- (expressionIR # expressionNoteIR) : % %
 
                     1. Result in: % % % |- % : STO_2 value_r
 
-              1. Else Phantom#1449
+              1. Else Phantom#1455
 
           2. Case (% matches pattern `||`)
 
@@ -26915,9 +26971,9 @@ relation Expr_inst: p IC STO |- (expressionIR # expressionNoteIR) : % %
 
                     1. Result in: % % % |- % : STO_2 value_r
 
-              1. Else Phantom#1450
+              1. Else Phantom#1456
 
-        2. Else Phantom#1451
+        2. Else Phantom#1457
 
   5. Case (% has type ternaryExpressionIR)
 
@@ -26941,7 +26997,7 @@ relation Expr_inst: p IC STO |- (expressionIR # expressionNoteIR) : % %
 
                 1. Result in: % % % |- % : STO_2 value_false
 
-          1. Else Phantom#1452
+          1. Else Phantom#1458
 
   6. Case (% has type castExpressionIR)
 
@@ -27061,11 +27117,11 @@ relation Expr_inst: p IC STO |- (expressionIR # expressionNoteIR) : % %
 
                                 1. Result in: % % % |- % : STO ((typeId . nameIR . value') as value)
 
-                            1. Else Phantom#1453
+                            1. Else Phantom#1459
 
-                    1. Else Phantom#1454
+                    1. Else Phantom#1460
 
-                1. Else Phantom#1455
+                1. Else Phantom#1461
 
         2. Case (% has type typedExpressionIR)
 
@@ -27085,9 +27141,9 @@ relation Expr_inst: p IC STO |- (expressionIR # expressionNoteIR) : % %
 
                         1. Result in: % % % |- % : STO ((d (n_size as int)) as value)
 
-                      1. Else Phantom#1456
+                      1. Else Phantom#1462
 
-                  1. Else Phantom#1457
+                  1. Else Phantom#1463
 
               2. (Expr_inst: p IC STO |- typedExpressionIR_base : STO_1 value)
 
@@ -27107,7 +27163,7 @@ relation Expr_inst: p IC STO |- (expressionIR # expressionNoteIR) : % %
 
                               1. Result in: % % % |- % : STO_1 value''
 
-                          1. Else Phantom#1458
+                          1. Else Phantom#1464
 
                   2. Case (% has type headerValue)
 
@@ -27123,7 +27179,7 @@ relation Expr_inst: p IC STO |- (expressionIR # expressionNoteIR) : % %
 
                               1. Result in: % % % |- % : STO_1 value''
 
-                          1. Else Phantom#1459
+                          1. Else Phantom#1465
 
                   3. Case (% has type headerUnionValue)
 
@@ -27139,9 +27195,9 @@ relation Expr_inst: p IC STO |- (expressionIR # expressionNoteIR) : % %
 
                               1. Result in: % % % |- % : STO_1 value''
 
-                          1. Else Phantom#1460
+                          1. Else Phantom#1466
 
-                1. Else Phantom#1461
+                1. Else Phantom#1467
 
   12. Case (% has type indexAccessExpressionIR)
 
@@ -27175,9 +27231,9 @@ relation Expr_inst: p IC STO |- (expressionIR # expressionNoteIR) : % %
 
                                 1. Result in: % % % |- % : STO_2 value'
 
-                            1. Else Phantom#1462
+                            1. Else Phantom#1468
 
-                        1. Else Phantom#1463
+                        1. Else Phantom#1469
 
                   2. Case (% has type headerStackValue)
 
@@ -27195,13 +27251,13 @@ relation Expr_inst: p IC STO |- (expressionIR # expressionNoteIR) : % %
 
                                 1. Result in: % % % |- % : STO_2 value'
 
-                            1. Else Phantom#1464
+                            1. Else Phantom#1470
 
-                        1. Else Phantom#1465
+                        1. Else Phantom#1471
 
-                1. Else Phantom#1466
+                1. Else Phantom#1472
 
-            1. Else Phantom#1467
+            1. Else Phantom#1473
 
   13. Case (% has type sliceAccessExpressionIR)
 
@@ -27257,7 +27313,7 @@ relation Expr_inst: p IC STO |- (expressionIR # expressionNoteIR) : % %
 
                         1. Result in: % % % |- % : STO $sizeof(typeIR_base, nameIR)
 
-                      1. Else Phantom#1468
+                      1. Else Phantom#1474
 
                 2. Case (% matches pattern `TYPE%.%`)
 
@@ -27279,7 +27335,7 @@ relation Expr_inst: p IC STO |- (expressionIR # expressionNoteIR) : % %
 
                                   1. Result in: % % % |- % : STO $sizeof(typeIR_base, nameIR)
 
-                                1. Else Phantom#1469
+                                1. Else Phantom#1475
 
                             2. Case false
 
@@ -27291,13 +27347,13 @@ relation Expr_inst: p IC STO |- (expressionIR # expressionNoteIR) : % %
 
                                     1. Result in: % % % |- % : STO $sizeof(typeIR_base, nameIR)
 
-                                  1. Else Phantom#1470
+                                  1. Else Phantom#1476
 
-                              1. Else Phantom#1471
+                              1. Else Phantom#1477
 
-                      1. Else Phantom#1472
+                      1. Else Phantom#1478
 
-              1. Else Phantom#1473
+              1. Else Phantom#1479
 
             2. If ((callableTargetIR matches pattern `(%)`)), then
 
@@ -27309,7 +27365,7 @@ relation Expr_inst: p IC STO |- (expressionIR # expressionNoteIR) : % %
 
                     1. Result in: % % % |- % : STO_1 value
 
-            2. Else Phantom#1474
+            2. Else Phantom#1480
 
   15. Case (% has type parenthesizedExpressionIR)
 
@@ -27321,7 +27377,7 @@ relation Expr_inst: p IC STO |- (expressionIR # expressionNoteIR) : % %
 
           1. Result in: % % % |- % : STO_1 value
 
-2. Else Phantom#1475
+2. Else Phantom#1481
 
 relation Exprs_inst: p IC store |- (typedExpressionIR)* : % %
 
@@ -27331,7 +27387,7 @@ relation Exprs_inst: p IC store |- (typedExpressionIR)* : % %
 
     1. Result in: % % % |- % : store []
 
-  1. Else Phantom#1476
+  1. Else Phantom#1482
 
   2. If (((typedExpressionIR)* matches pattern _ :: _)), then
 
@@ -27343,7 +27399,7 @@ relation Exprs_inst: p IC store |- (typedExpressionIR)* : % %
 
           1. Result in: % % % |- % : STO_2 value_h :: (value_t)*
 
-  2. Else Phantom#1477
+  2. Else Phantom#1483
 
 relation Argument_inst: p IC STO_0 |- argumentIR : % %
 
@@ -27369,7 +27425,7 @@ relation Argument_inst: p IC STO_0 |- argumentIR : % %
 
           1. Result in: % % % |- % : STO_1 value
 
-1. Else Phantom#1478
+1. Else Phantom#1484
 
 relation DirectApplicationStmt_inst: p IC STO_0 |- (constructorTargetIR .apply( argumentListIR );) : % % %
 
@@ -27495,7 +27551,7 @@ relation Stmt_inst: p IC STO |- statementIR : % % %
 
                 1. Result in: % % % |- % : IC STO_1 (forStatementIR' as statementIR)
 
-      1. Else Phantom#1479
+      1. Else Phantom#1485
 
       2. Group forStatementIR-in: p IC STO |- (forStatementIR as statementIR) : % % %
 
@@ -27523,9 +27579,9 @@ relation Stmt_inst: p IC STO |- statementIR : % % %
 
                     1. Result in: % % % |- % : IC STO_1 (forStatementIR' as statementIR)
 
-              1. Else Phantom#1480
+              1. Else Phantom#1486
 
-        1. Else Phantom#1481
+        1. Else Phantom#1487
 
   8. Case (% has type breakStatementIR)
 
@@ -27553,7 +27609,7 @@ relation Stmt_inst: p IC STO |- statementIR : % % %
 
           1. Result in: % % % |- % : IC STO_1 ((switch( typedExpressionIR ){ switchCaseListIR_inst }) as statementIR)
 
-1. Else Phantom#1482
+1. Else Phantom#1488
 
 2. If ((p matches pattern `LOCAL`)), then
 
@@ -27581,9 +27637,9 @@ relation Stmt_inst: p IC STO |- statementIR : % % %
 
                 1. Result in: % % % |- % : IC_3 STO_1 ((annotationList { blockElementStatementListIR_inst }) as statementIR)
 
-  1. Else Phantom#1483
+  1. Else Phantom#1489
 
-2. Else Phantom#1484
+2. Else Phantom#1490
 
 relation BlockElementStmt_inst: instContext store |- blockElementStatementIR : % % %
 
@@ -27621,7 +27677,7 @@ relation BlockElementStmtList_inst: instContext store |- (blockElementStatementI
 
     1. Result in: % % |- % : instContext store []
 
-  1. Else Phantom#1485
+  1. Else Phantom#1491
 
   2. If (((blockElementStatementIR)* matches pattern _ :: _)), then
 
@@ -27633,7 +27689,7 @@ relation BlockElementStmtList_inst: instContext store |- (blockElementStatementI
 
           1. Result in: % % |- % : IC_2 STO_2 blockElementStatementIR_h_inst :: (blockElementStatementIR_t_inst)*
 
-  2. Else Phantom#1486
+  2. Else Phantom#1492
 
 relation Block_inst: IC_0 STO_0 |- (annotationList { blockElementStatementListIR }) : % % %
 
@@ -27683,7 +27739,7 @@ relation ExternMethods_inst: instContext |- (externMethodPrototypeIR)* : %
 
     1. Result in: % |- % : instContext
 
-  1. Else Phantom#1487
+  1. Else Phantom#1493
 
   2. If (((externMethodPrototypeIR)* matches pattern _ :: _)), then
 
@@ -27695,7 +27751,7 @@ relation ExternMethods_inst: instContext |- (externMethodPrototypeIR)* : %
 
           1. Result in: % |- % : IC_2
 
-  2. Else Phantom#1488
+  2. Else Phantom#1494
 
 relation ParserStmt_inst: IC_0 STO |- parserStatementIR : % % %
 
@@ -27733,7 +27789,7 @@ relation ParserStmt_inst: IC_0 STO |- parserStatementIR : % % %
 
               1. Result in: % % |- % : IC_1 STO_1 (emptyStatementIR_inst as parserStatementIR)
 
-          1. Else Phantom#1489
+          1. Else Phantom#1495
 
   4. Case (% has type assignmentStatementIR)
 
@@ -27749,7 +27805,7 @@ relation ParserStmt_inst: IC_0 STO |- parserStatementIR : % % %
 
               1. Result in: % % |- % : IC_1 STO_1 (assignmentStatementIR_inst as parserStatementIR)
 
-          1. Else Phantom#1490
+          1. Else Phantom#1496
 
   5. Case (% has type callStatementIR)
 
@@ -27765,7 +27821,7 @@ relation ParserStmt_inst: IC_0 STO |- parserStatementIR : % % %
 
               1. Result in: % % |- % : IC_1 STO_1 (callStatementIR_inst as parserStatementIR)
 
-          1. Else Phantom#1491
+          1. Else Phantom#1497
 
   6. Case (% has type directApplicationStatementIR)
 
@@ -27825,7 +27881,7 @@ relation ParserStmts_inst: instContext store |- (parserStatementIR)* : % % %
 
     1. Result in: % % |- % : instContext store []
 
-  1. Else Phantom#1492
+  1. Else Phantom#1498
 
   2. If (((parserStatementIR)* matches pattern _ :: _)), then
 
@@ -27837,7 +27893,7 @@ relation ParserStmts_inst: instContext store |- (parserStatementIR)* : % % %
 
           1. Result in: % % |- % : IC_2 STO_2 parserStatementIR_h_inst :: (parserStatementIR_t_inst)*
 
-  2. Else Phantom#1493
+  2. Else Phantom#1499
 
 relation ParserState_inst: IC_0 STO_0 |- parserStateIR : % %
 
@@ -27861,7 +27917,7 @@ relation ParserStates_inst: instContext store |- (parserStateIR)* : % %
 
     1. Result in: % % |- % : instContext store
 
-  1. Else Phantom#1494
+  1. Else Phantom#1500
 
   2. If (((parserStateIR)* matches pattern _ :: _)), then
 
@@ -27873,7 +27929,7 @@ relation ParserStates_inst: instContext store |- (parserStateIR)* : % %
 
           1. Result in: % % |- % : IC_2 STO_2
 
-  2. Else Phantom#1495
+  2. Else Phantom#1501
 
 relation ParserLocalDecl_inst: IC_0 STO |- parserLocalDeclarationIR : % % %
 
@@ -27939,9 +27995,9 @@ relation ParserLocalDecl_inst: IC_0 STO |- parserLocalDeclarationIR : % % %
 
                                 1. Result in: % % |- % : IC_0 STO_2 (constantDeclarationIR as parserLocalDeclarationIR)
 
-                1. Else Phantom#1496
+                1. Else Phantom#1502
 
-          1. Else Phantom#1497
+          1. Else Phantom#1503
 
 relation ParserLocalDecls_inst: instContext store |- (parserLocalDeclarationIR)* : % % %
 
@@ -27951,7 +28007,7 @@ relation ParserLocalDecls_inst: instContext store |- (parserLocalDeclarationIR)*
 
     1. Result in: % % |- % : instContext store []
 
-  1. Else Phantom#1498
+  1. Else Phantom#1504
 
   2. If (((parserLocalDeclarationIR)* matches pattern _ :: _)), then
 
@@ -27963,7 +28019,79 @@ relation ParserLocalDecls_inst: instContext store |- (parserLocalDeclarationIR)*
 
           1. Result in: % % |- % : IC_2 STO_2 parserLocalDeclarationIR_h_inst :: (parserLocalDeclarationIR_t_inst)*
 
-  2. Else Phantom#1499
+  2. Else Phantom#1505
+
+relation TableAction_inst: IC STO |- (annotationList tableActionReferenceIR #( parameterListIR , parameterListIR_control );) : % %
+
+1. Group : IC STO |- (annotationList tableActionReferenceIR #( parameterListIR , parameterListIR_control );) : % %
+
+  1. (Let (prefixedNameIR _controlPlaneNameIR ( argumentListIR )) be tableActionReferenceIR)
+
+    1. (Let ((callableId, callableDef))? be $find_callableDef_non_overload_i((local), IC, prefixedNameIR))
+
+      1. If ((((callableId, callableDef))? matches pattern (_))), then
+
+        1. (Let ?((_callableId, callableDef)) be ((callableId, callableDef))?)
+
+          1. If ((callableDef has type actionDef)), then
+
+            1. (Let actionDef be (callableDef as actionDef))
+
+              1. (Let (annotationList_actionDef action nameIR ( _parameterListIR ) _blockStatementIR) be actionDef)
+
+                1. (Let (nameIR')* be $name_annotation(annotationList_actionDef))
+
+                  1. If (((nameIR')* matches pattern [ _/1 ])), then
+
+                    1. (Let [nameIR_anno] be (nameIR')*)
+
+                      1. (Let controlPlaneNameIR be IC.path ++ [nameIR_anno])
+
+                        1. (Let tableActionReferenceIR' be (prefixedNameIR controlPlaneNameIR ( argumentListIR )))
+
+                          1. (Let tableActionIR be (annotationList tableActionReferenceIR' #( parameterListIR , parameterListIR_control );))
+
+                            1. Result in: % % |- % : STO tableActionIR
+
+                  1. Else Phantom#1506
+
+                2. If (([] = $name_annotation(annotationList_actionDef))), then
+
+                  1. (Let controlPlaneNameIR be IC.path ++ [nameIR])
+
+                    1. (Let tableActionReferenceIR' be (prefixedNameIR controlPlaneNameIR ( argumentListIR )))
+
+                      1. (Let tableActionIR be (annotationList tableActionReferenceIR' #( parameterListIR , parameterListIR_control );))
+
+                        1. Result in: % % |- % : STO tableActionIR
+
+                2. Else Phantom#1507
+
+          1. Else Phantom#1508
+
+      1. Else Phantom#1509
+
+relation TableActions_inst: IC store |- (tableActionIR)* : % %
+
+1. Group : IC store |- (tableActionIR)* : % %
+
+  1. If (((tableActionIR)* = [])), then
+
+    1. Result in: % % |- % : store []
+
+  1. Else Phantom#1510
+
+  2. If (((tableActionIR)* matches pattern _ :: _)), then
+
+    1. (Let tableActionIR_h :: (tableActionIR_t)* be (tableActionIR)*)
+
+      1. (TableAction_inst: IC store |- tableActionIR_h : STO_1 tableActionIR_h_inst)
+
+        1. (TableActions_inst: IC STO_1 |- (tableActionIR_t)* : STO_2 (tableActionIR_t_inst)*)
+
+          1. Result in: % % |- % : STO_1 tableActionIR_h_inst :: (tableActionIR_t_inst)*
+
+  2. Else Phantom#1511
 
 relation TableProperty_inst: IC STO |- tablePropertyIR : % %
 
@@ -27979,11 +28107,15 @@ relation TableProperty_inst: IC STO |- tablePropertyIR : % %
 
   2. Case (% has type tableActionsPropertyIR)
 
-    1. (Let tableActionsPropertyIR be (tablePropertyIR as tableActionsPropertyIR))
+    1. (Let (actions={ tableActionListIR }) be (tablePropertyIR as tableActionsPropertyIR))
 
-      1. Group tableActionsPropertyIR: IC STO |- (tableActionsPropertyIR as tablePropertyIR) : % %
+      1. Group tableActionsPropertyIR: IC STO |- ((actions={ tableActionListIR }) as tablePropertyIR) : % %
 
-        1. Result in: % % |- % : STO (tableActionsPropertyIR as tablePropertyIR)
+        1. (TableActions_inst: IC STO |- tableActionListIR : STO_1 tableActionListIR_inst)
+
+          1. (Let tableActionsPropertyIR be (actions={ tableActionListIR_inst }))
+
+            1. Result in: % % |- % : STO_1 (tableActionsPropertyIR as tablePropertyIR)
 
   3. Case (% has type tableDefaultActionPropertyIR)
 
@@ -28037,7 +28169,7 @@ relation TableProperties_inst: IC store |- (tablePropertyIR)* : % %
 
     1. Result in: % % |- % : store []
 
-  1. Else Phantom#1500
+  1. Else Phantom#1512
 
   2. If (((tablePropertyIR)* matches pattern _ :: _)), then
 
@@ -28049,7 +28181,7 @@ relation TableProperties_inst: IC store |- (tablePropertyIR)* : % %
 
           1. Result in: % % |- % : STO_2 tablePropertyIR_h_inst :: (tablePropertyIR_t_inst)*
 
-  2. Else Phantom#1501
+  2. Else Phantom#1513
 
 relation ControlLocalDecl_inst: IC_0 STO |- controlLocalDeclarationIR : % % %
 
@@ -28129,7 +28261,7 @@ relation ControlLocalDecl_inst: IC_0 STO |- controlLocalDeclarationIR : % % %
 
                                     1. Result in: % % |- % : IC_1 STO_2 ?((constantDeclarationIR as controlLocalDeclarationIR))
 
-                              1. Else Phantom#1502
+                              1. Else Phantom#1514
 
                               2. (Let (nameIR')* be $name_annotation(annotationList))
 
@@ -28147,9 +28279,9 @@ relation ControlLocalDecl_inst: IC_0 STO |- controlLocalDeclarationIR : % % %
 
                                             1. Result in: % % |- % : IC_1 STO_3 ?((constantDeclarationIR as controlLocalDeclarationIR))
 
-                                1. Else Phantom#1503
+                                1. Else Phantom#1515
 
-                  1. Else Phantom#1504
+                  1. Else Phantom#1516
 
 relation ControlLocalDecls_inst: instContext store |- (controlLocalDeclarationIR)* : % % %
 
@@ -28159,7 +28291,7 @@ relation ControlLocalDecls_inst: instContext store |- (controlLocalDeclarationIR
 
     1. Result in: % % |- % : instContext store []
 
-  1. Else Phantom#1505
+  1. Else Phantom#1517
 
   2. If (((controlLocalDeclarationIR)* matches pattern _ :: _)), then
 
@@ -28183,7 +28315,7 @@ relation ControlLocalDecls_inst: instContext store |- (controlLocalDeclarationIR
 
                 1. Result in: % % |- % : IC_2 STO_2 controlLocalDeclarationIR_h_inst :: (controlLocalDeclarationIR_t_inst)*
 
-  2. Else Phantom#1506
+  2. Else Phantom#1518
 
 relation ConstDecl_inst: p IC_0 |- (annotationList const typeIR nameIR (=`value value) ;) : %
 
@@ -28231,7 +28363,7 @@ relation InstDecl_inst: p IC_0 STO_0 |- (annotationList typeIR constructorTarget
 
                                   1. Result in: % % % |- % : IC_1 STO_3 constantDeclarationIR
 
-          1. Else Phantom#1507
+          1. Else Phantom#1519
 
       2. (Let nameIR' be $name_annotation_default(annotationList, nameIR))
 
@@ -28251,7 +28383,7 @@ relation InstDecl_inst: p IC_0 STO_0 |- (annotationList typeIR constructorTarget
 
                       1. Result in: % % % |- % : IC_1 STO_2 constantDeclarationIR
 
-            1. Else Phantom#1508
+            1. Else Phantom#1520
 
 relation FuncDecl_inst: p IC_0 |- (annotationList (typeIR nameIR < typeParameterListIR_expl , typeParameterListIR_impl >( parameterListIR )) blockStatementIR) : %
 
@@ -28595,11 +28727,11 @@ relation Decl_inst: IC_0 STO |- declarationIR : % %
 
                                               1. Result in: % % |- % : IC_1 STO
 
-                                      1. Else Phantom#1509
+                                      1. Else Phantom#1521
 
-                              1. Else Phantom#1510
+                              1. Else Phantom#1522
 
-                        1. Else Phantom#1511
+                        1. Else Phantom#1523
 
         2. Case (% matches pattern `%TYPE%%;`)
 
@@ -28665,7 +28797,7 @@ relation Decls_inst: instContext store |- (declarationIR)* : % %
 
     1. Result in: % % |- % : instContext store
 
-  1. Else Phantom#1512
+  1. Else Phantom#1524
 
   2. If (((declarationIR)* matches pattern _ :: _)), then
 
@@ -28677,7 +28809,7 @@ relation Decls_inst: instContext store |- (declarationIR)* : % %
 
           1. Result in: % % |- % : IC_2 STO_2
 
-  2. Else Phantom#1513
+  2. Else Phantom#1525
 
 relation Program_inst: |- p4program : % %
 
@@ -28715,9 +28847,9 @@ relation Copy_in_inst: store p_caller IC_caller (argumentIR)* @ p_callee instCon
 
       1. Result in: % % % % @ % % % ~> store instContext
 
-    1. Else Phantom#1514
+    1. Else Phantom#1526
 
-  1. Else Phantom#1515
+  1. Else Phantom#1527
 
   2. If (((argumentIR)* matches pattern _ :: _)), then
 
@@ -28733,9 +28865,9 @@ relation Copy_in_inst: store p_caller IC_caller (argumentIR)* @ p_callee instCon
 
               1. Result in: % % % % @ % % % ~> STO_2 IC_callee_2
 
-      1. Else Phantom#1516
+      1. Else Phantom#1528
 
-  2. Else Phantom#1517
+  2. Else Phantom#1529
 
 relation Copy_in_argument_inst_default: store p_caller IC_caller @ p_callee IC_callee_0 parameterIR ~> % %
 
@@ -28769,7 +28901,7 @@ relation Copy_in_argument_inst_default: store p_caller IC_caller @ p_callee IC_c
 
                 1. Result in: % % % @ % % % ~> store IC_callee_1
 
-    1. Else Phantom#1518
+    1. Else Phantom#1530
 
 relation Copy_in_inst_default: store p_caller IC_caller @ p_callee instContext (parameterIR)* ~> % %
 
@@ -28779,7 +28911,7 @@ relation Copy_in_inst_default: store p_caller IC_caller @ p_callee instContext (
 
     1. Result in: % % % @ % % % ~> store instContext
 
-  1. Else Phantom#1519
+  1. Else Phantom#1531
 
   2. If (((parameterIR)* matches pattern _ :: _)), then
 
@@ -28791,7 +28923,7 @@ relation Copy_in_inst_default: store p_caller IC_caller @ p_callee instContext (
 
           1. Result in: % % % @ % % % ~> STO_2 IC_callee_2
 
-  2. Else Phantom#1520
+  2. Else Phantom#1532
 
 relation Constructor_inst: p IC |- prefixedNameIR < (typeArgumentIR)* >( (argumentIR)* ): % < % >(# % # % )
 
@@ -28807,9 +28939,9 @@ relation Constructor_inst: p IC |- prefixedNameIR < (typeArgumentIR)* >( (argume
 
           1. Result in: % % |- % < % >( % ): constructorDef < (typeArgumentIR)* >(# (id_default)* # (id_optional)* )
 
-      1. Else Phantom#1521
+      1. Else Phantom#1533
 
-  1. Else Phantom#1522
+  1. Else Phantom#1534
 
   2. (Let (typeDefIR)? be $find_typeDef_i(p, IC, prefixedNameIR))
 
@@ -28827,11 +28959,11 @@ relation Constructor_inst: p IC |- prefixedNameIR < (typeArgumentIR)* >( (argume
 
                 1. Result in: % % |- % < % >( % ): constructorDef < (typeArgumentIR)* >(# (id_default)* # (id_optional)* )
 
-            1. Else Phantom#1523
+            1. Else Phantom#1535
 
-        1. Else Phantom#1524
+        1. Else Phantom#1536
 
-    1. Else Phantom#1525
+    1. Else Phantom#1537
 
   3. If (((typeArgumentIR)* = [])), then
 
@@ -28855,13 +28987,13 @@ relation Constructor_inst: p IC |- prefixedNameIR < (typeArgumentIR)* >( (argume
 
                       1. Result in: % % |- % < % >( % ): constructorDef < (typeArgumentIR')* >(# (id_default)* # (id_optional)* )
 
-                  1. Else Phantom#1526
+                  1. Else Phantom#1538
 
-          1. Else Phantom#1527
+          1. Else Phantom#1539
 
-      1. Else Phantom#1528
+      1. Else Phantom#1540
 
-  3. Else Phantom#1529
+  3. Else Phantom#1541
 
 relation Constructor_call: p IC STO_0 |- constructorDef < (typeArgumentIR)* >( (argumentIR)* # (id_default)* # (id_optional)* ): % %
 
@@ -28919,9 +29051,9 @@ relation Constructor_call: p IC STO_0 |- constructorDef < (typeArgumentIR)* >( (
 
                                                     1. Result in: % % % |- % < % >( % # % # % ): STO_2 object_extern
 
-                                      1. Else Phantom#1530
+                                      1. Else Phantom#1542
 
-                              1. Else Phantom#1531
+                              1. Else Phantom#1543
 
   2. Case (% has type parserObjectConstructorDef)
 
@@ -28999,7 +29131,7 @@ relation Constructor_call: p IC STO_0 |- constructorDef < (typeArgumentIR)* >( (
 
                                         1. Result in: % % % |- % < % >( % # % # % ): STO_4 object_control
 
-                                  1. Else Phantom#1532
+                                  1. Else Phantom#1544
 
   4. Case (% has type packageObjectConstructorDef)
 
@@ -29049,7 +29181,7 @@ relation SwitchCase_inst: p IC store |- switchCaseIR : % %
 
               1. Result in: % % % |- % : STO_1 (switchLabelIR : blockStatementIR_inst)
 
-          1. Else Phantom#1533
+          1. Else Phantom#1545
 
     2. Case (% matches pattern `%:`)
 
@@ -29065,7 +29197,7 @@ relation SwitchCases_inst: p IC store |- (switchCaseIR)* : % %
 
     1. Result in: % % % |- % : store []
 
-  1. Else Phantom#1534
+  1. Else Phantom#1546
 
   2. If (((switchCaseIR)* matches pattern _ :: _)), then
 
@@ -29077,7 +29209,7 @@ relation SwitchCases_inst: p IC store |- (switchCaseIR)* : % %
 
           1. Result in: % % % |- % : STO_2 switchCaseIR_h' :: (switchCaseIR_t')*
 
-  2. Else Phantom#1535
+  2. Else Phantom#1547
 
 def $merge_frames(frame, ({ ((id : value))* }))
 
@@ -29089,7 +29221,7 @@ def $merge_externMethodDefEnvs(externMethodDefEnv, set<pair<callableId, callable
 
   1. Return externMethodDefEnv
 
-1. Else Phantom#1536
+1. Else Phantom#1548
 
 2. (Let ({ (pair<callableId, callableDef>)* }) be set<pair<callableId, callableDef>>)
 
@@ -29107,9 +29239,9 @@ def $merge_externMethodDefEnvs(externMethodDefEnv, set<pair<callableId, callable
 
               1. Return $merge_externMethodDefEnvs(externMethodDefEnv_post, ({ ((callableId_t : callableDef_t))* }))
 
-      1. Else Phantom#1537
+      1. Else Phantom#1549
 
-  1. Else Phantom#1538
+  1. Else Phantom#1550
 
 relation ObjectDecl_inst: IC_0 store |- objectDeclarationIR : % %
 
@@ -29141,7 +29273,7 @@ relation ObjectDecls_inst: instContext store |- (objectDeclarationIR)* : % %
 
     1. Result in: % % |- % : instContext store
 
-  1. Else Phantom#1539
+  1. Else Phantom#1551
 
   2. If (((objectDeclarationIR)* matches pattern _ :: _)), then
 
@@ -29153,7 +29285,7 @@ relation ObjectDecls_inst: instContext store |- (objectDeclarationIR)* : % %
 
           1. Result in: % % |- % : IC_2 STO_2
 
-  2. Else Phantom#1540
+  2. Else Phantom#1552
 
 def $callableId_of_externMethodPrototypeIR(externMethodPrototypeIR)
 
@@ -29219,15 +29351,15 @@ def $init_table((tablePropertyIR)*)
 
                                 1. Return TBL
 
-                          1. Else Phantom#1541
+                          1. Else Phantom#1553
 
-                  1. Else Phantom#1542
+                  1. Else Phantom#1554
 
-              1. Else Phantom#1543
+              1. Else Phantom#1555
 
-        1. Else Phantom#1544
+        1. Else Phantom#1556
 
-    1. Else Phantom#1545
+    1. Else Phantom#1557
 
 def $init_tableKeys((tablePropertyIR)*)
 
@@ -29243,15 +29375,15 @@ def $init_tableKeys((tablePropertyIR)*)
 
           1. Return tableKeysPropertyIR'
 
-      1. Else Phantom#1546
+      1. Else Phantom#1558
 
-  1. Else Phantom#1547
+  1. Else Phantom#1559
 
 2. If (([] = $filter_<tablePropertyIR>((tablePropertyIR)*, ((tablePropertyIR has type tableKeysPropertyIR))*))), then
 
   1. Return (key={ [] })
 
-2. Else Phantom#1548
+2. Else Phantom#1560
 
 def $init_tableEntries((tablePropertyIR)*)
 
@@ -29267,15 +29399,15 @@ def $init_tableEntries((tablePropertyIR)*)
 
           1. Return tableEntriesPropertyIR'
 
-      1. Else Phantom#1549
+      1. Else Phantom#1561
 
-  1. Else Phantom#1550
+  1. Else Phantom#1562
 
 2. If (([] = $filter_<tablePropertyIR>((tablePropertyIR)*, ((tablePropertyIR has type tableEntriesPropertyIR))*))), then
 
   1. Return ((`empty) ?() entries={ [] })
 
-2. Else Phantom#1551
+2. Else Phantom#1563
 
 syntax globalEvalLayer = globalInstLayer
 
@@ -29299,7 +29431,7 @@ def $exit_e(EC)
 
       1. Return EC[local.frames = (frame_t)*]
 
-  1. Else Phantom#1552
+  1. Else Phantom#1564
 
 def $inherit_e(cursor, EC)
 
@@ -29373,7 +29505,7 @@ def $add_var_e(cursor, EC, prefixedNameIR, value)
 
           1. Return EC[block.frame = frame]
 
-    1. Else Phantom#1553
+    1. Else Phantom#1565
 
   3. Case (% matches pattern `LOCAL`)
 
@@ -29391,9 +29523,9 @@ def $add_var_e(cursor, EC, prefixedNameIR, value)
 
                 1. Return EC[local.frames = frame_h' :: (frame_t)*]
 
-          1. Else Phantom#1554
+          1. Else Phantom#1566
 
-    1. Else Phantom#1555
+    1. Else Phantom#1567
 
 def $add_vars_e(p, EC, (prefixedNameIR)*, (value)*)
 
@@ -29405,7 +29537,7 @@ def $add_vars_e(p, EC, (prefixedNameIR)*, (value)*)
 
       1. Return EC
 
-    1. Else Phantom#1556
+    1. Else Phantom#1568
 
   2. Case (% matches pattern _ :: _)
 
@@ -29421,7 +29553,7 @@ def $add_vars_e(p, EC, (prefixedNameIR)*, (value)*)
 
               1. Return EC''
 
-      1. Else Phantom#1557
+      1. Else Phantom#1569
 
 def $update_var_e(p, EC, prefixedNameIR, value)
 
@@ -29433,7 +29565,7 @@ def $update_var_e(p, EC, prefixedNameIR, value)
 
       1. Return EC[global.frame = frame]
 
-1. Else Phantom#1558
+1. Else Phantom#1570
 
 2. Case analysis on p
 
@@ -29451,9 +29583,9 @@ def $update_var_e(p, EC, prefixedNameIR, value)
 
               1. Return EC[global.frame = frame']
 
-          1. Else Phantom#1559
+          1. Else Phantom#1571
 
-    1. Else Phantom#1560
+    1. Else Phantom#1572
 
   2. Case (% matches pattern `BLOCK`)
 
@@ -29475,7 +29607,7 @@ def $update_var_e(p, EC, prefixedNameIR, value)
 
               1. Return $update_var_e((global), EC, (` id), value)
 
-    1. Else Phantom#1561
+    1. Else Phantom#1573
 
   3. Case (% matches pattern `LOCAL`)
 
@@ -29487,7 +29619,7 @@ def $update_var_e(p, EC, prefixedNameIR, value)
 
           1. Return $update_var_e((block), EC, (` id), value)
 
-        1. Else Phantom#1562
+        1. Else Phantom#1574
 
         2. (Let (frame)* be EC.local.frames)
 
@@ -29511,9 +29643,9 @@ def $update_var_e(p, EC, prefixedNameIR, value)
 
                       1. Return EC_pop'[local.frames = frame_h :: EC_pop'.local.frames]
 
-          1. Else Phantom#1563
+          1. Else Phantom#1575
 
-    1. Else Phantom#1564
+    1. Else Phantom#1576
 
 def $find_var_e(prefixedNameIR, p, EC)
 
@@ -29531,7 +29663,7 @@ def $find_var_e(prefixedNameIR, p, EC)
 
             1. Return value'
 
-        1. Else Phantom#1565
+        1. Else Phantom#1577
 
   2. Case (% matches pattern ``%`)
 
@@ -29549,7 +29681,7 @@ def $find_var_e(prefixedNameIR, p, EC)
 
                 1. Return value'
 
-            1. Else Phantom#1566
+            1. Else Phantom#1578
 
         2. Case (% matches pattern `BLOCK`)
 
@@ -29561,13 +29693,13 @@ def $find_var_e(prefixedNameIR, p, EC)
 
                 1. Return value'
 
-            1. Else Phantom#1567
+            1. Else Phantom#1579
 
           2. If ((?() = $find_map<id, value>(EC.block.frame, id))), then
 
             1. Return $find_var_e((` id), (global), EC)
 
-          2. Else Phantom#1568
+          2. Else Phantom#1580
 
         3. Case (% matches pattern `LOCAL`)
 
@@ -29579,13 +29711,13 @@ def $find_var_e(prefixedNameIR, p, EC)
 
                 1. Return value'
 
-            1. Else Phantom#1569
+            1. Else Phantom#1581
 
           2. If ((?() = $find_maps<id, value>(EC.local.frames, id))), then
 
             1. Return $find_var_e((` id), (block), EC)
 
-          2. Else Phantom#1570
+          2. Else Phantom#1582
 
 def $find_typeDef_e(_cursor, EC, prefixedNameIR)
 
@@ -29621,15 +29753,15 @@ def $find_type_e(cursor, EC, nameIR)
 
           1. Return ?(typeIR')
 
-      1. Else Phantom#1571
+      1. Else Phantom#1583
 
     2. If ((?() = $find_map<typeId, typeIR>(EC.local.type, nameIR))), then
 
       1. Return $find_type_e((block), EC, nameIR)
 
-    2. Else Phantom#1572
+    2. Else Phantom#1584
 
-1. Else Phantom#1573
+1. Else Phantom#1585
 
 def $find_callableDef_overloaded_e(cursor, EC, prefixedNameIR, (argumentIR)*)
 
@@ -29653,13 +29785,13 @@ def $find_callableDef_overloaded_e(cursor, EC, prefixedNameIR, (argumentIR)*)
 
                   1. Return ?((callableId : ((global), callableDef) # (id_default)* # (id_optional)*))
 
-              1. Else Phantom#1574
+              1. Else Phantom#1586
 
             2. If ((?() = $find_overloaded<callableDef>(EC.global.callable, callTargetKey, $parameterListIR_of_callableDef))), then
 
               1. Return ?()
 
-            2. Else Phantom#1575
+            2. Else Phantom#1587
 
       2. Case (% matches pattern `.%`)
 
@@ -29675,13 +29807,13 @@ def $find_callableDef_overloaded_e(cursor, EC, prefixedNameIR, (argumentIR)*)
 
                   1. Return ?((callableId : ((global), callableDef) # (id_default)* # (id_optional)*))
 
-              1. Else Phantom#1576
+              1. Else Phantom#1588
 
             2. If ((?() = $find_overloaded<callableDef>(EC.global.callable, callTargetKey, $parameterListIR_of_callableDef))), then
 
               1. Return ?()
 
-            2. Else Phantom#1577
+            2. Else Phantom#1589
 
   2. Case (% matches pattern `BLOCK`)
 
@@ -29699,15 +29831,15 @@ def $find_callableDef_overloaded_e(cursor, EC, prefixedNameIR, (argumentIR)*)
 
                 1. Return ?((callableId : ((block), callableDef) # (id_default)* # (id_optional)*))
 
-            1. Else Phantom#1578
+            1. Else Phantom#1590
 
           2. If ((?() = $find_overloaded<callableDef>(EC.block.callable, callTargetKey, $parameterListIR_of_callableDef))), then
 
             1. Return $find_callableDef_overloaded_e((global), EC, (` nameIR), (argumentIR)*)
 
-          2. Else Phantom#1579
+          2. Else Phantom#1591
 
-    1. Else Phantom#1580
+    1. Else Phantom#1592
 
   3. Case (% matches pattern `LOCAL`)
 
@@ -29717,7 +29849,7 @@ def $find_callableDef_overloaded_e(cursor, EC, prefixedNameIR, (argumentIR)*)
 
         1. Return $find_callableDef_overloaded_e((block), EC, (` nameIR), (argumentIR)*)
 
-    1. Else Phantom#1581
+    1. Else Phantom#1593
 
 def $find_constructorDef_e(EC, prefixedNameIR, (argumentIR)*)
 
@@ -29849,7 +29981,7 @@ def $update_object_qualified_e(ARCH_0, objectId, object)
 
     1. Return ARCH_1
 
-1. Else Phantom#1582
+1. Else Phantom#1594
 
 def $update_object_unqualified_e(ARCH_0, id, object)
 
@@ -29871,9 +30003,9 @@ def $update_object_unqualified_e(ARCH_0, id, object)
 
                 1. Return ARCH_1
 
-          1. Else Phantom#1583
+          1. Else Phantom#1595
 
-      1. Else Phantom#1584
+      1. Else Phantom#1596
 
 def $update_objectState_e(ARCH_0, objectId, objectState)
 
@@ -29961,7 +30093,7 @@ relation Expr_eval: p EC ARCH |- (expressionIR # expressionNoteIR) : % % %
 
           1. Result in: % % % |- % : EC ARCH expressionResult
 
-  1. Else Phantom#1585
+  1. Else Phantom#1597
 
 2. Case analysis on expressionIR
 
@@ -30041,9 +30173,9 @@ relation Expr_eval: p EC ARCH |- (expressionIR # expressionNoteIR) : % % %
 
                         1. Result in: % % % |- % : EC_1 ARCH_1 expressionResult
 
-                  1. Else Phantom#1586
+                  1. Else Phantom#1598
 
-        1. Else Phantom#1587
+        1. Else Phantom#1599
 
         2. Case analysis on binop
 
@@ -30057,7 +30189,7 @@ relation Expr_eval: p EC ARCH |- (expressionIR # expressionNoteIR) : % % %
 
                   1. Result in: % % % |- % : EC_1 ARCH_1 (abortResult as expressionResult)
 
-              1. Else Phantom#1588
+              1. Else Phantom#1600
 
               2. Case analysis on expressionResult
 
@@ -30073,7 +30205,7 @@ relation Expr_eval: p EC ARCH |- (expressionIR # expressionNoteIR) : % % %
 
                     1. Result in: % % % |- % : EC_2 ARCH_2 expressionResult_r
 
-              2. Else Phantom#1589
+              2. Else Phantom#1601
 
           2. Case (% matches pattern `||`)
 
@@ -30085,7 +30217,7 @@ relation Expr_eval: p EC ARCH |- (expressionIR # expressionNoteIR) : % % %
 
                   1. Result in: % % % |- % : EC_1 ARCH_1 (abortResult as expressionResult)
 
-              1. Else Phantom#1590
+              1. Else Phantom#1602
 
               2. Case analysis on expressionResult
 
@@ -30101,9 +30233,9 @@ relation Expr_eval: p EC ARCH |- (expressionIR # expressionNoteIR) : % % %
 
                     1. Result in: % % % |- % : EC_2 ARCH_2 expressionResult_r
 
-              2. Else Phantom#1591
+              2. Else Phantom#1603
 
-        2. Else Phantom#1592
+        2. Else Phantom#1604
 
   5. Case (% has type ternaryExpressionIR)
 
@@ -30119,7 +30251,7 @@ relation Expr_eval: p EC ARCH |- (expressionIR # expressionNoteIR) : % % %
 
               1. Result in: % % % |- % : EC_1 ARCH_1 (abortResult as expressionResult)
 
-          1. Else Phantom#1593
+          1. Else Phantom#1605
 
           2. Case analysis on expressionResult
 
@@ -30135,7 +30267,7 @@ relation Expr_eval: p EC ARCH |- (expressionIR # expressionNoteIR) : % % %
 
                 1. Result in: % % % |- % : EC_2 ARCH_2 expressionResult_false
 
-          2. Else Phantom#1594
+          2. Else Phantom#1606
 
   6. Case (% has type castExpressionIR)
 
@@ -30331,11 +30463,11 @@ relation Expr_eval: p EC ARCH |- (expressionIR # expressionNoteIR) : % % %
 
                                   1. Result in: % % % |- % : EC ARCH expressionResult
 
-                            1. Else Phantom#1595
+                            1. Else Phantom#1607
 
-                    1. Else Phantom#1596
+                    1. Else Phantom#1608
 
-                1. Else Phantom#1597
+                1. Else Phantom#1609
 
         2. Case (% has type typedExpressionIR)
 
@@ -30399,7 +30531,7 @@ relation Expr_eval: p EC ARCH |- (expressionIR # expressionNoteIR) : % % %
 
                                                   1. Result in: % % % |- % : EC_1 ARCH_1 expressionResult'
 
-                                          1. Else Phantom#1598
+                                          1. Else Phantom#1610
 
                                 3. Case (% = "lastIndex")
 
@@ -30415,9 +30547,9 @@ relation Expr_eval: p EC ARCH |- (expressionIR # expressionNoteIR) : % % %
 
                                             1. Result in: % % % |- % : EC_1 ARCH_1 expressionResult'
 
-                                    1. Else Phantom#1599
+                                    1. Else Phantom#1611
 
-                              1. Else Phantom#1600
+                              1. Else Phantom#1612
 
                         2. Case (% has type structValue)
 
@@ -30435,7 +30567,7 @@ relation Expr_eval: p EC ARCH |- (expressionIR # expressionNoteIR) : % % %
 
                                       1. Result in: % % % |- % : EC_1 ARCH_1 expressionResult'
 
-                                1. Else Phantom#1601
+                                1. Else Phantom#1613
 
                         3. Case (% has type headerValue)
 
@@ -30453,7 +30585,7 @@ relation Expr_eval: p EC ARCH |- (expressionIR # expressionNoteIR) : % % %
 
                                       1. Result in: % % % |- % : EC_1 ARCH_1 expressionResult'
 
-                                1. Else Phantom#1602
+                                1. Else Phantom#1614
 
                         4. Case (% has type headerUnionValue)
 
@@ -30471,9 +30603,9 @@ relation Expr_eval: p EC ARCH |- (expressionIR # expressionNoteIR) : % % %
 
                                       1. Result in: % % % |- % : EC_1 ARCH_1 expressionResult'
 
-                                1. Else Phantom#1603
+                                1. Else Phantom#1615
 
-                      1. Else Phantom#1604
+                      1. Else Phantom#1616
 
               2. (Expr_eval: p EC ARCH |- typedExpressionIR_base : EC_1 ARCH_1 expressionResult)
 
@@ -30507,11 +30639,11 @@ relation Expr_eval: p EC ARCH |- (expressionIR # expressionNoteIR) : % % %
 
                                 1. Result in: % % % |- % : EC_1 ARCH_1 expressionResult'
 
-                          1. Else Phantom#1605
+                          1. Else Phantom#1617
 
-                    1. Else Phantom#1606
+                    1. Else Phantom#1618
 
-                1. Else Phantom#1607
+                1. Else Phantom#1619
 
   12. Case (% has type indexAccessExpressionIR)
 
@@ -30559,9 +30691,9 @@ relation Expr_eval: p EC ARCH |- (expressionIR # expressionNoteIR) : % % %
 
                                         1. Result in: % % % |- % : EC_1 ARCH_1 expressionResult
 
-                                  1. Else Phantom#1608
+                                  1. Else Phantom#1620
 
-                          1. Else Phantom#1609
+                          1. Else Phantom#1621
 
                       2. Case (% has type headerStackValue)
 
@@ -30587,13 +30719,13 @@ relation Expr_eval: p EC ARCH |- (expressionIR # expressionNoteIR) : % % %
 
                                             1. Result in: % % % |- % : EC_1 ARCH_1 expressionResult
 
-                                      1. Else Phantom#1610
+                                      1. Else Phantom#1622
 
-                          1. Else Phantom#1611
+                          1. Else Phantom#1623
 
-                    1. Else Phantom#1612
+                    1. Else Phantom#1624
 
-                1. Else Phantom#1613
+                1. Else Phantom#1625
 
   13. Case (% has type sliceAccessExpressionIR)
 
@@ -30623,7 +30755,7 @@ relation Expr_eval: p EC ARCH |- (expressionIR # expressionNoteIR) : % % %
 
                       1. Result in: % % % |- % : EC_1 ARCH_1 expressionResult
 
-                1. Else Phantom#1614
+                1. Else Phantom#1626
 
   14. Case (% has type callExpressionIR)
 
@@ -30669,9 +30801,9 @@ relation Expr_eval: p EC ARCH |- (expressionIR # expressionNoteIR) : % % %
 
                                 1. Result in: % % % |- % : EC_2 ARCH_2 ((` value') as expressionResult)
 
-                            1. Else Phantom#1615
+                            1. Else Phantom#1627
 
-      1. Else Phantom#1616
+      1. Else Phantom#1628
 
   15. Case (% has type parenthesizedExpressionIR)
 
@@ -30683,7 +30815,7 @@ relation Expr_eval: p EC ARCH |- (expressionIR # expressionNoteIR) : % % %
 
           1. Result in: % % % |- % : EC_1 ARCH_1 expressionResult
 
-2. Else Phantom#1617
+2. Else Phantom#1629
 
 syntax expressionListResult = 
    | ` value*
@@ -30698,7 +30830,7 @@ relation Exprs_eval: p evalContext arch |- (typedExpressionIR)* : % % %
 
     1. Result in: % % % |- % : evalContext arch ((` []) as expressionListResult)
 
-  1. Else Phantom#1618
+  1. Else Phantom#1630
 
   2. If (((typedExpressionIR)* matches pattern _ :: _)), then
 
@@ -30734,7 +30866,7 @@ relation Exprs_eval: p evalContext arch |- (typedExpressionIR)* : % % %
 
                       1. Result in: % % % |- % : EC_2 ARCH_2 ((` value_h :: (value_t)*) as expressionListResult)
 
-  2. Else Phantom#1619
+  2. Else Phantom#1631
 
 syntax keysetExpressionResult = 
    | ` setValue*
@@ -30775,7 +30907,7 @@ relation Argument_eval: p EC_0 ARCH_0 |- argumentIR : % % %
 
           1. Result in: % % % |- % : EC_1 ARCH_1 expressionResult
 
-1. Else Phantom#1620
+1. Else Phantom#1632
 
 syntax storageReferenceResult = 
    | ` storageReference?
@@ -30802,7 +30934,7 @@ relation Argument_eval_lvalue: p EC_0 ARCH_0 |- argumentIR : % % %
 
                 1. Result in: % % % |- % : EC_1 ARCH_1 storageReferenceResult
 
-          1. Else Phantom#1621
+          1. Else Phantom#1633
 
   2. Case (% matches pattern `%=%`)
 
@@ -30820,7 +30952,7 @@ relation Argument_eval_lvalue: p EC_0 ARCH_0 |- argumentIR : % % %
 
                 1. Result in: % % % |- % : EC_1 ARCH_1 storageReferenceResult
 
-          1. Else Phantom#1622
+          1. Else Phantom#1634
 
   3. Case (% matches pattern `%=_`)
 
@@ -30890,7 +31022,7 @@ relation Lvalue_eval: p EC ARCH |- (lvalueIR # lvalueNoteIR) : % % %
 
                                     1. Result in: % % % |- % : EC_1 ARCH_1 (rejectTransitionResult as storageReferenceResult)
 
-                                1. Else Phantom#1623
+                                1. Else Phantom#1635
 
                                 2. If ((n_idx < n_size)), then
 
@@ -30898,9 +31030,9 @@ relation Lvalue_eval: p EC ARCH |- (lvalueIR # lvalueNoteIR) : % % %
 
                                     1. Result in: % % % |- % : EC_1 ARCH_1 storageReferenceResult'
 
-                                2. Else Phantom#1624
+                                2. Else Phantom#1636
 
-                              1. Else Phantom#1625
+                              1. Else Phantom#1637
 
                         2. Case false
 
@@ -30908,7 +31040,7 @@ relation Lvalue_eval: p EC ARCH |- (lvalueIR # lvalueNoteIR) : % % %
 
                             1. Result in: % % % |- % : EC_1 ARCH_1 storageReferenceResult'
 
-                1. Else Phantom#1626
+                1. Else Phantom#1638
 
   3. Case (% matches pattern `%[%]`)
 
@@ -30956,9 +31088,9 @@ relation Lvalue_eval: p EC ARCH |- (lvalueIR # lvalueNoteIR) : % % %
 
                                   1. Result in: % % % |- % : EC_2 ARCH_2 storageReferenceResult'
 
-                            1. Else Phantom#1627
+                            1. Else Phantom#1639
 
-                1. Else Phantom#1628
+                1. Else Phantom#1640
 
   4. Case (% matches pattern `%[%:%]`)
 
@@ -31006,9 +31138,9 @@ relation Lvalue_eval: p EC ARCH |- (lvalueIR # lvalueNoteIR) : % % %
 
                                   1. Result in: % % % |- % : EC_1 ARCH_1 storageReferenceResult'
 
-                            1. Else Phantom#1629
+                            1. Else Phantom#1641
 
-                1. Else Phantom#1630
+                1. Else Phantom#1642
 
   5. Case (% matches pattern `(%)`)
 
@@ -31066,11 +31198,11 @@ relation Lvalue_read: p EC ARCH |- storageReference : %
 
                                 1. Result in: % % % |- % : value'
 
-                            1. Else Phantom#1631
+                            1. Else Phantom#1643
 
-                      1. Else Phantom#1632
+                      1. Else Phantom#1644
 
-                  1. Else Phantom#1633
+                  1. Else Phantom#1645
 
             2. Case (% has type headerStackValue)
 
@@ -31086,9 +31218,9 @@ relation Lvalue_read: p EC ARCH |- storageReference : %
 
                         1. Result in: % % % |- % : value
 
-                    1. Else Phantom#1634
+                    1. Else Phantom#1646
 
-                  1. Else Phantom#1635
+                  1. Else Phantom#1647
 
             3. Case (% has type structValue)
 
@@ -31104,7 +31236,7 @@ relation Lvalue_read: p EC ARCH |- storageReference : %
 
                         1. Result in: % % % |- % : value'
 
-                    1. Else Phantom#1636
+                    1. Else Phantom#1648
 
             4. Case (% has type headerValue)
 
@@ -31120,7 +31252,7 @@ relation Lvalue_read: p EC ARCH |- storageReference : %
 
                         1. Result in: % % % |- % : value'
 
-                    1. Else Phantom#1637
+                    1. Else Phantom#1649
 
             5. Case (% has type headerUnionValue)
 
@@ -31136,9 +31268,9 @@ relation Lvalue_read: p EC ARCH |- storageReference : %
 
                         1. Result in: % % % |- % : value'
 
-                    1. Else Phantom#1638
+                    1. Else Phantom#1650
 
-          1. Else Phantom#1639
+          1. Else Phantom#1651
 
   3. Case (% matches pattern `%[%]`)
 
@@ -31174,7 +31306,7 @@ relation Lvalue_read: p EC ARCH |- storageReference : %
 
                                   1. Result in: % % % |- % : value''
 
-                            1. Else Phantom#1640
+                            1. Else Phantom#1652
 
                           2. Case false
 
@@ -31188,11 +31320,11 @@ relation Lvalue_read: p EC ARCH |- storageReference : %
 
                                     1. Result in: % % % |- % : value'''
 
-                              1. Else Phantom#1641
+                              1. Else Phantom#1653
 
-              1. Else Phantom#1642
+              1. Else Phantom#1654
 
-      1. Else Phantom#1643
+      1. Else Phantom#1655
 
   4. Case (% matches pattern `%[%:%]`)
 
@@ -31246,7 +31378,7 @@ relation Lvalue_write: p EC_0 ARCH |- storageReference -> value : %
 
                           1. Result in: % % % |- % -> % : EC_1
 
-                  1. Else Phantom#1644
+                  1. Else Phantom#1656
 
             2. Case (% has type structValue)
 
@@ -31322,13 +31454,13 @@ relation Lvalue_write: p EC_0 ARCH |- storageReference -> value : %
 
                                                 1. Result in: % % % |- % -> % : EC_1
 
-                                1. Else Phantom#1645
+                                1. Else Phantom#1657
 
-                          1. Else Phantom#1646
+                          1. Else Phantom#1658
 
-                      1. Else Phantom#1647
+                      1. Else Phantom#1659
 
-          1. Else Phantom#1648
+          1. Else Phantom#1660
 
   3. Case (% matches pattern `%[%]`)
 
@@ -31368,15 +31500,15 @@ relation Lvalue_write: p EC_0 ARCH |- storageReference -> value : %
 
                                       1. Result in: % % % |- % -> % : EC_1
 
-                            1. Else Phantom#1649
+                            1. Else Phantom#1661
 
                           2. Case false
 
                             1. Result in: % % % |- % -> % : EC_0
 
-              1. Else Phantom#1650
+              1. Else Phantom#1662
 
-      1. Else Phantom#1651
+      1. Else Phantom#1663
 
   4. Case (% matches pattern `%[%:%]`)
 
@@ -31469,7 +31601,7 @@ relation Stmt_eval: p EC ARCH |- statementIR : % % %
 
                               1. Result in: % % % |- % : EC_3 ARCH_2 ((`empty) as statementResult)
 
-                1. Else Phantom#1652
+                1. Else Phantom#1664
 
   3. Case (% has type callStatementIR)
 
@@ -31547,7 +31679,7 @@ relation Stmt_eval: p EC ARCH |- statementIR : % % %
 
                     1. Result in: % % % |- % : EC_cond ARCH_cond (abortResult as statementResult)
 
-                1. Else Phantom#1653
+                1. Else Phantom#1665
 
                 2. Case analysis on expressionResult
 
@@ -31561,7 +31693,7 @@ relation Stmt_eval: p EC ARCH |- statementIR : % % %
 
                     1. Result in: % % % |- % : EC_cond ARCH_cond ((`empty) as statementResult)
 
-                2. Else Phantom#1654
+                2. Else Phantom#1666
 
           2. Case (% matches pattern `IF(%)%ELSE%`)
 
@@ -31575,7 +31707,7 @@ relation Stmt_eval: p EC ARCH |- statementIR : % % %
 
                     1. Result in: % % % |- % : EC_cond ARCH_cond (abortResult as statementResult)
 
-                1. Else Phantom#1655
+                1. Else Phantom#1667
 
                 2. Case analysis on expressionResult
 
@@ -31591,9 +31723,9 @@ relation Stmt_eval: p EC ARCH |- statementIR : % % %
 
                       1. Result in: % % % |- % : EC_else ARCH_else statementResult
 
-                2. Else Phantom#1656
+                2. Else Phantom#1668
 
-1. Else Phantom#1657
+1. Else Phantom#1669
 
 2. If ((p matches pattern `LOCAL`)), then
 
@@ -31665,9 +31797,9 @@ relation Stmt_eval: p EC ARCH |- statementIR : % % %
 
                             1. Result in: % % % |- % : EC_4 ARCH_2 statementResult'
 
-                  1. Else Phantom#1658
+                  1. Else Phantom#1670
 
-        1. Else Phantom#1659
+        1. Else Phantom#1671
 
         2. Group forStatementIR-in: (local) EC ARCH |- (forStatementIR as statementIR) : % % %
 
@@ -31715,7 +31847,7 @@ relation Stmt_eval: p EC ARCH |- statementIR : % % %
 
                   1. Result in: % % % |- % : EC_1 ARCH_1 statementResult
 
-          1. Else Phantom#1660
+          1. Else Phantom#1672
 
     3. Case (% has type breakStatement)
 
@@ -31769,9 +31901,9 @@ relation Stmt_eval: p EC ARCH |- statementIR : % % %
 
                         1. Result in: % % % |- % : EC_2 ARCH_2 statementResult
 
-  1. Else Phantom#1661
+  1. Else Phantom#1673
 
-2. Else Phantom#1662
+2. Else Phantom#1674
 
 relation BlockElementStmt_eval: EC_0 arch |- blockElementStatementIR : % % %
 
@@ -31811,7 +31943,7 @@ relation BlockElementStmtList_eval: evalContext arch |- (blockElementStatementIR
 
     1. Result in: % % |- % : evalContext arch ((`empty) as statementResult)
 
-  1. Else Phantom#1663
+  1. Else Phantom#1675
 
   2. If (((blockElementStatementIR)* matches pattern _ :: _)), then
 
@@ -31823,7 +31955,7 @@ relation BlockElementStmtList_eval: evalContext arch |- (blockElementStatementIR
 
           1. Result in: % % |- % : EC_1 ARCH_1 statementResult
 
-        1. Else Phantom#1664
+        1. Else Phantom#1676
 
         2. If ((statementResult has type continueEmptyResult)), then
 
@@ -31833,9 +31965,9 @@ relation BlockElementStmtList_eval: evalContext arch |- (blockElementStatementIR
 
               1. Result in: % % |- % : EC_2 ARCH_2 statementResult'
 
-        2. Else Phantom#1665
+        2. Else Phantom#1677
 
-  2. Else Phantom#1666
+  2. Else Phantom#1678
 
 relation Block_eval: EC_0 ARCH_0 |- (annotationList { blockElementStatementListIR }) : % % %
 
@@ -31885,7 +32017,7 @@ relation ParserStmt_eval: EC_0 ARCH |- parserStatementIR : % % %
 
                 1. Result in: % % |- % : EC_1 ARCH_1 ((`empty) as parserStatementResult)
 
-          1. Else Phantom#1667
+          1. Else Phantom#1679
 
   3. Case (% has type emptyStatementIR)
 
@@ -31901,7 +32033,7 @@ relation ParserStmt_eval: EC_0 ARCH |- parserStatementIR : % % %
 
               1. Result in: % % |- % : EC_1 ARCH_1 ((`empty) as parserStatementResult)
 
-          1. Else Phantom#1668
+          1. Else Phantom#1680
 
   4. Case (% has type assignmentStatementIR)
 
@@ -31925,7 +32057,7 @@ relation ParserStmt_eval: EC_0 ARCH |- parserStatementIR : % % %
 
                 1. Result in: % % |- % : EC_1 ARCH_1 ((`empty) as parserStatementResult)
 
-          1. Else Phantom#1669
+          1. Else Phantom#1681
 
   5. Case (% has type callStatementIR)
 
@@ -31949,7 +32081,7 @@ relation ParserStmt_eval: EC_0 ARCH |- parserStatementIR : % % %
 
                 1. Result in: % % |- % : EC_1 ARCH_1 ((`empty) as parserStatementResult)
 
-          1. Else Phantom#1670
+          1. Else Phantom#1682
 
   6. Case (% has type parserBlockStatementIR)
 
@@ -31985,7 +32117,7 @@ relation ParserStmt_eval: EC_0 ARCH |- parserStatementIR : % % %
 
                     1. Result in: % % |- % : EC_cond ARCH_cond (rejectTransitionResult as parserStatementResult)
 
-                1. Else Phantom#1671
+                1. Else Phantom#1683
 
                 2. Case analysis on expressionResult
 
@@ -31999,7 +32131,7 @@ relation ParserStmt_eval: EC_0 ARCH |- parserStatementIR : % % %
 
                     1. Result in: % % |- % : EC_cond ARCH_cond ((`empty) as parserStatementResult)
 
-                2. Else Phantom#1672
+                2. Else Phantom#1684
 
           2. Case (% matches pattern `IF(%)%ELSE%`)
 
@@ -32021,9 +32153,9 @@ relation ParserStmt_eval: EC_0 ARCH |- parserStatementIR : % % %
 
                       1. Result in: % % |- % : EC_else ARCH_else parserStatementResult
 
-                1. Else Phantom#1673
+                1. Else Phantom#1685
 
-1. Else Phantom#1674
+1. Else Phantom#1686
 
 relation ParserStmts_eval: evalContext arch |- (parserStatementIR)* : % % %
 
@@ -32033,7 +32165,7 @@ relation ParserStmts_eval: evalContext arch |- (parserStatementIR)* : % % %
 
     1. Result in: % % |- % : evalContext arch ((`empty) as parserStatementResult)
 
-  1. Else Phantom#1675
+  1. Else Phantom#1687
 
   2. If (((parserStatementIR)* matches pattern _ :: _)), then
 
@@ -32057,7 +32189,7 @@ relation ParserStmts_eval: evalContext arch |- (parserStatementIR)* : % % %
 
                 1. Result in: % % |- % : EC_2 ARCH_2 parserStatementResult'
 
-  2. Else Phantom#1676
+  2. Else Phantom#1688
 
 syntax transitionResult = 
    | accept
@@ -32104,7 +32236,7 @@ relation ParserSelect_eval: EC_0 ARCH_0 |- selectExpressionIR : % % %
 
                         1. Result in: % % |- % : EC_2 ARCH_2 (rejectTransitionResult as transitionResult)
 
-                    1. Else Phantom#1677
+                    1. Else Phantom#1689
 
                     2. If (((nameIR_state)? matches pattern (_))), then
 
@@ -32114,9 +32246,9 @@ relation ParserSelect_eval: EC_0 ARCH_0 |- selectExpressionIR : % % %
 
                           1. Result in: % % |- % : EC_3 ARCH_3 transitionResult
 
-                    2. Else Phantom#1678
+                    2. Else Phantom#1690
 
-      1. Else Phantom#1679
+      1. Else Phantom#1691
 
 relation ParserTransition_eval: evalContext arch |- (transition stateExpressionIR) : % % %
 
@@ -32140,13 +32272,13 @@ relation ParserTransition_eval: evalContext arch |- (transition stateExpressionI
 
               1. Result in: % % |- % : evalContext arch ((reject errorValue) as transitionResult)
 
-        1. Else Phantom#1680
+        1. Else Phantom#1692
 
         2. If (((nameIR =/= "accept") /\ (nameIR =/= "reject"))), then
 
           1. Result in: % % |- % : evalContext arch ((state nameIR) as transitionResult)
 
-        2. Else Phantom#1681
+        2. Else Phantom#1693
 
     2. Case (% has type selectExpressionIR)
 
@@ -32214,7 +32346,7 @@ relation ParserState_trans: EC_0 ARCH_0 |-transition nameIR : % % %
 
                   1. Result in: % % |-transition % : EC_2 ARCH_2 transitionResult'
 
-    1. Else Phantom#1682
+    1. Else Phantom#1694
 
 syntax parserDeclarationResult = parserStatementResult
 
@@ -32254,9 +32386,9 @@ relation ParserLocalDecl_eval: EC_0 ARCH |- parserLocalDeclarationIR : % % %
 
                 1. Result in: % % |- % : EC_1 ARCH_1 ((`empty) as parserDeclarationResult)
 
-          1. Else Phantom#1683
+          1. Else Phantom#1695
 
-1. Else Phantom#1684
+1. Else Phantom#1696
 
 relation ParserLocalDecls_eval: evalContext arch |- (parserLocalDeclarationIR)* : % % %
 
@@ -32266,7 +32398,7 @@ relation ParserLocalDecls_eval: evalContext arch |- (parserLocalDeclarationIR)* 
 
     1. Result in: % % |- % : evalContext arch ((`empty) as parserDeclarationResult)
 
-  1. Else Phantom#1685
+  1. Else Phantom#1697
 
   2. If (((parserLocalDeclarationIR)* matches pattern _ :: _)), then
 
@@ -32288,7 +32420,7 @@ relation ParserLocalDecls_eval: evalContext arch |- (parserLocalDeclarationIR)* 
 
               1. Result in: % % |- % : EC_2 ARCH_2 parserStatementResult
 
-  2. Else Phantom#1686
+  2. Else Phantom#1698
 
 syntax tableResult = 
    | exit
@@ -32356,7 +32488,7 @@ relation Table_eval: EC_0 ARCH_0 |- typeId TBL : % % %
 
                                         1. Result in: % % |- % % : EC_3 ARCH_3 ((return ?((tableMetadataStructValue as value))) as tableResult)
 
-                          1. Else Phantom#1687
+                          1. Else Phantom#1699
 
 syntax controlBodyResult = 
    | exit
@@ -32382,13 +32514,13 @@ relation ControlBody_eval: EC_0 ARCH_0 |- controlBodyIR : % % %
 
           1. Result in: % % |- % : EC_1 ARCH_1 ((exit) as controlBodyResult)
 
-    1. Else Phantom#1688
+    1. Else Phantom#1700
 
     2. If ((statementResult = ((return ?()) as statementResult))), then
 
       1. Result in: % % |- % : EC_1 ARCH_1 ((return ?()) as controlBodyResult)
 
-    2. Else Phantom#1689
+    2. Else Phantom#1701
 
 syntax controlLocalDeclarationResult = 
    | `empty
@@ -32430,9 +32562,9 @@ relation ControlLocalDecl_eval: EC_0 ARCH |- controlLocalDeclarationIR : % % %
 
                 1. Result in: % % |- % : EC_1 ARCH_1 ((`empty) as controlLocalDeclarationResult)
 
-          1. Else Phantom#1690
+          1. Else Phantom#1702
 
-1. Else Phantom#1691
+1. Else Phantom#1703
 
 relation ControlLocalDecls_eval: evalContext arch |- (controlLocalDeclarationIR)* : % % %
 
@@ -32442,7 +32574,7 @@ relation ControlLocalDecls_eval: evalContext arch |- (controlLocalDeclarationIR)
 
     1. Result in: % % |- % : evalContext arch ((`empty) as controlLocalDeclarationResult)
 
-  1. Else Phantom#1692
+  1. Else Phantom#1704
 
   2. If (((controlLocalDeclarationIR)* matches pattern _ :: _)), then
 
@@ -32466,7 +32598,7 @@ relation ControlLocalDecls_eval: evalContext arch |- (controlLocalDeclarationIR)
 
                 1. Result in: % % |- % : EC_2 ARCH_2 controlLocalDeclarationResult'
 
-  2. Else Phantom#1693
+  2. Else Phantom#1705
 
 syntax declarationResult = 
    | `empty
@@ -32550,9 +32682,9 @@ relation Callee_eval: p EC ARCH |- callableTargetIR <_>( argumentListIR ): % % %
 
                       1. Result in: % % % |- % <_>( % ): EC ARCH ((` (actionCallee as callee)) as calleeResult)
 
-              1. Else Phantom#1694
+              1. Else Phantom#1706
 
-          1. Else Phantom#1695
+          1. Else Phantom#1707
 
       2. Group externFunctionCallee: p EC ARCH |- (referenceExpressionIR as callableTargetIR) <_>( argumentListIR ): % % %
 
@@ -32572,9 +32704,9 @@ relation Callee_eval: p EC ARCH |- callableTargetIR <_>( argumentListIR ): % % %
 
                       1. Result in: % % % |- % <_>( % ): EC ARCH ((` (externFunctionCallee as callee)) as calleeResult)
 
-              1. Else Phantom#1696
+              1. Else Phantom#1708
 
-          1. Else Phantom#1697
+          1. Else Phantom#1709
 
       3. Group definedFunctionCallee: p EC ARCH |- (referenceExpressionIR as callableTargetIR) <_>( argumentListIR ): % % %
 
@@ -32594,9 +32726,9 @@ relation Callee_eval: p EC ARCH |- callableTargetIR <_>( argumentListIR ): % % %
 
                       1. Result in: % % % |- % <_>( % ): EC ARCH ((` (definedFunctionCallee as callee)) as calleeResult)
 
-              1. Else Phantom#1698
+              1. Else Phantom#1710
 
-          1. Else Phantom#1699
+          1. Else Phantom#1711
 
   2. Case (% matches pattern `%.%`)
 
@@ -32618,9 +32750,9 @@ relation Callee_eval: p EC ARCH |- callableTargetIR <_>( argumentListIR ): % % %
 
                     1. Result in: % % % |- % <_>( % ): EC_1 ARCH_1 (abortResult as calleeResult)
 
-                1. Else Phantom#1700
+                1. Else Phantom#1712
 
-          1. Else Phantom#1701
+          1. Else Phantom#1713
 
         2. Case analysis on nameIR
 
@@ -32650,13 +32782,13 @@ relation Callee_eval: p EC ARCH |- callableTargetIR <_>( argumentListIR ): % % %
 
                                   1. Result in: % % % |- % <_>( % ): EC_1 ARCH_1 ((` (builtinMethodCallee as callee)) as calleeResult)
 
-                          1. Else Phantom#1702
+                          1. Else Phantom#1714
 
-                      1. Else Phantom#1703
+                      1. Else Phantom#1715
 
-                1. Else Phantom#1704
+                1. Else Phantom#1716
 
-            1. Else Phantom#1705
+            1. Else Phantom#1717
 
           2. Case (% = "pop_front")
 
@@ -32684,13 +32816,13 @@ relation Callee_eval: p EC ARCH |- callableTargetIR <_>( argumentListIR ): % % %
 
                                   1. Result in: % % % |- % <_>( % ): EC_1 ARCH_1 ((` (builtinMethodCallee as callee)) as calleeResult)
 
-                          1. Else Phantom#1706
+                          1. Else Phantom#1718
 
-                      1. Else Phantom#1707
+                      1. Else Phantom#1719
 
-                1. Else Phantom#1708
+                1. Else Phantom#1720
 
-            1. Else Phantom#1709
+            1. Else Phantom#1721
 
           3. Case (% = "isValid")
 
@@ -32716,13 +32848,13 @@ relation Callee_eval: p EC ARCH |- callableTargetIR <_>( argumentListIR ): % % %
 
                                 1. Result in: % % % |- % <_>( % ): EC_1 ARCH_1 ((` (builtinMethodCallee as callee)) as calleeResult)
 
-                          1. Else Phantom#1710
+                          1. Else Phantom#1722
 
-                      1. Else Phantom#1711
+                      1. Else Phantom#1723
 
-                1. Else Phantom#1712
+                1. Else Phantom#1724
 
-            1. Else Phantom#1713
+            1. Else Phantom#1725
 
           4. Case (% = "setValid")
 
@@ -32748,13 +32880,13 @@ relation Callee_eval: p EC ARCH |- callableTargetIR <_>( argumentListIR ): % % %
 
                                 1. Result in: % % % |- % <_>( % ): EC_1 ARCH_1 ((` (builtinMethodCallee as callee)) as calleeResult)
 
-                          1. Else Phantom#1714
+                          1. Else Phantom#1726
 
-                      1. Else Phantom#1715
+                      1. Else Phantom#1727
 
-                1. Else Phantom#1716
+                1. Else Phantom#1728
 
-            1. Else Phantom#1717
+            1. Else Phantom#1729
 
           5. Case (% = "setInvalid")
 
@@ -32780,15 +32912,15 @@ relation Callee_eval: p EC ARCH |- callableTargetIR <_>( argumentListIR ): % % %
 
                                 1. Result in: % % % |- % <_>( % ): EC_1 ARCH_1 ((` (builtinMethodCallee as callee)) as calleeResult)
 
-                          1. Else Phantom#1718
+                          1. Else Phantom#1730
 
-                      1. Else Phantom#1719
+                      1. Else Phantom#1731
 
-                1. Else Phantom#1720
+                1. Else Phantom#1732
 
-            1. Else Phantom#1721
+            1. Else Phantom#1733
 
-        2. Else Phantom#1722
+        2. Else Phantom#1734
 
       2. Group externMethodCallee: p EC ARCH |- (typedExpressionIR . nameIR) <_>( argumentListIR ): % % %
 
@@ -32850,21 +32982,21 @@ relation Callee_eval: p EC ARCH |- callableTargetIR <_>( argumentListIR ): % % %
 
                                                           1. Result in: % % % |- % <_>( % ): EC_1 ARCH_1 ((` (externMethodCallee as callee)) as calleeResult)
 
-                                                      1. Else Phantom#1723
+                                                      1. Else Phantom#1735
 
-                                                  1. Else Phantom#1724
+                                                  1. Else Phantom#1736
 
-                                              1. Else Phantom#1725
+                                              1. Else Phantom#1737
 
-                                      1. Else Phantom#1726
+                                      1. Else Phantom#1738
 
-                                  1. Else Phantom#1727
+                                  1. Else Phantom#1739
 
-                            1. Else Phantom#1728
+                            1. Else Phantom#1740
 
-                      1. Else Phantom#1729
+                      1. Else Phantom#1741
 
-          1. Else Phantom#1730
+          1. Else Phantom#1742
 
       3. If ((nameIR = "apply")), then
 
@@ -32926,17 +33058,17 @@ relation Callee_eval: p EC ARCH |- callableTargetIR <_>( argumentListIR ): % % %
 
                                                           1. Result in: % % % |- % <_>( % ): EC_1 ARCH_1 ((` (parserApplyMethodCallee as callee)) as calleeResult)
 
-                                                    1. Else Phantom#1731
+                                                    1. Else Phantom#1743
 
-                                        1. Else Phantom#1732
+                                        1. Else Phantom#1744
 
-                                    1. Else Phantom#1733
+                                    1. Else Phantom#1745
 
-                              1. Else Phantom#1734
+                              1. Else Phantom#1746
 
-                        1. Else Phantom#1735
+                        1. Else Phantom#1747
 
-            1. Else Phantom#1736
+            1. Else Phantom#1748
 
         2. Group controlApplyMethodCallee: p EC ARCH |- (typedExpressionIR . "apply") <_>( argumentListIR ): % % %
 
@@ -32996,21 +33128,21 @@ relation Callee_eval: p EC ARCH |- callableTargetIR <_>( argumentListIR ): % % %
 
                                                           1. Result in: % % % |- % <_>( % ): EC_1 ARCH_1 ((` (controlApplyMethodCallee as callee)) as calleeResult)
 
-                                                    1. Else Phantom#1737
+                                                    1. Else Phantom#1749
 
-                                        1. Else Phantom#1738
+                                        1. Else Phantom#1750
 
-                                    1. Else Phantom#1739
+                                    1. Else Phantom#1751
 
-                              1. Else Phantom#1740
+                              1. Else Phantom#1752
 
-                        1. Else Phantom#1741
+                        1. Else Phantom#1753
 
-            1. Else Phantom#1742
+            1. Else Phantom#1754
 
-      3. Else Phantom#1743
+      3. Else Phantom#1755
 
-1. Else Phantom#1744
+1. Else Phantom#1756
 
 2. (Let (argumentIR)* be argumentListIR)
 
@@ -33068,21 +33200,21 @@ relation Callee_eval: p EC ARCH |- callableTargetIR <_>( argumentListIR ): % % %
 
                                                 1. Result in: % % % |- % <_>( % ): EC_1 ARCH_1 ((` (tableApplyMethodCallee as callee)) as calleeResult)
 
-                                          1. Else Phantom#1745
+                                          1. Else Phantom#1757
 
-                                      1. Else Phantom#1746
+                                      1. Else Phantom#1758
 
-                                1. Else Phantom#1747
+                                1. Else Phantom#1759
 
-                          1. Else Phantom#1748
+                          1. Else Phantom#1760
 
-              1. Else Phantom#1749
+              1. Else Phantom#1761
 
-        1. Else Phantom#1750
+        1. Else Phantom#1762
 
-      1. Else Phantom#1751
+      1. Else Phantom#1763
 
-  1. Else Phantom#1752
+  1. Else Phantom#1764
 
 syntax copyInArgumentResult = 
    | ` storageReference?
@@ -33113,7 +33245,7 @@ relation Copy_in_argument: ARCH_0 |- p_caller EC_caller_0 (annotationList direct
 
               1. Result in: % |- % % % @ % % % ~> ARCH_1 EC_caller_1 EC_callee_1 # ((` ?()) as copyInArgumentResult)
 
-  1. Else Phantom#1753
+  1. Else Phantom#1765
 
 2. Case analysis on direction
 
@@ -33145,7 +33277,7 @@ relation Copy_in_argument: ARCH_0 |- p_caller EC_caller_0 (annotationList direct
 
                       1. Result in: % |- % % % @ % % % ~> ARCH_1 EC_caller_1 EC_callee_1 # ((` ?(storageReference')) as copyInArgumentResult)
 
-              1. Else Phantom#1754
+              1. Else Phantom#1766
 
   2. Case (% matches pattern `OUT`)
 
@@ -33173,7 +33305,7 @@ relation Copy_in_argument: ARCH_0 |- p_caller EC_caller_0 (annotationList direct
 
                     1. Result in: % |- % % % @ % % % ~> ARCH_1 EC_caller_1 EC_callee_1 # ((` (storageReference)?) as copyInArgumentResult)
 
-2. Else Phantom#1755
+2. Else Phantom#1767
 
 syntax copyInResult = 
    | ` storageReference?*
@@ -33192,9 +33324,9 @@ relation Copy_in: p_shared arch |- p_caller evalContext (parameterIR)* @ p_calle
 
         1. Result in: % % |- % % % @ % % % ~> arch evalContext EC_callee_1 # ((` []) as copyInResult)
 
-    1. Else Phantom#1756
+    1. Else Phantom#1768
 
-  1. Else Phantom#1757
+  1. Else Phantom#1769
 
   2. If (((parameterIR)* matches pattern _ :: _)), then
 
@@ -33240,11 +33372,11 @@ relation Copy_in: p_shared arch |- p_caller evalContext (parameterIR)* @ p_calle
 
                                 1. Result in: % % |- % % % @ % % % ~> ARCH_2 EC_caller_2 EC_callee_2 # ((` ((storageReference')?)*) as copyInResult)
 
-                          1. Else Phantom#1758
+                          1. Else Phantom#1770
 
-      1. Else Phantom#1759
+      1. Else Phantom#1771
 
-  2. Else Phantom#1760
+  2. Else Phantom#1772
 
 relation Copy_in_default: (parameterIR)* @ p_callee EC_callee_0 ~> %
 
@@ -33264,9 +33396,9 @@ relation Copy_in_default: (parameterIR)* @ p_callee EC_callee_0 ~> %
 
               1. Result in: % @ % % ~> EC_callee_1
 
-        1. Else Phantom#1761
+        1. Else Phantom#1773
 
-    1. Else Phantom#1762
+    1. Else Phantom#1774
 
 relation Copy_out_argument: ARCH |- p_caller EC_caller_0 (annotationList direction typeIR nameIR parameterInitializerOptIR) @ p_callee EC_callee (storageReference)? ~> %
 
@@ -33278,9 +33410,9 @@ relation Copy_out_argument: ARCH |- p_caller EC_caller_0 (annotationList directi
 
       1. Result in: % |- % % % @ % % % ~> EC_caller_0
 
-    1. Else Phantom#1763
+    1. Else Phantom#1775
 
-1. Else Phantom#1764
+1. Else Phantom#1776
 
 2. Group out-inout: ARCH |- p_caller EC_caller_0 (annotationList direction typeIR nameIR parameterInitializerOptIR) @ p_callee EC_callee (storageReference)? ~> %
 
@@ -33292,7 +33424,7 @@ relation Copy_out_argument: ARCH |- p_caller EC_caller_0 (annotationList directi
 
         1. Result in: % |- % % % @ % % % ~> EC_caller_0
 
-      1. Else Phantom#1765
+      1. Else Phantom#1777
 
     2. Case (% matches pattern (_))
 
@@ -33306,7 +33438,7 @@ relation Copy_out_argument: ARCH |- p_caller EC_caller_0 (annotationList directi
 
               1. Result in: % |- % % % @ % % % ~> EC_caller_1
 
-        1. Else Phantom#1766
+        1. Else Phantom#1778
 
 relation Copy_out: p_shared ARCH |- p_caller EC_caller_0 parameterListIR @ p_callee EC_callee ((storageReference)?)* ~> %
 
@@ -33364,7 +33496,7 @@ relation Call_eval: p EC_0 ARCH_0 |- callee @< typeArgumentListIR >( argumentLis
 
                                     1. Result in: % % % |- % @< % >( % ): EC_2 ARCH_2 ((exit) as callResult)
 
-                              1. Else Phantom#1767
+                              1. Else Phantom#1779
 
                               2. If ((actionResult = ((return ?()) as actionResult))), then
 
@@ -33372,11 +33504,11 @@ relation Call_eval: p EC_0 ARCH_0 |- callee @< typeArgumentListIR >( argumentLis
 
                                   1. Result in: % % % |- % @< % >( % ): EC_2 ARCH_2 ((return ?()) as callResult)
 
-                              2. Else Phantom#1768
+                              2. Else Phantom#1780
 
-                    1. Else Phantom#1769
+                    1. Else Phantom#1781
 
-        1. Else Phantom#1770
+        1. Else Phantom#1782
 
     2. Case (% has type definedFunctionCallee)
 
@@ -33416,7 +33548,7 @@ relation Call_eval: p EC_0 ARCH_0 |- callee @< typeArgumentListIR >( argumentLis
 
                                   1. Result in: % % % |- % @< % >( % ): EC_2 ARCH_2 (definedFunctionResult as callResult)
 
-  1. Else Phantom#1771
+  1. Else Phantom#1783
 
   2. (Let (argumentIR)* be argumentListIR)
 
@@ -33460,7 +33592,7 @@ relation Call_eval: p EC_0 ARCH_0 |- callee @< typeArgumentListIR >( argumentLis
 
                                     1. Result in: % % % |- % @< % >( % ): EC_2 ARCH_2 callResult
 
-    1. Else Phantom#1772
+    1. Else Phantom#1784
 
   3. If ((callee has type builtinMethodCallee)), then
 
@@ -33540,9 +33672,9 @@ relation Call_eval: p EC_0 ARCH_0 |- callee @< typeArgumentListIR >( argumentLis
 
                                                                         1. Result in: % % % |- % @< % >( % ): EC_2 ARCH_1 ((return ?()) as callResult)
 
-                                                          1. Else Phantom#1773
+                                                          1. Else Phantom#1785
 
-                                                  1. Else Phantom#1774
+                                                  1. Else Phantom#1786
 
                                                   2. If ((n_count >= n_size)), then
 
@@ -33556,17 +33688,17 @@ relation Call_eval: p EC_0 ARCH_0 |- callee @< typeArgumentListIR >( argumentLis
 
                                                             1. Result in: % % % |- % @< % >( % ): EC_2 ARCH_1 ((return ?()) as callResult)
 
-                                                  2. Else Phantom#1775
+                                                  2. Else Phantom#1787
 
-                                              1. Else Phantom#1776
+                                              1. Else Phantom#1788
 
-                                        1. Else Phantom#1777
+                                        1. Else Phantom#1789
 
-                          1. Else Phantom#1778
+                          1. Else Phantom#1790
 
-                      1. Else Phantom#1779
+                      1. Else Phantom#1791
 
-                    1. Else Phantom#1780
+                    1. Else Phantom#1792
 
                   2. Case (% = "pop_front")
 
@@ -33628,9 +33760,9 @@ relation Call_eval: p EC_0 ARCH_0 |- callee @< typeArgumentListIR >( argumentLis
 
                                                                       1. Result in: % % % |- % @< % >( % ): EC_2 ARCH_1 ((return ?()) as callResult)
 
-                                                      1. Else Phantom#1781
+                                                      1. Else Phantom#1793
 
-                                                  1. Else Phantom#1782
+                                                  1. Else Phantom#1794
 
                                                   2. If ((n_count >= n_size)), then
 
@@ -33648,23 +33780,23 @@ relation Call_eval: p EC_0 ARCH_0 |- callee @< typeArgumentListIR >( argumentLis
 
                                                                 1. Result in: % % % |- % @< % >( % ): EC_2 ARCH_1 ((return ?()) as callResult)
 
-                                                        1. Else Phantom#1783
+                                                        1. Else Phantom#1795
 
-                                                  2. Else Phantom#1784
+                                                  2. Else Phantom#1796
 
-                                              1. Else Phantom#1785
+                                              1. Else Phantom#1797
 
-                                        1. Else Phantom#1786
+                                        1. Else Phantom#1798
 
-                          1. Else Phantom#1787
+                          1. Else Phantom#1799
 
-                      1. Else Phantom#1788
+                      1. Else Phantom#1800
 
-                    1. Else Phantom#1789
+                    1. Else Phantom#1801
 
-                1. Else Phantom#1790
+                1. Else Phantom#1802
 
-          1. Else Phantom#1791
+          1. Else Phantom#1803
 
           2. If ((argumentListIR = [])), then
 
@@ -33706,11 +33838,11 @@ relation Call_eval: p EC_0 ARCH_0 |- callee @< typeArgumentListIR >( argumentLis
 
                                       1. Result in: % % % |- % @< % >( % ): EC_0 ARCH_0 (returnResult as callResult)
 
-                        1. Else Phantom#1792
+                        1. Else Phantom#1804
 
-                    1. Else Phantom#1793
+                    1. Else Phantom#1805
 
-                  1. Else Phantom#1794
+                  1. Else Phantom#1806
 
                 2. Case (% = "setValid")
 
@@ -33734,11 +33866,11 @@ relation Call_eval: p EC_0 ARCH_0 |- callee @< typeArgumentListIR >( argumentLis
 
                                     1. Result in: % % % |- % @< % >( % ): EC_1 ARCH_0 (returnResult as callResult)
 
-                        1. Else Phantom#1795
+                        1. Else Phantom#1807
 
-                    1. Else Phantom#1796
+                    1. Else Phantom#1808
 
-                  1. Else Phantom#1797
+                  1. Else Phantom#1809
 
                 3. Case (% = "setInvalid")
 
@@ -33762,19 +33894,19 @@ relation Call_eval: p EC_0 ARCH_0 |- callee @< typeArgumentListIR >( argumentLis
 
                                     1. Result in: % % % |- % @< % >( % ): EC_1 ARCH_0 (returnResult as callResult)
 
-                        1. Else Phantom#1798
+                        1. Else Phantom#1810
 
-                    1. Else Phantom#1799
+                    1. Else Phantom#1811
 
-                  1. Else Phantom#1800
+                  1. Else Phantom#1812
 
-              1. Else Phantom#1801
+              1. Else Phantom#1813
 
-          2. Else Phantom#1802
+          2. Else Phantom#1814
 
-      1. Else Phantom#1803
+      1. Else Phantom#1815
 
-  3. Else Phantom#1804
+  3. Else Phantom#1816
 
   4. (Let (argumentIR)* be argumentListIR)
 
@@ -33824,9 +33956,9 @@ relation Call_eval: p EC_0 ARCH_0 |- callee @< typeArgumentListIR >( argumentLis
 
                                           1. Result in: % % % |- % @< % >( % ): EC_2 ARCH_2 callResult
 
-            1. Else Phantom#1805
+            1. Else Phantom#1817
 
-    1. Else Phantom#1806
+    1. Else Phantom#1818
 
 2. Case analysis on callee
 
@@ -33896,9 +34028,9 @@ relation Call_eval: p EC_0 ARCH_0 |- callee @< typeArgumentListIR >( argumentLis
 
                                             1. Result in: % % % |- % @< % >( % ): EC_2 ARCH_3 ((return ?()) as callResult)
 
-                                    1. Else Phantom#1807
+                                    1. Else Phantom#1819
 
-                    1. Else Phantom#1808
+                    1. Else Phantom#1820
 
   2. Case (% has type controlApplyMethodCallee)
 
@@ -33960,7 +34092,7 @@ relation Call_eval: p EC_0 ARCH_0 |- callee @< typeArgumentListIR >( argumentLis
 
                                               1. Result in: % % % |- % @< % >( % ): EC_2 ARCH_3 ((exit) as callResult)
 
-                                        1. Else Phantom#1809
+                                        1. Else Phantom#1821
 
                                         2. If ((controlBodyResult = ((return ?()) as controlBodyResult))), then
 
@@ -33968,9 +34100,9 @@ relation Call_eval: p EC_0 ARCH_0 |- callee @< typeArgumentListIR >( argumentLis
 
                                             1. Result in: % % % |- % @< % >( % ): EC_2 ARCH_3 ((return ?()) as callResult)
 
-                                        2. Else Phantom#1810
+                                        2. Else Phantom#1822
 
-                      1. Else Phantom#1811
+                      1. Else Phantom#1823
 
   3. Case (% has type tableApplyMethodCallee)
 
@@ -34010,9 +34142,9 @@ relation Call_eval: p EC_0 ARCH_0 |- callee @< typeArgumentListIR >( argumentLis
 
                               1. Result in: % % % |- % @< % >( % ): EC_1 ARCH_1 (returnResult as callResult)
 
-                1. Else Phantom#1812
+                1. Else Phantom#1824
 
-2. Else Phantom#1813
+2. Else Phantom#1825
 
 extern relation ExternFunctionCall_eval: evalContext arch |- nameIR ( (nameIR')* ): % % %
 
@@ -34028,7 +34160,7 @@ def $match_keysets((setValue)*, (value)*)
 
       1. Return true
 
-    1. Else Phantom#1814
+    1. Else Phantom#1826
 
   2. Case (% matches pattern [ _/1 ])
 
@@ -34042,9 +34174,9 @@ def $match_keysets((setValue)*, (value)*)
 
             1. Return $match_keyset(setValue', value_key)
 
-          1. Else Phantom#1815
+          1. Else Phantom#1827
 
-      1. Else Phantom#1816
+      1. Else Phantom#1828
 
   3. Case (% matches pattern _ :: _)
 
@@ -34068,19 +34200,19 @@ def $match_keysets((setValue)*, (value)*)
 
                   1. Return false
 
-            1. Else Phantom#1817
+            1. Else Phantom#1829
 
-          1. Else Phantom#1818
+          1. Else Phantom#1830
 
-      1. Else Phantom#1819
+      1. Else Phantom#1831
 
-1. Else Phantom#1820
+1. Else Phantom#1832
 
 2. If (((setValue)* = [(set{...})])), then
 
   1. Return true
 
-2. Else Phantom#1821
+2. Else Phantom#1833
 
 def $match_keyset(setValue, value_key)
 
@@ -34169,11 +34301,11 @@ relation Expr_eval_keyset_simple: EC_0 ARCH_0 |- simpleKeysetExpressionIR : % % 
 
                                   1. Result in: % % |- % : EC_1 ARCH_1 ((` setValue) as simpleKeysetExpressionResult)
 
-                            1. Else Phantom#1822
+                            1. Else Phantom#1834
 
-                        1. Else Phantom#1823
+                        1. Else Phantom#1835
 
-                1. Else Phantom#1824
+                1. Else Phantom#1836
 
   2. Case (% matches pattern `%&&&%`)
 
@@ -34251,7 +34383,7 @@ relation Expr_eval_keyset_simple: EC_0 ARCH_0 |- simpleKeysetExpressionIR : % % 
 
                           1. Result in: % % |- % : EC_2 ARCH_2 ((` setValue) as simpleKeysetExpressionResult)
 
-1. Else Phantom#1825
+1. Else Phantom#1837
 
 2. Group default-any: EC_0 ARCH_0 |- simpleKeysetExpressionIR : % % %
 
@@ -34261,7 +34393,7 @@ relation Expr_eval_keyset_simple: EC_0 ARCH_0 |- simpleKeysetExpressionIR : % % 
 
       1. Result in: % % |- % : EC_0 ARCH_0 ((` setValue) as simpleKeysetExpressionResult)
 
-  1. Else Phantom#1826
+  1. Else Phantom#1838
 
 relation Exprs_eval_keyset_simple: evalContext arch |- (simpleKeysetExpressionIR)* : % % %
 
@@ -34271,7 +34403,7 @@ relation Exprs_eval_keyset_simple: evalContext arch |- (simpleKeysetExpressionIR
 
     1. Result in: % % |- % : evalContext arch ((` []) as keysetExpressionResult)
 
-  1. Else Phantom#1827
+  1. Else Phantom#1839
 
   2. If (((simpleKeysetExpressionIR)* matches pattern _ :: _)), then
 
@@ -34309,7 +34441,7 @@ relation Exprs_eval_keyset_simple: evalContext arch |- (simpleKeysetExpressionIR
 
                         1. Result in: % % |- % : EC_2 ARCH_2 keysetExpressionResult'
 
-  2. Else Phantom#1828
+  2. Else Phantom#1840
 
 relation ForUpdateStmt_eval: EC_0 ARCH_0 |- forUpdateStatementIR : % % %
 
@@ -34341,7 +34473,7 @@ relation ForUpdateStmts_eval: evalContext arch |- (forUpdateStatementIR)* : % % 
 
     1. Result in: % % |- % : evalContext arch ((`empty) as statementResult)
 
-  1. Else Phantom#1829
+  1. Else Phantom#1841
 
   2. If (((forUpdateStatementIR)* matches pattern _ :: _)), then
 
@@ -34365,9 +34497,9 @@ relation ForUpdateStmts_eval: evalContext arch |- (forUpdateStatementIR)* : % % 
 
                 1. Result in: % % |- % : EC_2 ARCH_2 statementResult'
 
-        1. Else Phantom#1830
+        1. Else Phantom#1842
 
-  2. Else Phantom#1831
+  2. Else Phantom#1843
 
 relation ForInitStmt_eval: EC_0 arch |- forInitStatementIR : % % %
 
@@ -34389,7 +34521,7 @@ relation ForInitStmt_eval: EC_0 arch |- forInitStatementIR : % % %
 
                 1. Result in: % % |- % : EC_1 arch ((`empty) as statementResult)
 
-        1. Else Phantom#1832
+        1. Else Phantom#1844
 
       2. (Let (annotationList typeIR nameIR initializerOptIR) be forInitStatementIR)
 
@@ -34415,7 +34547,7 @@ relation ForInitStmt_eval: EC_0 arch |- forInitStatementIR : % % %
 
                       1. Result in: % % |- % : EC_2 ARCH_1 ((`empty) as statementResult)
 
-        1. Else Phantom#1833
+        1. Else Phantom#1845
 
     2. Case (% has type forUpdateStatementIR)
 
@@ -34433,7 +34565,7 @@ relation ForInitStmts_eval: evalContext arch |- (forInitStatementIR)* : % % %
 
     1. Result in: % % |- % : evalContext arch ((`empty) as statementResult)
 
-  1. Else Phantom#1834
+  1. Else Phantom#1846
 
   2. If (((forInitStatementIR)* matches pattern _ :: _)), then
 
@@ -34457,9 +34589,9 @@ relation ForInitStmts_eval: evalContext arch |- (forInitStatementIR)* : % % %
 
                 1. Result in: % % |- % : EC_2 ARCH_2 statementResult'
 
-        1. Else Phantom#1835
+        1. Else Phantom#1847
 
-  2. Else Phantom#1836
+  2. Else Phantom#1848
 
 relation ForThreeClauseStmt_eval: EC_0 ARCH_0 |- typedExpressionIR statementIR forUpdateStatementListIR : % % %
 
@@ -34473,7 +34605,7 @@ relation ForThreeClauseStmt_eval: EC_0 ARCH_0 |- typedExpressionIR statementIR f
 
         1. Result in: % % |- % % % : EC_1 ARCH_1 (abortResult as statementResult)
 
-    1. Else Phantom#1837
+    1. Else Phantom#1849
 
     2. Case analysis on expressionResult
 
@@ -34505,7 +34637,7 @@ relation ForThreeClauseStmt_eval: EC_0 ARCH_0 |- typedExpressionIR statementIR f
 
                 1. Result in: % % |- % % % : EC_2 ARCH_2 ((`empty) as statementResult)
 
-          1. Else Phantom#1838
+          1. Else Phantom#1850
 
           2. If (((statementResult = ((`empty) as statementResult)) \/ (statementResult = ((continue) as statementResult)))), then
 
@@ -34527,11 +34659,11 @@ relation ForThreeClauseStmt_eval: EC_0 ARCH_0 |- typedExpressionIR statementIR f
 
                       1. Result in: % % |- % % % : EC_4 ARCH_4 statementResult''
 
-              1. Else Phantom#1839
+              1. Else Phantom#1851
 
-          2. Else Phantom#1840
+          2. Else Phantom#1852
 
-    2. Else Phantom#1841
+    2. Else Phantom#1853
 
 relation ForCollectionExpr_eval: EC_0 ARCH_0 |- forCollectionExpressionIR : % % %
 
@@ -34575,7 +34707,7 @@ relation ForCollectionExpr_eval: EC_0 ARCH_0 |- forCollectionExpressionIR : % % 
 
                         1. Result in: % % |- % : EC_1 ARCH_1 ((` (value')*) as expressionListResult)
 
-                1. Else Phantom#1842
+                1. Else Phantom#1854
 
   2. Case (% matches pattern `%..%`)
 
@@ -34631,21 +34763,21 @@ def $values_of_setValue((set< typeIR >), setValue)
 
           1. Return value_l :: $values_of_setValue((set< typeIR >), (set{ value_l_inc .. value_r }))
 
-    1. Else Phantom#1843
+    1. Else Phantom#1855
 
     2. If ($bin_eq(value_l, value_r)), then
 
       1. Return [value_l]
 
-    2. Else Phantom#1844
+    2. Else Phantom#1856
 
     3. If ($bin_gt(value_l, value_r)), then
 
       1. Return []
 
-    3. Else Phantom#1845
+    3. Else Phantom#1857
 
-1. Else Phantom#1846
+1. Else Phantom#1858
 
 relation ForInStmt_eval: evalContext arch |- nameIR (value)* statementIR : % % %
 
@@ -34655,7 +34787,7 @@ relation ForInStmt_eval: evalContext arch |- nameIR (value)* statementIR : % % %
 
     1. Result in: % % |- % % % : evalContext arch ((`empty) as statementResult)
 
-  1. Else Phantom#1847
+  1. Else Phantom#1859
 
   2. If (((value)* matches pattern _ :: _)), then
 
@@ -34685,7 +34817,7 @@ relation ForInStmt_eval: evalContext arch |- nameIR (value)* statementIR : % % %
 
                 1. Result in: % % |- % % % : EC_2 ARCH_1 ((`empty) as statementResult)
 
-          1. Else Phantom#1848
+          1. Else Phantom#1860
 
           2. If (((statementResult = ((`empty) as statementResult)) \/ (statementResult = ((continue) as statementResult)))), then
 
@@ -34693,9 +34825,9 @@ relation ForInStmt_eval: evalContext arch |- nameIR (value)* statementIR : % % %
 
               1. Result in: % % |- % % % : EC_3 ARCH_2 statementResult'
 
-          2. Else Phantom#1849
+          2. Else Phantom#1861
 
-  2. Else Phantom#1850
+  2. Else Phantom#1862
 
 relation Switch_table_eval: EC_0 ARCH_0 |-switch( id_enum ){ (switchCaseIR)* }: % % %
 
@@ -34753,7 +34885,7 @@ relation SwitchCases_table_eval: id |- (switchCaseIR)* : %
 
     1. Result in: % |- % : ?()
 
-  1. Else Phantom#1851
+  1. Else Phantom#1863
 
   2. If (((switchCaseIR)* matches pattern _ :: _)), then
 
@@ -34797,9 +34929,9 @@ relation SwitchCases_table_eval: id |- (switchCaseIR)* : %
 
                           1. Result in: % |- % : ?(blockStatementIR)
 
-                      1. Else Phantom#1852
+                      1. Else Phantom#1864
 
-                  1. Else Phantom#1853
+                  1. Else Phantom#1865
 
               2. Case false
 
@@ -34807,7 +34939,7 @@ relation SwitchCases_table_eval: id |- (switchCaseIR)* : %
 
                   1. Result in: % |- % : (blockStatementIR)?
 
-  2. Else Phantom#1854
+  2. Else Phantom#1866
 
 def $is_non_fallthrough_switchCaseIR(switchCaseIR)
 
@@ -34861,7 +34993,7 @@ relation SwitchLabel_general_eval: cursor EC_0 ARCH_0 |- switchLabelIR : % % %
 
             1. Result in: % % % |- % : EC_1 ARCH_1 expressionResult
 
-1. Else Phantom#1855
+1. Else Phantom#1867
 
 def $match_switchLabelIR_general(value, value')
 
@@ -34885,7 +35017,7 @@ relation SwitchCases_general_eval: cursor EC_0 ARCH_0 value |- (switchCaseIR)* :
 
       1. Result in: % % % % |- % : EC_0 ARCH_0 ?()
 
-    1. Else Phantom#1856
+    1. Else Phantom#1868
 
     2. If (((switchCaseIR)* matches pattern _ :: _)), then
 
@@ -34915,7 +35047,7 @@ relation SwitchCases_general_eval: cursor EC_0 ARCH_0 value |- (switchCaseIR)* :
 
                           1. Result in: % % % % |- % : EC_2 ARCH_2 (blockStatementIR)?
 
-                1. Else Phantom#1857
+                1. Else Phantom#1869
 
           2. Case (% matches pattern `%:`)
 
@@ -34943,9 +35075,9 @@ relation SwitchCases_general_eval: cursor EC_0 ARCH_0 value |- (switchCaseIR)* :
 
                                   1. Result in: % % % % |- % : EC_1 ARCH_1 ?(blockStatementIR)
 
-                              1. Else Phantom#1858
+                              1. Else Phantom#1870
 
-                          1. Else Phantom#1859
+                          1. Else Phantom#1871
 
                       2. Case false
 
@@ -34953,11 +35085,11 @@ relation SwitchCases_general_eval: cursor EC_0 ARCH_0 value |- (switchCaseIR)* :
 
                           1. Result in: % % % % |- % : EC_2 ARCH_2 (blockStatementIR)?
 
-                1. Else Phantom#1860
+                1. Else Phantom#1872
 
-    2. Else Phantom#1861
+    2. Else Phantom#1873
 
-1. Else Phantom#1862
+1. Else Phantom#1874
 
 syntax selectCaseMatchResult = 
    | ` nameIR?
@@ -34991,7 +35123,7 @@ relation SelectCase_match: EC_0 ARCH_0 (value_key)* |- (keysetExpressionIR : nam
 
               1. Result in: % % % |- % : EC_1 ARCH_1 ((` ?(nameIR)) as selectCaseMatchResult)
 
-    1. Else Phantom#1863
+    1. Else Phantom#1875
 
 relation SelectCases_match: evalContext arch (value_key)* |- (selectCaseIR)* : % % %
 
@@ -35001,7 +35133,7 @@ relation SelectCases_match: evalContext arch (value_key)* |- (selectCaseIR)* : %
 
     1. Result in: % % % |- % : evalContext arch ((` ?()) as selectCaseMatchResult)
 
-  1. Else Phantom#1864
+  1. Else Phantom#1876
 
   2. If (((selectCaseIR)* matches pattern _ :: _)), then
 
@@ -35027,7 +35159,7 @@ relation SelectCases_match: evalContext arch (value_key)* |- (selectCaseIR)* : %
 
                   1. Result in: % % % |- % : EC_1 ARCH_1 ((` ?(nameIR_state)) as selectCaseMatchResult)
 
-              1. Else Phantom#1865
+              1. Else Phantom#1877
 
         2. If ((selectCaseMatchResult = ((` ?()) as selectCaseMatchResult))), then
 
@@ -35035,9 +35167,9 @@ relation SelectCases_match: evalContext arch (value_key)* |- (selectCaseIR)* : %
 
             1. Result in: % % % |- % : EC_2 ARCH_2 selectCaseMatchResult'
 
-        2. Else Phantom#1866
+        2. Else Phantom#1878
 
-  2. Else Phantom#1867
+  2. Else Phantom#1879
 
 syntax tableKeyValue = 
    | value : nameIR
@@ -35068,7 +35200,7 @@ relation TableKey_eval: EC_0 ARCH_0 |- (typedExpressionIR # nameIR' : nameIR ann
 
             1. Result in: % % |- % : EC_1 ARCH_1 ((` tableKeyValue) as tableKeyResult)
 
-    1. Else Phantom#1868
+    1. Else Phantom#1880
 
 syntax tableKeysResult = 
    | ` tableKeyValue*
@@ -35082,7 +35214,7 @@ relation TableKeys_eval: evalContext arch |- (tableKeyIR)* : % % %
 
     1. Result in: % % |- % : evalContext arch ((` []) as tableKeysResult)
 
-  1. Else Phantom#1869
+  1. Else Phantom#1881
 
   2. If (((tableKeyIR)* matches pattern _ :: _)), then
 
@@ -35120,7 +35252,7 @@ relation TableKeys_eval: evalContext arch |- (tableKeyIR)* : % % %
 
                         1. Result in: % % |- % : EC_2 ARCH_2 ((` (tableKeyValue)*) as tableKeysResult)
 
-  2. Else Phantom#1870
+  2. Else Phantom#1882
 
 def $get_tableEntryPriority((tableEntryPriorityIR)?)
 
@@ -35142,7 +35274,7 @@ def $get_tableEntryPriority((tableEntryPriorityIR)?)
 
             1. Return ?(n)
 
-        1. Else Phantom#1871
+        1. Else Phantom#1883
 
 syntax tableMatch = 
    | nat? : tableActionReferenceIR
@@ -35187,7 +35319,7 @@ relation TableMatch_eval: EC_0 ARCH_0 |- (tableKeyValue)* @ tableEntryIR : % % %
 
                       1. Result in: % % |- % @ % : EC_1 ARCH_1 ((` ?(tableMatch)) as tableMatchResult)
 
-        1. Else Phantom#1872
+        1. Else Phantom#1884
 
 syntax tableMatchesResult = 
    | ` tableMatch*
@@ -35201,7 +35333,7 @@ relation TableMatches_eval: evalContext arch |- (tableKeyValue)* @ (tableEntryIR
 
     1. Result in: % % |- % @ % : evalContext arch ((` []) as tableMatchesResult)
 
-  1. Else Phantom#1873
+  1. Else Phantom#1885
 
   2. If (((tableEntryIR)* matches pattern _ :: _)), then
 
@@ -35239,7 +35371,7 @@ relation TableMatches_eval: evalContext arch |- (tableKeyValue)* @ (tableEntryIR
 
                         1. Result in: % % |- % @ % : EC_2 ARCH_2 ((` (tableMatch)*) as tableMatchesResult)
 
-  2. Else Phantom#1874
+  2. Else Phantom#1886
 
 def $largest_priority_wins(TBL)
 
@@ -35261,17 +35393,17 @@ def $largest_priority_wins(TBL)
 
                 1. Return b
 
-            1. Else Phantom#1875
+            1. Else Phantom#1887
 
-        1. Else Phantom#1876
+        1. Else Phantom#1888
 
-    1. Else Phantom#1877
+    1. Else Phantom#1889
 
   2. If (([] = $filter_<tableCustomPropertyIR>((tableCustomPropertyIR)*, ($is_largest_priority_wins(tableCustomPropertyIR))*))), then
 
     1. Return true
 
-  2. Else Phantom#1878
+  2. Else Phantom#1890
 
 def $is_largest_priority_wins(tableCustomPropertyIR)
 
@@ -35305,7 +35437,7 @@ def $select_action(TBL, (tableMatch)*)
 
         1. Return tableActionReferenceIR
 
-1. Else Phantom#1879
+1. Else Phantom#1891
 
 2. If ((|(tableMatch)*| > 1)), then
 
@@ -35329,7 +35461,7 @@ def $select_action(TBL, (tableMatch)*)
 
                     1. Return tableActionReferenceIR_h
 
-                1. Else Phantom#1880
+                1. Else Phantom#1892
 
             2. Case false
 
@@ -35339,11 +35471,11 @@ def $select_action(TBL, (tableMatch)*)
 
                   1. Return tableActionReferenceIR_h
 
-              1. Else Phantom#1881
+              1. Else Phantom#1893
 
-    1. Else Phantom#1882
+    1. Else Phantom#1894
 
-2. Else Phantom#1883
+2. Else Phantom#1895
 
 relation Copy_out_inner: ARCH |- p_caller evalContext (parameterIR)* @ p_callee EC_callee ((storageReference)?)* ~> %
 
@@ -35355,9 +35487,9 @@ relation Copy_out_inner: ARCH |- p_caller evalContext (parameterIR)* @ p_callee 
 
       1. Result in: % |- % % % @ % % % ~> evalContext
 
-    1. Else Phantom#1884
+    1. Else Phantom#1896
 
-  1. Else Phantom#1885
+  1. Else Phantom#1897
 
   2. If (((parameterIR)* matches pattern _ :: _)), then
 
@@ -35375,9 +35507,9 @@ relation Copy_out_inner: ARCH |- p_caller evalContext (parameterIR)* @ p_callee 
 
                 1. Result in: % |- % % % @ % % % ~> EC_caller_2
 
-        1. Else Phantom#1886
+        1. Else Phantom#1898
 
-  2. Else Phantom#1887
+  2. Else Phantom#1899
 
 syntax actionResult = 
    | exit
@@ -35403,13 +35535,13 @@ relation ActionBody_eval: EC_0 ARCH_0 |- blockStatementIR : % % %
 
           1. Result in: % % |- % : EC_1 ARCH_1 ((exit) as actionResult)
 
-    1. Else Phantom#1888
+    1. Else Phantom#1900
 
     2. If ((statementResult = ((return ?()) as statementResult))), then
 
       1. Result in: % % |- % : EC_1 ARCH_1 ((return ?()) as actionResult)
 
-    2. Else Phantom#1889
+    2. Else Phantom#1901
 
 syntax definedFunctionResult = 
    | exit
@@ -35441,7 +35573,7 @@ relation DefinedFunctionBody_eval: EC_0 ARCH_0 |- blockStatementIR : % % %
 
           1. Result in: % % |- % : EC_1 ARCH_1 (returnResult as definedFunctionResult)
 
-    1. Else Phantom#1890
+    1. Else Phantom#1902
 
 def $isValid_fieldValue((value id ;))
 
@@ -35483,11 +35615,11 @@ relation Extern_init: EC ARCH_0 |- nameIR_extern nameIR : %
 
                       1. Result in: % % |- % % : ARCH_2
 
-          1. Else Phantom#1891
+          1. Else Phantom#1903
 
-        1. Else Phantom#1892
+        1. Else Phantom#1904
 
-      1. Else Phantom#1893
+      1. Else Phantom#1905
 
 relation Program_init: |- p4program : % %
 
@@ -35663,7 +35795,7 @@ def $tableObject_create_entry_priority(tableEntryPriorityInterface)
 
     1. Return ?()
 
-  1. Else Phantom#1894
+  1. Else Phantom#1906
 
 2. If ((tableEntryPriorityInterface matches pattern (_))), then
 
@@ -35675,9 +35807,9 @@ def $tableObject_create_entry_priority(tableEntryPriorityInterface)
 
         1. Return ?((priority= (d (n_priority as int)) :))
 
-    1. Else Phantom#1895
+    1. Else Phantom#1907
 
-2. Else Phantom#1896
+2. Else Phantom#1908
 
 def $needs_priority_tableKeysPropertyIR((key={ (tableKeyIR)* }))
 
@@ -35719,11 +35851,11 @@ def $tableObject_create_entry_key(EC, (nameIR_key, text, typeIR), (tableKeyInter
 
                               1. Return simpleKeysetExpressionIR
 
-                      1. Else Phantom#1897
+                      1. Else Phantom#1909
 
-            1. Else Phantom#1898
+            1. Else Phantom#1910
 
-      1. Else Phantom#1899
+      1. Else Phantom#1911
 
   2. Case (% = "ternary")
 
@@ -35767,9 +35899,9 @@ def $tableObject_create_entry_key(EC, (nameIR_key, text, typeIR), (tableKeyInter
 
                                           1. Return simpleKeysetExpressionIR
 
-                                    1. Else Phantom#1900
+                                    1. Else Phantom#1912
 
-                        1. Else Phantom#1901
+                        1. Else Phantom#1913
 
             2. Case (% matches pattern ``BIN%`)
 
@@ -35803,13 +35935,13 @@ def $tableObject_create_entry_key(EC, (nameIR_key, text, typeIR), (tableKeyInter
 
                                           1. Return simpleKeysetExpressionIR
 
-                                    1. Else Phantom#1902
+                                    1. Else Phantom#1914
 
-                        1. Else Phantom#1903
+                        1. Else Phantom#1915
 
-          1. Else Phantom#1904
+          1. Else Phantom#1916
 
-      1. Else Phantom#1905
+      1. Else Phantom#1917
 
   3. Case (% = "lpm")
 
@@ -35857,11 +35989,11 @@ def $tableObject_create_entry_key(EC, (nameIR_key, text, typeIR), (tableKeyInter
 
                                               1. Return simpleKeysetExpressionIR
 
-                                        1. Else Phantom#1906
+                                        1. Else Phantom#1918
 
-                            1. Else Phantom#1907
+                            1. Else Phantom#1919
 
-                  1. Else Phantom#1908
+                  1. Else Phantom#1920
 
             2. Case (% matches pattern ``BIN%`)
 
@@ -35899,11 +36031,11 @@ def $tableObject_create_entry_key(EC, (nameIR_key, text, typeIR), (tableKeyInter
 
                                               1. Return simpleKeysetExpressionIR
 
-                                        1. Else Phantom#1909
+                                        1. Else Phantom#1921
 
-                            1. Else Phantom#1910
+                            1. Else Phantom#1922
 
-                  1. Else Phantom#1911
+                  1. Else Phantom#1923
 
             3. Case (% matches pattern `%`SLASH%`)
 
@@ -35943,17 +36075,17 @@ def $tableObject_create_entry_key(EC, (nameIR_key, text, typeIR), (tableKeyInter
 
                                                 1. Return simpleKeysetExpressionIR
 
-                                          1. Else Phantom#1912
+                                          1. Else Phantom#1924
 
-                                  1. Else Phantom#1913
+                                  1. Else Phantom#1925
 
-                        1. Else Phantom#1914
+                        1. Else Phantom#1926
 
-                    1. Else Phantom#1915
+                    1. Else Phantom#1927
 
-          1. Else Phantom#1916
+          1. Else Phantom#1928
 
-      1. Else Phantom#1917
+      1. Else Phantom#1929
 
   4. Case (% = "optional")
 
@@ -35997,17 +36129,17 @@ def $tableObject_create_entry_key(EC, (nameIR_key, text, typeIR), (tableKeyInter
 
                                           1. Return simpleKeysetExpressionIR
 
-                                    1. Else Phantom#1918
+                                    1. Else Phantom#1930
 
-                        1. Else Phantom#1919
+                        1. Else Phantom#1931
 
-              1. Else Phantom#1920
+              1. Else Phantom#1932
 
-          1. Else Phantom#1921
+          1. Else Phantom#1933
 
-      1. Else Phantom#1922
+      1. Else Phantom#1934
 
-1. Else Phantom#1923
+1. Else Phantom#1935
 
 def $tableObject_create_entry_keys(evalContext, ((nameIR, nameIR, typeIR))*, tableKeysetInterface)
 
@@ -36015,7 +36147,7 @@ def $tableObject_create_entry_keys(evalContext, ((nameIR, nameIR, typeIR))*, tab
 
   1. Return []
 
-1. Else Phantom#1924
+1. Else Phantom#1936
 
 2. (Let (tableKeyInterface)* be tableKeysetInterface)
 
@@ -36027,7 +36159,7 @@ def $tableObject_create_entry_keys(evalContext, ((nameIR, nameIR, typeIR))*, tab
 
         1. Return simpleKeysetExpressionIR_h :: $tableObject_create_entry_keys(evalContext, ((nameIR_key_t, nameIR_matchKind_t, typeIR_t))*, (tableKeyInterface)*)
 
-  1. Else Phantom#1925
+  1. Else Phantom#1937
 
 def $interface_of_tableKeyIR((typedExpressionIR # nameIR_key : nameIR_matchKind annotationList ;))
 
@@ -36047,7 +36179,7 @@ def $tableObject_create_entry_keyset(EC, (key={ (tableKeyIR)* }), (tableKeyInter
 
         1. Return ((( (simpleKeysetExpressionIR)* )) as keysetExpressionIR)
 
-    1. Else Phantom#1926
+    1. Else Phantom#1938
 
 def $alias_to_original_lookup_map((parameterIR)*)
 
@@ -36085,9 +36217,9 @@ def $align_tableActionArgumentInterfaces((parameterIR)*, ((nameIR_arg, i_arg))*)
 
               1. Return (i_aligned)*
 
-          1. Else Phantom#1927
+          1. Else Phantom#1939
 
-    1. Else Phantom#1928
+    1. Else Phantom#1940
 
 def $align_tableActionArgumentInterfaces'(({ ((id_arg : i_arg))* }), (_annotationList _direction _typeIR nameIR_param _parameterInitializerOptIR))
 
@@ -36121,7 +36253,7 @@ def $find_tableActionIR_by_name((tableActionIR)*, nameIR)
 
                 1. Return $find_tableActionIR_by_name((tableActionIR_t)*, nameIR)
 
-          1. Else Phantom#1929
+          1. Else Phantom#1941
 
           2. (Let (nameIR_annotation)* be $name_annotation(annotationList))
 
@@ -36139,7 +36271,7 @@ def $find_tableActionIR_by_name((tableActionIR)*, nameIR)
 
                     1. Return $find_tableActionIR_by_name((tableActionIR_t)*, nameIR)
 
-            1. Else Phantom#1930
+            1. Else Phantom#1942
 
 def $find_tableActionIR_by_dotPrefix((tableActionIR)*, nameIR)
 
@@ -36159,7 +36291,7 @@ def $find_tableActionIR_by_dotPrefix((tableActionIR)*, nameIR)
 
           1. Return $find_tableActionIR_by_dotPrefix((tableActionIR_t)*, nameIR)
 
-        1. Else Phantom#1931
+        1. Else Phantom#1943
 
       2. (Let (annotationList (prefixedNameIR _controlPlaneNameIR ( (argumentIR_data)* )) #( _parameterListIR , (parameterIR_control)* );) be tableActionIR_h)
 
@@ -36171,9 +36303,9 @@ def $find_tableActionIR_by_dotPrefix((tableActionIR)*, nameIR)
 
               1. Return $find_tableActionIR_by_dotPrefix((tableActionIR_t)*, nameIR)
 
-            1. Else Phantom#1932
+            1. Else Phantom#1944
 
-          1. Else Phantom#1933
+          1. Else Phantom#1945
 
           2. (Let (nameIR_annotation_dotPrefix)* be $filter_<nameIR>((nameIR_annotation)*, ($starts_with(nameIR_annotation, "."))*))
 
@@ -36185,9 +36317,9 @@ def $find_tableActionIR_by_dotPrefix((tableActionIR)*, nameIR)
 
                   1. Return $find_tableActionIR_by_dotPrefix((tableActionIR_t)*, nameIR)
 
-                1. Else Phantom#1934
+                1. Else Phantom#1946
 
-            1. Else Phantom#1935
+            1. Else Phantom#1947
 
             2. (Let (nameIR_annotation_strip)* be ($strip_prefix(nameIR_annotation_dotPrefix, "."))*)
 
@@ -36197,7 +36329,7 @@ def $find_tableActionIR_by_dotPrefix((tableActionIR)*, nameIR)
 
                   1. Return ?((nameIR_action, tableActionIR_h))
 
-              1. Else Phantom#1936
+              1. Else Phantom#1948
 
 def $tableObject_create_entry_action(EC, (actions={ (tableActionIR)* }), (nameIR_action_update, (tableActionArgumentInterface_update)*))
 
@@ -36225,9 +36357,9 @@ def $tableObject_create_entry_action(EC, (actions={ (tableActionIR)* }), (nameIR
 
                       1. Return ((` nameIR_found) controlPlaneNameIR ( (argumentIR)* ))
 
-                1. Else Phantom#1937
+                1. Else Phantom#1949
 
-  1. Else Phantom#1938
+  1. Else Phantom#1950
 
 2. If ((?() = $find_tableActionIR_by_dotPrefix((tableActionIR)*, nameIR_action_update))), then
 
@@ -36255,11 +36387,11 @@ def $tableObject_create_entry_action(EC, (actions={ (tableActionIR)* }), (nameIR
 
                         1. Return ((` nameIR_found) controlPlaneNameIR ( (argumentIR)* ))
 
-                  1. Else Phantom#1939
+                  1. Else Phantom#1951
 
-    1. Else Phantom#1940
+    1. Else Phantom#1952
 
-2. Else Phantom#1941
+2. Else Phantom#1953
 
 def $tableObject_add_entry(EC, (table typeId { frame TBL }), tableEntryPriorityInterface, tableKeysetInterface, tableActionInterface)
 
@@ -36281,7 +36413,7 @@ def $tableObject_add_entry(EC, (table typeId { frame TBL }), tableEntryPriorityI
 
                 1. Return (table typeId { frame TBL_updated })
 
-  1. Else Phantom#1942
+  1. Else Phantom#1954
 
 def $tableObject_add_default_action(EC, (table typeId { frame TBL }), tableActionInterface)
 
@@ -36297,7 +36429,7 @@ def $tableObject_add_default_action(EC, (table typeId { frame TBL }), tableActio
 
           1. Return (table typeId { frame TBL_updated })
 
-  1. Else Phantom#1943
+  1. Else Phantom#1955
 
 relation V1Model_init: |- p4program : % %
 
@@ -36335,9 +36467,9 @@ relation V1Model_init_packet_in: EC_0 ARCH_0 |- objectState_packet_in : % %
 
                       1. Result in: % % |- % : EC_1 ARCH_2
 
-            1. Else Phantom#1944
+            1. Else Phantom#1956
 
-        1. Else Phantom#1945
+        1. Else Phantom#1957
 
 relation V1Model_init_packet_out: EC_0 ARCH_0 |- objectState_packet_out : % %
 
@@ -36365,9 +36497,9 @@ relation V1Model_init_packet_out: EC_0 ARCH_0 |- objectState_packet_out : % %
 
                       1. Result in: % % |- % : EC_1 ARCH_2
 
-            1. Else Phantom#1946
+            1. Else Phantom#1958
 
-        1. Else Phantom#1947
+        1. Else Phantom#1959
 
 relation V1Model_init_globals: EC_0 ARCH |- i_port : %
 
@@ -36417,15 +36549,15 @@ relation V1Model_init_globals: EC_0 ARCH |- i_port : %
 
                                             1. Result in: % % |- % : EC_4
 
-                              1. Else Phantom#1948
+                              1. Else Phantom#1960
 
-                    1. Else Phantom#1949
+                    1. Else Phantom#1961
 
-              1. Else Phantom#1950
+              1. Else Phantom#1962
 
-        1. Else Phantom#1951
+        1. Else Phantom#1963
 
-    1. Else Phantom#1952
+    1. Else Phantom#1964
 
 def $V1Model_setup_packet_in_argument(EC)
 
@@ -36441,7 +36573,7 @@ def $V1Model_setup_packet_in_argument(EC)
 
           1. Return argumentIR_packet_in
 
-  1. Else Phantom#1953
+  1. Else Phantom#1965
 
 def $V1Model_setup_packet_out_argument(EC)
 
@@ -36457,7 +36589,7 @@ def $V1Model_setup_packet_out_argument(EC)
 
           1. Return argumentIR_packet_out
 
-  1. Else Phantom#1954
+  1. Else Phantom#1966
 
 def $V1Model_setup_hdr_argument(ARCH)
 
@@ -36481,11 +36613,11 @@ def $V1Model_setup_hdr_argument(ARCH)
 
                   1. Return argumentIR_hdr
 
-            1. Else Phantom#1955
+            1. Else Phantom#1967
 
-      1. Else Phantom#1956
+      1. Else Phantom#1968
 
-  1. Else Phantom#1957
+  1. Else Phantom#1969
 
 def $V1Model_setup_meta_argument(ARCH)
 
@@ -36509,11 +36641,11 @@ def $V1Model_setup_meta_argument(ARCH)
 
                   1. Return argumentIR_meta
 
-            1. Else Phantom#1958
+            1. Else Phantom#1970
 
-      1. Else Phantom#1959
+      1. Else Phantom#1971
 
-  1. Else Phantom#1960
+  1. Else Phantom#1972
 
 def $V1Model_setup_standard_metadata_argument(EC)
 
@@ -36529,7 +36661,7 @@ def $V1Model_setup_standard_metadata_argument(EC)
 
           1. Return argumentIR_standard_metadata
 
-  1. Else Phantom#1961
+  1. Else Phantom#1973
 
 def $V1Model_setup_main_callee(EC, ARCH)
 
@@ -36567,15 +36699,15 @@ def $V1Model_setup_main_callee(EC, ARCH)
 
                                 1. Return typedExpressionIR_main
 
-                        1. Else Phantom#1962
+                        1. Else Phantom#1974
 
-                  1. Else Phantom#1963
+                  1. Else Phantom#1975
 
-            1. Else Phantom#1964
+            1. Else Phantom#1976
 
-        1. Else Phantom#1965
+        1. Else Phantom#1977
 
-  1. Else Phantom#1966
+  1. Else Phantom#1978
 
 def $V1Model_setup_parser_callee(EC, ARCH, typedExpressionIR_main)
 
@@ -36613,15 +36745,15 @@ def $V1Model_setup_parser_callee(EC, ARCH, typedExpressionIR_main)
 
                                 1. Return typedExpressionIR_parser
 
-                        1. Else Phantom#1967
+                        1. Else Phantom#1979
 
-                  1. Else Phantom#1968
+                  1. Else Phantom#1980
 
-            1. Else Phantom#1969
+            1. Else Phantom#1981
 
-        1. Else Phantom#1970
+        1. Else Phantom#1982
 
-  1. Else Phantom#1971
+  1. Else Phantom#1983
 
 def $V1Model_setup_verify_callee(EC, ARCH, typedExpressionIR_main)
 
@@ -36659,15 +36791,15 @@ def $V1Model_setup_verify_callee(EC, ARCH, typedExpressionIR_main)
 
                                 1. Return typedExpressionIR_verify
 
-                        1. Else Phantom#1972
+                        1. Else Phantom#1984
 
-                  1. Else Phantom#1973
+                  1. Else Phantom#1985
 
-            1. Else Phantom#1974
+            1. Else Phantom#1986
 
-        1. Else Phantom#1975
+        1. Else Phantom#1987
 
-  1. Else Phantom#1976
+  1. Else Phantom#1988
 
 def $V1Model_setup_ingress_callee(EC, ARCH, typedExpressionIR_main)
 
@@ -36705,15 +36837,15 @@ def $V1Model_setup_ingress_callee(EC, ARCH, typedExpressionIR_main)
 
                                 1. Return typedExpressionIR_ingress
 
-                        1. Else Phantom#1977
+                        1. Else Phantom#1989
 
-                  1. Else Phantom#1978
+                  1. Else Phantom#1990
 
-            1. Else Phantom#1979
+            1. Else Phantom#1991
 
-        1. Else Phantom#1980
+        1. Else Phantom#1992
 
-  1. Else Phantom#1981
+  1. Else Phantom#1993
 
 def $V1Model_setup_egress_callee(EC, ARCH, typedExpressionIR_main)
 
@@ -36751,15 +36883,15 @@ def $V1Model_setup_egress_callee(EC, ARCH, typedExpressionIR_main)
 
                                 1. Return typedExpressionIR_egress
 
-                        1. Else Phantom#1982
+                        1. Else Phantom#1994
 
-                  1. Else Phantom#1983
+                  1. Else Phantom#1995
 
-            1. Else Phantom#1984
+            1. Else Phantom#1996
 
-        1. Else Phantom#1985
+        1. Else Phantom#1997
 
-  1. Else Phantom#1986
+  1. Else Phantom#1998
 
 def $V1Model_setup_check_callee(EC, ARCH, typedExpressionIR_main)
 
@@ -36797,15 +36929,15 @@ def $V1Model_setup_check_callee(EC, ARCH, typedExpressionIR_main)
 
                                 1. Return typedExpressionIR_check
 
-                        1. Else Phantom#1987
+                        1. Else Phantom#1999
 
-                  1. Else Phantom#1988
+                  1. Else Phantom#2000
 
-            1. Else Phantom#1989
+            1. Else Phantom#2001
 
-        1. Else Phantom#1990
+        1. Else Phantom#2002
 
-  1. Else Phantom#1991
+  1. Else Phantom#2003
 
 def $V1Model_setup_deparse_callee(EC, ARCH, typedExpressionIR_main)
 
@@ -36837,13 +36969,13 @@ def $V1Model_setup_deparse_callee(EC, ARCH, typedExpressionIR_main)
 
                           1. Return typedExpressionIR_deparse
 
-                  1. Else Phantom#1992
+                  1. Else Phantom#2004
 
-            1. Else Phantom#1993
+            1. Else Phantom#2005
 
-        1. Else Phantom#1994
+        1. Else Phantom#2006
 
-  1. Else Phantom#1995
+  1. Else Phantom#2007
 
 relation V1Model_parser: EC_0 ARCH_0 |- % % %
 
@@ -36881,7 +37013,7 @@ relation V1Model_parser: EC_0 ARCH_0 |- % % %
 
                           1. Result in: % % |- EC_1 ARCH_1 (rejectTransitionResult as transitionResult)
 
-                    1. Else Phantom#1996
+                    1. Else Phantom#2008
 
 relation V1Model_verify: EC_0 ARCH_0 |- % % %
 
@@ -36915,7 +37047,7 @@ relation V1Model_verify: EC_0 ARCH_0 |- % % %
 
                       1. Result in: % % |- EC_1 ARCH_1 ((exit) as callResult)
 
-                1. Else Phantom#1997
+                1. Else Phantom#2009
 
 relation V1Model_ingress: EC_0 ARCH_0 |- % % %
 
@@ -36951,7 +37083,7 @@ relation V1Model_ingress: EC_0 ARCH_0 |- % % %
 
                         1. Result in: % % |- EC_1 ARCH_1 ((return ?()) as callResult)
 
-                  1. Else Phantom#1998
+                  1. Else Phantom#2010
 
 relation V1Model_egress: EC_0 ARCH_0 |- % % %
 
@@ -36987,7 +37119,7 @@ relation V1Model_egress: EC_0 ARCH_0 |- % % %
 
                         1. Result in: % % |- EC_1 ARCH_1 ((exit) as callResult)
 
-                  1. Else Phantom#1999
+                  1. Else Phantom#2011
 
 relation V1Model_check: EC_0 ARCH_0 |- % % %
 
@@ -37021,7 +37153,7 @@ relation V1Model_check: EC_0 ARCH_0 |- % % %
 
                       1. Result in: % % |- EC_1 ARCH_1 ((exit) as callResult)
 
-                1. Else Phantom#2000
+                1. Else Phantom#2012
 
 relation V1Model_deparse: EC_0 ARCH_0 |- % % %
 
@@ -37055,7 +37187,7 @@ relation V1Model_deparse: EC_0 ARCH_0 |- % % %
 
                       1. Result in: % % |- EC_1 ARCH_1 ((exit) as callResult)
 
-                1. Else Phantom#2001
+                1. Else Phantom#2013
 
 def $field_list_annotation_index(annotationList)
 
@@ -37177,13 +37309,13 @@ def $V1Model_meta_fields_of_index(ARCH, integerLiteral_index)
 
                       1. Return (nameIR_field)*
 
-                1. Else Phantom#2002
+                1. Else Phantom#2014
 
-            1. Else Phantom#2003
+            1. Else Phantom#2015
 
-      1. Else Phantom#2004
+      1. Else Phantom#2016
 
-  1. Else Phantom#2005
+  1. Else Phantom#2017
 
 relation V1Model_copy_meta_fields: EC_capture EC_0 ARCH |- (nameIR)* : %
 
@@ -37193,7 +37325,7 @@ relation V1Model_copy_meta_fields: EC_capture EC_0 ARCH |- (nameIR)* : %
 
     1. Result in: % % % |- % : EC_0
 
-  1. Else Phantom#2006
+  1. Else Phantom#2018
 
   2. If (((nameIR)* matches pattern _ :: _)), then
 
@@ -37209,7 +37341,7 @@ relation V1Model_copy_meta_fields: EC_capture EC_0 ARCH |- (nameIR)* : %
 
               1. Result in: % % % |- % : EC_2
 
-  2. Else Phantom#2007
+  2. Else Phantom#2019
 
 relation V1Model_setup_preserved_meta_fields: EC_0 ARCH |- integerLiteral_index : %
 
@@ -37239,11 +37371,11 @@ relation V1Model_setup_preserved_meta_fields: EC_0 ARCH |- integerLiteral_index 
 
                         1. Result in: % % |- % : EC_2
 
-              1. Else Phantom#2008
+              1. Else Phantom#2020
 
-        1. Else Phantom#2009
+        1. Else Phantom#2021
 
-    1. Else Phantom#2010
+    1. Else Phantom#2022
 
 relation EBPF_init: |- p4program : % %
 
@@ -37281,9 +37413,9 @@ relation EBPF_init_packet_in: EC_0 ARCH_0 |- objectState_packet_in : % %
 
                       1. Result in: % % |- % : EC_1 ARCH_2
 
-            1. Else Phantom#2011
+            1. Else Phantom#2023
 
-        1. Else Phantom#2012
+        1. Else Phantom#2024
 
 relation EBPF_init_globals: EC_0 ARCH |- %
 
@@ -37311,11 +37443,11 @@ relation EBPF_init_globals: EC_0 ARCH |- %
 
                       1. Result in: % % |- EC_2
 
-              1. Else Phantom#2013
+              1. Else Phantom#2025
 
-        1. Else Phantom#2014
+        1. Else Phantom#2026
 
-    1. Else Phantom#2015
+    1. Else Phantom#2027
 
 def $eBPF_setup_packet_in_argument(EC)
 
@@ -37331,7 +37463,7 @@ def $eBPF_setup_packet_in_argument(EC)
 
           1. Return argumentIR_packet_in
 
-  1. Else Phantom#2016
+  1. Else Phantom#2028
 
 def $eBPF_setup_headers_argument(ARCH)
 
@@ -37355,11 +37487,11 @@ def $eBPF_setup_headers_argument(ARCH)
 
                   1. Return argumentIR_headers
 
-            1. Else Phantom#2017
+            1. Else Phantom#2029
 
-      1. Else Phantom#2018
+      1. Else Phantom#2030
 
-  1. Else Phantom#2019
+  1. Else Phantom#2031
 
 def $eBPF_setup_main_callee(EC, ARCH)
 
@@ -37391,13 +37523,13 @@ def $eBPF_setup_main_callee(EC, ARCH)
 
                           1. Return typedExpressionIR_main
 
-                  1. Else Phantom#2020
+                  1. Else Phantom#2032
 
-            1. Else Phantom#2021
+            1. Else Phantom#2033
 
-        1. Else Phantom#2022
+        1. Else Phantom#2034
 
-  1. Else Phantom#2023
+  1. Else Phantom#2035
 
 def $eBPF_setup_parse_callee(EC, ARCH, typedExpressionIR_main)
 
@@ -37429,13 +37561,13 @@ def $eBPF_setup_parse_callee(EC, ARCH, typedExpressionIR_main)
 
                           1. Return typedExpressionIR_parse
 
-                  1. Else Phantom#2024
+                  1. Else Phantom#2036
 
-            1. Else Phantom#2025
+            1. Else Phantom#2037
 
-        1. Else Phantom#2026
+        1. Else Phantom#2038
 
-  1. Else Phantom#2027
+  1. Else Phantom#2039
 
 def $eBPF_setup_filter_callee(EC, ARCH, typedExpressionIR_main)
 
@@ -37467,13 +37599,13 @@ def $eBPF_setup_filter_callee(EC, ARCH, typedExpressionIR_main)
 
                           1. Return typedExpressionIR_filter
 
-                  1. Else Phantom#2028
+                  1. Else Phantom#2040
 
-            1. Else Phantom#2029
+            1. Else Phantom#2041
 
-        1. Else Phantom#2030
+        1. Else Phantom#2042
 
-  1. Else Phantom#2031
+  1. Else Phantom#2043
 
 relation EBPF_parse: EC_0 ARCH_0 |- % % %
 
@@ -37507,7 +37639,7 @@ relation EBPF_parse: EC_0 ARCH_0 |- % % %
 
                       1. Result in: % % |- EC_1 ARCH_1 (rejectTransitionResult as transitionResult)
 
-                1. Else Phantom#2032
+                1. Else Phantom#2044
 
 relation EBPF_filter: EC_0 ARCH_0 |- % % %
 
@@ -37541,7 +37673,7 @@ relation EBPF_filter: EC_0 ARCH_0 |- % % %
 
                       1. Result in: % % |- EC_1 ARCH_1 ((exit) as callResult)
 
-                1. Else Phantom#2033
+                1. Else Phantom#2045
 
 relation PSA_init: |- p4program : % %
 
@@ -37575,11 +37707,11 @@ def $PSA_setup_normal_meta_argument(ARCH)
 
                   1. Return argumentIR_normal_meta
 
-            1. Else Phantom#2034
+            1. Else Phantom#2046
 
-      1. Else Phantom#2035
+      1. Else Phantom#2047
 
-  1. Else Phantom#2036
+  1. Else Phantom#2048
 
 def $PSA_setup_clone_i2e_meta_argument(ARCH)
 
@@ -37603,11 +37735,11 @@ def $PSA_setup_clone_i2e_meta_argument(ARCH)
 
                   1. Return argumentIR_clone_i2e_meta
 
-            1. Else Phantom#2037
+            1. Else Phantom#2049
 
-      1. Else Phantom#2038
+      1. Else Phantom#2050
 
-  1. Else Phantom#2039
+  1. Else Phantom#2051
 
 def $PSA_setup_clone_e2e_meta_argument(ARCH)
 
@@ -37631,11 +37763,11 @@ def $PSA_setup_clone_e2e_meta_argument(ARCH)
 
                   1. Return argumentIR_clone_e2e_meta
 
-            1. Else Phantom#2040
+            1. Else Phantom#2052
 
-      1. Else Phantom#2041
+      1. Else Phantom#2053
 
-  1. Else Phantom#2042
+  1. Else Phantom#2054
 
 def $PSA_setup_resubmit_meta_argument(ARCH)
 
@@ -37659,11 +37791,11 @@ def $PSA_setup_resubmit_meta_argument(ARCH)
 
                   1. Return argumentIR_resubmit_meta
 
-            1. Else Phantom#2043
+            1. Else Phantom#2055
 
-      1. Else Phantom#2044
+      1. Else Phantom#2056
 
-  1. Else Phantom#2045
+  1. Else Phantom#2057
 
 def $PSA_setup_recirculate_meta_argument(ARCH)
 
@@ -37687,11 +37819,11 @@ def $PSA_setup_recirculate_meta_argument(ARCH)
 
                   1. Return argumentIR_recirculate_meta
 
-            1. Else Phantom#2046
+            1. Else Phantom#2058
 
-      1. Else Phantom#2047
+      1. Else Phantom#2059
 
-  1. Else Phantom#2048
+  1. Else Phantom#2060
 
 def $PSA_setup_main_callee(EC, ARCH)
 
@@ -37773,29 +37905,29 @@ def $PSA_setup_main_callee(EC, ARCH)
 
                                                                             1. Return typedExpressionIR_main
 
-                                                                  1. Else Phantom#2049
+                                                                  1. Else Phantom#2061
 
-                                                            1. Else Phantom#2050
+                                                            1. Else Phantom#2062
 
-                                                      1. Else Phantom#2051
+                                                      1. Else Phantom#2063
 
-                                                1. Else Phantom#2052
+                                                1. Else Phantom#2064
 
-                                          1. Else Phantom#2053
+                                          1. Else Phantom#2065
 
-                                    1. Else Phantom#2054
+                                    1. Else Phantom#2066
 
-                              1. Else Phantom#2055
+                              1. Else Phantom#2067
 
-                        1. Else Phantom#2056
+                        1. Else Phantom#2068
 
-                  1. Else Phantom#2057
+                  1. Else Phantom#2069
 
-            1. Else Phantom#2058
+            1. Else Phantom#2070
 
-        1. Else Phantom#2059
+        1. Else Phantom#2071
 
-  1. Else Phantom#2060
+  1. Else Phantom#2072
 
 relation PSA_ingress_init_packet_in: EC_0 ARCH_0 |- objectState_packet_in : % %
 
@@ -37823,9 +37955,9 @@ relation PSA_ingress_init_packet_in: EC_0 ARCH_0 |- objectState_packet_in : % %
 
                       1. Result in: % % |- % : EC_1 ARCH_2
 
-            1. Else Phantom#2061
+            1. Else Phantom#2073
 
-        1. Else Phantom#2062
+        1. Else Phantom#2074
 
 relation PSA_ingress_init_packet_out: EC_0 ARCH_0 |- objectState_packet_out : % %
 
@@ -37853,9 +37985,9 @@ relation PSA_ingress_init_packet_out: EC_0 ARCH_0 |- objectState_packet_out : % 
 
                       1. Result in: % % |- % : EC_1 ARCH_2
 
-            1. Else Phantom#2063
+            1. Else Phantom#2075
 
-        1. Else Phantom#2064
+        1. Else Phantom#2076
 
 relation PSA_ingress_init_parser_input_metadata: EC_0 ARCH |- i_port t_path : %
 
@@ -38043,27 +38175,27 @@ relation PSA_ingress_init_globals: EC_0 ARCH |- i_port : %
 
                                                                                             1. Result in: % % |- % : EC_10
 
-                                                                                1. Else Phantom#2065
+                                                                                1. Else Phantom#2077
 
-                                                                          1. Else Phantom#2066
+                                                                          1. Else Phantom#2078
 
-                                                                    1. Else Phantom#2067
+                                                                    1. Else Phantom#2079
 
-                                                              1. Else Phantom#2068
+                                                              1. Else Phantom#2080
 
-                                                  1. Else Phantom#2069
+                                                  1. Else Phantom#2081
 
-                                        1. Else Phantom#2070
+                                        1. Else Phantom#2082
 
-                              1. Else Phantom#2071
+                              1. Else Phantom#2083
 
-                    1. Else Phantom#2072
+                    1. Else Phantom#2084
 
-              1. Else Phantom#2073
+              1. Else Phantom#2085
 
-        1. Else Phantom#2074
+        1. Else Phantom#2086
 
-    1. Else Phantom#2075
+    1. Else Phantom#2087
 
 def $PSA_setup_ingress_packet_in_argument(EC)
 
@@ -38079,7 +38211,7 @@ def $PSA_setup_ingress_packet_in_argument(EC)
 
           1. Return argumentIR_packet_in
 
-  1. Else Phantom#2076
+  1. Else Phantom#2088
 
 def $PSA_setup_ingress_packet_out_argument(EC)
 
@@ -38095,7 +38227,7 @@ def $PSA_setup_ingress_packet_out_argument(EC)
 
           1. Return argumentIR_packet_out
 
-  1. Else Phantom#2077
+  1. Else Phantom#2089
 
 def $PSA_setup_ingress_hdr_argument(ARCH)
 
@@ -38119,11 +38251,11 @@ def $PSA_setup_ingress_hdr_argument(ARCH)
 
                   1. Return argumentIR_hdr
 
-            1. Else Phantom#2078
+            1. Else Phantom#2090
 
-      1. Else Phantom#2079
+      1. Else Phantom#2091
 
-  1. Else Phantom#2080
+  1. Else Phantom#2092
 
 def $PSA_setup_ingress_user_meta_argument(ARCH)
 
@@ -38147,11 +38279,11 @@ def $PSA_setup_ingress_user_meta_argument(ARCH)
 
                   1. Return argumentIR_user_meta
 
-            1. Else Phantom#2081
+            1. Else Phantom#2093
 
-      1. Else Phantom#2082
+      1. Else Phantom#2094
 
-  1. Else Phantom#2083
+  1. Else Phantom#2095
 
 def $PSA_setup_ingress_parser_input_metadata_argument(EC)
 
@@ -38167,7 +38299,7 @@ def $PSA_setup_ingress_parser_input_metadata_argument(EC)
 
           1. Return argumentIR_parser_input_metadata
 
-  1. Else Phantom#2084
+  1. Else Phantom#2096
 
 def $PSA_setup_ingress_input_metadata_argument(EC)
 
@@ -38183,7 +38315,7 @@ def $PSA_setup_ingress_input_metadata_argument(EC)
 
           1. Return argumentIR_input_metadata
 
-  1. Else Phantom#2085
+  1. Else Phantom#2097
 
 def $PSA_setup_ingress_output_metadata_argument(EC)
 
@@ -38199,7 +38331,7 @@ def $PSA_setup_ingress_output_metadata_argument(EC)
 
           1. Return argumentIR_output_metadata
 
-  1. Else Phantom#2086
+  1. Else Phantom#2098
 
 def $PSA_setup_ingress_pipeline_callee(EC, ARCH, typedExpressionIR_main)
 
@@ -38263,23 +38395,23 @@ def $PSA_setup_ingress_pipeline_callee(EC, ARCH, typedExpressionIR_main)
 
                                                           1. Return typedExpressionIR_ingress_pipeline
 
-                                                1. Else Phantom#2087
+                                                1. Else Phantom#2099
 
-                                          1. Else Phantom#2088
+                                          1. Else Phantom#2100
 
-                                    1. Else Phantom#2089
+                                    1. Else Phantom#2101
 
-                              1. Else Phantom#2090
+                              1. Else Phantom#2102
 
-                        1. Else Phantom#2091
+                        1. Else Phantom#2103
 
-                  1. Else Phantom#2092
+                  1. Else Phantom#2104
 
-            1. Else Phantom#2093
+            1. Else Phantom#2105
 
-        1. Else Phantom#2094
+        1. Else Phantom#2106
 
-  1. Else Phantom#2095
+  1. Else Phantom#2107
 
 def $PSA_setup_ingress_parser_callee(EC, ARCH, typedExpressionIR_ingress_pipeline)
 
@@ -38331,19 +38463,19 @@ def $PSA_setup_ingress_parser_callee(EC, ARCH, typedExpressionIR_ingress_pipelin
 
                                               1. Return typedExpressionIR_ingress_parser
 
-                                    1. Else Phantom#2096
+                                    1. Else Phantom#2108
 
-                              1. Else Phantom#2097
+                              1. Else Phantom#2109
 
-                        1. Else Phantom#2098
+                        1. Else Phantom#2110
 
-                  1. Else Phantom#2099
+                  1. Else Phantom#2111
 
-            1. Else Phantom#2100
+            1. Else Phantom#2112
 
-        1. Else Phantom#2101
+        1. Else Phantom#2113
 
-  1. Else Phantom#2102
+  1. Else Phantom#2114
 
 def $PSA_setup_ingress_callee(EC, ARCH, typedExpressionIR_ingress_pipeline)
 
@@ -38383,15 +38515,15 @@ def $PSA_setup_ingress_callee(EC, ARCH, typedExpressionIR_ingress_pipeline)
 
                                   1. Return typedExpressionIR_ingress
 
-                        1. Else Phantom#2103
+                        1. Else Phantom#2115
 
-                  1. Else Phantom#2104
+                  1. Else Phantom#2116
 
-            1. Else Phantom#2105
+            1. Else Phantom#2117
 
-        1. Else Phantom#2106
+        1. Else Phantom#2118
 
-  1. Else Phantom#2107
+  1. Else Phantom#2119
 
 def $PSA_setup_ingress_deparser_callee(EC, ARCH, typedExpressionIR_ingress_pipeline)
 
@@ -38449,21 +38581,21 @@ def $PSA_setup_ingress_deparser_callee(EC, ARCH, typedExpressionIR_ingress_pipel
 
                                                     1. Return typedExpressionIR_ingress_deparser
 
-                                          1. Else Phantom#2108
+                                          1. Else Phantom#2120
 
-                                    1. Else Phantom#2109
+                                    1. Else Phantom#2121
 
-                              1. Else Phantom#2110
+                              1. Else Phantom#2122
 
-                        1. Else Phantom#2111
+                        1. Else Phantom#2123
 
-                  1. Else Phantom#2112
+                  1. Else Phantom#2124
 
-            1. Else Phantom#2113
+            1. Else Phantom#2125
 
-        1. Else Phantom#2114
+        1. Else Phantom#2126
 
-  1. Else Phantom#2115
+  1. Else Phantom#2127
 
 relation PSA_ingress_parser: EC_0 ARCH_0 |- % % %
 
@@ -38507,7 +38639,7 @@ relation PSA_ingress_parser: EC_0 ARCH_0 |- % % %
 
                                 1. Result in: % % |- EC_1 ARCH_1 (rejectTransitionResult as transitionResult)
 
-                          1. Else Phantom#2116
+                          1. Else Phantom#2128
 
 relation PSA_ingress: EC_0 ARCH_0 |- % % %
 
@@ -38547,7 +38679,7 @@ relation PSA_ingress: EC_0 ARCH_0 |- % % %
 
                             1. Result in: % % |- EC_1 ARCH_1 ((return ?()) as callResult)
 
-                      1. Else Phantom#2117
+                      1. Else Phantom#2129
 
 relation PSA_ingress_deparser: EC_0 ARCH_0 |- % % %
 
@@ -38593,7 +38725,7 @@ relation PSA_ingress_deparser: EC_0 ARCH_0 |- % % %
 
                                   1. Result in: % % |- EC_1 ARCH_1 ((exit) as callResult)
 
-                            1. Else Phantom#2118
+                            1. Else Phantom#2130
 
 relation PSA_egress_init_packet_in: EC_0 ARCH_0 |- objectState_packet_in : % %
 
@@ -38621,9 +38753,9 @@ relation PSA_egress_init_packet_in: EC_0 ARCH_0 |- objectState_packet_in : % %
 
                       1. Result in: % % |- % : EC_1 ARCH_2
 
-            1. Else Phantom#2119
+            1. Else Phantom#2131
 
-        1. Else Phantom#2120
+        1. Else Phantom#2132
 
 relation PSA_egress_init_packet_out: EC_0 ARCH_0 |- objectState_packet_out : % %
 
@@ -38651,9 +38783,9 @@ relation PSA_egress_init_packet_out: EC_0 ARCH_0 |- objectState_packet_out : % %
 
                       1. Result in: % % |- % : EC_1 ARCH_2
 
-            1. Else Phantom#2121
+            1. Else Phantom#2133
 
-        1. Else Phantom#2122
+        1. Else Phantom#2134
 
 relation PSA_egress_init_parser_input_metadata: EC_0 ARCH |- i_port t_path : %
 
@@ -38845,25 +38977,25 @@ relation PSA_egress_init_globals: EC_0 ARCH |- i_port : %
 
                                                                                         1. Result in: % % |- % : EC_8
 
-                                                                                  1. Else Phantom#2123
+                                                                                  1. Else Phantom#2135
 
-                                                                        1. Else Phantom#2124
+                                                                        1. Else Phantom#2136
 
-                                                            1. Else Phantom#2125
+                                                            1. Else Phantom#2137
 
-                                                  1. Else Phantom#2126
+                                                  1. Else Phantom#2138
 
-                                        1. Else Phantom#2127
+                                        1. Else Phantom#2139
 
-                              1. Else Phantom#2128
+                              1. Else Phantom#2140
 
-                    1. Else Phantom#2129
+                    1. Else Phantom#2141
 
-              1. Else Phantom#2130
+              1. Else Phantom#2142
 
-        1. Else Phantom#2131
+        1. Else Phantom#2143
 
-    1. Else Phantom#2132
+    1. Else Phantom#2144
 
 def $PSA_setup_egress_packet_in_argument(EC)
 
@@ -38879,7 +39011,7 @@ def $PSA_setup_egress_packet_in_argument(EC)
 
           1. Return argumentIR_packet_in
 
-  1. Else Phantom#2133
+  1. Else Phantom#2145
 
 def $PSA_setup_egress_packet_out_argument(EC)
 
@@ -38895,7 +39027,7 @@ def $PSA_setup_egress_packet_out_argument(EC)
 
           1. Return argumentIR_packet_out
 
-  1. Else Phantom#2134
+  1. Else Phantom#2146
 
 def $PSA_setup_egress_hdr_argument(ARCH)
 
@@ -38919,11 +39051,11 @@ def $PSA_setup_egress_hdr_argument(ARCH)
 
                   1. Return argumentIR_hdr
 
-            1. Else Phantom#2135
+            1. Else Phantom#2147
 
-      1. Else Phantom#2136
+      1. Else Phantom#2148
 
-  1. Else Phantom#2137
+  1. Else Phantom#2149
 
 def $PSA_setup_egress_user_meta_argument(ARCH)
 
@@ -38947,11 +39079,11 @@ def $PSA_setup_egress_user_meta_argument(ARCH)
 
                   1. Return argumentIR_user_meta
 
-            1. Else Phantom#2138
+            1. Else Phantom#2150
 
-      1. Else Phantom#2139
+      1. Else Phantom#2151
 
-  1. Else Phantom#2140
+  1. Else Phantom#2152
 
 def $PSA_setup_egress_parser_input_metadata_argument(EC)
 
@@ -38967,7 +39099,7 @@ def $PSA_setup_egress_parser_input_metadata_argument(EC)
 
           1. Return argumentIR_parser_input_metadata
 
-  1. Else Phantom#2141
+  1. Else Phantom#2153
 
 def $PSA_setup_egress_input_metadata_argument(EC)
 
@@ -38983,7 +39115,7 @@ def $PSA_setup_egress_input_metadata_argument(EC)
 
           1. Return argumentIR_input_metadata
 
-  1. Else Phantom#2142
+  1. Else Phantom#2154
 
 def $PSA_setup_egress_output_metadata_argument(EC)
 
@@ -38999,7 +39131,7 @@ def $PSA_setup_egress_output_metadata_argument(EC)
 
           1. Return argumentIR_output_metadata
 
-  1. Else Phantom#2143
+  1. Else Phantom#2155
 
 def $PSA_setup_egress_deparser_input_metadata_argument(EC)
 
@@ -39015,7 +39147,7 @@ def $PSA_setup_egress_deparser_input_metadata_argument(EC)
 
           1. Return argumentIR_deparser_input_metadata
 
-  1. Else Phantom#2144
+  1. Else Phantom#2156
 
 def $PSA_setup_egress_pipeline_callee(EC, ARCH, typedExpressionIR_main)
 
@@ -39079,23 +39211,23 @@ def $PSA_setup_egress_pipeline_callee(EC, ARCH, typedExpressionIR_main)
 
                                                           1. Return typedExpressionIR_egress_pipeline
 
-                                                1. Else Phantom#2145
+                                                1. Else Phantom#2157
 
-                                          1. Else Phantom#2146
+                                          1. Else Phantom#2158
 
-                                    1. Else Phantom#2147
+                                    1. Else Phantom#2159
 
-                              1. Else Phantom#2148
+                              1. Else Phantom#2160
 
-                        1. Else Phantom#2149
+                        1. Else Phantom#2161
 
-                  1. Else Phantom#2150
+                  1. Else Phantom#2162
 
-            1. Else Phantom#2151
+            1. Else Phantom#2163
 
-        1. Else Phantom#2152
+        1. Else Phantom#2164
 
-  1. Else Phantom#2153
+  1. Else Phantom#2165
 
 def $PSA_setup_egress_parser_callee(EC, ARCH, typedExpressionIR_egress_pipeline)
 
@@ -39153,21 +39285,21 @@ def $PSA_setup_egress_parser_callee(EC, ARCH, typedExpressionIR_egress_pipeline)
 
                                                     1. Return typedExpressionIR_egress_parser
 
-                                          1. Else Phantom#2154
+                                          1. Else Phantom#2166
 
-                                    1. Else Phantom#2155
+                                    1. Else Phantom#2167
 
-                              1. Else Phantom#2156
+                              1. Else Phantom#2168
 
-                        1. Else Phantom#2157
+                        1. Else Phantom#2169
 
-                  1. Else Phantom#2158
+                  1. Else Phantom#2170
 
-            1. Else Phantom#2159
+            1. Else Phantom#2171
 
-        1. Else Phantom#2160
+        1. Else Phantom#2172
 
-  1. Else Phantom#2161
+  1. Else Phantom#2173
 
 def $PSA_setup_egress_callee(EC, ARCH, typedExpressionIR_egress_pipeline)
 
@@ -39207,15 +39339,15 @@ def $PSA_setup_egress_callee(EC, ARCH, typedExpressionIR_egress_pipeline)
 
                                   1. Return typedExpressionIR_egress
 
-                        1. Else Phantom#2162
+                        1. Else Phantom#2174
 
-                  1. Else Phantom#2163
+                  1. Else Phantom#2175
 
-            1. Else Phantom#2164
+            1. Else Phantom#2176
 
-        1. Else Phantom#2165
+        1. Else Phantom#2177
 
-  1. Else Phantom#2166
+  1. Else Phantom#2178
 
 def $PSA_setup_egress_deparser_callee(EC, ARCH, typedExpressionIR_egress_pipeline)
 
@@ -39267,19 +39399,19 @@ def $PSA_setup_egress_deparser_callee(EC, ARCH, typedExpressionIR_egress_pipelin
 
                                               1. Return typedExpressionIR_egress_deparser
 
-                                    1. Else Phantom#2167
+                                    1. Else Phantom#2179
 
-                              1. Else Phantom#2168
+                              1. Else Phantom#2180
 
-                        1. Else Phantom#2169
+                        1. Else Phantom#2181
 
-                  1. Else Phantom#2170
+                  1. Else Phantom#2182
 
-            1. Else Phantom#2171
+            1. Else Phantom#2183
 
-        1. Else Phantom#2172
+        1. Else Phantom#2184
 
-  1. Else Phantom#2173
+  1. Else Phantom#2185
 
 relation PSA_egress_parser: EC_0 ARCH_0 |- % % %
 
@@ -39325,7 +39457,7 @@ relation PSA_egress_parser: EC_0 ARCH_0 |- % % %
 
                                   1. Result in: % % |- EC_1 ARCH_1 (rejectTransitionResult as transitionResult)
 
-                            1. Else Phantom#2174
+                            1. Else Phantom#2186
 
 relation PSA_egress: EC_0 ARCH_0 |- % % %
 
@@ -39365,7 +39497,7 @@ relation PSA_egress: EC_0 ARCH_0 |- % % %
 
                             1. Result in: % % |- EC_1 ARCH_1 ((return ?()) as callResult)
 
-                      1. Else Phantom#2175
+                      1. Else Phantom#2187
 
 relation PSA_egress_deparser: EC_0 ARCH_0 |- % % %
 
@@ -39411,4 +39543,4 @@ relation PSA_egress_deparser: EC_0 ARCH_0 |- % % %
 
                                   1. Result in: % % |- EC_1 ARCH_1 ((exit) as callResult)
 
-                            1. Else Phantom#2176
+                            1. Else Phantom#2188

--- a/p4spec/test/run/dune
+++ b/p4spec/test/run/dune
@@ -107,9 +107,7 @@
      -e
      ../../../../../excludes/static
      -p4-dir
-     ../../../../../p4c/testdata/p4_16_samples
-     -p4-dir
-     ../../../../../testdata/custom)))))
+     ../../../../../p4c/testdata/p4_16_samples)))))
 
 (rule
  (target run_neg_il.actual)
@@ -154,9 +152,7 @@
      -e
      ../../../../../excludes/static
      -p4-dir
-     ../../../../../p4c/testdata/p4_16_samples
-     -p4-dir
-     ../../../../../testdata/custom)))))
+     ../../../../../p4c/testdata/p4_16_samples)))))
 
 (rule
  (target run_neg_sl.actual)
@@ -204,9 +200,7 @@
      -e
      ../../../../../excludes/static
      -p4-dir
-     ../../../../../p4c/testdata/p4_16_samples
-     -p4-dir
-     ../../../../../testdata/custom)))))
+     ../../../../../p4c/testdata/p4_16_samples)))))
 
 (rule
  (target run_neg_il_det.actual)
@@ -253,9 +247,7 @@
      -e
      ../../../../../excludes/static
      -p4-dir
-     ../../../../../p4c/testdata/p4_16_samples
-     -p4-dir
-     ../../../../../testdata/custom)))))
+     ../../../../../p4c/testdata/p4_16_samples)))))
 
 (rule
  (target run_neg_sl_det.actual)

--- a/p4spec/test/run/run_neg_il.expected
+++ b/p4spec/test/run/run_neg_il.expected
@@ -1693,4 +1693,6 @@ Excluding file: ../../../../../p4c/testdata/p4_16_errors/width_e.p4
 >>> Running interpreter test (Program_ok) on ../../../../../p4c/testdata/p4_16_errors/wrong-cast.p4
 Error on run: ../../../../../p4c/testdata/p4_16_errors/wrong-cast.p4
 
-Running interpreter test (Program_ok): [EXCLUDE] 46/564 (8.16%) [PASS] 0/564 (0.00%) [FAIL] 518/564 (91.84%)
+Running interpreter test (Program_ok): [EXCLUDE] 46/564 (8.16%) [PASS] 0/564 (0.00%) [FAIL] 518/564 (91.84%) [PATCH] 0/564 (0.00%)
+
+Running interpreter test (Program_ok): [PATCH]: [EXCLUDE] 0/0 (0.00%) [PASS] 0/0 (0.00%) [FAIL] 0/0 (0.00%)

--- a/p4spec/test/run/run_pos_il.expected
+++ b/p4spec/test/run/run_pos_il.expected
@@ -1,4 +1,4 @@
-Running interpreter test (Program_inst) on 1312 files
+Running interpreter test (Program_inst) on 1307 files
 
 
 >>> Running interpreter test (Program_inst) on ../../../../../p4c/testdata/p4_16_samples/action-bind.p4
@@ -3922,19 +3922,6 @@ Run success: ../../../../../p4c/testdata/p4_16_samples/xdp_vlan_push_pop_ebpf-ke
 >>> Running interpreter test (Program_inst) on ../../../../../p4c/testdata/p4_16_samples/xor_test.p4
 Run success: ../../../../../p4c/testdata/p4_16_samples/xor_test.p4
 
->>> Running interpreter test (Program_inst) on ../../../../../testdata/custom/for-in-loop-return.p4
-Run success: ../../../../../testdata/custom/for-in-loop-return.p4
+Running interpreter test (Program_inst): [EXCLUDE] 92/1307 (7.04%) [PASS] 1215/1307 (92.96%) [FAIL] 0/1307 (0.00%) [PATCH] 0/1307 (0.00%)
 
->>> Running interpreter test (Program_inst) on ../../../../../testdata/custom/for-in.p4
-Run success: ../../../../../testdata/custom/for-in.p4
-
->>> Running interpreter test (Program_inst) on ../../../../../testdata/custom/for-loop-break.p4
-Run success: ../../../../../testdata/custom/for-loop-break.p4
-
->>> Running interpreter test (Program_inst) on ../../../../../testdata/custom/for-loop-exit.p4
-Run success: ../../../../../testdata/custom/for-loop-exit.p4
-
->>> Running interpreter test (Program_inst) on ../../../../../testdata/custom/for-update-exit.p4
-Run success: ../../../../../testdata/custom/for-update-exit.p4
-
-Running interpreter test (Program_inst): [EXCLUDE] 92/1312 (7.01%) [PASS] 1220/1312 (92.99%) [FAIL] 0/1312 (0.00%)
+Running interpreter test (Program_inst): [PATCH]: [EXCLUDE] 0/0 (0.00%) [PASS] 0/0 (0.00%) [FAIL] 0/0 (0.00%)

--- a/p4spec/test/run/run_pos_sl.expected
+++ b/p4spec/test/run/run_pos_sl.expected
@@ -1,4 +1,4 @@
-Running interpreter test (Program_inst) on 1312 files
+Running interpreter test (Program_inst) on 1307 files
 
 
 >>> Running interpreter test (Program_inst) on ../../../../../p4c/testdata/p4_16_samples/action-bind.p4
@@ -3922,21 +3922,6 @@ Run success: ../../../../../p4c/testdata/p4_16_samples/xdp_vlan_push_pop_ebpf-ke
 >>> Running interpreter test (Program_inst) on ../../../../../p4c/testdata/p4_16_samples/xor_test.p4
 Run success: ../../../../../p4c/testdata/p4_16_samples/xor_test.p4
 
->>> Running interpreter test (Program_inst) on ../../../../../testdata/custom/for-in-loop-return.p4
-Run success: ../../../../../testdata/custom/for-in-loop-return.p4
-
->>> Running interpreter test (Program_inst) on ../../../../../testdata/custom/for-in.p4
-Run success: ../../../../../testdata/custom/for-in.p4
-
->>> Running interpreter test (Program_inst) on ../../../../../testdata/custom/for-loop-break.p4
-Run success: ../../../../../testdata/custom/for-loop-break.p4
-
->>> Running interpreter test (Program_inst) on ../../../../../testdata/custom/for-loop-exit.p4
-Run success: ../../../../../testdata/custom/for-loop-exit.p4
-
->>> Running interpreter test (Program_inst) on ../../../../../testdata/custom/for-update-exit.p4
-Run success: ../../../../../testdata/custom/for-update-exit.p4
-
-Running interpreter test (Program_inst): [EXCLUDE] 92/1312 (7.01%) [PASS] 1220/1312 (92.99%) [FAIL] 0/1312 (0.00%) [PATCH] 0/1312 (0.00%)
+Running interpreter test (Program_inst): [EXCLUDE] 92/1307 (7.04%) [PASS] 1215/1307 (92.96%) [FAIL] 0/1307 (0.00%) [PATCH] 0/1307 (0.00%)
 
 Running interpreter test (Program_inst): [PATCH]: [EXCLUDE] 0/0 (0.00%) [PASS] 0/0 (0.00%) [FAIL] 0/0 (0.00%)

--- a/p4spec/test/sim/sim_ebpf_p4c_il.expected
+++ b/p4spec/test/sim/sim_ebpf_p4c_il.expected
@@ -43,7 +43,8 @@ Run success: ../../../../../patches/ebpf/hit_ebpf.stf
 Run success: ../../../../../patches/ebpf/issue870_ebpf.stf
 
 >>> Running simulation test (ebpf) on ../../../../../patches/ebpf/key-issue-1020_ebpf.p4 with packet input ../../../../../patches/ebpf/key-issue-1020_ebpf.stf
-Error on run: ../../../../../patches/ebpf/key-issue-1020_ebpf.stf
+[PASS] Transmitted (0) 001B17000130B88198B7AEB70800450000344A6F4000400653920A0198453212C86ACF2C01BBD0FA585C4CCCB2AC80100353C31400000101080A0192463911A0C06F
+Run success: ../../../../../patches/ebpf/key-issue-1020_ebpf.stf
 
 >>> Running simulation test (ebpf) on ../../../../../p4c/testdata/p4_16_samples/key_ebpf.p4 with packet input ../../../../../patches/ebpf/key_ebpf.stf
 [PASS] Transmitted (0) 001B17000130B88198B7AEB70800450000344A6F4000400653920A0198453212C86ACF2C01BBD0FA585C4CCCB2AC80100353C31400000101080A0192463911A0C06F
@@ -121,4 +122,9 @@ Run success: ../../../../../p4c/testdata/p4_16_samples/valid_ebpf.stf
 [PASS] Transmitted (0) 0100000000000000000000000000000000000000ABCDEF01
 Run success: ../../../../../p4c/testdata/p4_16_samples/verify_ebpf.stf
 
-Running simulation test (ebpf): [EXCLUDE] 2/17 (11.76%) [PASS] 14/17 (82.35%) [FAIL] 1/17 (5.88%)
+Running simulation test (ebpf): [EXCLUDE] 2/17 (11.76%) [PASS] 15/17 (88.24%) [FAIL] 0/17 (0.00%) [PATCH] 9/17 (52.94%)
+
+Running simulation test (ebpf): [PATCH]: [EXCLUDE] 0/9 (0.00%) [PASS] 9/9 (100.00%) [FAIL] 0/9 (0.00%)
+
+Running simulation test (ebpf) [EXCLUDE by subdir]:
+  dynamic/p4c-specific: 2

--- a/p4spec/test/sim/sim_ebpf_p4testgen_il.expected
+++ b/p4spec/test/sim/sim_ebpf_p4testgen_il.expected
@@ -477,4 +477,10 @@ Run success: ../../../../../testdata/p4testgen/verify_ebpf/verify_ebpf_1.stf
 >>> Running simulation test (ebpf) on ../../../../../p4c/testdata/p4_16_samples/verify_ebpf.p4 with packet input ../../../../../testdata/p4testgen/verify_ebpf/verify_ebpf_2.stf
 Run success: ../../../../../testdata/p4testgen/verify_ebpf/verify_ebpf_2.stf
 
-Running simulation test (ebpf): [EXCLUDE] 10/144 (6.94%) [PASS] 134/144 (93.06%) [FAIL] 0/144 (0.00%)
+Running simulation test (ebpf): [EXCLUDE] 10/144 (6.94%) [PASS] 134/144 (93.06%) [FAIL] 0/144 (0.00%) [PATCH] 6/144 (4.17%)
+
+Running simulation test (ebpf): [PATCH]: [EXCLUDE] 0/6 (0.00%) [PASS] 6/6 (100.00%) [FAIL] 0/6 (0.00%)
+
+Running simulation test (ebpf) [EXCLUDE by subdir]:
+  dynamic/p4c: 3
+  dynamic/p4c-specific: 7

--- a/p4spec/test/sim/sim_psa_p4c_il.expected
+++ b/p4spec/test/sim/sim_psa_p4c_il.expected
@@ -194,4 +194,10 @@ Run success: ../../../../../p4c/testdata/p4_16_samples/psa-unicast-or-drop-bmv2.
 [PASS] Transmitted (3) 000000000003000000000000FFFF
 Run success: ../../../../../p4c/testdata/p4_16_samples/psa-unicast-or-drop-corrected-bmv2.stf
 
-Running simulation test (psa): [EXCLUDE] 2/26 (7.69%) [PASS] 24/26 (92.31%) [FAIL] 0/26 (0.00%)
+Running simulation test (psa): [EXCLUDE] 2/26 (7.69%) [PASS] 24/26 (92.31%) [FAIL] 0/26 (0.00%) [PATCH] 3/26 (11.54%)
+
+Running simulation test (psa): [PATCH]: [EXCLUDE] 0/3 (0.00%) [PASS] 3/3 (100.00%) [FAIL] 0/3 (0.00%)
+
+Running simulation test (psa) [EXCLUDE by subdir]:
+  dynamic/p4c-specific: 1
+  static/p4-spec: 1

--- a/p4spec/test/sim/sim_v1model_custom_il.expected
+++ b/p4spec/test/sim/sim_v1model_custom_il.expected
@@ -27,4 +27,6 @@ Run success: ../../../../../testdata/custom/for-loop-exit.stf
 [PASS] Transmitted (0) 0000000000
 Run success: ../../../../../testdata/custom/for-update-exit.stf
 
-Running simulation test (v1model): [EXCLUDE] 0/5 (0.00%) [PASS] 5/5 (100.00%) [FAIL] 0/5 (0.00%)
+Running simulation test (v1model): [EXCLUDE] 0/5 (0.00%) [PASS] 5/5 (100.00%) [FAIL] 0/5 (0.00%) [PATCH] 0/5 (0.00%)
+
+Running simulation test (v1model): [PATCH]: [EXCLUDE] 0/0 (0.00%) [PASS] 0/0 (0.00%) [FAIL] 0/0 (0.00%)

--- a/p4spec/test/sim/sim_v1model_p4c_il.expected
+++ b/p4spec/test/sim/sim_v1model_p4c_il.expected
@@ -1179,4 +1179,12 @@ Run success: ../../../../../p4c/testdata/p4_16_samples/v1model-const-entries-bmv
 [PASS] Transmitted (8) 525400123502001122330C5508004500001C0001000040118BBD0A00020FE101020316A100500008F9D9
 Run success: ../../../../../patches/v1model/v1model-special-ops-bmv2.stf
 
-Running simulation test (v1model): [EXCLUDE] 8/203 (3.94%) [PASS] 195/203 (96.06%) [FAIL] 0/203 (0.00%)
+Running simulation test (v1model): [EXCLUDE] 8/203 (3.94%) [PASS] 195/203 (96.06%) [FAIL] 0/203 (0.00%) [PATCH] 5/203 (2.46%)
+
+Running simulation test (v1model): [PATCH]: [EXCLUDE] 0/5 (0.00%) [PASS] 5/5 (100.00%) [FAIL] 0/5 (0.00%)
+
+Running simulation test (v1model) [EXCLUDE by subdir]:
+  dynamic/p4c-specific: 2
+  static/future: 2
+  static/p4-spec: 3
+  static/p4c: 1

--- a/p4spec/test/sim/sim_v1model_p4testgen_il.expected
+++ b/p4spec/test/sim/sim_v1model_p4testgen_il.expected
@@ -42,13 +42,16 @@ Run success: ../../../../../testdata/p4testgen/actions-almost-duplicate-names1/a
 Run success: ../../../../../testdata/p4testgen/actions-almost-duplicate-names1/actions-almost-duplicate-names1_2.stf
 
 >>> Running simulation test (v1model) on ../../../../../p4c/testdata/p4_16_samples/actions-almost-duplicate-names1.p4 with packet input ../../../../../testdata/p4testgen/actions-almost-duplicate-names1/actions-almost-duplicate-names1_3.stf
-Error on run: ../../../../../testdata/p4testgen/actions-almost-duplicate-names1/actions-almost-duplicate-names1_3.stf
+[PASS] Transmitted (0) 000000000000000000000000000000000000000000
+Run success: ../../../../../testdata/p4testgen/actions-almost-duplicate-names1/actions-almost-duplicate-names1_3.stf
 
 >>> Running simulation test (v1model) on ../../../../../p4c/testdata/p4_16_samples/actions-almost-duplicate-names1.p4 with packet input ../../../../../testdata/p4testgen/actions-almost-duplicate-names1/actions-almost-duplicate-names1_4.stf
-Error on run: ../../../../../testdata/p4testgen/actions-almost-duplicate-names1/actions-almost-duplicate-names1_4.stf
+[PASS] Transmitted (0) 000000000000000000000000000000000000000000
+Run success: ../../../../../testdata/p4testgen/actions-almost-duplicate-names1/actions-almost-duplicate-names1_4.stf
 
 >>> Running simulation test (v1model) on ../../../../../p4c/testdata/p4_16_samples/actions-almost-duplicate-names1.p4 with packet input ../../../../../testdata/p4testgen/actions-almost-duplicate-names1/actions-almost-duplicate-names1_5.stf
-Error on run: ../../../../../testdata/p4testgen/actions-almost-duplicate-names1/actions-almost-duplicate-names1_5.stf
+[PASS] Transmitted (0) 000000000000000000000000000000000000000000
+Run success: ../../../../../testdata/p4testgen/actions-almost-duplicate-names1/actions-almost-duplicate-names1_5.stf
 
 >>> Running simulation test (v1model) on ../../../../../p4c/testdata/p4_16_samples/actions-almost-duplicate-names1.p4 with packet input ../../../../../testdata/p4testgen/actions-almost-duplicate-names1/actions-almost-duplicate-names1_6.stf
 [PASS] Transmitted (0) 000000000000000000000000000000000000000000
@@ -8096,4 +8099,14 @@ Run success: ../../../../../testdata/p4testgen/xor_test/xor_test_8.stf
 [PASS] Transmitted (0) 0000000000
 Run success: ../../../../../testdata/p4testgen/xor_test/xor_test_9.stf
 
-Running simulation test (v1model): [EXCLUDE] 131/1982 (6.61%) [PASS] 1830/1982 (92.33%) [FAIL] 21/1982 (1.06%)
+Running simulation test (v1model): [EXCLUDE] 131/1982 (6.61%) [PASS] 1833/1982 (92.48%) [FAIL] 18/1982 (0.91%) [PATCH] 11/1982 (0.55%)
+
+Running simulation test (v1model): [PATCH]: [EXCLUDE] 0/11 (0.00%) [PASS] 11/11 (100.00%) [FAIL] 0/11 (0.00%)
+
+Running simulation test (v1model) [EXCLUDE by subdir]:
+  dynamic/p4c: 5
+  dynamic/p4c-specific: 24
+  static/future: 16
+  static/p4-spec: 25
+  static/p4c: 29
+  static/p4c-specific: 32

--- a/p4spec/test/sim/sim_v1model_p4testgen_sl.expected
+++ b/p4spec/test/sim/sim_v1model_p4testgen_sl.expected
@@ -42,13 +42,16 @@ Run success: ../../../../../testdata/p4testgen/actions-almost-duplicate-names1/a
 Run success: ../../../../../testdata/p4testgen/actions-almost-duplicate-names1/actions-almost-duplicate-names1_2.stf
 
 >>> Running simulation test (v1model) on ../../../../../p4c/testdata/p4_16_samples/actions-almost-duplicate-names1.p4 with packet input ../../../../../testdata/p4testgen/actions-almost-duplicate-names1/actions-almost-duplicate-names1_3.stf
-Error on run: ../../../../../testdata/p4testgen/actions-almost-duplicate-names1/actions-almost-duplicate-names1_3.stf
+[PASS] Transmitted (0) 000000000000000000000000000000000000000000
+Run success: ../../../../../testdata/p4testgen/actions-almost-duplicate-names1/actions-almost-duplicate-names1_3.stf
 
 >>> Running simulation test (v1model) on ../../../../../p4c/testdata/p4_16_samples/actions-almost-duplicate-names1.p4 with packet input ../../../../../testdata/p4testgen/actions-almost-duplicate-names1/actions-almost-duplicate-names1_4.stf
-Error on run: ../../../../../testdata/p4testgen/actions-almost-duplicate-names1/actions-almost-duplicate-names1_4.stf
+[PASS] Transmitted (0) 000000000000000000000000000000000000000000
+Run success: ../../../../../testdata/p4testgen/actions-almost-duplicate-names1/actions-almost-duplicate-names1_4.stf
 
 >>> Running simulation test (v1model) on ../../../../../p4c/testdata/p4_16_samples/actions-almost-duplicate-names1.p4 with packet input ../../../../../testdata/p4testgen/actions-almost-duplicate-names1/actions-almost-duplicate-names1_5.stf
-Error on run: ../../../../../testdata/p4testgen/actions-almost-duplicate-names1/actions-almost-duplicate-names1_5.stf
+[PASS] Transmitted (0) 000000000000000000000000000000000000000000
+Run success: ../../../../../testdata/p4testgen/actions-almost-duplicate-names1/actions-almost-duplicate-names1_5.stf
 
 >>> Running simulation test (v1model) on ../../../../../p4c/testdata/p4_16_samples/actions-almost-duplicate-names1.p4 with packet input ../../../../../testdata/p4testgen/actions-almost-duplicate-names1/actions-almost-duplicate-names1_6.stf
 [PASS] Transmitted (0) 000000000000000000000000000000000000000000
@@ -8096,7 +8099,7 @@ Run success: ../../../../../testdata/p4testgen/xor_test/xor_test_8.stf
 [PASS] Transmitted (0) 0000000000
 Run success: ../../../../../testdata/p4testgen/xor_test/xor_test_9.stf
 
-Running simulation test (v1model): [EXCLUDE] 131/1982 (6.61%) [PASS] 1830/1982 (92.33%) [FAIL] 21/1982 (1.06%) [PATCH] 11/1982 (0.55%)
+Running simulation test (v1model): [EXCLUDE] 131/1982 (6.61%) [PASS] 1833/1982 (92.48%) [FAIL] 18/1982 (0.91%) [PATCH] 11/1982 (0.55%)
 
 Running simulation test (v1model): [PATCH]: [EXCLUDE] 0/11 (0.00%) [PASS] 11/11 (100.00%) [FAIL] 0/11 (0.00%)
 

--- a/patches/v1model/issue298-bmv2/issue298-bmv2_1.stf
+++ b/patches/v1model/issue298-bmv2/issue298-bmv2_1.stf
@@ -1,3 +1,75 @@
-setdefault "main.ig.round_tbl" "read_round"()
-add "main.eg.drop_tbl" "meta.local_metadata.set_drop":0x0 "_drop"()
+# p4testgen seed: none
+# Date generated: 2026-02-19-08:35:23.878
+# Current node coverage: 0
+# Traces
+# [P4Testgen MethodCall]: *.copy_in("TopParser");
+# [Parser] TopParser
+# [State] start
+# [MethodCall]: b.extract<ethernet_t>(p.ethernet);
+# [ExtractSuccess] p.ethernet@0 | Condition: |*packetLen_bits(bit<32>)| >= 112; | Extract Size: 112 -> p.ethernet.dstAddr = 0x0000_0000_0000 | p.ethernet.srcAddr = 0x0000_0000_0000 | p.ethernet.etherType = 0x0800
+# [State] parse_ipv4
+# [MethodCall]: b.extract<ipv4_t>(p.ipv4);
+# [ExtractSuccess] p.ipv4@112 | Condition: |*packetLen_bits(bit<32>)| >= 272; | Extract Size: 160 -> p.ipv4.version = 0x0 | p.ipv4.ihl = 0x0 | p.ipv4.diffserv = 0x00 | p.ipv4.totalLen = 0x0000 | p.ipv4.identification = 0x0000 | p.ipv4.flags = 0x0 | p.ipv4.fragOffset = 0x0000 | p.ipv4.ttl = 0x00 | p.ipv4.protocol = 0x11 | p.ipv4.hdrChecksum = 0x0000 | p.ipv4.srcAddr = 0x0000_0000 | p.ipv4.dstAddr = 0x0000_0000
+# [State] parse_udp
+# [MethodCall]: b.extract<udp_t>(p.udp);
+# [ExtractSuccess] p.udp@272 | Condition: |*packetLen_bits(bit<32>)| >= 336; | Extract Size: 64 -> p.udp.srcPort = 0x0000 | p.udp.dstPort = 0x8888 | p.udp.length_ = 0x0000 | p.udp.checksum = 0x0000
+# [State] parse_myhdr
+# [MethodCall]: b.extract<myhdr_t>(p.myhdr);
+# [ExtractSuccess] p.myhdr@336 | Condition: |*packetLen_bits(bit<32>)| >= 400; | Extract Size: 64 -> p.myhdr.msgtype = 0x0000 | p.myhdr.inst = 0x0000_0000 | p.myhdr.rnd = 0x0000
+# [State] accept
+# [P4Testgen MethodCall]: *.copy_out("TopParser");
+# [P4Testgen MethodCall]: *.copy_in("verifyChecksum");
+# [Control verifyChecksum start]
+# [MethodCall]: verify_checksum<tuple_0, bit<16>>(hdr.ipv4.isValid(), {  f0:hdr.ipv4.version;  f1:hdr.ipv4.ihl;  f2:hdr.ipv4.diffserv;  f3:hdr.ipv4.totalLen;  f4:hdr.ipv4.identification;  f5:hdr.ipv4.flags;  f6:hdr.ipv4.fragOffset;  f7:hdr.ipv4.ttl;  f8:hdr.ipv4.protocol;  f9:hdr.ipv4.srcAddr;  f10:hdr.ipv4.dstAddr; }, hdr.ipv4.hdrChecksum, 6);
+# [P4Testgen MethodCall]: *.copy_out("verifyChecksum");
+# [P4Testgen MethodCall]: *.copy_in("ingress");
+# [Control ingress start]
+# [P4Testgen If Statement]: Condition: true; Result: true
+# [P4Testgen If Statement]: Condition: true; Result: true
+# [MethodCall]: round_tbl_0/round_tbl.apply();
+# [Table Branch: ingress.round_tbl| Overriding default action: ingress.read_round]
+# [MethodCall]: read_round();
+# [MethodCall]: registerRound_0/registerRound.read(meta.local_metadata.round, hdr.myhdr.inst);
+# [RegisterRead: Index |pktvar_20(bit<32>)| into field meta.local_metadata.round;]
+# [P4Testgen AssignmentStatement]: meta.local_metadata.round = 0;
+# [P4Testgen MethodCall]: *.copy_out("ingress");
+# [P4Testgen AssignmentStatement]: *standard_metadata.egress_port = 0;
+# [P4Testgen If Statement]: Condition: 0 != 0; Result: false
+# [P4Testgen MethodCall]: *.copy_in("egress");
+# [Control egress start]
+# [MethodCall]: drop_tbl_0/drop_tbl.apply();
+# [Table Branch: egress.drop_tbl | Key(s): 0| Chosen action: egress._drop]
+# [MethodCall]: _drop();
+# [MethodCall]: mark_to_drop(standard_metadata);
+# [mark_to_drop executed.]
+# [P4Testgen MethodCall]: *.copy_out("egress");
+# [P4Testgen MethodCall]: *.copy_in("computeChecksum");
+# [Control computeChecksum start]
+# [MethodCall]: update_checksum<tuple_0, bit<16>>(hdr.ipv4.isValid(), {  f0:hdr.ipv4.version;  f1:hdr.ipv4.ihl;  f2:hdr.ipv4.diffserv;  f3:hdr.ipv4.totalLen;  f4:hdr.ipv4.identification;  f5:hdr.ipv4.flags;  f6:hdr.ipv4.fragOffset;  f7:hdr.ipv4.ttl;  f8:hdr.ipv4.protocol;  f9:hdr.ipv4.srcAddr;  f10:hdr.ipv4.dstAddr; }, hdr.ipv4.hdrChecksum, 6);
+# [P4Testgen MethodCall]: *.copy_out("computeChecksum");
+# [P4Testgen MethodCall]: *.copy_in("TopDeparser");
+# [Control TopDeparser start]
+# [MethodCall]: packet.emit<ethernet_t>(hdr.ethernet);
+# [Emit]: {$headerValid:true;;    dstAddr:0;  srcAddr:0;  etherType:2048;  }
+# [MethodCall]: packet.emit<ipv4_t>(hdr.ipv4);
+# [Emit]: {$headerValid:true;;    version:0;  ihl:0;  diffserv:0;  totalLen:0;  identification:0;  flags:0;  fragOffset:0;  ttl:0;  protocol:17;  hdrChecksum:0;  srcAddr:0;  dstAddr:0;  }
+# [MethodCall]: packet.emit<udp_t>(hdr.udp);
+# [Emit]: {$headerValid:true;;    srcPort:0;  dstPort:34952;  length_:0;  checksum:0;  }
+# [MethodCall]: packet.emit<myhdr_t>(hdr.myhdr);
+# [Emit]: {$headerValid:true;;    msgtype:0;  inst:0;  rnd:0;  }
+# [P4Testgen MethodCall]: *.copy_out("TopDeparser");
+# [P4Testgen MethodCall]: *.prepend_emit_buffer();
+# [Prepending the emit buffer to the program packet]
+# [P4Testgen If Statement]: Condition: 511 == 511; Result: true
+# [P4Testgen MethodCall]: *.drop_and_exit();
+# [Packet marked dropped]
+
+# Table ingress.round_tbl
+setdefault "ingress.round_tbl" "ingress.read_round"()
+
+# Table egress.drop_tbl
+add "egress.drop_tbl" "meta.local_metadata.set_drop":0x0 "egress._drop"()
+
+
 packet 0 000000000000000000000000080000000000000000000011FFEE00000000000000000000888800000000000000000000000000
+

--- a/patches/v1model/issue298-bmv2/issue298-bmv2_10.stf
+++ b/patches/v1model/issue298-bmv2/issue298-bmv2_10.stf
@@ -1,2 +1,67 @@
-add "main.eg.drop_tbl" "meta.local_metadata.set_drop":0x0 "_drop"()
+# p4testgen seed: none
+# Date generated: 2026-02-19-08:35:23.947
+# Current node coverage: 0
+# Traces
+# [P4Testgen MethodCall]: *.copy_in("TopParser");
+# [Parser] TopParser
+# [State] start
+# [MethodCall]: b.extract<ethernet_t>(p.ethernet);
+# [ExtractSuccess] p.ethernet@0 | Condition: |*packetLen_bits(bit<32>)| >= 112; | Extract Size: 112 -> p.ethernet.dstAddr = 0x0000_0000_0000 | p.ethernet.srcAddr = 0x0000_0000_0000 | p.ethernet.etherType = 0x0800
+# [State] parse_ipv4
+# [MethodCall]: b.extract<ipv4_t>(p.ipv4);
+# [ExtractSuccess] p.ipv4@112 | Condition: |*packetLen_bits(bit<32>)| >= 272; | Extract Size: 160 -> p.ipv4.version = 0x0 | p.ipv4.ihl = 0x0 | p.ipv4.diffserv = 0x00 | p.ipv4.totalLen = 0x0000 | p.ipv4.identification = 0x0000 | p.ipv4.flags = 0x0 | p.ipv4.fragOffset = 0x0000 | p.ipv4.ttl = 0x00 | p.ipv4.protocol = 0x11 | p.ipv4.hdrChecksum = 0x0000 | p.ipv4.srcAddr = 0x0000_0000 | p.ipv4.dstAddr = 0x0000_0000
+# [State] parse_udp
+# [MethodCall]: b.extract<udp_t>(p.udp);
+# [ExtractSuccess] p.udp@272 | Condition: |*packetLen_bits(bit<32>)| >= 336; | Extract Size: 64 -> p.udp.srcPort = 0x0000 | p.udp.dstPort = 0x8888 | p.udp.length_ = 0x0000 | p.udp.checksum = 0x0000
+# [State] parse_myhdr
+# [MethodCall]: b.extract<myhdr_t>(p.myhdr);
+# [ExtractFailure] p.myhdr@336 | Condition: !(|*packetLen_bits(bit<32>)| >= 400); | Extract Size: 64
+# [P4Testgen AssignmentStatement]: standard_metadata.parser_error = 1;
+# [P4Testgen MethodCall]: *.copy_out("TopParser");
+# [P4Testgen MethodCall]: *.copy_in("verifyChecksum");
+# [Control verifyChecksum start]
+# [MethodCall]: verify_checksum<tuple_0, bit<16>>(hdr.ipv4.isValid(), {  f0:hdr.ipv4.version;  f1:hdr.ipv4.ihl;  f2:hdr.ipv4.diffserv;  f3:hdr.ipv4.totalLen;  f4:hdr.ipv4.identification;  f5:hdr.ipv4.flags;  f6:hdr.ipv4.fragOffset;  f7:hdr.ipv4.ttl;  f8:hdr.ipv4.protocol;  f9:hdr.ipv4.srcAddr;  f10:hdr.ipv4.dstAddr; }, hdr.ipv4.hdrChecksum, 6);
+# [P4Testgen AssignmentStatement]: *standard_metadata.checksum_error = 1;
+# [P4Testgen MethodCall]: *.copy_out("verifyChecksum");
+# [P4Testgen MethodCall]: *.copy_in("ingress");
+# [Control ingress start]
+# [P4Testgen If Statement]: Condition: true; Result: true
+# [P4Testgen If Statement]: Condition: false; Result: false
+# [P4Testgen MethodCall]: *.copy_out("ingress");
+# [P4Testgen AssignmentStatement]: *standard_metadata.egress_port = 0;
+# [P4Testgen If Statement]: Condition: 0 != 0; Result: false
+# [P4Testgen MethodCall]: *.copy_in("egress");
+# [Control egress start]
+# [MethodCall]: drop_tbl_0/drop_tbl.apply();
+# [Table Branch: egress.drop_tbl | Key(s): 0| Chosen action: egress._drop]
+# [MethodCall]: _drop();
+# [MethodCall]: mark_to_drop(standard_metadata);
+# [mark_to_drop executed.]
+# [P4Testgen MethodCall]: *.copy_out("egress");
+# [P4Testgen MethodCall]: *.copy_in("computeChecksum");
+# [Control computeChecksum start]
+# [MethodCall]: update_checksum<tuple_0, bit<16>>(hdr.ipv4.isValid(), {  f0:hdr.ipv4.version;  f1:hdr.ipv4.ihl;  f2:hdr.ipv4.diffserv;  f3:hdr.ipv4.totalLen;  f4:hdr.ipv4.identification;  f5:hdr.ipv4.flags;  f6:hdr.ipv4.fragOffset;  f7:hdr.ipv4.ttl;  f8:hdr.ipv4.protocol;  f9:hdr.ipv4.srcAddr;  f10:hdr.ipv4.dstAddr; }, hdr.ipv4.hdrChecksum, 6);
+# [P4Testgen MethodCall]: *.copy_out("computeChecksum");
+# [P4Testgen MethodCall]: *.copy_in("TopDeparser");
+# [Control TopDeparser start]
+# [MethodCall]: packet.emit<ethernet_t>(hdr.ethernet);
+# [Emit]: {$headerValid:true;;    dstAddr:0;  srcAddr:0;  etherType:2048;  }
+# [MethodCall]: packet.emit<ipv4_t>(hdr.ipv4);
+# [Emit]: {$headerValid:true;;    version:0;  ihl:0;  diffserv:0;  totalLen:0;  identification:0;  flags:0;  fragOffset:0;  ttl:0;  protocol:17;  hdrChecksum:0;  srcAddr:0;  dstAddr:0;  }
+# [MethodCall]: packet.emit<udp_t>(hdr.udp);
+# [Emit]: {$headerValid:true;;    srcPort:0;  dstPort:34952;  length_:0;  checksum:0;  }
+# [MethodCall]: packet.emit<myhdr_t>(hdr.myhdr);
+# [Invalid emit: { msgtype = TaintedExpression(bit<16>), inst = TaintedExpression(bit<32>), rnd = TaintedExpression(bit<16>) }]
+# [P4Testgen MethodCall]: *.copy_out("TopDeparser");
+# [P4Testgen MethodCall]: *.prepend_emit_buffer();
+# [Prepending the emit buffer to the program packet]
+# [P4Testgen If Statement]: Condition: 511 == 511; Result: true
+# [P4Testgen MethodCall]: *.drop_and_exit();
+# [Packet marked dropped]
+
+# Table egress.drop_tbl
+add "egress.drop_tbl" "meta.local_metadata.set_drop":0x0 "egress._drop"()
+
+
 packet 0 00000000000000000000000008000000000000000000001100000000000000000000000088880000000000000000000000
+

--- a/patches/v1model/issue298-bmv2/issue298-bmv2_2.stf
+++ b/patches/v1model/issue298-bmv2/issue298-bmv2_2.stf
@@ -1,4 +1,73 @@
-setdefault "main.ig.round_tbl" "read_round"()
-add "main.eg.drop_tbl" "meta.local_metadata.set_drop":0x0 "NoAction"()
+# p4testgen seed: none
+# Date generated: 2026-02-19-08:35:23.885
+# Current node coverage: 0
+# Traces
+# [P4Testgen MethodCall]: *.copy_in("TopParser");
+# [Parser] TopParser
+# [State] start
+# [MethodCall]: b.extract<ethernet_t>(p.ethernet);
+# [ExtractSuccess] p.ethernet@0 | Condition: |*packetLen_bits(bit<32>)| >= 112; | Extract Size: 112 -> p.ethernet.dstAddr = 0x0000_0000_0000 | p.ethernet.srcAddr = 0x0000_0000_0000 | p.ethernet.etherType = 0x0800
+# [State] parse_ipv4
+# [MethodCall]: b.extract<ipv4_t>(p.ipv4);
+# [ExtractSuccess] p.ipv4@112 | Condition: |*packetLen_bits(bit<32>)| >= 272; | Extract Size: 160 -> p.ipv4.version = 0x0 | p.ipv4.ihl = 0x0 | p.ipv4.diffserv = 0x00 | p.ipv4.totalLen = 0x0000 | p.ipv4.identification = 0x0000 | p.ipv4.flags = 0x0 | p.ipv4.fragOffset = 0x0000 | p.ipv4.ttl = 0x00 | p.ipv4.protocol = 0x11 | p.ipv4.hdrChecksum = 0xFFEE | p.ipv4.srcAddr = 0x0000_0000 | p.ipv4.dstAddr = 0x0000_0000
+# [State] parse_udp
+# [MethodCall]: b.extract<udp_t>(p.udp);
+# [ExtractSuccess] p.udp@272 | Condition: |*packetLen_bits(bit<32>)| >= 336; | Extract Size: 64 -> p.udp.srcPort = 0x0000 | p.udp.dstPort = 0x8888 | p.udp.length_ = 0x0000 | p.udp.checksum = 0x0000
+# [State] parse_myhdr
+# [MethodCall]: b.extract<myhdr_t>(p.myhdr);
+# [ExtractSuccess] p.myhdr@336 | Condition: |*packetLen_bits(bit<32>)| >= 400; | Extract Size: 64 -> p.myhdr.msgtype = 0x0000 | p.myhdr.inst = 0x0000_0000 | p.myhdr.rnd = 0x0000
+# [State] accept
+# [P4Testgen MethodCall]: *.copy_out("TopParser");
+# [P4Testgen MethodCall]: *.copy_in("verifyChecksum");
+# [Control verifyChecksum start]
+# [MethodCall]: verify_checksum<tuple_0, bit<16>>(hdr.ipv4.isValid(), {  f0:hdr.ipv4.version;  f1:hdr.ipv4.ihl;  f2:hdr.ipv4.diffserv;  f3:hdr.ipv4.totalLen;  f4:hdr.ipv4.identification;  f5:hdr.ipv4.flags;  f6:hdr.ipv4.fragOffset;  f7:hdr.ipv4.ttl;  f8:hdr.ipv4.protocol;  f9:hdr.ipv4.srcAddr;  f10:hdr.ipv4.dstAddr; }, hdr.ipv4.hdrChecksum, 6);
+# [P4Testgen MethodCall]: *.copy_out("verifyChecksum");
+# [P4Testgen MethodCall]: *.copy_in("ingress");
+# [Control ingress start]
+# [P4Testgen If Statement]: Condition: true; Result: true
+# [P4Testgen If Statement]: Condition: true; Result: true
+# [MethodCall]: round_tbl_0/round_tbl.apply();
+# [Table Branch: ingress.round_tbl| Overriding default action: ingress.read_round]
+# [MethodCall]: read_round();
+# [MethodCall]: registerRound_0/registerRound.read(meta.local_metadata.round, hdr.myhdr.inst);
+# [RegisterRead: Index |pktvar_20(bit<32>)| into field meta.local_metadata.round;]
+# [P4Testgen AssignmentStatement]: meta.local_metadata.round = 0;
+# [P4Testgen MethodCall]: *.copy_out("ingress");
+# [P4Testgen AssignmentStatement]: *standard_metadata.egress_port = 0;
+# [P4Testgen If Statement]: Condition: 0 != 0; Result: false
+# [P4Testgen MethodCall]: *.copy_in("egress");
+# [Control egress start]
+# [MethodCall]: drop_tbl_0/drop_tbl.apply();
+# [Table Branch: egress.drop_tbl | Key(s): 0| Chosen action: NoAction]
+# [MethodCall]: NoAction_1/NoAction();
+# [P4Testgen MethodCall]: *.copy_out("egress");
+# [P4Testgen MethodCall]: *.copy_in("computeChecksum");
+# [Control computeChecksum start]
+# [MethodCall]: update_checksum<tuple_0, bit<16>>(hdr.ipv4.isValid(), {  f0:hdr.ipv4.version;  f1:hdr.ipv4.ihl;  f2:hdr.ipv4.diffserv;  f3:hdr.ipv4.totalLen;  f4:hdr.ipv4.identification;  f5:hdr.ipv4.flags;  f6:hdr.ipv4.fragOffset;  f7:hdr.ipv4.ttl;  f8:hdr.ipv4.protocol;  f9:hdr.ipv4.srcAddr;  f10:hdr.ipv4.dstAddr; }, hdr.ipv4.hdrChecksum, 6);
+# [P4Testgen MethodCall]: *.copy_out("computeChecksum");
+# [P4Testgen MethodCall]: *.copy_in("TopDeparser");
+# [Control TopDeparser start]
+# [MethodCall]: packet.emit<ethernet_t>(hdr.ethernet);
+# [Emit]: {$headerValid:true;;    dstAddr:0;  srcAddr:0;  etherType:2048;  }
+# [MethodCall]: packet.emit<ipv4_t>(hdr.ipv4);
+# [Emit]: {$headerValid:true;;    version:0;  ihl:0;  diffserv:0;  totalLen:0;  identification:0;  flags:0;  fragOffset:0;  ttl:0;  protocol:17;  hdrChecksum:0;  srcAddr:0;  dstAddr:0;  }
+# [MethodCall]: packet.emit<udp_t>(hdr.udp);
+# [Emit]: {$headerValid:true;;    srcPort:0;  dstPort:34952;  length_:0;  checksum:0;  }
+# [MethodCall]: packet.emit<myhdr_t>(hdr.myhdr);
+# [Emit]: {$headerValid:true;;    msgtype:0;  inst:0;  rnd:0;  }
+# [P4Testgen MethodCall]: *.copy_out("TopDeparser");
+# [P4Testgen MethodCall]: *.prepend_emit_buffer();
+# [Prepending the emit buffer to the program packet]
+# [P4Testgen If Statement]: Condition: 511 == 0; Result: false
+# [P4Testgen MethodCall]: *.invoke_traffic_manager();
+
+# Table ingress.round_tbl
+setdefault "ingress.round_tbl" "ingress.read_round"()
+
+# Table egress.drop_tbl
+add "egress.drop_tbl" "meta.local_metadata.set_drop":0x0 "NoAction"()
+
+
 packet 0 000000000000000000000000080000000000000000000011FFEE00000000000000000000888800000000000000000000000000
 expect 0 000000000000000000000000080000000000000000000011FFEE00000000000000000000888800000000000000000000000000$
+

--- a/patches/v1model/issue298-bmv2/issue298-bmv2_4.stf
+++ b/patches/v1model/issue298-bmv2/issue298-bmv2_4.stf
@@ -1,3 +1,76 @@
-setdefault "main.ig.round_tbl" "read_round"()
-add "main.eg.drop_tbl" "meta.local_metadata.set_drop":0x0 "_drop"()
+# p4testgen seed: none
+# Date generated: 2026-02-19-08:35:23.900
+# Current node coverage: 0
+# Traces
+# [P4Testgen MethodCall]: *.copy_in("TopParser");
+# [Parser] TopParser
+# [State] start
+# [MethodCall]: b.extract<ethernet_t>(p.ethernet);
+# [ExtractSuccess] p.ethernet@0 | Condition: |*packetLen_bits(bit<32>)| >= 112; | Extract Size: 112 -> p.ethernet.dstAddr = 0x0000_0000_0000 | p.ethernet.srcAddr = 0x0000_0000_0000 | p.ethernet.etherType = 0x0800
+# [State] parse_ipv4
+# [MethodCall]: b.extract<ipv4_t>(p.ipv4);
+# [ExtractSuccess] p.ipv4@112 | Condition: |*packetLen_bits(bit<32>)| >= 272; | Extract Size: 160 -> p.ipv4.version = 0x0 | p.ipv4.ihl = 0x0 | p.ipv4.diffserv = 0x00 | p.ipv4.totalLen = 0x0000 | p.ipv4.identification = 0x0000 | p.ipv4.flags = 0x0 | p.ipv4.fragOffset = 0x0000 | p.ipv4.ttl = 0x00 | p.ipv4.protocol = 0x11 | p.ipv4.hdrChecksum = 0x0000 | p.ipv4.srcAddr = 0x0000_0000 | p.ipv4.dstAddr = 0x0000_0000
+# [State] parse_udp
+# [MethodCall]: b.extract<udp_t>(p.udp);
+# [ExtractSuccess] p.udp@272 | Condition: |*packetLen_bits(bit<32>)| >= 336; | Extract Size: 64 -> p.udp.srcPort = 0x0000 | p.udp.dstPort = 0x8888 | p.udp.length_ = 0x0000 | p.udp.checksum = 0x0000
+# [State] parse_myhdr
+# [MethodCall]: b.extract<myhdr_t>(p.myhdr);
+# [ExtractSuccess] p.myhdr@336 | Condition: |*packetLen_bits(bit<32>)| >= 400; | Extract Size: 64 -> p.myhdr.msgtype = 0x0000 | p.myhdr.inst = 0x0000_0000 | p.myhdr.rnd = 0x0000
+# [State] accept
+# [P4Testgen MethodCall]: *.copy_out("TopParser");
+# [P4Testgen MethodCall]: *.copy_in("verifyChecksum");
+# [Control verifyChecksum start]
+# [MethodCall]: verify_checksum<tuple_0, bit<16>>(hdr.ipv4.isValid(), {  f0:hdr.ipv4.version;  f1:hdr.ipv4.ihl;  f2:hdr.ipv4.diffserv;  f3:hdr.ipv4.totalLen;  f4:hdr.ipv4.identification;  f5:hdr.ipv4.flags;  f6:hdr.ipv4.fragOffset;  f7:hdr.ipv4.ttl;  f8:hdr.ipv4.protocol;  f9:hdr.ipv4.srcAddr;  f10:hdr.ipv4.dstAddr; }, hdr.ipv4.hdrChecksum, 6);
+# [P4Testgen AssignmentStatement]: *standard_metadata.checksum_error = 1;
+# [P4Testgen MethodCall]: *.copy_out("verifyChecksum");
+# [P4Testgen MethodCall]: *.copy_in("ingress");
+# [Control ingress start]
+# [P4Testgen If Statement]: Condition: true; Result: true
+# [P4Testgen If Statement]: Condition: true; Result: true
+# [MethodCall]: round_tbl_0/round_tbl.apply();
+# [Table Branch: ingress.round_tbl| Overriding default action: ingress.read_round]
+# [MethodCall]: read_round();
+# [MethodCall]: registerRound_0/registerRound.read(meta.local_metadata.round, hdr.myhdr.inst);
+# [RegisterRead: Index |pktvar_20(bit<32>)| into field meta.local_metadata.round;]
+# [P4Testgen AssignmentStatement]: meta.local_metadata.round = 0;
+# [P4Testgen MethodCall]: *.copy_out("ingress");
+# [P4Testgen AssignmentStatement]: *standard_metadata.egress_port = 0;
+# [P4Testgen If Statement]: Condition: 0 != 0; Result: false
+# [P4Testgen MethodCall]: *.copy_in("egress");
+# [Control egress start]
+# [MethodCall]: drop_tbl_0/drop_tbl.apply();
+# [Table Branch: egress.drop_tbl | Key(s): 0| Chosen action: egress._drop]
+# [MethodCall]: _drop();
+# [MethodCall]: mark_to_drop(standard_metadata);
+# [mark_to_drop executed.]
+# [P4Testgen MethodCall]: *.copy_out("egress");
+# [P4Testgen MethodCall]: *.copy_in("computeChecksum");
+# [Control computeChecksum start]
+# [MethodCall]: update_checksum<tuple_0, bit<16>>(hdr.ipv4.isValid(), {  f0:hdr.ipv4.version;  f1:hdr.ipv4.ihl;  f2:hdr.ipv4.diffserv;  f3:hdr.ipv4.totalLen;  f4:hdr.ipv4.identification;  f5:hdr.ipv4.flags;  f6:hdr.ipv4.fragOffset;  f7:hdr.ipv4.ttl;  f8:hdr.ipv4.protocol;  f9:hdr.ipv4.srcAddr;  f10:hdr.ipv4.dstAddr; }, hdr.ipv4.hdrChecksum, 6);
+# [P4Testgen MethodCall]: *.copy_out("computeChecksum");
+# [P4Testgen MethodCall]: *.copy_in("TopDeparser");
+# [Control TopDeparser start]
+# [MethodCall]: packet.emit<ethernet_t>(hdr.ethernet);
+# [Emit]: {$headerValid:true;;    dstAddr:0;  srcAddr:0;  etherType:2048;  }
+# [MethodCall]: packet.emit<ipv4_t>(hdr.ipv4);
+# [Emit]: {$headerValid:true;;    version:0;  ihl:0;  diffserv:0;  totalLen:0;  identification:0;  flags:0;  fragOffset:0;  ttl:0;  protocol:17;  hdrChecksum:0;  srcAddr:0;  dstAddr:0;  }
+# [MethodCall]: packet.emit<udp_t>(hdr.udp);
+# [Emit]: {$headerValid:true;;    srcPort:0;  dstPort:34952;  length_:0;  checksum:0;  }
+# [MethodCall]: packet.emit<myhdr_t>(hdr.myhdr);
+# [Emit]: {$headerValid:true;;    msgtype:0;  inst:0;  rnd:0;  }
+# [P4Testgen MethodCall]: *.copy_out("TopDeparser");
+# [P4Testgen MethodCall]: *.prepend_emit_buffer();
+# [Prepending the emit buffer to the program packet]
+# [P4Testgen If Statement]: Condition: 511 == 511; Result: true
+# [P4Testgen MethodCall]: *.drop_and_exit();
+# [Packet marked dropped]
+
+# Table ingress.round_tbl
+setdefault "ingress.round_tbl" "ingress.read_round"()
+
+# Table egress.drop_tbl
+add "egress.drop_tbl" "meta.local_metadata.set_drop":0x0 "egress._drop"()
+
+
 packet 0 0000000000000000000000000800000000000000000000112C0000000000000000000000888800000000000000000000000000
+

--- a/patches/v1model/issue298-bmv2/issue298-bmv2_5.stf
+++ b/patches/v1model/issue298-bmv2/issue298-bmv2_5.stf
@@ -1,4 +1,74 @@
-setdefault "main.ig.round_tbl" "read_round"()
-add "main.eg.drop_tbl" "meta.local_metadata.set_drop":0x0 "NoAction"()
+# p4testgen seed: none
+# Date generated: 2026-02-19-08:35:23.906
+# Current node coverage: 0
+# Traces
+# [P4Testgen MethodCall]: *.copy_in("TopParser");
+# [Parser] TopParser
+# [State] start
+# [MethodCall]: b.extract<ethernet_t>(p.ethernet);
+# [ExtractSuccess] p.ethernet@0 | Condition: |*packetLen_bits(bit<32>)| >= 112; | Extract Size: 112 -> p.ethernet.dstAddr = 0x0000_0000_0000 | p.ethernet.srcAddr = 0x0000_0000_0000 | p.ethernet.etherType = 0x0800
+# [State] parse_ipv4
+# [MethodCall]: b.extract<ipv4_t>(p.ipv4);
+# [ExtractSuccess] p.ipv4@112 | Condition: |*packetLen_bits(bit<32>)| >= 272; | Extract Size: 160 -> p.ipv4.version = 0x0 | p.ipv4.ihl = 0x0 | p.ipv4.diffserv = 0x00 | p.ipv4.totalLen = 0x0000 | p.ipv4.identification = 0x0000 | p.ipv4.flags = 0x0 | p.ipv4.fragOffset = 0x0000 | p.ipv4.ttl = 0x00 | p.ipv4.protocol = 0x11 | p.ipv4.hdrChecksum = 0x2C00 | p.ipv4.srcAddr = 0x0000_0000 | p.ipv4.dstAddr = 0x0000_0000
+# [State] parse_udp
+# [MethodCall]: b.extract<udp_t>(p.udp);
+# [ExtractSuccess] p.udp@272 | Condition: |*packetLen_bits(bit<32>)| >= 336; | Extract Size: 64 -> p.udp.srcPort = 0x0000 | p.udp.dstPort = 0x8888 | p.udp.length_ = 0x0000 | p.udp.checksum = 0x0000
+# [State] parse_myhdr
+# [MethodCall]: b.extract<myhdr_t>(p.myhdr);
+# [ExtractSuccess] p.myhdr@336 | Condition: |*packetLen_bits(bit<32>)| >= 400; | Extract Size: 64 -> p.myhdr.msgtype = 0x0000 | p.myhdr.inst = 0x0000_0000 | p.myhdr.rnd = 0x0000
+# [State] accept
+# [P4Testgen MethodCall]: *.copy_out("TopParser");
+# [P4Testgen MethodCall]: *.copy_in("verifyChecksum");
+# [Control verifyChecksum start]
+# [MethodCall]: verify_checksum<tuple_0, bit<16>>(hdr.ipv4.isValid(), {  f0:hdr.ipv4.version;  f1:hdr.ipv4.ihl;  f2:hdr.ipv4.diffserv;  f3:hdr.ipv4.totalLen;  f4:hdr.ipv4.identification;  f5:hdr.ipv4.flags;  f6:hdr.ipv4.fragOffset;  f7:hdr.ipv4.ttl;  f8:hdr.ipv4.protocol;  f9:hdr.ipv4.srcAddr;  f10:hdr.ipv4.dstAddr; }, hdr.ipv4.hdrChecksum, 6);
+# [P4Testgen AssignmentStatement]: *standard_metadata.checksum_error = 1;
+# [P4Testgen MethodCall]: *.copy_out("verifyChecksum");
+# [P4Testgen MethodCall]: *.copy_in("ingress");
+# [Control ingress start]
+# [P4Testgen If Statement]: Condition: true; Result: true
+# [P4Testgen If Statement]: Condition: true; Result: true
+# [MethodCall]: round_tbl_0/round_tbl.apply();
+# [Table Branch: ingress.round_tbl| Overriding default action: ingress.read_round]
+# [MethodCall]: read_round();
+# [MethodCall]: registerRound_0/registerRound.read(meta.local_metadata.round, hdr.myhdr.inst);
+# [RegisterRead: Index |pktvar_20(bit<32>)| into field meta.local_metadata.round;]
+# [P4Testgen AssignmentStatement]: meta.local_metadata.round = 0;
+# [P4Testgen MethodCall]: *.copy_out("ingress");
+# [P4Testgen AssignmentStatement]: *standard_metadata.egress_port = 0;
+# [P4Testgen If Statement]: Condition: 0 != 0; Result: false
+# [P4Testgen MethodCall]: *.copy_in("egress");
+# [Control egress start]
+# [MethodCall]: drop_tbl_0/drop_tbl.apply();
+# [Table Branch: egress.drop_tbl | Key(s): 0| Chosen action: NoAction]
+# [MethodCall]: NoAction_1/NoAction();
+# [P4Testgen MethodCall]: *.copy_out("egress");
+# [P4Testgen MethodCall]: *.copy_in("computeChecksum");
+# [Control computeChecksum start]
+# [MethodCall]: update_checksum<tuple_0, bit<16>>(hdr.ipv4.isValid(), {  f0:hdr.ipv4.version;  f1:hdr.ipv4.ihl;  f2:hdr.ipv4.diffserv;  f3:hdr.ipv4.totalLen;  f4:hdr.ipv4.identification;  f5:hdr.ipv4.flags;  f6:hdr.ipv4.fragOffset;  f7:hdr.ipv4.ttl;  f8:hdr.ipv4.protocol;  f9:hdr.ipv4.srcAddr;  f10:hdr.ipv4.dstAddr; }, hdr.ipv4.hdrChecksum, 6);
+# [P4Testgen MethodCall]: *.copy_out("computeChecksum");
+# [P4Testgen MethodCall]: *.copy_in("TopDeparser");
+# [Control TopDeparser start]
+# [MethodCall]: packet.emit<ethernet_t>(hdr.ethernet);
+# [Emit]: {$headerValid:true;;    dstAddr:0;  srcAddr:0;  etherType:2048;  }
+# [MethodCall]: packet.emit<ipv4_t>(hdr.ipv4);
+# [Emit]: {$headerValid:true;;    version:0;  ihl:0;  diffserv:0;  totalLen:0;  identification:0;  flags:0;  fragOffset:0;  ttl:0;  protocol:17;  hdrChecksum:0;  srcAddr:0;  dstAddr:0;  }
+# [MethodCall]: packet.emit<udp_t>(hdr.udp);
+# [Emit]: {$headerValid:true;;    srcPort:0;  dstPort:34952;  length_:0;  checksum:0;  }
+# [MethodCall]: packet.emit<myhdr_t>(hdr.myhdr);
+# [Emit]: {$headerValid:true;;    msgtype:0;  inst:0;  rnd:0;  }
+# [P4Testgen MethodCall]: *.copy_out("TopDeparser");
+# [P4Testgen MethodCall]: *.prepend_emit_buffer();
+# [Prepending the emit buffer to the program packet]
+# [P4Testgen If Statement]: Condition: 511 == 0; Result: false
+# [P4Testgen MethodCall]: *.invoke_traffic_manager();
+
+# Table ingress.round_tbl
+setdefault "ingress.round_tbl" "ingress.read_round"()
+
+# Table egress.drop_tbl
+add "egress.drop_tbl" "meta.local_metadata.set_drop":0x0 "NoAction"()
+
+
 packet 0 0000000000000000000000000800000000000000000000112C0000000000000000000000888800000000000000000000000000
 expect 0 000000000000000000000000080000000000000000000011FFEE00000000000000000000888800000000000000000000000000$
+

--- a/patches/v1model/issue298-bmv2/issue298-bmv2_7.stf
+++ b/patches/v1model/issue298-bmv2/issue298-bmv2_7.stf
@@ -1,2 +1,66 @@
-add "main.eg.drop_tbl" "meta.local_metadata.set_drop":0x0 "_drop"()
+# p4testgen seed: none
+# Date generated: 2026-02-19-08:35:23.930
+# Current node coverage: 0
+# Traces
+# [P4Testgen MethodCall]: *.copy_in("TopParser");
+# [Parser] TopParser
+# [State] start
+# [MethodCall]: b.extract<ethernet_t>(p.ethernet);
+# [ExtractSuccess] p.ethernet@0 | Condition: |*packetLen_bits(bit<32>)| >= 112; | Extract Size: 112 -> p.ethernet.dstAddr = 0x0000_0000_0000 | p.ethernet.srcAddr = 0x0000_0000_0000 | p.ethernet.etherType = 0x0800
+# [State] parse_ipv4
+# [MethodCall]: b.extract<ipv4_t>(p.ipv4);
+# [ExtractSuccess] p.ipv4@112 | Condition: |*packetLen_bits(bit<32>)| >= 272; | Extract Size: 160 -> p.ipv4.version = 0x0 | p.ipv4.ihl = 0x0 | p.ipv4.diffserv = 0x00 | p.ipv4.totalLen = 0x0000 | p.ipv4.identification = 0x0000 | p.ipv4.flags = 0x0 | p.ipv4.fragOffset = 0x0000 | p.ipv4.ttl = 0x00 | p.ipv4.protocol = 0x11 | p.ipv4.hdrChecksum = 0x0000 | p.ipv4.srcAddr = 0x0000_0000 | p.ipv4.dstAddr = 0x0000_0000
+# [State] parse_udp
+# [MethodCall]: b.extract<udp_t>(p.udp);
+# [ExtractSuccess] p.udp@272 | Condition: |*packetLen_bits(bit<32>)| >= 336; | Extract Size: 64 -> p.udp.srcPort = 0x0000 | p.udp.dstPort = 0x8888 | p.udp.length_ = 0x0000 | p.udp.checksum = 0x0000
+# [State] parse_myhdr
+# [MethodCall]: b.extract<myhdr_t>(p.myhdr);
+# [ExtractFailure] p.myhdr@336 | Condition: !(|*packetLen_bits(bit<32>)| >= 400); | Extract Size: 64
+# [P4Testgen AssignmentStatement]: standard_metadata.parser_error = 1;
+# [P4Testgen MethodCall]: *.copy_out("TopParser");
+# [P4Testgen MethodCall]: *.copy_in("verifyChecksum");
+# [Control verifyChecksum start]
+# [MethodCall]: verify_checksum<tuple_0, bit<16>>(hdr.ipv4.isValid(), {  f0:hdr.ipv4.version;  f1:hdr.ipv4.ihl;  f2:hdr.ipv4.diffserv;  f3:hdr.ipv4.totalLen;  f4:hdr.ipv4.identification;  f5:hdr.ipv4.flags;  f6:hdr.ipv4.fragOffset;  f7:hdr.ipv4.ttl;  f8:hdr.ipv4.protocol;  f9:hdr.ipv4.srcAddr;  f10:hdr.ipv4.dstAddr; }, hdr.ipv4.hdrChecksum, 6);
+# [P4Testgen MethodCall]: *.copy_out("verifyChecksum");
+# [P4Testgen MethodCall]: *.copy_in("ingress");
+# [Control ingress start]
+# [P4Testgen If Statement]: Condition: true; Result: true
+# [P4Testgen If Statement]: Condition: false; Result: false
+# [P4Testgen MethodCall]: *.copy_out("ingress");
+# [P4Testgen AssignmentStatement]: *standard_metadata.egress_port = 0;
+# [P4Testgen If Statement]: Condition: 0 != 0; Result: false
+# [P4Testgen MethodCall]: *.copy_in("egress");
+# [Control egress start]
+# [MethodCall]: drop_tbl_0/drop_tbl.apply();
+# [Table Branch: egress.drop_tbl | Key(s): 0| Chosen action: egress._drop]
+# [MethodCall]: _drop();
+# [MethodCall]: mark_to_drop(standard_metadata);
+# [mark_to_drop executed.]
+# [P4Testgen MethodCall]: *.copy_out("egress");
+# [P4Testgen MethodCall]: *.copy_in("computeChecksum");
+# [Control computeChecksum start]
+# [MethodCall]: update_checksum<tuple_0, bit<16>>(hdr.ipv4.isValid(), {  f0:hdr.ipv4.version;  f1:hdr.ipv4.ihl;  f2:hdr.ipv4.diffserv;  f3:hdr.ipv4.totalLen;  f4:hdr.ipv4.identification;  f5:hdr.ipv4.flags;  f6:hdr.ipv4.fragOffset;  f7:hdr.ipv4.ttl;  f8:hdr.ipv4.protocol;  f9:hdr.ipv4.srcAddr;  f10:hdr.ipv4.dstAddr; }, hdr.ipv4.hdrChecksum, 6);
+# [P4Testgen MethodCall]: *.copy_out("computeChecksum");
+# [P4Testgen MethodCall]: *.copy_in("TopDeparser");
+# [Control TopDeparser start]
+# [MethodCall]: packet.emit<ethernet_t>(hdr.ethernet);
+# [Emit]: {$headerValid:true;;    dstAddr:0;  srcAddr:0;  etherType:2048;  }
+# [MethodCall]: packet.emit<ipv4_t>(hdr.ipv4);
+# [Emit]: {$headerValid:true;;    version:0;  ihl:0;  diffserv:0;  totalLen:0;  identification:0;  flags:0;  fragOffset:0;  ttl:0;  protocol:17;  hdrChecksum:0;  srcAddr:0;  dstAddr:0;  }
+# [MethodCall]: packet.emit<udp_t>(hdr.udp);
+# [Emit]: {$headerValid:true;;    srcPort:0;  dstPort:34952;  length_:0;  checksum:0;  }
+# [MethodCall]: packet.emit<myhdr_t>(hdr.myhdr);
+# [Invalid emit: { msgtype = TaintedExpression(bit<16>), inst = TaintedExpression(bit<32>), rnd = TaintedExpression(bit<16>) }]
+# [P4Testgen MethodCall]: *.copy_out("TopDeparser");
+# [P4Testgen MethodCall]: *.prepend_emit_buffer();
+# [Prepending the emit buffer to the program packet]
+# [P4Testgen If Statement]: Condition: 511 == 511; Result: true
+# [P4Testgen MethodCall]: *.drop_and_exit();
+# [Packet marked dropped]
+
+# Table egress.drop_tbl
+add "egress.drop_tbl" "meta.local_metadata.set_drop":0x0 "egress._drop"()
+
+
 packet 0 000000000000000000000000080000000000000000000011FFEE0000000000000000000088880000000000000000000000
+

--- a/patches/v1model/issue298-bmv2/issue298-bmv2_8.stf
+++ b/patches/v1model/issue298-bmv2/issue298-bmv2_8.stf
@@ -1,3 +1,64 @@
-add "main.eg.drop_tbl" "meta.local_metadata.set_drop":0x0 "NoAction"()
+# p4testgen seed: none
+# Date generated: 2026-02-19-08:35:23.935
+# Current node coverage: 0
+# Traces
+# [P4Testgen MethodCall]: *.copy_in("TopParser");
+# [Parser] TopParser
+# [State] start
+# [MethodCall]: b.extract<ethernet_t>(p.ethernet);
+# [ExtractSuccess] p.ethernet@0 | Condition: |*packetLen_bits(bit<32>)| >= 112; | Extract Size: 112 -> p.ethernet.dstAddr = 0x0000_0000_0000 | p.ethernet.srcAddr = 0x0000_0000_0000 | p.ethernet.etherType = 0x0800
+# [State] parse_ipv4
+# [MethodCall]: b.extract<ipv4_t>(p.ipv4);
+# [ExtractSuccess] p.ipv4@112 | Condition: |*packetLen_bits(bit<32>)| >= 272; | Extract Size: 160 -> p.ipv4.version = 0x0 | p.ipv4.ihl = 0x0 | p.ipv4.diffserv = 0x00 | p.ipv4.totalLen = 0x0000 | p.ipv4.identification = 0x0000 | p.ipv4.flags = 0x0 | p.ipv4.fragOffset = 0x0000 | p.ipv4.ttl = 0x00 | p.ipv4.protocol = 0x11 | p.ipv4.hdrChecksum = 0xFFEE | p.ipv4.srcAddr = 0x0000_0000 | p.ipv4.dstAddr = 0x0000_0000
+# [State] parse_udp
+# [MethodCall]: b.extract<udp_t>(p.udp);
+# [ExtractSuccess] p.udp@272 | Condition: |*packetLen_bits(bit<32>)| >= 336; | Extract Size: 64 -> p.udp.srcPort = 0x0000 | p.udp.dstPort = 0x8888 | p.udp.length_ = 0x0000 | p.udp.checksum = 0x0000
+# [State] parse_myhdr
+# [MethodCall]: b.extract<myhdr_t>(p.myhdr);
+# [ExtractFailure] p.myhdr@336 | Condition: !(|*packetLen_bits(bit<32>)| >= 400); | Extract Size: 64
+# [P4Testgen AssignmentStatement]: standard_metadata.parser_error = 1;
+# [P4Testgen MethodCall]: *.copy_out("TopParser");
+# [P4Testgen MethodCall]: *.copy_in("verifyChecksum");
+# [Control verifyChecksum start]
+# [MethodCall]: verify_checksum<tuple_0, bit<16>>(hdr.ipv4.isValid(), {  f0:hdr.ipv4.version;  f1:hdr.ipv4.ihl;  f2:hdr.ipv4.diffserv;  f3:hdr.ipv4.totalLen;  f4:hdr.ipv4.identification;  f5:hdr.ipv4.flags;  f6:hdr.ipv4.fragOffset;  f7:hdr.ipv4.ttl;  f8:hdr.ipv4.protocol;  f9:hdr.ipv4.srcAddr;  f10:hdr.ipv4.dstAddr; }, hdr.ipv4.hdrChecksum, 6);
+# [P4Testgen MethodCall]: *.copy_out("verifyChecksum");
+# [P4Testgen MethodCall]: *.copy_in("ingress");
+# [Control ingress start]
+# [P4Testgen If Statement]: Condition: true; Result: true
+# [P4Testgen If Statement]: Condition: false; Result: false
+# [P4Testgen MethodCall]: *.copy_out("ingress");
+# [P4Testgen AssignmentStatement]: *standard_metadata.egress_port = 0;
+# [P4Testgen If Statement]: Condition: 0 != 0; Result: false
+# [P4Testgen MethodCall]: *.copy_in("egress");
+# [Control egress start]
+# [MethodCall]: drop_tbl_0/drop_tbl.apply();
+# [Table Branch: egress.drop_tbl | Key(s): 0| Chosen action: NoAction]
+# [MethodCall]: NoAction_1/NoAction();
+# [P4Testgen MethodCall]: *.copy_out("egress");
+# [P4Testgen MethodCall]: *.copy_in("computeChecksum");
+# [Control computeChecksum start]
+# [MethodCall]: update_checksum<tuple_0, bit<16>>(hdr.ipv4.isValid(), {  f0:hdr.ipv4.version;  f1:hdr.ipv4.ihl;  f2:hdr.ipv4.diffserv;  f3:hdr.ipv4.totalLen;  f4:hdr.ipv4.identification;  f5:hdr.ipv4.flags;  f6:hdr.ipv4.fragOffset;  f7:hdr.ipv4.ttl;  f8:hdr.ipv4.protocol;  f9:hdr.ipv4.srcAddr;  f10:hdr.ipv4.dstAddr; }, hdr.ipv4.hdrChecksum, 6);
+# [P4Testgen MethodCall]: *.copy_out("computeChecksum");
+# [P4Testgen MethodCall]: *.copy_in("TopDeparser");
+# [Control TopDeparser start]
+# [MethodCall]: packet.emit<ethernet_t>(hdr.ethernet);
+# [Emit]: {$headerValid:true;;    dstAddr:0;  srcAddr:0;  etherType:2048;  }
+# [MethodCall]: packet.emit<ipv4_t>(hdr.ipv4);
+# [Emit]: {$headerValid:true;;    version:0;  ihl:0;  diffserv:0;  totalLen:0;  identification:0;  flags:0;  fragOffset:0;  ttl:0;  protocol:17;  hdrChecksum:0;  srcAddr:0;  dstAddr:0;  }
+# [MethodCall]: packet.emit<udp_t>(hdr.udp);
+# [Emit]: {$headerValid:true;;    srcPort:0;  dstPort:34952;  length_:0;  checksum:0;  }
+# [MethodCall]: packet.emit<myhdr_t>(hdr.myhdr);
+# [Invalid emit: { msgtype = TaintedExpression(bit<16>), inst = TaintedExpression(bit<32>), rnd = TaintedExpression(bit<16>) }]
+# [P4Testgen MethodCall]: *.copy_out("TopDeparser");
+# [P4Testgen MethodCall]: *.prepend_emit_buffer();
+# [Prepending the emit buffer to the program packet]
+# [P4Testgen If Statement]: Condition: 511 == 0; Result: false
+# [P4Testgen MethodCall]: *.invoke_traffic_manager();
+
+# Table egress.drop_tbl
+add "egress.drop_tbl" "meta.local_metadata.set_drop":0x0 "NoAction"()
+
+
 packet 0 000000000000000000000000080000000000000000000011FFEE0000000000000000000088880000000000000000000000
 expect 0 000000000000000000000000080000000000000000000011FFEE0000000000000000000088880000000000000000000000$
+

--- a/spec-concrete/0-aux/0.0-stdlib.watsup
+++ b/spec-concrete/0-aux/0.0-stdlib.watsup
@@ -59,11 +59,18 @@ builtin dec $min_int(int*) : int
 
 builtin dec $text_to_int(text) : int
 builtin dec $int_to_text(int) : text
+builtin dec $split_text(text, text) : text*
 
 dec $concat_text(text*) : text
   hint(prose_in "the concatenation of" %0)
 def $concat_text(eps) = ""
 def $concat_text(t_h :: t_t*) = t_h ++ $concat_text(t_t*)
+
+dec $join_text(text*, text) : text
+  hint(prose_in "the result of joining" %0 "with separator" %1)
+def $join_text(eps, t_sep) = ""
+def $join_text([ t_h ], t_sep) = t_h
+def $join_text(t_h :: t_t*, t_sep) = t_h ++ t_sep ++ $join_text(t_t*, t_sep)
 
 dec $replace_text(text, text, text) : text
   hint(prose_in "the text" %0 "with all occurrences of" %1 "replaced by" %2)

--- a/spec-concrete/0-aux/0.0-stdlib.watsup
+++ b/spec-concrete/0-aux/0.0-stdlib.watsup
@@ -70,7 +70,8 @@ dec $join_text(text*, text) : text
   hint(prose_in "the result of joining" %0 "with separator" %1)
 def $join_text(eps, t_sep) = ""
 def $join_text([ t_h ], t_sep) = t_h
-def $join_text(t_h :: t_t*, t_sep) = t_h ++ t_sep ++ $join_text(t_t*, t_sep)
+def $join_text(t_h1 :: t_h2 :: t_t*, t_sep)
+  = t_h1 ++ t_sep ++ $join_text(t_h2 :: t_t*, t_sep)
 
 dec $replace_text(text, text, text) : text
   hint(prose_in "the text" %0 "with all occurrences of" %1 "replaced by" %2)

--- a/spec-concrete/4-p4-ir/4.0-ir-syntax.watsup
+++ b/spec-concrete/4-p4-ir/4.0-ir-syntax.watsup
@@ -740,7 +740,10 @@ syntax tableKeyListIR = tableKeyIR*
 ;;;;;;;; Table actions property
 ;;
 
-syntax tableActionReferenceIR = prefixedNameIR `( argumentListIR )
+syntax controlPlaneNameIR = nameIR*
+
+syntax tableActionReferenceIR =
+  prefixedNameIR controlPlaneNameIR `( argumentListIR )
 
 syntax tableActionIR =
   annotationList tableActionReferenceIR

--- a/spec-concrete/4-p4-ir/4.0-ir-syntax.watsup
+++ b/spec-concrete/4-p4-ir/4.0-ir-syntax.watsup
@@ -740,7 +740,7 @@ syntax tableKeyListIR = tableKeyIR*
 ;;;;;;;; Table actions property
 ;;
 
-syntax controlPlaneNameIR = nameIR*
+syntax controlPlaneNameIR = nameIR?
 
 syntax tableActionReferenceIR =
   prefixedNameIR controlPlaneNameIR `( argumentListIR )

--- a/spec-concrete/5-typing/5.14.1-typing-control-table.watsup
+++ b/spec-concrete/5-typing/5.14.1-typing-control-table.watsup
@@ -162,7 +162,7 @@ rulegroup TableAction_ok {
         = $add_action_tbl(TBLC_0, prefixedNameIR, parameterIR*, eps)
     ---- ;; create IR
     -- if tableActionIR
-        = annotationList_update (prefixedNameIR `( eps ))
+        = annotationList_update (prefixedNameIR eps `( eps ))
             `# `( parameterIR_data* `, parameterIR_control* ) `;
 
   ;;;; prefixedNonTypeName `( argumentList )
@@ -188,7 +188,7 @@ rulegroup TableAction_ok {
         = $add_action_tbl(TBLC_0, prefixedNameIR, parameterIR*, argumentIR_cast*)
     ---- ;; create IR
     -- if tableActionIR
-        = annotationList_update (prefixedNameIR `( argumentIR_cast* ))
+        = annotationList_update (prefixedNameIR eps `( argumentIR_cast* ))
             `# `( parameterIR_data* `, parameterIR_control* ) `;
 
 }
@@ -241,14 +241,14 @@ rulegroup TableDefaultAction_ok {
 
   rule TableDefaultAction_ok/prefixedNonTypeName:
     TC TBLC |- `= prefixedNonTypeName
-             : prefixedNameIR `( eps )
+             : prefixedNameIR eps `( eps )
     ---- ;; find matching action
     -- if prefixedNameIR = $prefixedNonTypeName(prefixedNonTypeName)
     -- if (eps, eps) = $find_action(TBLC, prefixedNameIR) 
 
   rule TableDefaultAction_ok/prefixedNonTypeName-argumentList:
     TC TBLC |- `= (prefixedNonTypeName `( argumentList ))
-             : prefixedNameIR `( argumentIR_cast* )
+             : prefixedNameIR eps `( argumentIR_cast* )
     ---- ;; find matching action
     -- if prefixedNameIR = $prefixedNonTypeName(prefixedNonTypeName)
     -- if (parameterIR_action*, argumentIR_action*)
@@ -658,14 +658,14 @@ rule TableEntry_keyset_ok/list:
 rulegroup TableEntry_action_ok {
 
   rule TableEntry_action_ok/prefixedNonTypeName:
-    TC TBLC |- prefixedNonTypeName : prefixedNameIR `( eps )
+    TC TBLC |- prefixedNonTypeName : prefixedNameIR eps `( eps )
     ---- ;; find matching action
     -- if prefixedNameIR = $prefixedNonTypeName(prefixedNonTypeName)
     -- if (eps, eps) = $find_action(TBLC, prefixedNameIR)
 
   rule TableEntry_action_ok/prefixedNonTypeName-argumentList:
     TC TBLC |- (prefixedNonTypeName `( argumentList ))
-             : prefixedNameIR `( argumentIR_cast* )
+             : prefixedNameIR eps `( argumentIR_cast* )
     ---- ;; find matching action
     -- if prefixedNameIR = $prefixedNonTypeName(prefixedNonTypeName)
     -- if (parameterIR_action*, argumentIR_action*)
@@ -1073,7 +1073,7 @@ def $insert_NoAction_tablePropertyIR(
   ---- ;; check that NoAction is not already present in actions
   -- if ACTIONS `= `{ tableActionIR* } = tablePropertyIR_h
   -- if (_ tableActionReferenceIR `# `( _ `, _ ) `; = tableActionIR)*
-  -- if tableActionReferenceIR_NoAction = (`. "NoAction") `( eps )
+  -- if tableActionReferenceIR_NoAction = (`. "NoAction") eps `( eps )
   -- if ~(tableActionReferenceIR_NoAction <- tableActionReferenceIR*)
   ---- ;; insert NoAction to table context and table properties
   -- if TBLC_1 = $add_action_tbl(TBLC_0, `. "NoAction", eps, eps)
@@ -1088,7 +1088,7 @@ def $insert_NoAction_tablePropertyIR(
   ---- ;; check that NoAction is already present in actions
   -- if ACTIONS `= `{ tableActionIR* } = tablePropertyIR_h
   -- if (_ tableActionReferenceIR `# `( _ `, _ ) `; = tableActionIR)*
-  -- if tableActionReferenceIR_NoAction = (`. "NoAction") `( eps )
+  -- if tableActionReferenceIR_NoAction = (`. "NoAction") eps `( eps )
   -- if (tableActionReferenceIR_NoAction <- tableActionReferenceIR*)
 def $insert_NoAction_tablePropertyIR(
     TBLC_0,
@@ -1118,7 +1118,7 @@ rulegroup Table_ok {
     -- TableProperties_ok: TC TBLC_0 |- tableProperty* : TBLC_1 tablePropertyIR*
     ---- ;; insert NoAction as default_action
     -- if tablePropertyIR_default_action
-        = `EMPTY eps DEFAULT_ACTION `= ((`` "NoAction") `( eps )) `;
+        = `EMPTY eps DEFAULT_ACTION `= ((`` "NoAction") eps `( eps )) `;
     -- if (TBLC_2, tablePropertyIR_updated*)
         = $insert_NoAction_tablePropertyIR(TBLC_1, tablePropertyIR*)
 

--- a/spec-concrete/6-dynamic-runtime/6.2.1-callable-def.watsup
+++ b/spec-concrete/6-dynamic-runtime/6.2.1-callable-def.watsup
@@ -9,7 +9,7 @@ syntax stateEnv, actionDefEnv, frame, tableObjectProperty
 ;;
 
 syntax actionDef =
-  ACTION nameIR `( parameterListIR ) blockStatementIR
+  annotationList ACTION nameIR `( parameterListIR ) blockStatementIR
 
 ;;
 ;;;; Function definitions

--- a/spec-concrete/6-dynamic-runtime/6.2.2-callable-def-aux.watsup
+++ b/spec-concrete/6-dynamic-runtime/6.2.2-callable-def-aux.watsup
@@ -9,7 +9,7 @@ dec $parameterListIR_of_callableDef(callableDef)
 
 dec $parameterListIR_of_actionDef(actionDef) : parameterIR*
 def $parameterListIR_of_actionDef(
-    ACTION _ `( parameterListIR ) _)
+    annotationList ACTION _ `( parameterListIR ) _)
   = parameterListIR
 
 def $parameterListIR_of_callableDef(actionDef)

--- a/spec-concrete/7-instantiation/7.02-inst-context.watsup
+++ b/spec-concrete/7-instantiation/7.02-inst-context.watsup
@@ -211,15 +211,19 @@ def $add_callableDef_non_overload_i(BLOCK, IC, callableId, callableDef)
 ;;; Finder for callable definitions
 
 dec $find_callableDef_non_overload_i(cursor, instContext, prefixedNameIR)
-  : (callableId, callableDef)?
+  : (cursor, callableId, callableDef)?
   hint(prose_in "the non-overloaded callable definition of" %2 "from the" %0 "layer of" %1)
 
 def $find_callableDef_non_overload_i(p, IC, `. nameIR)
-  = $find_non_overloaded<callableDef>(IC.GLOBAL.CALLABLE, nameIR)
+  = eps
+  -- if eps = $find_non_overloaded<callableDef>(IC.GLOBAL.CALLABLE, nameIR)
+def $find_callableDef_non_overload_i(p, IC, `. nameIR)
+  = (GLOBAL, callableId, callableDef)
+  -- if (callableId, callableDef) = $find_non_overloaded<callableDef>(IC.GLOBAL.CALLABLE, nameIR)
 def $find_callableDef_non_overload_i(GLOBAL, IC, `` nameIR)
-  = $find_non_overloaded<callableDef>(IC.GLOBAL.CALLABLE, nameIR)
+  = $find_callableDef_non_overload_i(GLOBAL, IC, `. nameIR)
 def $find_callableDef_non_overload_i(BLOCK, IC, `` nameIR)
-  = (callableId, callableDef)
+  = (BLOCK, callableId, callableDef)
   -- if (callableId, callableDef)
       = $find_non_overloaded<callableDef>(IC.BLOCK.CALLABLE, nameIR)
 def $find_callableDef_non_overload_i(BLOCK, IC, `` nameIR)

--- a/spec-concrete/7-instantiation/7.02-inst-context.watsup
+++ b/spec-concrete/7-instantiation/7.02-inst-context.watsup
@@ -208,6 +208,27 @@ def $add_callableDef_non_overload_i(BLOCK, IC, callableId, callableDef)
   -- if callableDefEnv
       = $add_map<callableId, callableDef>(IC.BLOCK.CALLABLE, callableId, callableDef)
 
+;;; Finder for callable definitions
+
+dec $find_callableDef_non_overload_i(cursor, instContext, prefixedNameIR)
+  : (callableId, callableDef)?
+  hint(prose_in "the non-overloaded callable definition of" %2 "from the" %0 "layer of" %1)
+
+def $find_callableDef_non_overload_i(p, IC, `. nameIR)
+  = $find_non_overloaded<callableDef>(IC.GLOBAL.CALLABLE, nameIR)
+def $find_callableDef_non_overload_i(GLOBAL, IC, `` nameIR)
+  = $find_non_overloaded<callableDef>(IC.GLOBAL.CALLABLE, nameIR)
+def $find_callableDef_non_overload_i(BLOCK, IC, `` nameIR)
+  = (callableId, callableDef)
+  -- if (callableId, callableDef)
+      = $find_non_overloaded<callableDef>(IC.BLOCK.CALLABLE, nameIR)
+def $find_callableDef_non_overload_i(BLOCK, IC, `` nameIR)
+  = $find_callableDef_non_overload_i(GLOBAL, IC, `` nameIR)
+  -- if eps
+      = $find_non_overloaded<callableDef>(IC.BLOCK.CALLABLE, nameIR)
+def $find_callableDef_non_overload_i(LOCAL, IC, `` nameIR)
+  = $find_callableDef_non_overload_i(BLOCK, IC, `` nameIR)
+
 ;;; Adder for constructor definitions
 
 dec $add_constructorDef_i(instContext, callableId, constructorDef) : instContext

--- a/spec-concrete/7-instantiation/7.03-inst-relation.watsup
+++ b/spec-concrete/7-instantiation/7.03-inst-relation.watsup
@@ -150,6 +150,21 @@ relation ParserLocalDecls_inst:
 ;;;; Control instantiation
 ;;
 
+relation TableAction_inst:
+  instContext store |- tableActionIR : store tableActionIR
+  hint(input %0 %1 %2)
+  hint(prose_in "compile-time evaluation of" %2#", under context" %0#
+                "and store" %1)
+  hint(prose_out "store" %3 "and" %4)
+
+relation TableActions_inst:
+  instContext store |- tableActionIR*
+                     : store tableActionIR*
+  hint(input %0 %1 %2)
+  hint(prose_in "compile-time evaluation of" %2#", under context" %0#
+                "and store" %1)
+  hint(prose_out "store" %3 "and" %4)
+
 relation TableProperty_inst:
   instContext store |- tablePropertyIR
                      : store tablePropertyIR

--- a/spec-concrete/7-instantiation/7.07-inst-declaration.watsup
+++ b/spec-concrete/7-instantiation/7.07-inst-declaration.watsup
@@ -212,7 +212,7 @@ rule ActionDecl_inst:
           : IC_1
   ---- ;; bind action definition to callable environment
   -- if callableId = $callableId_IR(nameIR, parameterListIR)
-  -- if actionDef = ACTION nameIR `( parameterListIR ) blockStatementIR
+  -- if actionDef = annotationList ACTION nameIR `( parameterListIR ) blockStatementIR
   -- if IC_1 = $add_callableDef_non_overload_i(p, IC_0, callableId, actionDef)
 
 rule Decl_inst/actionDeclarationIR:

--- a/spec-concrete/7-instantiation/7.10.1-inst-control-table.watsup
+++ b/spec-concrete/7-instantiation/7.10.1-inst-control-table.watsup
@@ -19,7 +19,7 @@ rulegroup TableAction_inst {
     -- if nameIR_anno = $name_annotation(annotationList_actionDef)
     ---- ;; if name annotation has dot prefix, use a standalone name
     -- if $starts_with(nameIR_anno, ".")
-    -- if controlPlaneNameIR = [ $strip_prefix(nameIR_anno, ".") ]
+    -- if controlPlaneNameIR = $strip_prefix(nameIR_anno, ".")
     -- if tableActionReferenceIR'
         = prefixedNameIR controlPlaneNameIR `( argumentListIR )
     -- if tableActionIR = annotationList tableActionReferenceIR'
@@ -38,7 +38,11 @@ rulegroup TableAction_inst {
     -- if nameIR_anno = $name_annotation(annotationList_actionDef)
     -- if ~$starts_with(nameIR_anno, ".")
     -- if controlPlaneNameIR
-        = $ite<controlPlaneNameIR>(cursor = GLOBAL, nameIR, IC.PATH ++ nameIR_anno)
+        = $ite<controlPlaneNameIR>(
+            cursor = GLOBAL,
+            nameIR_anno,
+            $join_text(IC.PATH ++ nameIR_anno, ".")
+          )
     -- if tableActionReferenceIR'
         = prefixedNameIR controlPlaneNameIR `( argumentListIR )
     -- if tableActionIR = annotationList tableActionReferenceIR'
@@ -57,7 +61,11 @@ rulegroup TableAction_inst {
     ---- ;; todo
     -- if eps = $name_annotation(annotationList_actionDef)
     -- if controlPlaneNameIR
-        = $ite<controlPlaneNameIR>(cursor = GLOBAL, nameIR, IC.PATH ++ nameIR)
+        = $ite<controlPlaneNameIR>(
+            cursor = GLOBAL,
+            nameIR,
+            $join_text(IC.PATH ++ nameIR, ".")
+          )
     -- if tableActionReferenceIR'
         = prefixedNameIR controlPlaneNameIR `( argumentListIR )
     -- if tableActionIR = annotationList tableActionReferenceIR'

--- a/spec-concrete/7-instantiation/7.10.1-inst-control-table.watsup
+++ b/spec-concrete/7-instantiation/7.10.1-inst-control-table.watsup
@@ -12,7 +12,7 @@ rulegroup TableAction_inst {
             : STO tableActionIR
     -- if tableActionReferenceIR
         = prefixedNameIR _ `( argumentListIR )
-    -- if (_, actionDef)
+    -- if (cursor, _, actionDef)
         = $find_callableDef_non_overload_i(LOCAL, IC, prefixedNameIR)
     -- if annotationList_actionDef ACTION nameIR `( _ ) _
         = actionDef
@@ -31,13 +31,14 @@ rulegroup TableAction_inst {
             : STO tableActionIR
     -- if tableActionReferenceIR
         = prefixedNameIR _ `( argumentListIR )
-    -- if (_, actionDef)
+    -- if (cursor, _, actionDef)
         = $find_callableDef_non_overload_i(LOCAL, IC, prefixedNameIR)
     -- if annotationList_actionDef ACTION nameIR `( _ ) _
         = actionDef
     -- if nameIR_anno = $name_annotation(annotationList_actionDef)
     -- if ~$starts_with(nameIR_anno, ".")
-    -- if controlPlaneNameIR = IC.PATH ++ nameIR_anno
+    -- if controlPlaneNameIR
+        = $ite<controlPlaneNameIR>(cursor = GLOBAL, nameIR, IC.PATH ++ nameIR_anno)
     -- if tableActionReferenceIR'
         = prefixedNameIR controlPlaneNameIR `( argumentListIR )
     -- if tableActionIR = annotationList tableActionReferenceIR'
@@ -49,13 +50,14 @@ rulegroup TableAction_inst {
             : STO tableActionIR
     -- if tableActionReferenceIR
         = prefixedNameIR _ `( argumentListIR )
-    -- if (_, actionDef)
+    -- if (cursor, _, actionDef)
         = $find_callableDef_non_overload_i(LOCAL, IC, prefixedNameIR)
     -- if annotationList_actionDef ACTION nameIR `( _ ) _
         = actionDef
     ---- ;; todo
     -- if eps = $name_annotation(annotationList_actionDef)
-    -- if controlPlaneNameIR = IC.PATH ++ nameIR
+    -- if controlPlaneNameIR
+        = $ite<controlPlaneNameIR>(cursor = GLOBAL, nameIR, IC.PATH ++ nameIR)
     -- if tableActionReferenceIR'
         = prefixedNameIR controlPlaneNameIR `( argumentListIR )
     -- if tableActionIR = annotationList tableActionReferenceIR'

--- a/spec-concrete/7-instantiation/7.10.1-inst-control-table.watsup
+++ b/spec-concrete/7-instantiation/7.10.1-inst-control-table.watsup
@@ -1,4 +1,90 @@
 ;;
+;; Table action instantiation
+;;
+;; syntax tableActionIR
+;;
+
+rulegroup TableAction_inst {
+
+  rule TableAction_inst/name-annotation-dot-prefix:
+    IC STO |- annotationList tableActionReferenceIR
+              `# `( parameterListIR `, parameterListIR_control ) `;
+            : STO tableActionIR
+    -- if tableActionReferenceIR
+        = prefixedNameIR _ `( argumentListIR )
+    -- if (_, actionDef)
+        = $find_callableDef_non_overload_i(LOCAL, IC, prefixedNameIR)
+    -- if annotationList_actionDef ACTION nameIR `( _ ) _
+        = actionDef
+    -- if nameIR_anno = $name_annotation(annotationList_actionDef)
+    ---- ;; if name annotation has dot prefix, use a standalone name
+    -- if $starts_with(nameIR_anno, ".")
+    -- if controlPlaneNameIR = [ $strip_prefix(nameIR_anno, ".") ]
+    -- if tableActionReferenceIR'
+        = prefixedNameIR controlPlaneNameIR `( argumentListIR )
+    -- if tableActionIR = annotationList tableActionReferenceIR'
+          `# `( parameterListIR `, parameterListIR_control ) `;
+
+  rule TableAction_inst/name-annotation:
+    IC STO |- annotationList tableActionReferenceIR
+              `# `( parameterListIR `, parameterListIR_control ) `;
+            : STO tableActionIR
+    -- if tableActionReferenceIR
+        = prefixedNameIR _ `( argumentListIR )
+    -- if (_, actionDef)
+        = $find_callableDef_non_overload_i(LOCAL, IC, prefixedNameIR)
+    -- if annotationList_actionDef ACTION nameIR `( _ ) _
+        = actionDef
+    -- if nameIR_anno = $name_annotation(annotationList_actionDef)
+    -- if ~$starts_with(nameIR_anno, ".")
+    -- if controlPlaneNameIR = IC.PATH ++ nameIR_anno
+    -- if tableActionReferenceIR'
+        = prefixedNameIR controlPlaneNameIR `( argumentListIR )
+    -- if tableActionIR = annotationList tableActionReferenceIR'
+          `# `( parameterListIR `, parameterListIR_control ) `;
+
+  rule TableAction_inst/no-name-annotation:
+    IC STO |- annotationList tableActionReferenceIR
+              `# `( parameterListIR `, parameterListIR_control ) `;
+            : STO tableActionIR
+    -- if tableActionReferenceIR
+        = prefixedNameIR _ `( argumentListIR )
+    -- if (_, actionDef)
+        = $find_callableDef_non_overload_i(LOCAL, IC, prefixedNameIR)
+    -- if annotationList_actionDef ACTION nameIR `( _ ) _
+        = actionDef
+    ---- ;; todo
+    -- if eps = $name_annotation(annotationList_actionDef)
+    -- if controlPlaneNameIR = IC.PATH ++ nameIR
+    -- if tableActionReferenceIR'
+        = prefixedNameIR controlPlaneNameIR `( argumentListIR )
+    -- if tableActionIR = annotationList tableActionReferenceIR'
+          `# `( parameterListIR `, parameterListIR_control ) `;
+
+}
+
+;;
+;; Table actions instantiation
+;;
+;; syntax tableActionListIR
+;;
+
+rulegroup TableActions_inst {
+
+  rule TableActions_inst/nil:
+    IC STO |- eps : STO eps
+
+  rule TableActions_inst/cons:
+    IC STO_0 |- tableActionIR_h :: tableActionIR_t*
+              : STO_1 (tableActionIR_h_inst :: tableActionIR_t_inst*)
+    -- TableAction_inst:
+        IC STO_0 |- tableActionIR_h : STO_1 tableActionIR_h_inst
+    -- TableActions_inst:
+        IC STO_1 |- tableActionIR_t* : STO_2 tableActionIR_t_inst*
+
+}
+
+;;
 ;; Table property instantiation
 ;;
 ;; syntax tablePropertyIR
@@ -12,7 +98,11 @@ rule TableProperty_inst/tableKeysPropertyIR:
 ;;; ACTIONS `= `{ tableActionListIR }
 
 rule TableProperty_inst/tableActionsPropertyIR:
-  IC STO |- tableActionsPropertyIR : STO tableActionsPropertyIR
+  IC STO_0 |- ACTIONS `= `{ tableActionListIR }
+          : STO_1 tableActionsPropertyIR
+  -- TableActions_inst:
+      IC STO_0 |- tableActionListIR : STO_1 tableActionListIR_inst
+  -- if tableActionsPropertyIR = ACTIONS `= `{ tableActionListIR_inst }
 
 ;;; annotationList constOptIR DEFAULT_ACTION `= tableActionReferenceIR `;
 

--- a/spec-concrete/8-dynamic/8.09.1-eval-control-table.watsup
+++ b/spec-concrete/8-dynamic/8.09.1-eval-control-table.watsup
@@ -298,7 +298,7 @@ rulegroup Table_eval {
         EC_1 ARCH_1 |- tableKeyValue* `@ tableEntryListIR
                      : EC_2 ARCH_2 (`` tableMatch*)
     ---- ;; select an action
-    -- if prefixedNameIR `( argumentListIR )
+    -- if prefixedNameIR _ `( argumentListIR )
         = $select_action(TBL, tableMatch*)
     ---- ;; evaluate the action
     -- Stmt_eval:
@@ -318,7 +318,7 @@ rulegroup Table_eval {
         EC_1 ARCH_1 |- tableKeyValue* `@ tableEntryListIR
                      : EC_2 ARCH_2 (`` tableMatch*)
     ---- ;; select an action
-    -- if prefixedNameIR `( argumentListIR )
+    -- if prefixedNameIR _ `( argumentListIR )
         = $select_action(TBL, tableMatch*)
     ---- ;; evaluate the action
     -- Stmt_eval:

--- a/spec-concrete/8-dynamic/8.10.1-eval-call-callee.watsup
+++ b/spec-concrete/8-dynamic/8.10.1-eval-call-callee.watsup
@@ -17,7 +17,7 @@ rule Callee_eval/actionCallee:
       = $find_callableDef_overloaded_e(
           p, EC, referenceExpressionIR, argumentListIR)
   ---- ;; prepare the callee
-  -- if ACTION nameIR `( parameterListIR ) blockStatementIR = actionDef
+  -- if _ ACTION nameIR `( parameterListIR ) blockStatementIR = actionDef
   -- if actionCallee
       = ACTION p_ref `. nameIR `( parameterListIR `# id_default* ) blockStatementIR
 

--- a/spec-concrete/9-arch/9.1-table-interface.watsup
+++ b/spec-concrete/9-arch/9.1-table-interface.watsup
@@ -374,7 +374,7 @@ def $find_tableActionIR_by_name(
     tableActionIR_h :: tableActionIR_t*,
     nameIR_target
   ) = (nameIR_action, tableActionIR_h)
-  -- if annotationList (prefixedNameIR `( argumentIR_data* ))
+  -- if annotationList (prefixedNameIR _ `( argumentIR_data* ))
           `# `( _ `, parameterIR_control* ) `; = tableActionIR_h
   -- if nameIR_action = $flatten_prefixedNameIR(prefixedNameIR)
   -- if eps = $name_annotation(annotationList)
@@ -384,7 +384,7 @@ def $find_tableActionIR_by_name(
     tableActionIR_h :: tableActionIR_t*,
     nameIR_target
   ) = $find_tableActionIR_by_name(tableActionIR_t*, nameIR_target)
-  -- if annotationList (prefixedNameIR `( argumentIR_data* ))
+  -- if annotationList (prefixedNameIR _ `( argumentIR_data* ))
           `# `( _ `, parameterIR_control* ) `; = tableActionIR_h
   -- if nameIR_action = $flatten_prefixedNameIR(prefixedNameIR)
   -- if eps = $name_annotation(annotationList)
@@ -394,7 +394,7 @@ def $find_tableActionIR_by_name(
     tableActionIR_h :: tableActionIR_t*,
     nameIR
   ) = (nameIR_action, tableActionIR_h)
-  -- if annotationList (prefixedNameIR `( argumentIR_data* ))
+  -- if annotationList (prefixedNameIR _ `( argumentIR_data* ))
           `# `( _ `, parameterIR_control* ) `; = tableActionIR_h
   -- if nameIR_action = $flatten_prefixedNameIR(prefixedNameIR)
   -- if nameIR_annotation* = $name_annotation(annotationList)
@@ -406,7 +406,7 @@ def $find_tableActionIR_by_name(
     tableActionIR_h :: tableActionIR_t*,
     nameIR
   ) = $find_tableActionIR_by_name(tableActionIR_t*, nameIR)
-  -- if annotationList (prefixedNameIR `( argumentIR_data* ))
+  -- if annotationList (prefixedNameIR _ `( argumentIR_data* ))
           `# `( _ `, parameterIR_control* ) `; = tableActionIR_h
   -- if nameIR_action = $flatten_prefixedNameIR(prefixedNameIR)
   -- if nameIR_annotation* = $name_annotation(annotationList)
@@ -419,7 +419,7 @@ def $find_tableActionIR_by_dotPrefix(
     tableActionIR_h :: tableActionIR_t*,
     nameIR_target
   ) = $find_tableActionIR_by_dotPrefix(tableActionIR_t*, nameIR_target)
-  -- if annotationList (_ `( _ ))
+  -- if annotationList (_ _ `( _ ))
           `# `( _ `, _ ) `; = tableActionIR_h
   -- if eps = $name_annotation(annotationList)
 
@@ -427,7 +427,7 @@ def $find_tableActionIR_by_dotPrefix(
     tableActionIR_h :: tableActionIR_t*,
     nameIR
   ) = $find_tableActionIR_by_dotPrefix(tableActionIR_t*, nameIR)
-  -- if annotationList (prefixedNameIR `( argumentIR_data* ))
+  -- if annotationList (prefixedNameIR _ `( argumentIR_data* ))
           `# `( _ `, parameterIR_control* ) `; = tableActionIR_h
   -- if nameIR_annotation* = $name_annotation(annotationList)
   -- if nameIR_annotation* =/= eps
@@ -437,7 +437,7 @@ def $find_tableActionIR_by_dotPrefix(
     tableActionIR_h :: tableActionIR_t*,
     nameIR
   ) = $find_tableActionIR_by_dotPrefix(tableActionIR_t*, nameIR)
-  -- if annotationList (prefixedNameIR `( argumentIR_data* ))
+  -- if annotationList (prefixedNameIR _ `( argumentIR_data* ))
           `# `( _ `, parameterIR_control* ) `; = tableActionIR_h
   -- if nameIR_annotation* = $name_annotation(annotationList)
   -- if nameIR_annotation_dotPrefix* =
@@ -450,7 +450,7 @@ def $find_tableActionIR_by_dotPrefix(
     tableActionIR_h :: tableActionIR_t*,
     nameIR
   ) = (nameIR_action, tableActionIR_h)
-  -- if annotationList (prefixedNameIR `( argumentIR_data* ))
+  -- if annotationList (prefixedNameIR _ `( argumentIR_data* ))
           `# `( _ `, parameterIR_control* ) `; = tableActionIR_h
   -- if nameIR_annotation* = $name_annotation(annotationList)
   -- if nameIR_annotation_dotPrefix* =
@@ -471,11 +471,11 @@ def $tableObject_create_entry_action(
     EC,
     ACTIONS `= `{ tableActionIR* },
     (nameIR_action_update, tableActionArgumentInterface_update*))
-  = (`` nameIR_found) `( argumentIR* )
+  = (`` nameIR_found) controlPlaneNameIR `( argumentIR* )
   ---- ;; fetch table action interface
   -- if (nameIR_found, tableActionIR_found)
       = $find_tableActionIR_by_dotPrefix(tableActionIR*, nameIR_action_update)
-  -- if annotationList (prefixedNameIR `( argumentIR_data* ))
+  -- if annotationList (prefixedNameIR controlPlaneNameIR `( argumentIR_data* ))
           `# `( _ `, parameterIR_control* ) `; = tableActionIR_found
   ---- ;; align action arguments with control plane parameters
   -- if i_arg_aligned*
@@ -493,13 +493,13 @@ def $tableObject_create_entry_action(
     EC,
     ACTIONS `= `{ tableActionIR* },
     (nameIR_action_update, tableActionArgumentInterface_update*))
-  = (`` nameIR_found) `( argumentIR* )
+  = (`` nameIR_found) controlPlaneNameIR `( argumentIR* )
   ---- ;; fetch table action interface
   -- if eps
       = $find_tableActionIR_by_dotPrefix(tableActionIR*, nameIR_action_update)
   -- if (nameIR_found, tableActionIR_found)
       = $find_tableActionIR_by_name(tableActionIR*, nameIR_action_update)
-  -- if annotationList (prefixedNameIR `( argumentIR_data* ))
+  -- if annotationList (prefixedNameIR controlPlaneNameIR `( argumentIR_data* ))
           `# `( _ `, parameterIR_control* ) `; = tableActionIR_found
   ---- ;; align action arguments with control plane parameters
   -- if i_arg_aligned*

--- a/spec-concrete/9-arch/9.1-table-interface.watsup
+++ b/spec-concrete/9-arch/9.1-table-interface.watsup
@@ -364,99 +364,71 @@ def $align_tableActionArgumentInterfaces'(
     `{ (id_arg `: i_arg)* }, _ _ _ nameIR_param _)
   = $find_map<id, int>(`{ (id_arg `: i_arg)* }, nameIR_param)
 
-;;; Find table action by either its identifier or @name annotation
+;;; Find table action by qualified name
 
-dec $find_tableActionIR_by_name(tableActionIR*, nameIR) : (nameIR, tableActionIR)?
-dec $find_tableActionIR_by_dotPrefix(tableActionIR*, nameIR) : (nameIR, tableActionIR)?
+dec $find_tableActionIR_qualified(tableActionIR*, nameIR)
+  : (nameIR, tableActionIR)?
 
-def $find_tableActionIR_by_name(eps, _) = eps
-def $find_tableActionIR_by_name(
+def $find_tableActionIR_qualified(eps, nameIR) = eps
+def $find_tableActionIR_qualified(
     tableActionIR_h :: tableActionIR_t*,
-    nameIR_target
-  ) = (nameIR_action, tableActionIR_h)
-  -- if annotationList (prefixedNameIR _ `( argumentIR_data* ))
+    nameIR
+  ) = $find_tableActionIR_qualified(tableActionIR_t*, nameIR)
+  -- if annotationList tableActionReferenceIR
           `# `( _ `, parameterIR_control* ) `; = tableActionIR_h
-  -- if nameIR_action = $flatten_prefixedNameIR(prefixedNameIR)
-  -- if eps = $name_annotation(annotationList)
-  -- if nameIR_action = nameIR_target
-
-def $find_tableActionIR_by_name(
-    tableActionIR_h :: tableActionIR_t*,
-    nameIR_target
-  ) = $find_tableActionIR_by_name(tableActionIR_t*, nameIR_target)
-  -- if annotationList (prefixedNameIR _ `( argumentIR_data* ))
-          `# `( _ `, parameterIR_control* ) `; = tableActionIR_h
-  -- if nameIR_action = $flatten_prefixedNameIR(prefixedNameIR)
-  -- if eps = $name_annotation(annotationList)
-  -- if nameIR_action =/= nameIR_target
-
-def $find_tableActionIR_by_name(
+  -- if prefixedNameIR controlPlaneNameIR `( argumentIR_data* )
+      = tableActionReferenceIR
+  -- if nameIR =/= controlPlaneNameIR
+def $find_tableActionIR_qualified(
     tableActionIR_h :: tableActionIR_t*,
     nameIR
   ) = (nameIR_action, tableActionIR_h)
-  -- if annotationList (prefixedNameIR _ `( argumentIR_data* ))
+  -- if annotationList tableActionReferenceIR
           `# `( _ `, parameterIR_control* ) `; = tableActionIR_h
+  -- if prefixedNameIR controlPlaneNameIR `( argumentIR_data* )
+      = tableActionReferenceIR
+  -- if nameIR = controlPlaneNameIR
   -- if nameIR_action = $flatten_prefixedNameIR(prefixedNameIR)
-  -- if nameIR_annotation* = $name_annotation(annotationList)
-  -- if nameIR_annotation* =/= eps
-  -- if b_hit = ((nameIR = nameIR_action) \/ (nameIR <- nameIR_annotation*))
-  -- if b_hit
 
-def $find_tableActionIR_by_name(
+;;; Find table action by unqualified name
+;;; NOTE: performs greedy search
+
+dec $find_tableActionIR_unqualified(tableActionIR*, nameIR)
+  : (nameIR, tableActionIR)?
+dec $find_tableActionIR_unqualified'(tableActionIR*, nameIR)
+  : (nameIR, tableActionIR)?
+
+def $find_tableActionIR_unqualified(tableActionIR*, nameIR) = eps
+  -- if nameIR_split* = $split_text(nameIR, ".")
+  -- if $(|nameIR_split*| > 1)
+def $find_tableActionIR_unqualified(tableActionIR*, nameIR)
+  = $find_tableActionIR_unqualified'(tableActionIR*, nameIR_split*[0])
+  -- if nameIR_split* = $split_text(nameIR, ".")
+  -- if $(|nameIR_split*| = 1)
+
+def $find_tableActionIR_unqualified'(eps, nameIR) = eps
+def $find_tableActionIR_unqualified'(
     tableActionIR_h :: tableActionIR_t*,
     nameIR
-  ) = $find_tableActionIR_by_name(tableActionIR_t*, nameIR)
-  -- if annotationList (prefixedNameIR _ `( argumentIR_data* ))
+  ) = $find_tableActionIR_unqualified'(tableActionIR_t*, nameIR)
+  -- if annotationList tableActionReferenceIR
           `# `( _ `, parameterIR_control* ) `; = tableActionIR_h
-  -- if nameIR_action = $flatten_prefixedNameIR(prefixedNameIR)
-  -- if nameIR_annotation* = $name_annotation(annotationList)
-  -- if nameIR_annotation* =/= eps
-  -- if b_hit = ((nameIR = nameIR_action) \/ (nameIR <- nameIR_annotation*))
-  -- if ~b_hit
-
-def $find_tableActionIR_by_dotPrefix(eps, _) = eps
-def $find_tableActionIR_by_dotPrefix(
-    tableActionIR_h :: tableActionIR_t*,
-    nameIR_target
-  ) = $find_tableActionIR_by_dotPrefix(tableActionIR_t*, nameIR_target)
-  -- if annotationList (_ _ `( _ ))
-          `# `( _ `, _ ) `; = tableActionIR_h
-  -- if eps = $name_annotation(annotationList)
-
-def $find_tableActionIR_by_dotPrefix(
-    tableActionIR_h :: tableActionIR_t*,
-    nameIR
-  ) = $find_tableActionIR_by_dotPrefix(tableActionIR_t*, nameIR)
-  -- if annotationList (prefixedNameIR _ `( argumentIR_data* ))
-          `# `( _ `, parameterIR_control* ) `; = tableActionIR_h
-  -- if nameIR_annotation* = $name_annotation(annotationList)
-  -- if nameIR_annotation* =/= eps
-  -- if eps = $filter_<nameIR>(nameIR_annotation*, $starts_with(nameIR_annotation, ".")*)
-
-def $find_tableActionIR_by_dotPrefix(
-    tableActionIR_h :: tableActionIR_t*,
-    nameIR
-  ) = $find_tableActionIR_by_dotPrefix(tableActionIR_t*, nameIR)
-  -- if annotationList (prefixedNameIR _ `( argumentIR_data* ))
-          `# `( _ `, parameterIR_control* ) `; = tableActionIR_h
-  -- if nameIR_annotation* = $name_annotation(annotationList)
-  -- if nameIR_annotation_dotPrefix* =
-      $filter_<nameIR>(nameIR_annotation*, $starts_with(nameIR_annotation, ".")*)
-  -- if nameIR_annotation_dotPrefix* =/= eps
-  -- if nameIR_annotation_strip* = $strip_prefix(nameIR_annotation_dotPrefix, ".")*
-  -- if ~(nameIR <- nameIR_annotation_strip*)
-
-def $find_tableActionIR_by_dotPrefix(
+  -- if prefixedNameIR nameIR_controlPlane `( argumentIR_data* )
+      = tableActionReferenceIR
+  -- if nameIR_split* = $split_text(nameIR_controlPlane, ".")
+  -- if nameIR_unqualified :: _ = $rev_<nameIR>(nameIR_split*)
+  -- if nameIR =/= nameIR_unqualified
+def $find_tableActionIR_unqualified'(
     tableActionIR_h :: tableActionIR_t*,
     nameIR
   ) = (nameIR_action, tableActionIR_h)
-  -- if annotationList (prefixedNameIR _ `( argumentIR_data* ))
+  -- if annotationList tableActionReferenceIR
           `# `( _ `, parameterIR_control* ) `; = tableActionIR_h
-  -- if nameIR_annotation* = $name_annotation(annotationList)
-  -- if nameIR_annotation_dotPrefix* =
-      $filter_<nameIR>(nameIR_annotation*, $starts_with(nameIR_annotation, ".")*)
-  -- if nameIR_annotation_strip* = $strip_prefix(nameIR_annotation_dotPrefix, ".")*
-  -- if nameIR <- nameIR_annotation_strip*
+  -- if prefixedNameIR nameIR_controlPlane `( argumentIR_data* )
+      = tableActionReferenceIR
+  -- if nameIR_split* = $split_text(nameIR_controlPlane, ".")
+  -- if nameIR_unqualified :: _ = $rev_<nameIR>(nameIR_split*)
+  -- if nameIR = nameIR_unqualified
   -- if nameIR_action = $flatten_prefixedNameIR(prefixedNameIR)
 
 ;;; Table entry action creation
@@ -474,7 +446,7 @@ def $tableObject_create_entry_action(
   = (`` nameIR_found) controlPlaneNameIR `( argumentIR* )
   ---- ;; fetch table action interface
   -- if (nameIR_found, tableActionIR_found)
-      = $find_tableActionIR_by_dotPrefix(tableActionIR*, nameIR_action_update)
+      = $find_tableActionIR_qualified(tableActionIR*, nameIR_action_update)
   -- if annotationList (prefixedNameIR controlPlaneNameIR `( argumentIR_data* ))
           `# `( _ `, parameterIR_control* ) `; = tableActionIR_found
   ---- ;; align action arguments with control plane parameters
@@ -488,7 +460,6 @@ def $tableObject_create_entry_action(
   -- if (typedExpressionIR_arg_cast
       = $cast_control_plane(EC, typedExpressionIR_arg, typeIR_param))*
   -- if argumentIR* = argumentIR_data* ++ typedExpressionIR_arg_cast*
-
 def $tableObject_create_entry_action(
     EC,
     ACTIONS `= `{ tableActionIR* },
@@ -496,9 +467,9 @@ def $tableObject_create_entry_action(
   = (`` nameIR_found) controlPlaneNameIR `( argumentIR* )
   ---- ;; fetch table action interface
   -- if eps
-      = $find_tableActionIR_by_dotPrefix(tableActionIR*, nameIR_action_update)
+      = $find_tableActionIR_qualified(tableActionIR*, nameIR_action_update)
   -- if (nameIR_found, tableActionIR_found)
-      = $find_tableActionIR_by_name(tableActionIR*, nameIR_action_update)
+      = $find_tableActionIR_unqualified(tableActionIR*, nameIR_action_update)
   -- if annotationList (prefixedNameIR controlPlaneNameIR `( argumentIR_data* ))
           `# `( _ `, parameterIR_control* ) `; = tableActionIR_found
   ---- ;; align action arguments with control plane parameters


### PR DESCRIPTION
This PR adds supports for adding table entries with qualified action names from the control plane.

Every action entry in a table now stores a control plane name. Upon table entry installation, the control plane will compare a given name to each control plane names within the action list.

Also, `run` tests do not run tests in `testdata/custom` anymore.