### PR TITLE
Expand the IL/SL interpreter and antiunify to support struct expression to struct value assignment pattern  

### DIFF
--- a/p4spec/lib/interp/interp-il/interp.ml
+++ b/p4spec/lib/interp/interp-il/interp.ml
@@ -31,6 +31,10 @@ module Make (Arch : Sim.ARCH) : Sim.INTERP_IL = struct
     | VarE id, _ -> Ctx.add_value ctx (id, []) value
     | TupleE exps, TupleV values -> assign_exps ctx exps values
     | CaseE (_, exps), CaseV (_, values) -> assign_exps ctx exps values
+    | StrE exps, StructV values ->
+        let exps = List.map snd exps in
+        let values = List.map snd values in
+        assign_exps ctx exps values
     | OptE exp_opt, OptV value_opt -> (
         match (exp_opt, value_opt) with
         | Some exp, Some value -> assign_exp ctx exp value

--- a/p4spec/lib/interp/interp-sl/interp.ml
+++ b/p4spec/lib/interp/interp-sl/interp.ml
@@ -46,6 +46,15 @@ module Make (Arch : Sim.ARCH) : Sim.INTERP_SL = struct
             Hook.on_value_dependency value_inner value Dep.Edges.Assign)
           values_inner;
         ctx
+    | StrE exps_inner, StructV values_inner ->
+        let exps_inner = List.map snd exps_inner in
+        let values_inner = List.map snd values_inner in
+        let ctx = assign_exps ctx exps_inner values_inner in
+        List.iter
+          (fun value_inner ->
+            Hook.on_value_dependency value_inner value Dep.Edges.Assign)
+          values_inner;
+        ctx
     | OptE exp_opt, OptV value_opt -> (
         match (exp_opt, value_opt) with
         | Some exp_inner, Some value_inner ->

--- a/p4spec/lib/pass/elaborate/antiunify.ml
+++ b/p4spec/lib/pass/elaborate/antiunify.ml
@@ -37,6 +37,15 @@ let rec overlap_exp (tdenv : Envs.TDEnv.t) (frees : IdSet.t)
           CaseE (mixop_template, exps_template) $$ (at, note)
         in
         Ok (frees, unifiers, exp_template)
+    | StrE atoms_exps_template, StrE atoms_exps ->
+        let atoms_template = List.map fst atoms_exps_template in
+        let exps_template = List.map snd atoms_exps_template in
+        let exps = List.map snd atoms_exps in
+        let* frees, unifiers, exps_template =
+          overlap_exps tdenv frees unifiers exps_template exps
+        in
+        let exp_template = StrE (List.combine atoms_template exps_template) $$ (at, note) in
+        Ok (frees, unifiers, exp_template)
     | _ ->
         fail exp.at
           (Format.asprintf "cannot anti-unify expressions %s and %s"
@@ -139,6 +148,10 @@ let rec populate_exp (unifiers : IdSet.t) (exp_template : exp) (exp : exp) :
         populate_exps unifiers exps_template exps
     | CaseE (mixop_template, exps_template), CaseE (mixop, exps)
       when Il.Eq.eq_mixop mixop_template mixop ->
+        populate_exps unifiers exps_template exps
+    | StrE atoms_exps_template, StrE atoms_exps ->
+        let exps_template = List.map snd atoms_exps_template in
+        let exps = List.map snd atoms_exps in
         populate_exps unifiers exps_template exps
     | _ ->
         let exp_match =

--- a/p4spec/lib/pass/structure/antiunify.ml
+++ b/p4spec/lib/pass/structure/antiunify.ml
@@ -29,6 +29,10 @@ let rec populate_exp_template (uenv : UEnv.t) (exp_template : exp) (exp : exp) :
     | CaseE (mixop_template, exps_template), CaseE (mixop, exps)
       when Il.Eq.eq_mixop mixop_template mixop ->
         populate_exps_templates uenv exps_template exps
+    | StrE atoms_exps_template, StrE atoms_exps ->
+        let exps_template = List.map snd atoms_exps_template in
+        let exps = List.map snd atoms_exps in
+        populate_exps_templates uenv exps_template exps
     | ( IterE (exp_template, (iter_template, vars_template)),
         IterE (exp, (iter, vars)) )
       when Il.Eq.eq_iter iter_template iter ->
@@ -87,6 +91,15 @@ let rec antiunify_exp (frees : IdSet.t) (uenv : UEnv.t) (exp_template : exp)
         let exp_template =
           CaseE (mixop_template, exps_template) $$ (at, note)
         in
+        (frees, uenv, exp_template)
+    | StrE atoms_exps_template, StrE atoms_exps ->
+        let atoms_template = List.map fst atoms_exps_template in
+        let exps_template = List.map snd atoms_exps_template in
+        let exps = List.map snd atoms_exps in
+        let frees, uenv, exps_template =
+          antiunify_exps frees uenv exps_template exps
+        in
+        let exp_template = StrE (List.combine atoms_template exps_template) $$ (at, note) in
         (frees, uenv, exp_template)
     | ( IterE (exp_template, (iter_template, vars_template)),
         IterE (exp, (iter, vars)) )


### PR DESCRIPTION
While writing validation rules of Wasm in P4-SpecTec, I found a pattern where struct expressions are matched against struct values, as in the following example:
```
syntax limits = {MIN i64, MAX i64?}

relation Limits_ok: context range |- limits : OK  hint(input %0 %1 %2)

rule Limits_ok/without-max:
  C_0 range |- { MIN i64, MAX eps } : OK
  -- if $le_u(i64, range)
```

In ```Limits_ok```, one of the inputs, ```limits```, is a meta-type that expects a struct value. However, the current IL/SL interpreter does not support this kind of assignment pattern.

This PR fills in that missing pattern support, and it now works correctly for such cases.

Thank you in advance for the review. 