### PR TITLE
Expand the IL/SL interpreter and antiunify to support struct expression to struct value assignment pattern

### DIFF
--- a/p4spec/lib/interp/interp-il/interp.ml
+++ b/p4spec/lib/interp/interp-il/interp.ml
@@ -31,9 +31,9 @@ module Make (Arch : Sim.ARCH) : Sim.INTERP_IL = struct
     | VarE id, _ -> Ctx.add_value ctx (id, []) value
     | TupleE exps, TupleV values -> assign_exps ctx exps values
     | CaseE (_, exps), CaseV (_, values) -> assign_exps ctx exps values
-    | StrE exps, StructV values ->
-        let exps = List.map snd exps in
-        let values = List.map snd values in
+    | StrE expfields, StructV valuefields ->
+        let exps = List.map snd expfields in
+        let values = List.map snd valuefields in
         assign_exps ctx exps values
     | OptE exp_opt, OptV value_opt -> (
         match (exp_opt, value_opt) with

--- a/p4spec/lib/interp/interp-il/interp.ml
+++ b/p4spec/lib/interp/interp-il/interp.ml
@@ -31,6 +31,10 @@ module Make (Arch : Sim.ARCH) : Sim.INTERP_IL = struct
     | VarE id, _ -> Ctx.add_value ctx (id, []) value
     | TupleE exps, TupleV values -> assign_exps ctx exps values
     | CaseE (_, exps), CaseV (_, values) -> assign_exps ctx exps values
+    | StrE exps, StructV values ->
+        let exps = List.map snd exps in
+        let values = List.map snd values in
+        assign_exps ctx exps values
     | OptE exp_opt, OptV value_opt -> (
         match (exp_opt, value_opt) with
         | Some exp, Some value -> assign_exp ctx exp value

--- a/p4spec/lib/interp/interp-sl/interp.ml
+++ b/p4spec/lib/interp/interp-sl/interp.ml
@@ -46,9 +46,9 @@ module Make (Arch : Sim.ARCH) : Sim.INTERP_SL = struct
             Hook.on_value_dependency value_inner value Dep.Edges.Assign)
           values_inner;
         ctx
-    | StrE exps_inner, StructV values_inner ->
-        let exps_inner = List.map snd exps_inner in
-        let values_inner = List.map snd values_inner in
+    | StrE expfields, StructV valuefields ->
+        let exps_inner = List.map snd expfields in
+        let values_inner = List.map snd valuefields in
         let ctx = assign_exps ctx exps_inner values_inner in
         List.iter
           (fun value_inner ->

--- a/p4spec/lib/interp/interp-sl/interp.ml
+++ b/p4spec/lib/interp/interp-sl/interp.ml
@@ -46,6 +46,15 @@ module Make (Arch : Sim.ARCH) : Sim.INTERP_SL = struct
             Hook.on_value_dependency value_inner value Dep.Edges.Assign)
           values_inner;
         ctx
+    | StrE exps_inner, StructV values_inner ->
+        let exps_inner = List.map snd exps_inner in
+        let values_inner = List.map snd values_inner in
+        let ctx = assign_exps ctx exps_inner values_inner in
+        List.iter
+          (fun value_inner ->
+            Hook.on_value_dependency value_inner value Dep.Edges.Assign)
+          values_inner;
+        ctx
     | OptE exp_opt, OptV value_opt -> (
         match (exp_opt, value_opt) with
         | Some exp_inner, Some value_inner ->

--- a/p4spec/lib/pass/elaborate/antiunify.ml
+++ b/p4spec/lib/pass/elaborate/antiunify.ml
@@ -11,6 +11,12 @@ let rec overlap_exp (tdenv : Envs.TDEnv.t) (frees : IdSet.t)
     (unifiers : IdSet.t) (exp_template : exp) (exp : exp) :
     (IdSet.t * IdSet.t * exp) attempt =
   let at, note = (exp_template.at, exp_template.note) in
+  let fail =
+    fail exp.at
+      (Format.asprintf "cannot anti-unify expressions %s and %s"
+         (Il.Print.string_of_exp exp_template)
+         (Il.Print.string_of_exp exp))
+  in
   let overlap_exp_unequal' () : (IdSet.t * IdSet.t * exp) attempt =
     match (exp_template.it, exp.it) with
     | VarE id_template, _ when IdSet.mem id_template unifiers ->
@@ -37,20 +43,18 @@ let rec overlap_exp (tdenv : Envs.TDEnv.t) (frees : IdSet.t)
           CaseE (mixop_template, exps_template) $$ (at, note)
         in
         Ok (frees, unifiers, exp_template)
-    | StrE atoms_exps_template, StrE atoms_exps ->
-        let atoms_template = List.map fst atoms_exps_template in
-        let exps_template = List.map snd atoms_exps_template in
-        let exps = List.map snd atoms_exps in
-        let* frees, unifiers, exps_template =
-          overlap_exps tdenv frees unifiers exps_template exps
-        in
-        let exp_template = StrE (List.combine atoms_template exps_template) $$ (at, note) in
-        Ok (frees, unifiers, exp_template)
-    | _ ->
-        fail exp.at
-          (Format.asprintf "cannot anti-unify expressions %s and %s"
-             (Il.Print.string_of_exp exp_template)
-             (Il.Print.string_of_exp exp))
+    | StrE expfields_template, StrE expfields ->
+        let atoms_template, exps_template = List.split expfields_template in
+        let atoms, exps = List.split expfields in
+        if not (List.for_all2 Il.Eq.eq_atom atoms_template atoms) then fail
+        else
+          let* frees, unifiers, exps_template =
+            overlap_exps tdenv frees unifiers exps_template exps
+          in
+          let expfields_template = List.combine atoms_template exps_template in
+          let exp_template = StrE expfields_template $$ (at, note) in
+          Ok (frees, unifiers, exp_template)
+    | _ -> fail
   in
   let overlap_exp_unequal () : (IdSet.t * IdSet.t * exp) attempt =
     match overlap_exp_unequal' () with
@@ -60,11 +64,7 @@ let rec overlap_exp (tdenv : Envs.TDEnv.t) (frees : IdSet.t)
         let plaintyp_template = typ_template |> Plaintyp.of_internal_typ in
         let plaintyp = exp.note $ exp.at |> Plaintyp.of_internal_typ in
         if not (Types.Equiv.equiv_plaintyp tdenv plaintyp_template plaintyp)
-        then
-          fail exp.at
-            (Format.asprintf "cannot anti-unify expressions %s and %s"
-               (Il.Print.string_of_exp exp_template)
-               (Il.Print.string_of_exp exp))
+        then fail
         else
           let id_fresh, typ_fresh, iter_fresh =
             Fresh.fresh_var_from_typ frees exp_template.at typ_template
@@ -149,9 +149,9 @@ let rec populate_exp (unifiers : IdSet.t) (exp_template : exp) (exp : exp) :
     | CaseE (mixop_template, exps_template), CaseE (mixop, exps)
       when Il.Eq.eq_mixop mixop_template mixop ->
         populate_exps unifiers exps_template exps
-    | StrE atoms_exps_template, StrE atoms_exps ->
-        let exps_template = List.map snd atoms_exps_template in
-        let exps = List.map snd atoms_exps in
+    | StrE expfields_template, StrE expfields ->
+        let exps_template = List.map snd expfields_template in
+        let exps = List.map snd expfields in
         populate_exps unifiers exps_template exps
     | _ ->
         let exp_match =

--- a/p4spec/lib/pass/elaborate/antiunify.ml
+++ b/p4spec/lib/pass/elaborate/antiunify.ml
@@ -37,6 +37,15 @@ let rec overlap_exp (tdenv : Envs.TDEnv.t) (frees : IdSet.t)
           CaseE (mixop_template, exps_template) $$ (at, note)
         in
         Ok (frees, unifiers, exp_template)
+    | StrE atoms_exps_template, StrE atoms_exps ->
+        let atoms_template = List.map fst atoms_exps_template in
+        let exps_template = List.map snd atoms_exps_template in
+        let exps = List.map snd atoms_exps in
+        let* frees, unifiers, exps_template =
+          overlap_exps tdenv frees unifiers exps_template exps
+        in
+        let exp_template = StrE (List.combine atoms_template exps_template) $$ (at, note) in
+        Ok (frees, unifiers, exp_template)
     | _ ->
         fail exp.at
           (Format.asprintf "cannot anti-unify expressions %s and %s"
@@ -139,6 +148,10 @@ let rec populate_exp (unifiers : IdSet.t) (exp_template : exp) (exp : exp) :
         populate_exps unifiers exps_template exps
     | CaseE (mixop_template, exps_template), CaseE (mixop, exps)
       when Il.Eq.eq_mixop mixop_template mixop ->
+        populate_exps unifiers exps_template exps
+    | StrE atoms_exps_template, StrE atoms_exps ->
+        let exps_template = List.map snd atoms_exps_template in
+        let exps = List.map snd atoms_exps in
         populate_exps unifiers exps_template exps
     | _ ->
         let exp_match =

--- a/p4spec/lib/pass/structure/antiunify.ml
+++ b/p4spec/lib/pass/structure/antiunify.ml
@@ -29,6 +29,10 @@ let rec populate_exp_template (uenv : UEnv.t) (exp_template : exp) (exp : exp) :
     | CaseE (mixop_template, exps_template), CaseE (mixop, exps)
       when Il.Eq.eq_mixop mixop_template mixop ->
         populate_exps_templates uenv exps_template exps
+    | StrE atoms_exps_template, StrE atoms_exps ->
+        let exps_template = List.map snd atoms_exps_template in
+        let exps = List.map snd atoms_exps in
+        populate_exps_templates uenv exps_template exps
     | ( IterE (exp_template, (iter_template, vars_template)),
         IterE (exp, (iter, vars)) )
       when Il.Eq.eq_iter iter_template iter ->
@@ -87,6 +91,15 @@ let rec antiunify_exp (frees : IdSet.t) (uenv : UEnv.t) (exp_template : exp)
         let exp_template =
           CaseE (mixop_template, exps_template) $$ (at, note)
         in
+        (frees, uenv, exp_template)
+    | StrE atoms_exps_template, StrE atoms_exps ->
+        let atoms_template = List.map fst atoms_exps_template in
+        let exps_template = List.map snd atoms_exps_template in
+        let exps = List.map snd atoms_exps in
+        let frees, uenv, exps_template =
+          antiunify_exps frees uenv exps_template exps
+        in
+        let exp_template = StrE (List.combine atoms_template exps_template) $$ (at, note) in
         (frees, uenv, exp_template)
     | ( IterE (exp_template, (iter_template, vars_template)),
         IterE (exp, (iter, vars)) )

--- a/p4spec/lib/pass/structure/antiunify.ml
+++ b/p4spec/lib/pass/structure/antiunify.ml
@@ -1,6 +1,7 @@
 open Domain.Lib
 open Lang
 open Il
+open Error
 open Util.Source
 
 (* Unification environment: a map from original id to its unified id *)
@@ -29,9 +30,9 @@ let rec populate_exp_template (uenv : UEnv.t) (exp_template : exp) (exp : exp) :
     | CaseE (mixop_template, exps_template), CaseE (mixop, exps)
       when Il.Eq.eq_mixop mixop_template mixop ->
         populate_exps_templates uenv exps_template exps
-    | StrE atoms_exps_template, StrE atoms_exps ->
-        let exps_template = List.map snd atoms_exps_template in
-        let exps = List.map snd atoms_exps in
+    | StrE expfields_template, StrE expfields ->
+        let exps_template = List.map snd expfields_template in
+        let exps = List.map snd expfields in
         populate_exps_templates uenv exps_template exps
     | ( IterE (exp_template, (iter_template, vars_template)),
         IterE (exp, (iter, vars)) )
@@ -59,6 +60,12 @@ and populate_exps_templates (uenv : UEnv.t) (exps_template : exp list)
 
 let rec antiunify_exp (frees : IdSet.t) (uenv : UEnv.t) (exp_template : exp)
     (exp : exp) : IdSet.t * UEnv.t * exp =
+  let fail () =
+    error exp.at
+      (Format.asprintf "cannot anti-unify expressions %s and %s"
+         (Il.Print.string_of_exp exp_template)
+         (Il.Print.string_of_exp exp))
+  in
   let antiunify_exp_unequal () =
     let at, note = (exp_template.at, exp_template.note) in
     match (exp_template.it, exp.it) with
@@ -92,14 +99,15 @@ let rec antiunify_exp (frees : IdSet.t) (uenv : UEnv.t) (exp_template : exp)
           CaseE (mixop_template, exps_template) $$ (at, note)
         in
         (frees, uenv, exp_template)
-    | StrE atoms_exps_template, StrE atoms_exps ->
-        let atoms_template = List.map fst atoms_exps_template in
-        let exps_template = List.map snd atoms_exps_template in
-        let exps = List.map snd atoms_exps in
+    | StrE expfields_template, StrE expfields ->
+        let atoms_template, exps_template = List.split expfields_template in
+        let atoms, exps = List.split expfields in
+        if not (List.for_all2 Il.Eq.eq_atom atoms_template atoms) then fail ();
         let frees, uenv, exps_template =
           antiunify_exps frees uenv exps_template exps
         in
-        let exp_template = StrE (List.combine atoms_template exps_template) $$ (at, note) in
+        let expfields_template = List.combine atoms_template exps_template in
+        let exp_template = StrE expfields_template $$ (at, note) in
         (frees, uenv, exp_template)
     | ( IterE (exp_template, (iter_template, vars_template)),
         IterE (exp, (iter, vars)) )
@@ -124,11 +132,7 @@ let rec antiunify_exp (frees : IdSet.t) (uenv : UEnv.t) (exp_template : exp)
           IterE (exp_template, (iter_template, vars_template)) $$ (at, note)
         in
         (frees, uenv, exp_template)
-    | _ ->
-        Format.asprintf "cannot anti-unify expressions %s and %s"
-          (Il.Print.string_of_exp exp_template)
-          (Il.Print.string_of_exp exp)
-        |> failwith
+    | _ -> fail ()
   in
   if Il.Eq.eq_exp exp_template exp then (frees, uenv, exp_template)
   else antiunify_exp_unequal ()


### PR DESCRIPTION
While writing validation rules of Wasm in P4-SpecTec, I found a pattern where struct expressions are matched against struct values, as in the following example:
```
syntax limits = {MIN i64, MAX i64?}

relation Limits_ok: context range |- limits : OK  hint(input %0 %1 %2)

rule Limits_ok/without-max:
  C_0 range |- { MIN i64, MAX eps } : OK
  -- if $le_u(i64, range)
```

In ```Limits_ok```, one of the inputs, ```limits```, is a meta-type that expects a struct value. However, the current IL/SL interpreter does not support this kind of assignment pattern.

This PR fills in that missing pattern support, and it now works correctly for such cases.

Thank you in advance for the review. 