### PR TITLE
Fix gnupg2 package name in asciidoctor installer script

### DIFF
--- a/docs/install-asciidoctor-linux.sh
+++ b/docs/install-asciidoctor-linux.sh
@@ -133,7 +133,7 @@ TIME_START=$(date +%s)
 # my own convenience):
 if [ "${ID}" = "ubuntu" ]
 then
-    sudo apt-get --yes install gnupg curl
+    sudo apt-get --yes install gnupg2 curl
 elif [ "${ID}" = "fedora" ]
 then
     sudo dnf -y update


### PR DESCRIPTION
This PR fixes a typo in `docs/install-asciidoctor-linux.sh`. `gnupg2` should be installed instead of `gnupg`.