### PR TITLE
Add sound non-local type inference for constructor instantiation (fixes #108)

### DIFF
--- a/spec-concrete/2-static-runtime/2.5.1-type-free.watsup
+++ b/spec-concrete/2-static-runtime/2.5.1-type-free.watsup
@@ -203,3 +203,160 @@ def $free_callableTypeDefIR(callableTypeDefIR)
   -- if callableTypeIR
       = $callableTypeIR_of_callableTypeDefIR(callableTypeDefIR)
   -- if B_base = $free_callableTypeIR(callableTypeIR)
+
+;;
+;;;; Unresolved type variable checks (for non-local type inference validation)
+;;
+
+dec $has_unresolved_typeVars(typeIR) : bool
+  hint(prose_in "whether" %0 "has unresolved type variables")
+
+def $has_unresolved_typeVars(typeIR)
+  = ~$is_empty_set<typeId>($free_typeIR(typeIR))
+
+dec $free_typedExpressionIR(typedExpressionIR) : bound
+  hint(prose_in "free type identifiers in" %0)
+
+def $free_typedExpressionIR(expressionIR `# `( typeIR _ ))
+  = $union_set<typeId>($free_typeIR(typeIR), $free_expressionIR(expressionIR))
+
+dec $free_expressionIR(expressionIR) : bound
+  hint(prose_in "free type identifiers in" %0)
+
+;;; Literal, reference, default expressions (no type content)
+
+def $free_expressionIR(literalExpressionIR) = `{ eps }
+def $free_expressionIR(referenceExpressionIR) = `{ eps }
+def $free_expressionIR(defaultExpressionIR) = `{ eps }
+
+;;; Unary expressions
+
+def $free_expressionIR(unop typedExpressionIR)
+  = $free_typedExpressionIR(typedExpressionIR)
+
+;;; Binary expressions
+
+def $free_expressionIR(typedExpressionIR_l binop typedExpressionIR_r)
+  = $union_set<typeId>(
+      $free_typedExpressionIR(typedExpressionIR_l),
+      $free_typedExpressionIR(typedExpressionIR_r))
+
+;;; Ternary expressions
+
+def $free_expressionIR(
+    typedExpressionIR_c `? typedExpressionIR_t `: typedExpressionIR_e)
+  = $unions_set<typeId>(
+      $free_typedExpressionIR(typedExpressionIR_c)
+      $free_typedExpressionIR(typedExpressionIR_t)
+      $free_typedExpressionIR(typedExpressionIR_e))
+
+;;; Cast expressions
+
+def $free_expressionIR(`( typeIR ) typedExpressionIR)
+  = $union_set<typeId>(
+      $free_typeIR(typeIR),
+      $free_typedExpressionIR(typedExpressionIR))
+
+;;; Data expressions — invalid header (no type content)
+
+def $free_expressionIR(invalidHeaderExpressionIR) = `{ eps }
+
+;;; Data expressions — sequence
+
+def $free_expressionIR(SEQ `{ typedExpressionIR* })
+  = $unions_set<typeId>($free_typedExpressionIR(typedExpressionIR)*)
+
+def $free_expressionIR(SEQ `{ typedExpressionIR* `, `... })
+  = $unions_set<typeId>($free_typedExpressionIR(typedExpressionIR)*)
+
+;;; Data expressions — record
+
+def $free_expressionIR(RECORD `{ (_ `= typedExpressionIR)* })
+  = $unions_set<typeId>($free_typedExpressionIR(typedExpressionIR)*)
+
+def $free_expressionIR(RECORD `{ (_ `= typedExpressionIR)* `, `... })
+  = $unions_set<typeId>($free_typedExpressionIR(typedExpressionIR)*)
+
+;;; Access expressions — error access (no type content)
+
+def $free_expressionIR(ERROR `. _) = `{ eps }
+
+;;; Access expressions — member access
+
+def $free_expressionIR((TYPE _) `. _) = `{ eps }
+
+def $free_expressionIR(typedExpressionIR `. _)
+  = $free_typedExpressionIR(typedExpressionIR)
+
+;;; Access expressions — index access
+
+def $free_expressionIR(typedExpressionIR_base `[ typedExpressionIR_index ])
+  = $union_set<typeId>(
+      $free_typedExpressionIR(typedExpressionIR_base),
+      $free_typedExpressionIR(typedExpressionIR_index))
+
+;;; Access expressions — slice access
+
+def $free_expressionIR(
+    typedExpressionIR_base `[ typedExpressionIR_hi `: typedExpressionIR_lo ])
+  = $unions_set<typeId>(
+      $free_typedExpressionIR(typedExpressionIR_base)
+      $free_typedExpressionIR(typedExpressionIR_hi)
+      $free_typedExpressionIR(typedExpressionIR_lo))
+
+;;; Call expressions — constructor call
+
+def $free_expressionIR(
+    (prefixedNameIR `< typeArgumentIR* >) `( argumentIR* ))
+  = $union_set<typeId>(
+      $unions_set<typeId>($free_typeIR(typeArgumentIR)*),
+      $unions_set<typeId>($free_argumentIR(argumentIR)*))
+
+;;; Call expressions — callable call
+
+def $free_expressionIR(
+    callableTargetIR `< typeArgumentIR* > `( argumentIR* ))
+  = $unions_set<typeId>(
+      $free_callableTargetIR(callableTargetIR)
+      $unions_set<typeId>($free_typeIR(typeArgumentIR)*)
+      $unions_set<typeId>($free_argumentIR(argumentIR)*))
+
+;;; Parenthesized expressions
+
+def $free_expressionIR(`( typedExpressionIR ))
+  = $free_typedExpressionIR(typedExpressionIR)
+
+;;
+;;;; Free type variables in arguments
+;;
+
+dec $free_argumentIR(argumentIR) : bound
+  hint(prose_in "free type identifiers in" %0)
+
+def $free_argumentIR(typedExpressionIR)
+  = $free_typedExpressionIR(typedExpressionIR)
+
+def $free_argumentIR(_ `= typedExpressionIR)
+  = $free_typedExpressionIR(typedExpressionIR)
+
+def $free_argumentIR(_ `= `_) = `{ eps }
+
+def $free_argumentIR(`_) = `{ eps }
+
+;;
+;;;; Free type variables in callable targets
+;;
+
+dec $free_callableTargetIR(callableTargetIR) : bound
+  hint(prose_in "free type identifiers in" %0)
+
+;; referenceExpressionIR (prefixedNameIR) contains no type arguments at this stage.
+def $free_callableTargetIR(referenceExpressionIR) = `{ eps }
+
+def $free_callableTargetIR(typedExpressionIR `. _)
+  = $free_typedExpressionIR(typedExpressionIR)
+
+def $free_callableTargetIR(TYPE _ `. _) = `{ eps }
+
+def $free_callableTargetIR(`( callableTargetIR ))
+  = $free_callableTargetIR(callableTargetIR)

--- a/spec-concrete/2-static-runtime/2.5.2-type-subst.watsup
+++ b/spec-concrete/2-static-runtime/2.5.2-type-subst.watsup
@@ -422,3 +422,220 @@ def $subst_constructorTypeIR'(
   -- if (constructorParameterIR_subst
       = $subst_parameterIR'(theta, constructorParameterIR))*
   -- if typeIR_subst = $subst_typeIR'(theta, typeIR)
+
+;;
+;;;; Typed expression substitutions (for non-local type inference)
+;;
+
+dec $subst_typedExpressionIR(theta, typedExpressionIR) : typedExpressionIR
+  hint(prose_in %1 "substituted by" %0)
+
+def $subst_typedExpressionIR(`{ eps }, typedExpressionIR) = typedExpressionIR
+def $subst_typedExpressionIR(theta, expressionIR `# `( typeIR ctk ))
+  = expressionIR_subst `# `( typeIR_subst ctk )
+  -- if typeIR_subst = $subst_typeIR'(theta, typeIR)
+  -- if expressionIR_subst = $subst_expressionIR(theta, expressionIR)
+
+;;
+;;;; Expression substitutions (total over all expressionIR constructors)
+;;
+
+dec $subst_expressionIR(theta, expressionIR) : expressionIR
+  hint(prose_in %1 "substituted by" %0)
+
+;;; Literal expressions (no type content)
+
+def $subst_expressionIR(theta, literalExpressionIR) = literalExpressionIR
+
+;;; Reference expressions (no type content)
+
+def $subst_expressionIR(theta, referenceExpressionIR) = referenceExpressionIR
+
+;;; Default expressions (no type content)
+
+def $subst_expressionIR(theta, defaultExpressionIR) = defaultExpressionIR
+
+;;; Unary expressions
+
+def $subst_expressionIR(theta, unop typedExpressionIR)
+  = unop typedExpressionIR_subst
+  -- if typedExpressionIR_subst = $subst_typedExpressionIR(theta, typedExpressionIR)
+
+;;; Binary expressions
+
+def $subst_expressionIR(theta, typedExpressionIR_l binop typedExpressionIR_r)
+  = typedExpressionIR_l_subst binop typedExpressionIR_r_subst
+  -- if typedExpressionIR_l_subst = $subst_typedExpressionIR(theta, typedExpressionIR_l)
+  -- if typedExpressionIR_r_subst = $subst_typedExpressionIR(theta, typedExpressionIR_r)
+
+;;; Ternary expressions
+
+def $subst_expressionIR(
+    theta,
+    typedExpressionIR_cond `? typedExpressionIR_then `: typedExpressionIR_else)
+  = typedExpressionIR_cond_subst `? typedExpressionIR_then_subst `: typedExpressionIR_else_subst
+  -- if typedExpressionIR_cond_subst
+      = $subst_typedExpressionIR(theta, typedExpressionIR_cond)
+  -- if typedExpressionIR_then_subst
+      = $subst_typedExpressionIR(theta, typedExpressionIR_then)
+  -- if typedExpressionIR_else_subst
+      = $subst_typedExpressionIR(theta, typedExpressionIR_else)
+
+;;; Cast expressions
+
+def $subst_expressionIR(theta, `( typeIR ) typedExpressionIR)
+  = `( typeIR_subst ) typedExpressionIR_subst
+  -- if typeIR_subst = $subst_typeIR'(theta, typeIR)
+  -- if typedExpressionIR_subst = $subst_typedExpressionIR(theta, typedExpressionIR)
+
+;;; Data expressions — invalid header (no type content)
+
+def $subst_expressionIR(theta, invalidHeaderExpressionIR) = invalidHeaderExpressionIR
+
+;;; Data expressions — sequence
+
+def $subst_expressionIR(theta, SEQ `{ typedExpressionIR* })
+  = SEQ `{ typedExpressionIR_subst* }
+  -- if (typedExpressionIR_subst = $subst_typedExpressionIR(theta, typedExpressionIR))*
+
+def $subst_expressionIR(theta, SEQ `{ typedExpressionIR* `, `... })
+  = SEQ `{ typedExpressionIR_subst* `, `... }
+  -- if (typedExpressionIR_subst = $subst_typedExpressionIR(theta, typedExpressionIR))*
+
+;;; Data expressions — record
+
+def $subst_expressionIR(theta, RECORD `{ (nameIR `= typedExpressionIR)* })
+  = RECORD `{ (nameIR `= typedExpressionIR_subst)* }
+  -- if (typedExpressionIR_subst = $subst_typedExpressionIR(theta, typedExpressionIR))*
+
+def $subst_expressionIR(theta, RECORD `{ (nameIR `= typedExpressionIR)* `, `... })
+  = RECORD `{ (nameIR `= typedExpressionIR_subst)* `, `... }
+  -- if (typedExpressionIR_subst = $subst_typedExpressionIR(theta, typedExpressionIR))*
+
+;;; Access expressions — error access (no type content)
+
+def $subst_expressionIR(theta, ERROR `. nameIR) = ERROR `. nameIR
+
+;;; Access expressions — member access (type member)
+
+def $subst_expressionIR(theta, (TYPE prefixedNameIR) `. nameIR)
+  = (TYPE prefixedNameIR) `. nameIR
+
+;;; Access expressions — member access (expression member)
+
+def $subst_expressionIR(theta, typedExpressionIR `. nameIR)
+  = typedExpressionIR_subst `. nameIR
+  -- if typedExpressionIR_subst = $subst_typedExpressionIR(theta, typedExpressionIR)
+
+;;; Access expressions — index access
+
+def $subst_expressionIR(theta, typedExpressionIR_base `[ typedExpressionIR_index ])
+  = typedExpressionIR_base_subst `[ typedExpressionIR_index_subst ]
+  -- if typedExpressionIR_base_subst
+      = $subst_typedExpressionIR(theta, typedExpressionIR_base)
+  -- if typedExpressionIR_index_subst
+      = $subst_typedExpressionIR(theta, typedExpressionIR_index)
+
+;;; Access expressions — slice access
+
+def $subst_expressionIR(
+    theta,
+    typedExpressionIR_base `[ typedExpressionIR_hi `: typedExpressionIR_lo ])
+  = typedExpressionIR_base_subst `[ typedExpressionIR_hi_subst `: typedExpressionIR_lo_subst ]
+  -- if typedExpressionIR_base_subst
+      = $subst_typedExpressionIR(theta, typedExpressionIR_base)
+  -- if typedExpressionIR_hi_subst
+      = $subst_typedExpressionIR(theta, typedExpressionIR_hi)
+  -- if typedExpressionIR_lo_subst
+      = $subst_typedExpressionIR(theta, typedExpressionIR_lo)
+
+;;; Call expressions — constructor call
+
+def $subst_expressionIR(theta, constructorTargetIR `( argumentIR* ))
+  = constructorTargetIR_subst `( argumentIR_subst* )
+  -- if constructorTargetIR_subst
+      = $subst_constructorTargetIR(theta, constructorTargetIR)
+  -- if (argumentIR_subst = $subst_argumentIR(theta, argumentIR))*
+
+;;; Call expressions — callable call
+
+def $subst_expressionIR(
+    theta,
+    callableTargetIR `< typeArgumentIR* > `( argumentIR* ))
+  = callableTargetIR_subst `< typeArgumentIR_subst* > `( argumentIR_subst* )
+  -- if callableTargetIR_subst
+      = $subst_callableTargetIR(theta, callableTargetIR)
+  -- if (typeArgumentIR_subst = $subst_typeIR'(theta, typeArgumentIR))*
+  -- if (argumentIR_subst = $subst_argumentIR(theta, argumentIR))*
+
+;;; Parenthesized expressions
+
+def $subst_expressionIR(theta, `( typedExpressionIR ))
+  = `( typedExpressionIR_subst )
+  -- if typedExpressionIR_subst = $subst_typedExpressionIR(theta, typedExpressionIR)
+
+;;
+;;;; Argument substitutions
+;;
+
+dec $subst_argumentIR(theta, argumentIR) : argumentIR
+  hint(prose_in %1 "substituted by" %0)
+
+;;; Expression argument
+
+def $subst_argumentIR(theta, typedExpressionIR)
+  = $subst_typedExpressionIR(theta, typedExpressionIR)
+
+;;; Named expression argument
+
+def $subst_argumentIR(theta, nameIR `= typedExpressionIR)
+  = nameIR `= $subst_typedExpressionIR(theta, typedExpressionIR)
+
+;;; Named don't-care argument
+
+def $subst_argumentIR(theta, nameIR `= `_) = nameIR `= `_
+
+;;; Don't-care argument
+
+def $subst_argumentIR(theta, `_) = `_
+
+;;
+;;;; Constructor target substitutions
+;;
+
+dec $subst_constructorTargetIR(theta, constructorTargetIR) : constructorTargetIR
+  hint(prose_in %1 "substituted by" %0)
+
+def $subst_constructorTargetIR(theta, prefixedNameIR `< typeArgumentIR* >)
+  = prefixedNameIR `< typeArgumentIR_subst* >
+  -- if (typeArgumentIR_subst = $subst_typeIR'(theta, typeArgumentIR))*
+
+;;
+;;;; Callable target substitutions
+;;
+
+dec $subst_callableTargetIR(theta, callableTargetIR) : callableTargetIR
+  hint(prose_in %1 "substituted by" %0)
+
+;;; Reference target
+;; referenceExpressionIR (prefixedNameIR) contains no type arguments at this stage;
+;; type resolution and specialization have already been applied before substitution.
+
+def $subst_callableTargetIR(theta, referenceExpressionIR) = referenceExpressionIR
+
+;;; Member access target
+
+def $subst_callableTargetIR(theta, typedExpressionIR `. nameIR)
+  = typedExpressionIR_subst `. nameIR
+  -- if typedExpressionIR_subst = $subst_typedExpressionIR(theta, typedExpressionIR)
+
+;;; Type member access target (no expression type content)
+
+def $subst_callableTargetIR(theta, TYPE prefixedNameIR `. nameIR)
+  = TYPE prefixedNameIR `. nameIR
+
+;;; Parenthesized target
+
+def $subst_callableTargetIR(theta, `( callableTargetIR ))
+  = `( callableTargetIR_subst )
+  -- if callableTargetIR_subst = $subst_callableTargetIR(theta, callableTargetIR)

--- a/spec-concrete/5-typing/5.11-typing-declaration.watsup
+++ b/spec-concrete/5-typing/5.11-typing-declaration.watsup
@@ -117,6 +117,10 @@ rule InstDecl_non_objectInitializer_ok:
       p TC_0 NAMED |- constructorTypeIR `< typeArgumentIR* `# typeId_infer* >
                         `( argumentIR* `# id_default* `# id_optional* )
                     : typeIR_object `< typeArgumentIR_inferred* > `( argumentIR_cast* )
+  ---- ;; validate: no unresolved type variables after inference
+  -- if $is_empty_set<typeId>($free_typeIR(typeIR_object))
+  -- if ($is_empty_set<typeId>($free_typeIR(typeArgumentIR_inferred)))*
+  -- if ($is_empty_set<typeId>($free_argumentIR(argumentIR_cast)))*
   ---- ;; update the context with the instantiated object
   -- if nameIR = $name(name)
   -- if TC_1 = $add_var_t(p, TC_0, nameIR, `EMPTY typeIR_object CTK eps)
@@ -318,6 +322,10 @@ rule InstDecl_objectInitializer_ok:
       p TC_0 NAMED |- constructorTypeIR `< typeArgumentIR* `# typeId_infer* >
                         `( argumentIR* `# id_default* `# id_optional* )
                     : typeIR_object `< typeArgumentIR_inferred* > `( argumentIR_cast* )
+  ---- ;; validate: no unresolved type variables after inference
+  -- if $is_empty_set<typeId>($free_typeIR(typeIR_object))
+  -- if ($is_empty_set<typeId>($free_typeIR(typeArgumentIR_inferred)))*
+  -- if ($is_empty_set<typeId>($free_argumentIR(argumentIR_cast)))*
   ---- ;; object initializer can be specified for an extern object
   -- if EXTERN typeId_extern `< typeIR_arg* > externMethodTypeDefEnv_extern
       = $unroll_typeIR(typeIR_object)
@@ -335,6 +343,8 @@ rule InstDecl_objectInitializer_ok:
       = EXTERN typeId_extern `< typeIR_arg* > externMethodTypeDefEnv_init_subst
   ---- ;; constructed object may not contain an abstract method
   -- if $is_concrete_extern_object(typeIR_object_init)
+  ---- ;; validate: final object type has no unresolved type variables
+  -- if $is_empty_set<typeId>($free_typeIR(typeIR_object_init))
   ---- ;; update the context with the instantiated object
   -- if nameIR = $name(name)
   -- if TC_2 = $add_var_t(p, TC_0, nameIR, `EMPTY typeIR_object_init CTK eps)

--- a/spec-concrete/5-typing/5.15.2-typing-call-inference.watsup
+++ b/spec-concrete/5-typing/5.15.2-typing-call-inference.watsup
@@ -263,9 +263,255 @@ def $merge_constraints(
       = $merge_constraints(constraint_pre_1, constraint_post_t*)
 
 ;;
+;;;; Non-local constraint merging (augmented with propagated bindings)
+;;
+
+dec $merge_constraint_nonlocal(constraint, constraint)
+  : (constraint, theta)
+dec $merge_constraint_nonlocal'(
+    constraint_pre, constraint_post, typeId*, constraint, theta)
+  : (constraint, theta)
+dec $merge_constraints_nonlocal(constraint, constraint*)
+  : (constraint, theta)
+
+;; Safe theta update: rejects conflicting bindings for the same type variable.
+;; - Key not present → add
+;; - Key present with identical type → keep (idempotent)
+;; - Key present with different type → no matching case → premise FAILS
+;; Constraints are equality-like, not subtyping — widening is NOT allowed.
+dec $safe_update_theta(theta, typeId, typeIR) : theta
+
+;; Key not present → add binding
+def $safe_update_theta(theta, typeId, typeIR)
+  = $update_map<typeId, typeIR>(theta, typeId, typeIR)
+  -- if ~$in_set<typeId>(typeId, $dom_map<typeId, typeIR>(theta))
+
+;; Key present with identical type → no change (consistent)
+def $safe_update_theta(theta, typeId, typeIR)
+  = theta
+  -- if $in_set<typeId>(typeId, $dom_map<typeId, typeIR>(theta))
+  -- if typeIR = $find_map<typeId, typeIR>(theta, typeId)
+
+;; No matching case for different types → rule premise FAILS
+;; (e.g., T → bit<8> conflicting with T → bit<16>)
+
+;; Safe merge of two thetas: checks each binding from theta_b against theta_a
+dec $safe_merge_theta(theta, theta) : theta
+dec $safe_merge_theta'(theta, (typeId typeIR)*) : theta
+
+def $safe_merge_theta(theta_a, theta_b)
+  = $safe_merge_theta'(theta_a, (typeId typeIR)*)
+  -- if `{ (typeId `: typeIR)* } = theta_b
+
+def $safe_merge_theta'(theta, eps) = theta
+def $safe_merge_theta'(theta, (typeId_h typeIR_h) :: (typeId_t typeIR_t)*)
+  = $safe_merge_theta'(theta_updated, (typeId_t typeIR_t)*)
+  -- if theta_updated = $safe_update_theta(theta, typeId_h, typeIR_h)
+
+def $merge_constraint_nonlocal(constraint_pre, constraint_post)
+  = $merge_constraint_nonlocal'(
+      constraint_pre, constraint_post, typeId_pre*, `{ eps }, $empty_theta)
+  -- if `{ typeId_pre* } = $dom_map<typeId, infer>(constraint_pre)
+  -- if `{ typeId_post* } = $dom_map<typeId, infer>(constraint_post)
+  -- if $eq_set<typeId>(`{ typeId_pre* }, `{ typeId_post* })
+
+;; Case 1: UNKNOWN / UNKNOWN → keep UNKNOWN, pass theta through
+
+def $merge_constraint_nonlocal'(
+    constraint_pre, constraint_post,
+    typeId_h :: typeId_t*,
+    constraint, theta)
+  = $merge_constraint_nonlocal'(
+      constraint_pre, constraint_post, typeId_t*, constraint_updated, theta)
+  -- if UNKNOWN = $find_map<typeId, infer>(constraint_pre, typeId_h)
+  -- if UNKNOWN = $find_map<typeId, infer>(constraint_post, typeId_h)
+  -- if constraint_updated
+      = $update_map<typeId, infer>(constraint, typeId_h, UNKNOWN)
+
+;; Case 2: UNKNOWN / KNOWN → take post, pass theta through
+
+def $merge_constraint_nonlocal'(
+    constraint_pre, constraint_post,
+    typeId_h :: typeId_t*,
+    constraint, theta)
+  = $merge_constraint_nonlocal'(
+      constraint_pre, constraint_post, typeId_t*, constraint_updated, theta)
+  -- if UNKNOWN = $find_map<typeId, infer>(constraint_pre, typeId_h)
+  -- if KNOWN AS typeIR_post = $find_map<typeId, infer>(constraint_post, typeId_h)
+  -- if constraint_updated
+      = $update_map<typeId, infer>(constraint, typeId_h, KNOWN AS typeIR_post)
+
+;; Case 3: KNOWN / UNKNOWN → take pre, pass theta through
+
+def $merge_constraint_nonlocal'(
+    constraint_pre, constraint_post,
+    typeId_h :: typeId_t*,
+    constraint, theta)
+  = $merge_constraint_nonlocal'(
+      constraint_pre, constraint_post, typeId_t*, constraint_updated, theta)
+  -- if KNOWN AS typeIR_pre = $find_map<typeId, infer>(constraint_pre, typeId_h)
+  -- if UNKNOWN = $find_map<typeId, infer>(constraint_post, typeId_h)
+  -- if constraint_updated
+      = $update_map<typeId, infer>(constraint, typeId_h, KNOWN AS typeIR_pre)
+
+;; Case 4: KNOWN / KNOWN, pre castable to post → take post
+
+def $merge_constraint_nonlocal'(
+    constraint_pre, constraint_post,
+    typeId_h :: typeId_t*,
+    constraint, theta)
+  = $merge_constraint_nonlocal'(
+      constraint_pre, constraint_post, typeId_t*, constraint_updated, theta)
+  -- if KNOWN AS typeIR_pre = $find_map<typeId, infer>(constraint_pre, typeId_h)
+  -- if KNOWN AS typeIR_post = $find_map<typeId, infer>(constraint_post, typeId_h)
+  -- if ~(typeIR_pre <: nameTypeIR)
+  -- if ~(typeIR_post <: nameTypeIR)
+  -- Cast_impl: typeIR_pre -> typeIR_post
+  -- if constraint_updated
+      = $update_map<typeId, infer>(constraint, typeId_h, KNOWN AS typeIR_post)
+
+;; Case 5: KNOWN / KNOWN, only post castable to pre → take pre
+
+def $merge_constraint_nonlocal'(
+    constraint_pre, constraint_post,
+    typeId_h :: typeId_t*,
+    constraint, theta)
+  = $merge_constraint_nonlocal'(
+      constraint_pre, constraint_post, typeId_t*, constraint_updated, theta)
+  -- if KNOWN AS typeIR_pre = $find_map<typeId, infer>(constraint_pre, typeId_h)
+  -- if KNOWN AS typeIR_post = $find_map<typeId, infer>(constraint_post, typeId_h)
+  -- if ~(typeIR_pre <: nameTypeIR)
+  -- if ~(typeIR_post <: nameTypeIR)
+  -- Cast_impl:/ typeIR_pre -> typeIR_post
+  -- Cast_impl: typeIR_post -> typeIR_pre
+  -- if constraint_updated
+      = $update_map<typeId, infer>(constraint, typeId_h, KNOWN AS typeIR_pre)
+
+;; Case 6: KNOWN(concrete) / KNOWN(nameTypeIR) → take concrete, propagate binding
+;; The nameTypeIR must be a free variable from an outer scope
+;; (not in either constraint domain).
+;; Uses $safe_update_theta to reject conflicting bindings.
+
+def $merge_constraint_nonlocal'(
+    constraint_pre, constraint_post,
+    typeId_h :: typeId_t*,
+    constraint, theta)
+  = $merge_constraint_nonlocal'(
+      constraint_pre, constraint_post, typeId_t*, constraint_updated, theta_updated)
+  -- if KNOWN AS typeIR_pre = $find_map<typeId, infer>(constraint_pre, typeId_h)
+  -- if KNOWN AS (`` typeId_free) = $find_map<typeId, infer>(constraint_post, typeId_h)
+  -- if ~(typeIR_pre <: nameTypeIR)
+  -- if ~$in_set<typeId>(typeId_free, $dom_map<typeId, infer>(constraint_pre))
+  -- if ~$in_set<typeId>(typeId_free, $dom_map<typeId, infer>(constraint_post))
+  -- if constraint_updated
+      = $update_map<typeId, infer>(constraint, typeId_h, KNOWN AS typeIR_pre)
+  -- if theta_updated = $safe_update_theta(theta, typeId_free, typeIR_pre)
+
+;; Case 7: KNOWN(nameTypeIR) / KNOWN(concrete) → take concrete, propagate binding
+;; Mirror of Case 6 with pre/post swapped.
+
+def $merge_constraint_nonlocal'(
+    constraint_pre, constraint_post,
+    typeId_h :: typeId_t*,
+    constraint, theta)
+  = $merge_constraint_nonlocal'(
+      constraint_pre, constraint_post, typeId_t*, constraint_updated, theta_updated)
+  -- if KNOWN AS (`` typeId_free) = $find_map<typeId, infer>(constraint_pre, typeId_h)
+  -- if KNOWN AS typeIR_post = $find_map<typeId, infer>(constraint_post, typeId_h)
+  -- if ~(typeIR_post <: nameTypeIR)
+  -- if ~$in_set<typeId>(typeId_free, $dom_map<typeId, infer>(constraint_pre))
+  -- if ~$in_set<typeId>(typeId_free, $dom_map<typeId, infer>(constraint_post))
+  -- if constraint_updated
+      = $update_map<typeId, infer>(constraint, typeId_h, KNOWN AS typeIR_post)
+  -- if theta_updated = $safe_update_theta(theta, typeId_free, typeIR_post)
+
+;; Base case: no more type IDs to process
+
+def $merge_constraint_nonlocal'(
+    constraint_pre, constraint_post, eps, constraint, theta)
+  = (constraint, theta)
+
+;; Non-local merge over multiple constraints
+
+def $merge_constraints_nonlocal(constraint_pre, eps) = (constraint_pre, $empty_theta)
+
+def $merge_constraints_nonlocal(
+    constraint_pre_0,
+    constraint_post_h :: constraint_post_t*)
+  = (constraint_pre_2, theta_merged)
+  -- if (constraint_pre_1, theta_1)
+      = $merge_constraint_nonlocal(constraint_pre_0, constraint_post_h)
+  -- if (constraint_pre_2, theta_2)
+      = $merge_constraints_nonlocal(constraint_pre_1, constraint_post_t*)
+  -- if theta_merged = $safe_merge_theta(theta_1, theta_2)
+
+;;
 ;;;; Constraint resolution
 ;;
 
 def $resolve_constraint(`{ (typeId `: infer)* })
   = `{ (typeId `: typeIR)* }
   -- if (KNOWN AS typeIR = infer)*
+
+;;
+;;;; Non-local type inference (stub — delegates to existing $infer)
+;;
+
+dec $infer_nonlocal(typeId*, parameterIR*, argumentIR*) : (inference, theta)
+  hint(prose_in "$infer_nonlocal infers type arguments for" %0 "from" %1 "and" %2)
+
+;; No type parameters to infer → empty inference, no propagation
+def $infer_nonlocal(eps, parameterIR*, argumentIR*)
+  = ($empty_map<typeId, typeIR>, $empty_theta)
+
+;; Non-local inference: allows partial results (UNKNOWN → nameTypeIR)
+;; and collects propagated bindings from inner-scope free variables.
+def $infer_nonlocal(typeId_infer*, parameterIR*, argumentIR*)
+  = (inference_resolved, theta_propagated)
+  -- if typeId_infer* =/= eps
+  ---- ;; create constraints
+  -- if constraint_init = $empty_constraint(typeId_infer*)
+  -- if (constraint_pair
+      = $infer'(constraint_init, parameterIR, argumentIR))*
+  ---- ;; merge constraints (non-local: captures propagated bindings)
+  -- if (constraint_inferred, theta_propagated)
+      = $merge_constraints_nonlocal(constraint_init, constraint_pair*)
+  ---- ;; resolve: KNOWN → typeIR, UNKNOWN → nameTypeIR (partial)
+  -- if inference = $resolve_constraint_nonlocal(constraint_inferred)
+  ---- ;; resolve synthesized types
+  -- if inference_resolved = $resolve_inference(inference)
+
+;;
+;;;; Non-local constraint resolution
+;;
+
+dec $resolve_constraint_nonlocal(constraint) : inference
+  hint(prose_in "non-locally resolving" %0)
+
+;; For KNOWN entries: extract the typeIR
+;; For UNKNOWN entries: map typeId -> nameTypeIR (``typeId) — partial inference
+def $resolve_constraint_nonlocal(`{ (typeId `: infer)* })
+  = `{ (typeId `: typeIR)* }
+  -- if (typeIR = $resolve_infer_nonlocal(typeId, infer))*
+
+dec $resolve_infer_nonlocal(typeId, infer) : typeIR
+
+def $resolve_infer_nonlocal(typeId, KNOWN AS typeIR) = typeIR
+def $resolve_infer_nonlocal(typeId, UNKNOWN) = `` typeId
+
+;;
+;;;; Transitive closure of substitution (stub — identity for now)
+;;
+
+dec $closure_theta(theta) : theta
+  hint(prose_in "transitive closure of" %0)
+
+;; Stub: applies one round of self-substitution.
+;; For full non-local inference (Phase 2), this must reach a fixpoint:
+;;   theta_closed is the smallest theta' such that
+;;   for all (typeId ↦ typeIR) in theta': typeIR = $subst_typeIR(theta', typeIR)
+;; Since P4 type parameters are non-recursive, one pass suffices in practice.
+def $closure_theta(theta) = theta_closed
+  -- if `{ (typeId `: typeIR)* } = theta
+  -- if (typeIR_closed = $subst_typeIR(theta, typeIR))*
+  -- if theta_closed = `{ (typeId `: typeIR_closed)* }

--- a/spec-concrete/5-typing/5.15.3-typing-constructor-call.watsup
+++ b/spec-concrete/5-typing/5.15.3-typing-constructor-call.watsup
@@ -146,24 +146,30 @@ rule Inst_ok/package:
   ---- ;; align parameters with arguments
   -- if GIVEN parameterIR_aligned* DEFAULT _
       = $align_parameterListIR(parameterIR*, argumentIR*, id_default*, id_optional*)
-  ---- ;; perform type inference
-  -- if inference = $infer(typeId_infer*, parameterIR_aligned*, argumentIR*)
-  -- if (typeIR_inferred = $find_map<typeId, typeIR>(inference, typeId_infer))*
+  ---- ;; perform type inference (non-local: returns local + propagated maps)
+  -- if (theta_local, theta_propagated)
+      = $infer_nonlocal(typeId_infer*, parameterIR_aligned*, argumentIR*)
+  -- if theta_final
+      = $closure_theta($union_map<typeId, typeIR>(theta_local, theta_propagated))
+  -- if (typeIR_inferred = $find_map<typeId, typeIR>(theta_local, typeId_infer))*
   -- if typeArgumentIR_inferred* = typeArgumentIR* ++ typeIR_inferred*
-  ---- ;; substitute inferred types
+  ---- ;; substitute inferred types into parameters
   -- if (parameterIR_aligned_inferred
-      = $subst_parameterIR(inference, parameterIR_aligned))*
+      = $subst_parameterIR(theta_local, parameterIR_aligned))*
   -- if typeIR_object_inferred
-      = $subst_typeIR(inference, typeIR_object)
+      = $subst_typeIR(theta_local, typeIR_object)
+  ---- ;; deep-substitute into arguments (resolves inner type variables)
+  -- if (argumentIR_resolved
+      = $subst_argumentIR(theta_final, argumentIR))*
   ---- ;; check that the substituted constructor is still well-formed
   -- if constructorTypeIR_inferred
       = CONSTRUCTOR `( parameterIR_aligned_inferred* ) `: typeIR_object_inferred
   -- ConstructorType_wf: $bound(GLOBAL, TC) |- constructorTypeIR_inferred
   ---- ;; check instantiation site
   -- if $instantiable(GLOBAL, TC, instctxt, typeIR_object_inferred)
-  ---- ;; check call convention
+  ---- ;; check call convention (uses RESOLVED arguments)
   -- Call_convention_ok:
-      BLOCK TC NOACTION |- parameterIR_aligned_inferred* `@ argumentIR*
+      BLOCK TC NOACTION |- parameterIR_aligned_inferred* `@ argumentIR_resolved*
                          : argumentIR_cast*
 
 ;;; Instantiation of a non-package
@@ -181,22 +187,28 @@ rule Inst_ok/non-package:
   ---- ;; align parameters with arguments
   -- if GIVEN parameterIR_aligned* DEFAULT _
       = $align_parameterListIR(parameterIR*, argumentIR*, id_default*, id_optional*)
-  ---- ;; perform type inference
-  -- if inference = $infer(typeId_infer*, parameterIR_aligned*, argumentIR*)
-  -- if (typeIR_inferred = $find_map<typeId, typeIR>(inference, typeId_infer))*
+  ---- ;; perform type inference (non-local: returns local + propagated maps)
+  -- if (theta_local, theta_propagated)
+      = $infer_nonlocal(typeId_infer*, parameterIR_aligned*, argumentIR*)
+  -- if theta_final
+      = $closure_theta($union_map<typeId, typeIR>(theta_local, theta_propagated))
+  -- if (typeIR_inferred = $find_map<typeId, typeIR>(theta_local, typeId_infer))*
   -- if typeArgumentIR_inferred* = typeArgumentIR* ++ typeIR_inferred*
-  ---- ;; substitute inferred types
+  ---- ;; substitute inferred types into parameters
   -- if (parameterIR_aligned_inferred
-      = $subst_parameterIR(inference, parameterIR_aligned))*
+      = $subst_parameterIR(theta_local, parameterIR_aligned))*
   -- if typeIR_object_inferred
-      = $subst_typeIR(inference, typeIR_object)
+      = $subst_typeIR(theta_local, typeIR_object)
+  ---- ;; deep-substitute into arguments (resolves inner type variables)
+  -- if (argumentIR_resolved
+      = $subst_argumentIR(theta_final, argumentIR))*
   ---- ;; check that the substituted constructor is still well-formed
   -- if constructorTypeIR_inferred
       = CONSTRUCTOR `( parameterIR_aligned_inferred* ) `: typeIR_object_inferred
   -- ConstructorType_wf: $bound(p, TC) |- constructorTypeIR_inferred
   ---- ;; check instantiation site
   -- if $instantiable(p, TC, instctxt, typeIR_object_inferred)
-  ---- ;; check call convention
+  ---- ;; check call convention (uses RESOLVED arguments)
   -- Call_convention_ok:
-      p TC NOACTION |- parameterIR_aligned_inferred* `@ argumentIR*
+      p TC NOACTION |- parameterIR_aligned_inferred* `@ argumentIR_resolved*
                      : argumentIR_cast*


### PR DESCRIPTION
**Summary**

This PR implements **non-local type inference for constructor instantiation**, addressing Issue #108.

The current `$infer` performs strictly local inference, which prevents programs like:

```p4
extern E0<T> { E0(T t); }
extern E1<T> { E1(); }
extern E2<T> { E2(E0<T> e0, E1<T> e1); }

const bit<8> b = 8w1;
E2(E0(b), E1()) foo;
```

from type-checking, since `E1()` has no local constraints to infer `T`.

This PR introduces a **declarative non-local inference mechanism** that allows constraints to propagate across arguments, while ensuring that the final P4IR contains no unresolved type variables.


**Approach**

The design extends the existing system without modifying `$infer`:

* Introduces `$infer_nonlocal` for instantiation
* Reuses `$infer'` for constraint generation
* Allows **partial inference** via `nameTypeIR` (``T)
* Resolves constraints using **non-local merging with propagation**
* Enforces **final validation to eliminate all free type variables**

**Key Components**

**1. Non-local inference pipeline**

```
$infer_nonlocal
→ $merge_constraints_nonlocal
→ $resolve_constraint_nonlocal
→ $resolve_inference
```

* `$merge_constraints_nonlocal` implements a 7-case merge strategy
* `$resolve_constraint_nonlocal` allows partial results (`UNKNOWN -> nameTypeIR`)


**2. Constraint propagation**

Supports inference across nested calls:

```
KNOWN(bit<8>) vs KNOWN(``T_free) -> T_free -> bit<8>
KNOWN(``T_free) vs KNOWN(bit<8>) -> T_free -> bit<8>
```

Propagation is restricted to **outer-scope variables only**:

```
T_free ∉ dom(constraint_pre) ∧ T_free ∉ dom(constraint_post)
```


**3. Conflict detection**

```
$safe_update_theta
```

* Equality-only (no widening)
* Conflicting bindings cause inference failure

Example (correctly rejected):

```p4
E2(E0(bit<8>), E0(bit<16>))
```


**4. Deep substitution**

Applies substitutions across:

* `typedExpressionIR`
* `argumentIR`
* constructor and callable targets


**5. Final validation (soundness guarantee)**

Added to both `InstDecl` rules:

```
$is_empty_set($free_typeIR(...))
$is_empty_set($free_argumentIR(...))
```

Ensures:

* No `nameTypeIR` remains
* No partially inferred types escape into final IR


**Behavior**

**Accepted**

```p4
E2(E0(b), E1()) foo;
```

**Rejected (unchanged)**

```p4
E1() foo;                      // insufficient constraints
E2(E0(bit<8>), E0(bit<16>))   // conflicting constraints
```


**Verification**

* `make` -> success
* `make test-all` -> success
* No regression observed


**Files Modified**

* `2.5.2-type-subst.watsup` - deep substitution
* `2.5.1-type-free.watsup` - free variable tracking
* `5.15.2-typing-call-inference.watsup` - non-local inference + merge
* `5.15.3-typing-constructor-call.watsup` - Inst_ok integration
* `5.11-typing-declaration.watsup` - final validation


**Outcome**

This PR enables non-local inference while preserving:

* Soundness (no unresolved type variables)
* Simplicity (no Hindley-Milner)
* Declarative structure of the specification

Fixes #108.