### PR TITLE
Add IL/SL interpreter tracer

### DIFF
--- a/p4spec/bin/main.ml
+++ b/p4spec/bin/main.ml
@@ -262,6 +262,15 @@ let run_command =
      and no_cache = flag "-no-cache" no_arg ~doc:"disable caching"
      and det = flag "-det" no_arg ~doc:"deterministic mode"
      and profile = flag "-profile" no_arg ~doc:"profiling"
+     and trace =
+       Command.Param.choose_one
+         [
+           flag "-trace" no_arg ~doc:"emit execution trace"
+           |> map ~f:(fun b -> Core.Option.some_if b (Some Inst.Trace.Simple));
+           flag "-trace-full" no_arg ~doc:"emit full execution trace"
+           |> map ~f:(fun b -> Core.Option.some_if b (Some Inst.Trace.Full));
+         ]
+         ~if_nothing_chosen:(Default_to None)
      and mode =
        Command.Param.choose_one
          [
@@ -283,6 +292,15 @@ let run_command =
              let (module PH : Inst.Handler.HANDLER) = Inst.Profile.make () in
              [ (module PH : Inst.Handler.HANDLER) ]
            else []
+         in
+         let handlers =
+           match trace with
+           | Some level ->
+               let (module TH : Inst.Handler.HANDLER) =
+                 Inst.Trace.make ~level ()
+               in
+               handlers @ [ (module TH : Inst.Handler.HANDLER) ]
+           | None -> handlers
          in
          Inst.Hook.register handlers;
          Inst.Hook.init_spec spec_sim;
@@ -311,6 +329,15 @@ let sim_command =
      and no_cache = flag "-no-cache" no_arg ~doc:"disable caching"
      and det = flag "-det" no_arg ~doc:"deterministic mode"
      and profile = flag "-profile" no_arg ~doc:"profiling"
+     and trace =
+       Command.Param.choose_one
+         [
+           flag "-trace" no_arg ~doc:"emit execution trace"
+           |> map ~f:(fun b -> Core.Option.some_if b (Some Inst.Trace.Simple));
+           flag "-trace-full" no_arg ~doc:"emit full execution trace"
+           |> map ~f:(fun b -> Core.Option.some_if b (Some Inst.Trace.Full));
+         ]
+         ~if_nothing_chosen:(Default_to None)
      and mode =
        Command.Param.choose_one
          [
@@ -332,6 +359,15 @@ let sim_command =
              let (module PH : Inst.Handler.HANDLER) = Inst.Profile.make () in
              [ (module PH : Inst.Handler.HANDLER) ]
            else []
+         in
+         let handlers =
+           match trace with
+           | Some level ->
+               let (module TH : Inst.Handler.HANDLER) =
+                 Inst.Trace.make ~level ()
+               in
+               handlers @ [ (module TH : Inst.Handler.HANDLER) ]
+           | None -> handlers
          in
          Inst.Hook.register handlers;
          Inst.Hook.init_spec spec_sim;

--- a/p4spec/lib/interface/parser_debug.ml
+++ b/p4spec/lib/interface/parser_debug.ml
@@ -4,7 +4,6 @@
  *   Debugs parser stack state and token consumption
  *)
 
-module MI = MenhirLib.General
 module I = Parser.Incremental
 module Engine = Parser.MenhirInterpreter
 module P = Printf

--- a/p4spec/lib/interp/inst/trace.ml
+++ b/p4spec/lib/interp/inst/trace.ml
@@ -1,0 +1,87 @@
+open Domain.Lib
+open Lang
+module Value = Runtime.Value
+
+(* Verbosity level *)
+
+type level = Simple | Full
+
+(* String utilities *)
+
+let normalize_whitespace (s : string) : string =
+  let buf = Buffer.create (String.length s) in
+  let in_space = ref false in
+  String.iter
+    (fun c ->
+      if c = ' ' || c = '\t' || c = '\n' || c = '\r' then (
+        if not !in_space then Buffer.add_char buf ' ';
+        in_space := true)
+      else (
+        Buffer.add_char buf c;
+        in_space := false))
+    s;
+  Buffer.contents buf
+
+let summarize_value ?(max_len = 100) (value : Value.t) : string =
+  let summarize ?(max_len = 100) (s : string) : string =
+    if String.length s <= max_len then s
+    else String.sub s 0 (max_len - 3) ^ "..."
+  in
+  value |> Value.to_string |> summarize ~max_len
+
+let format_values (values : Value.t list) : string =
+  match values with
+  | [] -> ""
+  | _ ->
+      let svalues = List.map summarize_value values in
+      Format.sprintf "  [in: %s]" (String.concat ", " svalues)
+
+let make ?(level = Simple) ?(fmt = Format.std_formatter) () =
+  let depth = ref 0 in
+  let indent () =
+    Format.sprintf "[%2d] %s" !depth (String.make (!depth * 2) ' ')
+  in
+  let module H : Handler.HANDLER = struct
+    include Handler.Default
+
+    let init_spec _ = depth := 0
+
+    (* Common events *)
+
+    let on_rel_enter (rid : RId.t) (values : Value.t list) : unit =
+      Format.fprintf fmt "%s-> %s\n%!" (indent ()) rid.it;
+      if level = Full && values <> [] then
+        Format.fprintf fmt "%s%s\n%!" (indent ())
+          (format_values values |> normalize_whitespace);
+      incr depth
+
+    let on_rel_exit (rid : RId.t) : unit =
+      decr depth;
+      Format.fprintf fmt "%s<- %s\n%!" (indent ()) rid.it
+
+    let on_func_enter (fid : FId.t) (values : Value.t list) : unit =
+      Format.fprintf fmt "%s-> $%s\n%!" (indent ()) fid.it;
+      if level = Full && values <> [] then
+        Format.fprintf fmt "%s%s\n%!" (indent ())
+          (format_values values |> normalize_whitespace);
+      incr depth
+
+    let on_func_exit (fid : FId.t) : unit =
+      decr depth;
+      Format.fprintf fmt "%s<- $%s\n%!" (indent ()) fid.it
+
+    (* IL events *)
+
+    let on_prem (prem : Il.prem) : unit =
+      if level = Full then
+        Format.fprintf fmt "%s  | -- %s\n%!" (indent ())
+          (Il.Print.string_of_prem prem |> normalize_whitespace)
+
+    (* SL events *)
+
+    let on_instr (instr : Sl.instr) : unit =
+      if level = Full then
+        Format.fprintf fmt "%s  | %s\n%!" (indent ())
+          (Sl.Print.string_of_instr ~short:true instr |> normalize_whitespace)
+  end in
+  (module H : Handler.HANDLER)


### PR DESCRIPTION
## Summary

- Add `Inst.Trace` handler (`p4spec/lib/interp/inst/trace.ml`) that logs interpreter execution as an indented call tree
- Supports two verbosity levels: `Simple` (relation/function enter+exit) and `Full` (+ input values and premises)
- Wire `-trace` / `-trace-full` flags into both `run_command` and `sim_command` via `choose_one`, enforcing mutual exclusivity at the CLI level

An adaptation of: https://github.com/kaist-plrg/spectec-core/pull/8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)