### PR TITLE
Fix bug in parsing left-angle (`<`) in P4 programs

### DIFF
--- a/excludes/static/bug/left-angle-parsing.exclude
+++ b/excludes/static/bug/left-angle-parsing.exclude
@@ -1,1 +1,0 @@
-p4c/testdata/p4_16_samples/precedence-lt.p4

--- a/p4spec/lib/interface/context.ml
+++ b/p4spec/lib/interface/context.ml
@@ -16,7 +16,7 @@
 module SMap = Map.Make (String)
 
 type has_params = bool
-type tid = string option
+type tid = Empty | Local of string | Global of string
 
 type ident_kind =
   | TypeName of has_params * namespace
@@ -55,7 +55,7 @@ let declare (id : string) (k : ident_kind) : unit =
 let declare_type id has_params = declare id (TypeName (has_params, SMap.empty))
 let declare_types types = List.iter (fun s -> declare_type s false) types
 
-let declare_var ?(tid = None) id has_params =
+let declare_var ?(tid = Empty) id has_params =
   declare id (Ident (has_params, tid))
 
 let declare_vars vars = List.iter (fun s -> declare_var s false) vars
@@ -94,7 +94,7 @@ let get_kind (id : string) : ident_kind =
     match !parent_namespace with None -> !context | Some ns -> [ ns ]
   in
   let kind =
-    match find_opt id ctx with None -> Ident (false, None) | Some k -> k
+    match find_opt id ctx with None -> Ident (false, Empty) | Some k -> k
   in
   previous_id := Some id;
   kind
@@ -129,6 +129,15 @@ let go_toplevel () =
 
 let go_local () = context := !backup
 
+let get_global_context () =
+  let rec loop c =
+    match c with
+    | [] -> failwith "ill-formed context"
+    | [ _ ] -> c
+    | _ :: l -> loop l
+  in
+  loop !context
+
 let set_type_namespace (tid : string) (ns : namespace) =
   let rec loop = function
     | [] -> []
@@ -144,9 +153,14 @@ let set_parent_namespace () =
   let ( let* ) = Option.bind in
   let namespace =
     let* parent_id = !previous_id in
-    let* _, tid_opt = find_var_opt parent_id !context in
-    let* tid = tid_opt in
-    Option.map snd (find_type_opt tid !context)
+    let* _, tid = find_var_opt parent_id !context in
+    let* tid, ctx =
+      match tid with
+      | Empty -> None
+      | Local tid -> Some (tid, !context)
+      | Global tid -> Some (tid, get_global_context ())
+    in
+    Option.map snd (find_type_opt tid ctx)
   in
   let namespace = Option.value namespace ~default:SMap.empty in
   parent_namespace := Some namespace

--- a/p4spec/lib/interface/context.ml
+++ b/p4spec/lib/interface/context.ml
@@ -16,17 +16,32 @@
 module SMap = Map.Make (String)
 
 type has_params = bool
-type ident_kind = TypeName of has_params | Ident of has_params
-type t = ident_kind SMap.t list
+type tid = string option
+
+type ident_kind =
+  | TypeName of has_params * namespace
+  | Ident of has_params * tid
+
+and namespace = ident_kind SMap.t
+
+type t = namespace list
 
 (* Current context, stored as a mutable global variable *)
 let context : t ref = ref [ SMap.empty ]
 let backup : t ref = ref []
 
+(* Previously looked-up identifier *)
+let previous_id : string option ref = ref None
+
+(* Namespace of a member's parent *)
+let parent_namespace : namespace option ref = ref None
+
 (* Resets context *)
 let reset () =
   context := [ SMap.empty ];
-  backup := []
+  backup := [];
+  previous_id := None;
+  parent_namespace := None
 
 (* Associates [id] with [k] in map for current scope *)
 let declare (id : string) (k : ident_kind) : unit =
@@ -37,33 +52,55 @@ let declare (id : string) (k : ident_kind) : unit =
         (match k with TypeName _ -> "TypeName" | Ident _ -> "Ident");
       context := SMap.add id k m :: l
 
-let declare_type id has_params = declare id (TypeName has_params)
+let declare_type id has_params = declare id (TypeName (has_params, SMap.empty))
 let declare_types types = List.iter (fun s -> declare_type s false) types
-let declare_var id has_params = declare id (Ident has_params)
+
+let declare_var ?(tid = None) id has_params =
+  declare id (Ident (has_params, tid))
+
 let declare_vars vars = List.iter (fun s -> declare_var s false) vars
+
+let find_opt (id : string) (ctx : t) : ident_kind option =
+  let rec loop = function
+    | [] -> None
+    | m :: rest -> (
+        match SMap.find_opt id m with None -> loop rest | Some k -> Some k)
+  in
+  loop ctx
+
+let find_type_opt (id : string) (ctx : t) : (has_params * namespace) option =
+  let rec loop = function
+    | [] -> None
+    | m :: rest -> (
+        match SMap.find_opt id m with
+        | Some (TypeName (has_params, namespace)) -> Some (has_params, namespace)
+        | _ -> loop rest)
+  in
+  loop ctx
+
+let find_var_opt (id : string) (ctx : t) : (has_params * tid) option =
+  let rec loop = function
+    | [] -> None
+    | m :: rest -> (
+        match SMap.find_opt id m with
+        | Some (Ident (has_params, tid)) -> Some (has_params, tid)
+        | _ -> loop rest)
+  in
+  loop ctx
 
 (* Tests whether [id] is known as a type name. *)
 let get_kind (id : string) : ident_kind =
-  let rec loop = function
-    | [] -> Ident false
-    | m :: rest -> (
-        match SMap.find_opt id m with None -> loop rest | Some k -> k)
+  let ctx =
+    match !parent_namespace with None -> !context | Some ns -> [ ns ]
   in
-  loop !context
+  let kind =
+    match find_opt id ctx with None -> Ident (false, None) | Some k -> k
+  in
+  previous_id := Some id;
+  kind
 
 let is_typename (id : string) : bool =
   match get_kind id with TypeName _ -> true | _ -> false
-
-let mark_template (id : string) =
-  let rec loop = function
-    | [] -> []
-    | m :: rest -> (
-        match SMap.find_opt id m with
-        | None -> m :: loop rest
-        | Some (TypeName _) -> SMap.add id (TypeName true) m :: rest
-        | Some (Ident _) -> SMap.add id (Ident true) m :: rest)
-  in
-  context := loop !context
 
 (* Takes a snapshot of the current context. *)
 let push_scope () =
@@ -76,7 +113,9 @@ let pop_scope () =
   match !context with
   | [] -> failwith "ill-formed context"
   | [ _ ] -> failwith "pop would produce ill-formed context"
-  | _ :: l -> context := l
+  | s :: l ->
+      context := l;
+      s
 
 let go_toplevel () =
   let rec loop c =
@@ -90,13 +129,37 @@ let go_toplevel () =
 
 let go_local () = context := !backup
 
+let set_type_namespace (tid : string) (ns : namespace) =
+  let rec loop = function
+    | [] -> []
+    | m :: rest -> (
+        match SMap.find_opt tid m with
+        | Some (TypeName (has_params, _)) ->
+            SMap.add tid (TypeName (has_params, ns)) m :: rest
+        | _ -> m :: loop rest)
+  in
+  context := loop !context
+
+let set_parent_namespace () =
+  let ( let* ) = Option.bind in
+  let namespace =
+    let* parent_id = !previous_id in
+    let* _, tid_opt = find_var_opt parent_id !context in
+    let* tid = tid_opt in
+    Option.map snd (find_type_opt tid !context)
+  in
+  let namespace = Option.value namespace ~default:SMap.empty in
+  parent_namespace := Some namespace
+
+let clear_parent_namespace () = parent_namespace := None
+
 (* Printing functions for debugging *)
 let print_entry x k =
   match k with
-  | TypeName true -> Printf.printf "%s : type<...>" x
-  | TypeName false -> Printf.printf "%s : type" x
-  | Ident true -> Printf.printf "%s : ident<...>" x
-  | Ident false -> Printf.printf "%s : ident" x
+  | TypeName (true, _) -> Printf.printf "%s : type<...>" x
+  | TypeName (false, _) -> Printf.printf "%s : type" x
+  | Ident (true, _) -> Printf.printf "%s : ident<...>" x
+  | Ident (false, _) -> Printf.printf "%s : ident" x
 
 let print_map m =
   SMap.iter

--- a/p4spec/lib/interface/extract.ml
+++ b/p4spec/lib/interface/extract.ml
@@ -111,6 +111,42 @@ let id_of_parameter (value : value) : string =
         (F.asprintf "@id_of_parameter: expected parameter, got %s"
            (Il.Print.string_of_value value))
 
+(* Type identifier extraction *)
+
+let rec tid_of_typeRef (value : value) : Context.tid =
+  match flatten_case_v_opt value with
+  | Some ("baseType", _, _)
+  | Some ("headerStackType", _, _)
+  | Some ("listType", _, _)
+  | Some ("tupleType", _, _) ->
+      Empty
+  | Some ("typeIdentifier", [ "`TID" ], [ { it = TextV s; _ } ]) -> Local s
+  | Some ("prefixedTypeName", [ "`TID"; "." ], [ typeIdentifier ]) -> (
+      match tid_of_typeRef typeIdentifier with
+      | Local s -> Global s
+      | _ -> error no_region "@tid_of_typeRef: unreachable")
+  | Some ("specializedType", [ "<"; ">" ], [ prefixedTypeName; _ ]) ->
+      tid_of_typeRef prefixedTypeName
+  (* not a variant of typeRef *)
+  | _ ->
+      error no_region
+        (F.asprintf "@tid_of_typeRef: expected typeRef, got %s"
+           (Il.Print.string_of_value value))
+
+let tid_of_declaration (value : value) : Context.tid =
+  match flatten_case_v_opt value with
+  | Some ("constantDeclaration", [ "CONST"; ";" ], [ _; typeRef; _; _ ])
+  | Some ("instantiation", [ "("; ")"; ";" ], [ _; typeRef; _; _ ])
+  | Some ("instantiation", [ "("; ")"; ";" ], [ _; typeRef; _; _; _ ]) ->
+      tid_of_typeRef typeRef
+  | Some (name, _, _) ->
+      error no_region (F.sprintf "%s: no type identifier" name)
+  (* not a variant of declaration *)
+  | _ ->
+      error no_region
+        (F.asprintf "@tid_of_declaration: expected declaration, got %s"
+           (Il.Print.string_of_value value))
+
 (* Type parameter extraction *)
 
 let has_type_params (value : value) : bool =

--- a/p4spec/lib/interface/lexer.mll
+++ b/p4spec/lib/interface/lexer.mll
@@ -459,16 +459,16 @@ let rec lexer (lexbuf:lexbuf): token =
    match !lexer_state with
     | SIdent(id, next) ->
       begin match get_kind id with
-      | TypeName true ->
+      | TypeName (true, _) ->
         lexer_state := STemplate;
         TYPENAME
-      | Ident true ->
+      | Ident (true, _) ->
         lexer_state := STemplate;
         IDENTIFIER
-      | TypeName false ->
+      | TypeName (false, _) ->
         lexer_state := next;
         TYPENAME
-      | Ident false ->
+      | Ident (false, _) ->
         lexer_state := next;
         IDENTIFIER
       end

--- a/p4spec/lib/interface/parser.mly
+++ b/p4spec/lib/interface/parser.mly
@@ -43,6 +43,10 @@
           (Printf.sprintf "@declare_types_of_il: expected name, got %s"
            (Il.Print.string_of_value value))
 
+  let set_type_namespace_of_il (value : value) (ns : namespace) : unit =
+    let id = id_of_name value in
+    set_type_namespace id ns
+
   let position_to_pos (position : Lexing.position) =
     {
       file = position.pos_fname;
@@ -179,7 +183,8 @@
   (* >> Declaration *) declaration
   (* Annotations *) annotationToken annotationBody structuredAnnotationBody annotation annotationListNonEmpty annotationList p4program
 %type <Lang.Il.value> push_name push_externName
-%type <unit> push_scope pop_scope go_toplevel go_local
+%type <Context.namespace> pop_scope
+%type <unit> push_scope go_toplevel go_local set_parent_namespace clear_parent_namespace
 %%
 
 (**************************** CONTEXTS ******************************)
@@ -214,6 +219,14 @@ go_local:
 toplevel(X):
   | go_toplevel x = X go_local
     { x }
+;
+set_parent_namespace:
+  | (* empty *)
+    { set_parent_namespace() }
+;
+clear_parent_namespace:
+  | (* empty *)
+    { clear_parent_namespace() }
 ;
 
 (**************************** P4-16 GRAMMAR ******************************)
@@ -634,7 +647,7 @@ namedExpressionList:
 ;
 
 %inline memberAccessExpression:
-	| e = memberAccessBase DOT m = member %prec DOT
+	| e = memberAccessBase DOT set_parent_namespace m = member clear_parent_namespace %prec DOT
 		{ "memberAccessBase `. member" <| [ e; m ] <<| "memberAccessExpression" <<<| (at $sloc) }
 ;
 
@@ -663,7 +676,7 @@ namedExpressionList:
 ;
 
 %inline memberAccessExpressionNonBrace:
-	| e = memberAccessBaseNonBrace DOT m = member %prec DOT
+	| e = memberAccessBaseNonBrace DOT set_parent_namespace m = member clear_parent_namespace %prec DOT
 		{ "memberAccessBaseNonBrace `. member" <| [ e; m ] <<| "memberAccessExpressionNonBrace" <<<| (at $sloc) }
 ;
 
@@ -908,7 +921,7 @@ argumentList:
 lvalue:
 	| e = referenceExpression
     { e }
-	| lv = lvalue DOT m = member %prec DOT
+	| lv = lvalue DOT set_parent_namespace m = member clear_parent_namespace %prec DOT
 		{ "lvalue `. member" <| [ lv; m ] <<| "lvalue" <<<| (at $sloc) }
 	| lv = lvalue L_BRACKET i = expression R_BRACKET
 		{ "lvalue `[ expression ]" <| [ lv; i ] <<| "lvalue" <<<| (at $sloc) }
@@ -1295,10 +1308,12 @@ externFunctionDeclaration:
 
 %inline externMethodPrototype:
 	| al = annotationList p = functionPrototype pop_scope SEMICOLON
-    { "annotationList functionPrototype `;" <| [ al; p ] <<| "externMethodPrototype" <<<| (at $sloc) }
+    { declare_var (id_of_function_prototype p) (has_type_params_function_prototype p);
+      "annotationList functionPrototype `;" <| [ al; p ] <<| "externMethodPrototype" <<<| (at $sloc) }
 	| al = annotationList ABSTRACT p = functionPrototype
     pop_scope SEMICOLON
-    { "annotationList ABSTRACT functionPrototype `;" <| [ al; p ] <<| "externMethodPrototype" <<<| (at $sloc) }
+    { declare_var (id_of_function_prototype p) (has_type_params_function_prototype p);
+      "annotationList ABSTRACT functionPrototype `;" <| [ al; p ] <<| "externMethodPrototype" <<<| (at $sloc) }
 ;
 
 externConstructorOrMethodPrototype:
@@ -1316,9 +1331,10 @@ externConstructorOrMethodPrototypeList:
 
 externObjectDeclaration:
   | al = annotationList EXTERN n = push_externName tpl = typeParameterListOpt
-    L_BRACE pl = externConstructorOrMethodPrototypeList R_BRACE pop_scope
+    L_BRACE pl = externConstructorOrMethodPrototypeList R_BRACE s = pop_scope
     { let decl = "annotationList EXTERN name typeParameterListOpt `{ externConstructorOrMethodPrototypeList }" <| [ al; n; tpl; pl ] <<| "externObjectDeclaration" <<<| (at $sloc) in
       declare_type_of_il n (has_type_params_declaration decl);
+      set_type_namespace_of_il n s;
       decl }
 ;
 
@@ -1416,7 +1432,7 @@ parserStatementList:
 ;
 
 parserState:
-  | al = annotationList STATE n = push_name L_BRACE sl = parserStatementList t = transitionStatement R_BRACE
+  | al = annotationList STATE n = push_name L_BRACE sl = parserStatementList t = transitionStatement R_BRACE pop_scope
     { "annotationList STATE name `{ parserStatementList transitionStatement }" <| [ al; n; sl; t ] <<| "parserState" <<<| (at $sloc) }
 ;
 

--- a/p4spec/lib/interface/parser.mly
+++ b/p4spec/lib/interface/parser.mly
@@ -7,9 +7,11 @@
   open Flatten
   open Util.Source
 
-  let declare_var_of_il (value : value) (b : bool) : unit =
-    let id = id_of_name value in
-    declare_var id b
+  let declare_var_of_il ?(value_typeRef : value option) (value_var : value)
+      (b : bool) : unit =
+    let tid = Option.fold ~none:Empty ~some:tid_of_typeRef value_typeRef in
+    let id = id_of_name value_var in
+    declare_var ~tid id b
 
   let rec declare_vars_of_il (value : value) : unit =
     match flatten_case_v_opt value with
@@ -483,7 +485,7 @@ typeParameterListOpt:
 (* Parameters *)
 parameter:
 	| al = annotationList dir = direction t = typeRef n = name i = initializerOpt
-		{ declare_var_of_il n false;
+		{ declare_var_of_il ~value_typeRef:t n false;
       "annotationList direction type name initializerOpt" <| [ al; dir; t; n; i ] <<| "parameter" <<<| (at $sloc) }
 ;
 
@@ -1153,7 +1155,7 @@ initializerOpt:
 
 variableDeclaration:
   | al = annotationList t = typeRef n = name i = initializerOpt SEMICOLON
-    { declare_var_of_il n false;
+    { declare_var_of_il ~value_typeRef:t n false;
       "annotationList typeRef name initializerOpt `;" <| [ al; t; n; i ] <<| "variableDeclaration" <<<| (at $sloc) }
 ;
 
@@ -1610,10 +1612,10 @@ typeDeclaration:
 (* >> Declarations *)
 declaration:
   | const = constantDeclaration
-    { declare_var (id_of_declaration const) (has_type_params_declaration const);
+    { declare_var ~tid:(tid_of_declaration const) (id_of_declaration const) (has_type_params_declaration const);
       const }
   | inst = instantiation
-    { declare_var (id_of_declaration inst) false;
+    { declare_var ~tid:(tid_of_declaration inst) (id_of_declaration inst) false;
       inst }
   | func = functionDeclaration
     { declare_var (id_of_declaration func) (has_type_params_declaration func);

--- a/p4spec/test/run/run_pos_il.expected
+++ b/p4spec/test/run/run_pos_il.expected
@@ -2936,7 +2936,7 @@ Run success: ../../../../../p4c/testdata/p4_16_samples/pragma-string.p4
 Run success: ../../../../../p4c/testdata/p4_16_samples/pragmas.p4
 
 >>> Running interpreter test (Program_inst) on ../../../../../p4c/testdata/p4_16_samples/precedence-lt.p4
-Excluding file: ../../../../../p4c/testdata/p4_16_samples/precedence-lt.p4
+Run success: ../../../../../p4c/testdata/p4_16_samples/precedence-lt.p4
 
 >>> Running interpreter test (Program_inst) on ../../../../../p4c/testdata/p4_16_samples/precedence.p4
 Excluding file: ../../../../../p4c/testdata/p4_16_samples/precedence.p4
@@ -3922,6 +3922,6 @@ Run success: ../../../../../p4c/testdata/p4_16_samples/xdp_vlan_push_pop_ebpf-ke
 >>> Running interpreter test (Program_inst) on ../../../../../p4c/testdata/p4_16_samples/xor_test.p4
 Run success: ../../../../../p4c/testdata/p4_16_samples/xor_test.p4
 
-Running interpreter test (Program_inst): [EXCLUDE] 83/1307 (6.35%) [PASS] 1224/1307 (93.65%) [FAIL] 0/1307 (0.00%) [PATCH] 0/1307 (0.00%)
+Running interpreter test (Program_inst): [EXCLUDE] 82/1307 (6.27%) [PASS] 1225/1307 (93.73%) [FAIL] 0/1307 (0.00%) [PATCH] 0/1307 (0.00%)
 
 Running interpreter test (Program_inst): [PATCH]: [EXCLUDE] 0/0 (0.00%) [PASS] 0/0 (0.00%) [FAIL] 0/0 (0.00%)

--- a/p4spec/test/run/run_pos_sl.expected
+++ b/p4spec/test/run/run_pos_sl.expected
@@ -2936,7 +2936,7 @@ Run success: ../../../../../p4c/testdata/p4_16_samples/pragma-string.p4
 Run success: ../../../../../p4c/testdata/p4_16_samples/pragmas.p4
 
 >>> Running interpreter test (Program_inst) on ../../../../../p4c/testdata/p4_16_samples/precedence-lt.p4
-Excluding file: ../../../../../p4c/testdata/p4_16_samples/precedence-lt.p4
+Run success: ../../../../../p4c/testdata/p4_16_samples/precedence-lt.p4
 
 >>> Running interpreter test (Program_inst) on ../../../../../p4c/testdata/p4_16_samples/precedence.p4
 Excluding file: ../../../../../p4c/testdata/p4_16_samples/precedence.p4
@@ -3922,6 +3922,6 @@ Run success: ../../../../../p4c/testdata/p4_16_samples/xdp_vlan_push_pop_ebpf-ke
 >>> Running interpreter test (Program_inst) on ../../../../../p4c/testdata/p4_16_samples/xor_test.p4
 Run success: ../../../../../p4c/testdata/p4_16_samples/xor_test.p4
 
-Running interpreter test (Program_inst): [EXCLUDE] 83/1307 (6.35%) [PASS] 1224/1307 (93.65%) [FAIL] 0/1307 (0.00%) [PATCH] 0/1307 (0.00%)
+Running interpreter test (Program_inst): [EXCLUDE] 82/1307 (6.27%) [PASS] 1225/1307 (93.73%) [FAIL] 0/1307 (0.00%) [PATCH] 0/1307 (0.00%)
 
 Running interpreter test (Program_inst): [PATCH]: [EXCLUDE] 0/0 (0.00%) [PASS] 0/0 (0.00%) [FAIL] 0/0 (0.00%)


### PR DESCRIPTION
Fixes #43 

## Parsing left-angles (`<`) in P4 programs

Parsing left-angles in a P4 program is quite complicated. `<` can be used as a comparison operator of integers, or to specify type parameters/arguments. These usages are distinguished as different tokens, `L_ANGLE` and `L_ANGLE_ARGS`, and when the lexer reads `<`, it must determine how it is used before the parser analyzes it. This is required because the precedences of `L_ANGLE` and `L_ANGLE_ARGS` differ.

```p4
extern T f<T>(T x);
extern Object {
    T foo<T>();
}

struct data {
    bit<8> f;
    bit<8> foo;
}

control C(inout data d, inout bit<16> foo, Object o) {
    apply {
        if (4 + d.f < 10) { // HERE
            d.foo = (bit<8>)(o.foo<bit<16>>());
        }
    }
}
```
On each identifier, the parser is implemented to mark whether it requires type arguments. If so, a `<` following the identifier would be determined as `L_ANGLE_ARGS`, otherwise `L_ANGLE`. In the example above, at `HERE`, `d.f` refers to a struct field, and since its type is `bit<8>`, the following `<` is not used for type arguments.
However, due to the existence of the generic extern function `f<T>`, the lexer incorrectly determined the `f` in `d.f` as an identifier with type parameters, marking the `<` as `L_ANGLE_ARGS`. Because the operator precedence is determined as `L_ANGLE < PLUS < L_ANGLE_ARGS`, `4 + d.f < 10` was parsed as `4 + (d.f < 10)`, not `(4 + d.f) < 10`.

## Implementation

This PR fixes the issue above, mostly resembling the P4 parser implementation of p4c. The parser context in `p4spec/lib/interface/context.ml` is modified, and 2 global states are added.

```OCaml
type has_params = bool
type tid = Empty | Local of string | Global of string

type ident_kind =
  | TypeName of has_params * namespace
  | Ident of has_params * tid

and namespace = ident_kind SMap.t

type t = namespace list

(* Previously looked-up identifier *)
let previous_id : string option ref = ref None

(* Namespace of a member's parent *)
let parent_namespace : namespace option ref = ref None
```
In the context, each type name consists of its own namespace, and each identifer whose type is a type name holds a reference to it. `previous_id` is updated every time the lexer reads an identifier/type identifier, and `parent_namespace` is set to the namespace of `previous_id` when `set_parent_namespace` is called on parsing member accessing expressions/lvalues.

```OCaml
%inline memberAccessExpression:
	| e = memberAccessBase DOT set_parent_namespace m = member clear_parent_namespace %prec DOT
		{ "memberAccessBase `. member" <| [ e; m ] <<| "memberAccessExpression" <<<| (at $sloc) }
;
```
When `parent_namespace` is set, the `member` is searched only in the type's namespace. For example, `d.f` above would search `f` in `struct data`, instead of searching `f` in the current context. (This is just an intuitive explanation; the actual implementation leaves the namespace of `struct data` empty, since struct fields always do not have type parameters.)

When an extern object is declared, a namespace with its extern methods is stored within the context.

```OCaml
externObjectDeclaration:
  | al = annotationList EXTERN n = push_externName tpl = typeParameterListOpt
    L_BRACE pl = externConstructorOrMethodPrototypeList R_BRACE s = pop_scope
    { let decl = "annotationList EXTERN name typeParameterListOpt `{ externConstructorOrMethodPrototypeList }" <| [ al; n; tpl; pl ] <<| "externObjectDeclaration" <<<| (at $sloc) in
      declare_type_of_il n (has_type_params_declaration decl);
      set_type_namespace_of_il n s; (* The extern type in the context holds its namespace *)
      decl }
;
```
This is to handle cases such as `(bit<8>)(o.foo<bit<16>>())` above. `foo` is a generic method in `extern Object`, so the following `<` is determined as `L_ANGLE_ARGS`. Without this, if some parantheses are removed, e.g. `(bit<8>)o.foo<bit<16>>()`, this would fail to parse.

## Test results

`precedence-lt.p4` now passes the static type-checker test and `excludes/static/bug/left-angle-parsing.exclude` is removed.