### PR TITLE
Flat mixfix notation with inline arguments

### DIFF
--- a/p4spec/lib/backend-testgen-neg/config.ml
+++ b/p4spec/lib/backend-testgen-neg/config.ml
@@ -121,7 +121,7 @@ let load_def (tdenv : TDEnv.t) (def : def) : TDEnv.t =
       let td = Type.Typdef.Extern in
       TDEnv.add id td tdenv
   | TypD (id, tparams, deftyp, _) ->
-      let td = Type.Typdef.Defined (tparams, deftyp) in
+      let td = Type.Typdef.of_deftyp tparams deftyp in
       TDEnv.add id td tdenv
   | _ -> tdenv
 

--- a/p4spec/lib/backend-testgen-neg/mutate.ml
+++ b/p4spec/lib/backend-testgen-neg/mutate.ml
@@ -64,11 +64,11 @@ and gen_from_typ' (depth : int) (tdenv : TDEnv.t) (texts : value' list)
       match td with
       | Some (Defined (tparams, td)) -> (
           let theta = List.combine tparams targs |> TDEnv.of_list in
-          match td.it with
-          | PlainT typ ->
+          match td with
+          | `Plain typ ->
               typ |> Type.Subst.subst_typ theta
               |> gen_from_typ depth tdenv texts
-          | StructT typfields ->
+          | `Struct typfields ->
               let atoms, typs = List.split typfields in
               let* values =
                 typs
@@ -77,7 +77,7 @@ and gen_from_typ' (depth : int) (tdenv : TDEnv.t) (texts : value' list)
               in
               let valuefields = List.combine atoms values in
               StructV valuefields |> Option.some |> wrap_value_opt typ.it
-          | VariantT typcases ->
+          | `Variant (typcases, _) ->
               let nottyps' =
                 typcases
                 |> List.map (fun (nottyp, _, _) ->

--- a/p4spec/lib/domain/mixop.ml
+++ b/p4spec/lib/domain/mixop.ml
@@ -1,151 +1,82 @@
 open Util.Source
 
-(* Mixop is a generalized case constructor *)
+(* Mixop: a sequence of atoms and argument placeholders. *)
 
 type atom = Atom.t phrase [@@deriving yojson]
+type mixeme = Arg | Atom of atom [@@deriving yojson]
+type t = mixeme list [@@deriving yojson]
 
-type t =
-  | Arg
-  | Atom of atom
-  | Brack of atom * t * atom
-  | Infix of t * atom * t
-  | Seq of t list
-[@@deriving yojson]
+(* Comparison *)
 
 let compare_atom (atom_a : atom) (atom_b : atom) =
   Atom.compare atom_a.it atom_b.it
 
-let rec compare (mixop_a : t) (mixop_b : t) =
-  if mixop_a == mixop_b then 0
-  else
-    let tag (mixop : t) =
-      match mixop with
-      | Arg -> 0
-      | Atom _ -> 1
-      | Brack _ -> 2
-      | Infix _ -> 3
-      | Seq _ -> 4
-    in
-    match (mixop_a, mixop_b) with
-    | Arg, Arg -> 0
-    | Atom atom_a, Atom atom_b -> compare_atom atom_a atom_b
-    | Brack (atom_a_l, mixop_a, atom_a_r), Brack (atom_b_l, mixop_b, atom_b_r)
-      ->
-        let c = compare_atom atom_a_l atom_b_l in
-        if c <> 0 then c
-        else
-          let c = compare mixop_a mixop_b in
-          if c <> 0 then c else compare_atom atom_a_r atom_b_r
-    | Infix (mixop_a_l, atom_a, mixop_a_r), Infix (mixop_b_l, atom_b, mixop_b_r)
-      ->
-        let c = compare mixop_a_l mixop_b_l in
-        if c <> 0 then c
-        else
-          let c = compare_atom atom_a atom_b in
-          if c <> 0 then c else compare mixop_a_r mixop_b_r
-    | Seq mixops_a, Seq mixops_b -> compare_mixops mixops_a mixops_b
-    | mixop_a, mixop_b -> Int.compare (tag mixop_a) (tag mixop_b)
+let compare_mixeme (a : mixeme) (b : mixeme) =
+  match (a, b) with
+  | Arg, Arg -> 0
+  | Arg, Atom _ -> -1
+  | Atom _, Arg -> 1
+  | Atom atom_a, Atom atom_b -> compare_atom atom_a atom_b
 
-and compare_mixops (mixops_a : t list) (mixops_b : t list) =
-  match (mixops_a, mixops_b) with
-  | [], [] -> 0
-  | mixop_a :: mixops_a, mixop_b :: mixops_b ->
-      let c = compare mixop_a mixop_b in
-      if c <> 0 then c else compare_mixops mixops_a mixops_b
-  | [], _ -> -1
-  | _, [] -> 1
+let compare (mixop_a : t) (mixop_b : t) =
+  List.compare compare_mixeme mixop_a mixop_b
 
 let eq (mixop_a : t) (mixop_b : t) = compare mixop_a mixop_b = 0
 
 (* Arity *)
 
 let arity (mixop : t) : int =
-  let rec arity (mixop : t) : int =
-    match mixop with
-    | Arg -> 1
-    | Atom _ -> 0
-    | Brack (_, mixop, _) -> arity mixop
-    | Infix (mixop_l, _, mixop_r) -> arity mixop_l + arity mixop_r
-    | Seq mixops ->
-        List.fold_left (fun arity_acc mixop -> arity_acc + arity mixop) 0 mixops
-  in
-  arity mixop
+  List.fold_left (fun n p -> match p with Arg -> n + 1 | Atom _ -> n) 0 mixop
 
-(* Atoms *)
+(* Atoms in sequence *)
 
 let atoms (mixop : t) : atom list =
-  let rec atoms (mixop : t) : atom list =
-    match mixop with
-    | Arg -> []
-    | Atom atom -> [ atom ]
-    | Brack (atom_l, mixop, atom_r) -> (atom_l :: atoms mixop) @ [ atom_r ]
-    | Infix (mixop_l, atom, mixop_r) -> atoms mixop_l @ [ atom ] @ atoms mixop_r
-    | Seq mixops ->
-        List.fold_left
-          (fun atoms_acc mixop -> atoms_acc @ atoms mixop)
-          [] mixops
-  in
-  atoms mixop
+  List.filter_map (function Atom a -> Some a | Arg -> None) mixop
 
-(* Stringifier *)
-
-let string_of_mixop (mixop : t) =
-  let rec string_of_mixop (mixop : t) =
-    match mixop with
-    | Arg -> "%"
-    | Atom atom -> Atom.render_atom atom.it
-    | Brack (atom_l, mixop, atom_r) ->
-        Atom.render_atom atom_l.it ^ string_of_mixop mixop
-        ^ Atom.render_atom atom_r.it
-    | Infix (mixop_l, atom, mixop_r) ->
-        string_of_mixop mixop_l ^ Atom.render_atom atom.it
-        ^ string_of_mixop mixop_r
-    | Seq mixops -> String.concat " " (List.map string_of_mixop mixops)
-  in
-  "`" ^ string_of_mixop mixop ^ "`"
-
-(* Assembler *)
+(* Assembler: interleave rendered atoms and argument strings, space-joined *)
 
 let assemble ~(string_of_atom : atom -> string) (mixop : t) (args : string list)
     : string =
-  let rec assemble (mixop : t) (args : string list) : string * string list =
-    match mixop with
-    | Arg -> (
-        match args with
-        | [] -> failwith "not enough arguments"
-        | arg :: args -> (arg, args))
-    | Atom atom ->
-        let smixop = string_of_atom atom in
-        (smixop, args)
-    | Brack (atom_l, mixop, atom_r) ->
-        let smixop, args = assemble mixop args in
-        let smixop =
-          [ string_of_atom atom_l; smixop; string_of_atom atom_r ]
-          |> List.filter (fun s -> s <> "")
-          |> String.concat " "
-        in
-        (smixop, args)
-    | Infix (mixop_l, atom, mixop_r) ->
-        let smixop_l, args = assemble mixop_l args in
-        let smixop_r, args = assemble mixop_r args in
-        let smixop =
-          [ smixop_l; string_of_atom atom; smixop_r ]
-          |> List.filter (fun s -> s <> "")
-          |> String.concat " "
-        in
-        (smixop, args)
-    | Seq mixops ->
-        let smixops, args =
-          List.fold_left
-            (fun (smixops, args) mixop ->
-              let smixop, args = assemble mixop args in
-              (smixops @ [ smixop ], args))
-            ([], args) mixops
-        in
-        let smixop =
-          smixops |> List.filter (fun s -> s <> "") |> String.concat " "
-        in
-        (smixop, args)
+  let rec assemble mixop args mixemes_rev =
+    match (mixop, args) with
+    | [], [] -> List.rev mixemes_rev
+    | [], _ :: _ -> failwith "Mixop.assemble: too many arguments"
+    | Arg :: _, [] -> failwith "Mixop.assemble: not enough arguments"
+    | Arg :: rest, arg :: args_rest ->
+        assemble rest args_rest (arg :: mixemes_rev)
+    | Atom atom :: rest, args ->
+        assemble rest args (string_of_atom atom :: mixemes_rev)
   in
-  let smixop, args = assemble mixop args in
-  match args with [] -> smixop | _ -> failwith "too many arguments"
+  assemble mixop args [] |> List.filter (fun s -> s <> "") |> String.concat " "
+
+(* Stringifier
+
+   Workaround to match the output of tree-mixops.
+   Omit the space after an open bracket, and before a close bracket. *)
+
+let is_open_bracket : Atom.t -> bool = function
+  | LParen | LBrack | LBrace | LAngle -> true
+  | _ -> false
+
+let is_close_bracket : Atom.t -> bool = function
+  | RParen | RBrack | RBrace | RAngle -> true
+  | _ -> false
+
+let opens_bracket = function Atom a -> is_open_bracket a.it | Arg -> false
+let closes_bracket = function Atom a -> is_close_bracket a.it | Arg -> false
+
+let string_of_mixeme = function
+  | Arg -> "%"
+  | Atom atom -> Atom.render_atom atom.it
+
+let string_of_mixop (mixop : t) : string =
+  let rec string_of_mixemes = function
+    | [] -> ""
+    | [ mixeme ] -> string_of_mixeme mixeme
+    | left :: (right :: _ as rest) ->
+        let sep =
+          if opens_bracket left || closes_bracket right then "" else " "
+        in
+        string_of_mixeme left ^ sep ^ string_of_mixemes rest
+  in
+  "`" ^ string_of_mixemes mixop ^ "`"

--- a/p4spec/lib/frontend/parse.ml
+++ b/p4spec/lib/frontend/parse.ml
@@ -12,26 +12,28 @@ let with_lexbuf name lexbuf start =
     error (Lexer.region lexbuf) "syntax error: unexpected token"
 
 let parse_mixop str =
-  let rec mixop_of_nottyp (nottyp : El.nottyp) =
+  let rec mixop_of_nottyp (nottyp : El.nottyp) (mixop_rev : Mixop.t) : Mixop.t =
     match nottyp.it with
-    | AtomT atom -> Mixop.Atom atom
+    | AtomT atom -> Mixop.Atom atom :: mixop_rev
     | SeqT typs ->
-        let mixops = List.map mixop_of_typ typs in
-        Mixop.Seq mixops
+        List.fold_left
+          (fun mixop_rev typ -> mixop_of_typ typ mixop_rev)
+          mixop_rev typs
     | InfixT (typ_l, atom, typ_r) ->
-        let mixop_l = mixop_of_typ typ_l in
-        let mixop_r = mixop_of_typ typ_r in
-        Mixop.Infix (mixop_l, atom, mixop_r)
+        let mixop_rev = mixop_of_typ typ_l mixop_rev in
+        let mixop_rev = Mixop.Atom atom :: mixop_rev in
+        mixop_of_typ typ_r mixop_rev
     | BrackT (atom_l, typ, atom_r) ->
-        let mixop = mixop_of_typ typ in
-        Mixop.Brack (atom_l, mixop, atom_r)
-  and mixop_of_typ (typ : El.typ) =
+        let mixop_rev = Mixop.Atom atom_l :: mixop_rev in
+        let mixop_rev = mixop_of_typ typ mixop_rev in
+        Mixop.Atom atom_r :: mixop_rev
+  and mixop_of_typ (typ : El.typ) (mixop_rev : Mixop.t) =
     match typ with
-    | PlainT _ -> Mixop.Arg
-    | NotationT nottyp -> mixop_of_nottyp nottyp
+    | PlainT _ -> Mixop.Arg :: mixop_rev
+    | NotationT nottyp -> mixop_of_nottyp nottyp mixop_rev
   in
   let typ = Parser.check_typ Lexer.token (Lexing.from_string str) in
-  mixop_of_typ typ
+  List.rev (mixop_of_typ typ [])
 
 let parse_file file =
   let ic = open_in file in

--- a/p4spec/lib/interp/interp-il/ctx.ml
+++ b/p4spec/lib/interp/interp-il/ctx.ml
@@ -84,7 +84,7 @@ let load_def (def : def) : unit =
       let td = Typdef.Extern in
       add_typdef_global id td
   | TypD (id, tparams, deftyp, _) ->
-      let td = Typdef.Defined (tparams, deftyp) in
+      let td = Typdef.of_deftyp tparams deftyp in
       add_typdef_global id td
   | VarD _ -> ()
   | ExternRelD (id, nottyp, inputs, _) ->
@@ -146,7 +146,7 @@ let find_typdef (ctx : t) (tid : TId.t) : Typdef.t =
   | Some td -> td
   | None -> error_undef tid.at "type" tid.it
 
-let find_defined_typdef (ctx : t) (tid : TId.t) : tparam list * deftyp =
+let find_defined_typdef (ctx : t) (tid : TId.t) =
   match find_typdef ctx tid with
   | Param | Extern | Defining _ -> error_undef tid.at "defined type" tid.it
   | Defined (tparams, deftyp) -> (tparams, deftyp)

--- a/p4spec/lib/interp/interp-il/interp.ml
+++ b/p4spec/lib/interp/interp-il/interp.ml
@@ -66,7 +66,7 @@ module Make (Arch : Sim.ARCH) : Sim.INTERP_IL = struct
     let ctx_local =
       List.fold_left2
         (fun ctx_local tparam targ ->
-          let td = Type.Typdef.Defined ([], PlainT targ $ targ.at) in
+          let td = Type.Typdef.Defined ([], `Plain targ) in
           Ctx.add_typdef ctx_local tparam td)
         ctx_local tparams targs
     in
@@ -377,8 +377,8 @@ module Make (Arch : Sim.ARCH) : Sim.INTERP_IL = struct
     | VarT (tid, targs) -> (
         let tparams, deftyp = Ctx.find_defined_typdef ctx tid in
         let theta = TIdMap.of_lists tparams targs in
-        match deftyp.it with
-        | PlainT typ ->
+        match deftyp with
+        | `Plain typ ->
             let typ = Type.Subst.subst_typ theta typ in
             upcast ctx typ value
         | _ -> value)
@@ -414,8 +414,8 @@ module Make (Arch : Sim.ARCH) : Sim.INTERP_IL = struct
     | VarT (tid, targs) -> (
         let tparams, deftyp = Ctx.find_defined_typdef ctx tid in
         let theta = TIdMap.of_lists tparams targs in
-        match deftyp.it with
-        | PlainT typ ->
+        match deftyp with
+        | `Plain typ ->
             let typ = Type.Subst.subst_typ theta typ in
             downcast ctx typ value
         | _ -> value)
@@ -1286,7 +1286,7 @@ module Make (Arch : Sim.ARCH) : Sim.INTERP_IL = struct
             TDEnv.fold
               (fun tid typdef theta ->
                 match typdef with
-                | Type.Typdef.Defined ([], { it = Il.PlainT typ; _ }) ->
+                | Type.Typdef.Defined ([], `Plain typ) ->
                     TIdMap.add tid typ theta
                 | _ -> theta)
               ctx.local.tdenv TIdMap.empty
@@ -1430,7 +1430,7 @@ module Make (Arch : Sim.ARCH) : Sim.INTERP_IL = struct
       let ctx_local =
         List.fold_left2
           (fun ctx_local tparam targ ->
-            let td = Type.Typdef.Defined ([], PlainT targ $ targ.at) in
+            let td = Type.Typdef.Defined ([], `Plain targ) in
             Ctx.add_typdef ctx_local tparam td)
           ctx_local tparams targs
       in

--- a/p4spec/lib/interp/interp-sl/ctx.ml
+++ b/p4spec/lib/interp/interp-sl/ctx.ml
@@ -103,7 +103,7 @@ let load_def (def : def) : unit =
       let td = Typdef.Extern in
       add_typdef_global id td
   | TypD (id, tparams, deftyp, _) ->
-      let td = Typdef.Defined (tparams, deftyp) in
+      let td = Typdef.of_deftyp tparams deftyp in
       add_typdef_global id td
   | VarD _ -> ()
   | ExternRelD (id, rel_signature, _, _) ->
@@ -183,7 +183,7 @@ let find_typdef (ctx : t) (tid : TId.t) : Typdef.t =
   | Some td -> td
   | None -> back_undef tid.at "type" tid.it
 
-let find_defined_typdef (ctx : t) (tid : TId.t) : tparam list * deftyp =
+let find_defined_typdef (ctx : t) (tid : TId.t) =
   match find_typdef ctx tid with
   | Param | Extern | Defining _ -> back_undef tid.at "defined type" tid.it
   | Defined (tparams, deftyp) -> (tparams, deftyp)

--- a/p4spec/lib/interp/interp-sl/interp.ml
+++ b/p4spec/lib/interp/interp-sl/interp.ml
@@ -68,7 +68,7 @@ module Make (Arch : Sim.ARCH) : Sim.INTERP_SL = struct
     let tdenv_local =
       List.fold_left2
         (fun tdenv_local tparam targ ->
-          let td = Type.Typdef.Defined ([], Il.PlainT targ $ targ.at) in
+          let td = Type.Typdef.Defined ([], `Plain targ) in
           TDEnv.add tparam td tdenv_local)
         TDEnv.empty tparams targs
     in
@@ -444,8 +444,8 @@ module Make (Arch : Sim.ARCH) : Sim.INTERP_SL = struct
         | _ -> back_err_upcast ())
     | VarT (tid, targs) -> (
         let tparams, deftyp = Ctx.find_defined_typdef ctx tid in
-        match deftyp.it with
-        | PlainT typ ->
+        match deftyp with
+        | `Plain typ ->
             let theta = TIdMap.of_lists tparams targs in
             let typ = Type.Subst.subst_typ theta typ in
             upcast ctx typ value
@@ -487,8 +487,8 @@ module Make (Arch : Sim.ARCH) : Sim.INTERP_SL = struct
         | _ -> back_err_downcast ())
     | VarT (tid, targs) -> (
         let tparams, deftyp = Ctx.find_defined_typdef ctx tid in
-        match deftyp.it with
-        | PlainT typ ->
+        match deftyp with
+        | `Plain typ ->
             let theta = TIdMap.of_lists tparams targs in
             let typ = Type.Subst.subst_typ theta typ in
             downcast ctx typ value
@@ -1781,7 +1781,7 @@ module Make (Arch : Sim.ARCH) : Sim.INTERP_SL = struct
             TDEnv.fold
               (fun tid typdef theta ->
                 match typdef with
-                | Type.Typdef.Defined ([], { it = Il.PlainT typ; _ }) ->
+                | Type.Typdef.Defined ([], `Plain typ) ->
                     TIdMap.add tid typ theta
                 | _ -> theta)
               tdenv_local TIdMap.empty
@@ -1901,7 +1901,7 @@ module Make (Arch : Sim.ARCH) : Sim.INTERP_SL = struct
         id.at "arity mismatch in type arguments";
       List.fold_left2
         (fun tdenv_local tparam targ ->
-          let td = Type.Typdef.Defined ([], Il.PlainT targ $ targ.at) in
+          let td = Type.Typdef.Defined ([], `Plain targ) in
           TDEnv.add tparam td tdenv_local)
         TDEnv.empty tparams targs
     in

--- a/p4spec/lib/pass/elaborate/ctx.ml
+++ b/p4spec/lib/pass/elaborate/ctx.ml
@@ -95,33 +95,36 @@ let bound_metavar (ctx : t) (tid : TId.t) : bool =
 (* Finders for rules *)
 
 let find_defined_rel_opt (ctx : t) (rid : RId.t) :
-    (Il.nottyp * int list * Il.rulegroup list * Il.elsegroup option) option =
+    (Mixop.t * Il.nottyp * int list * Il.rulegroup list * Il.elsegroup option)
+    option =
   let rel_opt = REnv.find_opt rid ctx.renv in
   Option.bind rel_opt (function
-    | Rel.Defined (nottyp_il, inputs, rulegroups, elsegroup_opt) ->
-        Some (nottyp_il, inputs, rulegroups, elsegroup_opt)
+    | Rel.Defined (mixop_el, nottyp_il, inputs, rulegroups, elsegroup_opt) ->
+        Some (mixop_el, nottyp_il, inputs, rulegroups, elsegroup_opt)
     | Rel.Extern _ -> None)
 
 let find_defined_rel (ctx : t) (rid : RId.t) :
-    Il.nottyp * int list * Il.rulegroup list * Il.elsegroup option =
+    Mixop.t * Il.nottyp * int list * Il.rulegroup list * Il.elsegroup option =
   match find_defined_rel_opt ctx rid with
-  | Some (nottyp_il, inputs, rulegroups, elsegroup_opt) ->
-      (nottyp_il, inputs, rulegroups, elsegroup_opt)
+  | Some result -> result
   | None -> error_undef rid.at "defined relation" rid.it
 
 let bound_defined_rel (ctx : t) (rid : RId.t) : bool =
   find_defined_rel_opt ctx rid |> Option.is_some
 
 let find_rel_signature_opt (ctx : t) (rid : RId.t) :
-    (Il.nottyp * int list) option =
+    (Mixop.t * Il.nottyp * int list) option =
   REnv.find_opt rid ctx.renv
   |> Option.map (function
-         | Rel.Extern (nottyp_il, inputs) | Rel.Defined (nottyp_il, inputs, _, _)
-         -> (nottyp_il, inputs))
+       | Rel.Extern (mixop_el, nottyp_il, inputs) ->
+           (mixop_el, nottyp_il, inputs)
+       | Rel.Defined (mixop_el, nottyp_il, inputs, _, _) ->
+           (mixop_el, nottyp_il, inputs))
 
-let find_rel_signature (ctx : t) (rid : RId.t) : Il.nottyp * int list =
+let find_rel_signature (ctx : t) (rid : RId.t) : Mixop.t * Il.nottyp * int list
+    =
   match find_rel_signature_opt ctx rid with
-  | Some (nottyp_il, inputs) -> (nottyp_il, inputs)
+  | Some result -> result
   | None -> error_undef rid.at "relation" rid.it
 
 let bound_rel (ctx : t) (rid : RId.t) : bool =
@@ -129,7 +132,7 @@ let bound_rel (ctx : t) (rid : RId.t) : bool =
 
 let bound_rulegroup (ctx : t) (rid : RId.t) (rulegroupid : Id.t) : bool =
   match find_defined_rel_opt ctx rid with
-  | Some (_, _, rulegroups, elsegroup_opt) ->
+  | Some (_, _, _, rulegroups, elsegroup_opt) ->
       let rulegroupids =
         List.map
           (fun rulegroup ->
@@ -240,17 +243,17 @@ let add_tparams (ctx : t) (tparams : tparam list) : t =
 
 (* Adders for rules *)
 
-let add_extern_rel (ctx : t) (rid : RId.t) (nottyp_il : Il.nottyp)
-    (inputs : int list) : t =
+let add_extern_rel (ctx : t) (rid : RId.t) (mixop_el : Mixop.t)
+    (nottyp_il : Il.nottyp) (inputs : int list) : t =
   if bound_rel ctx rid then error_dup rid.at "relation" rid.it;
-  let rel = Rel.Extern (nottyp_il, inputs) in
+  let rel = Rel.Extern (mixop_el, nottyp_il, inputs) in
   let renv = REnv.add rid rel ctx.renv in
   { ctx with renv }
 
-let add_defined_rel (ctx : t) (rid : RId.t) (nottyp_il : Il.nottyp)
-    (inputs : int list) : t =
+let add_defined_rel (ctx : t) (rid : RId.t) (mixop_el : Mixop.t)
+    (nottyp_il : Il.nottyp) (inputs : int list) : t =
   if bound_rel ctx rid then error_dup rid.at "relation" rid.it;
-  let rel = Rel.Defined (nottyp_il, inputs, [], None) in
+  let rel = Rel.Defined (mixop_el, nottyp_il, inputs, [], None) in
   let renv = REnv.add rid rel ctx.renv in
   { ctx with renv }
 
@@ -260,11 +263,13 @@ let add_defined_rulegroup (ctx : t) (rid : RId.t) (rulegroup_il : Il.rulegroup)
   let rulegroupid, _, _ = rulegroup_il.it in
   if bound_rulegroup ctx rid rulegroupid then
     error_dup rulegroupid.at "rulegroup" rulegroupid.it;
-  let nottyp_il, inputs, rulegroups_il, elsegroup_il_opt =
+  let mixop_el, nottyp_il, inputs, rulegroups_il, elsegroup_il_opt =
     find_defined_rel ctx rid
   in
   let rulegroups_il = rulegroups_il @ [ rulegroup_il ] in
-  let rel = Rel.Defined (nottyp_il, inputs, rulegroups_il, elsegroup_il_opt) in
+  let rel =
+    Rel.Defined (mixop_el, nottyp_il, inputs, rulegroups_il, elsegroup_il_opt)
+  in
   let renv = REnv.add rid rel ctx.renv in
   { ctx with renv }
 
@@ -274,7 +279,7 @@ let add_defined_elsegroup (ctx : t) (rid : RId.t) (elsegroup_il : Il.elsegroup)
   let rulegroupid, _, _ = elsegroup_il.it in
   if bound_rulegroup ctx rid rulegroupid then
     error_dup rulegroupid.at "rulegroup" rulegroupid.it;
-  let nottyp_il, inputs, rulegroups_il, elsegroup_il_opt =
+  let mixop_el, nottyp_il, inputs, rulegroups_il, elsegroup_il_opt =
     find_defined_rel ctx rid
   in
   match elsegroup_il_opt with
@@ -282,7 +287,8 @@ let add_defined_elsegroup (ctx : t) (rid : RId.t) (elsegroup_il : Il.elsegroup)
   | None ->
       let elsegroup_il_opt = Some elsegroup_il in
       let rel =
-        Rel.Defined (nottyp_il, inputs, rulegroups_il, elsegroup_il_opt)
+        Rel.Defined
+          (mixop_el, nottyp_il, inputs, rulegroups_il, elsegroup_il_opt)
       in
       let renv = REnv.add rid rel ctx.renv in
       { ctx with renv }

--- a/p4spec/lib/pass/elaborate/dataflow/partialbind.ml
+++ b/p4spec/lib/pass/elaborate/dataflow/partialbind.ml
@@ -12,14 +12,12 @@ let rec is_singleton_case (dctx : Dctx.t) (typ : typ) : bool =
   | VarT (tid, targs) -> (
       let td = Dctx.find_typdef dctx tid in
       match td with
-      | Defined (tparams, deftyp) -> (
-          match deftyp.it with
-          | PlainT typ ->
-              let theta = TIdMap.of_lists tparams targs in
-              let typ = Type.Subst.subst_typ theta typ in
-              is_singleton_case dctx typ
-          | StructT _ -> false
-          | VariantT typcases -> List.length typcases = 1)
+      | Defined (tparams, `Plain typ) ->
+          let theta = TIdMap.of_lists tparams targs in
+          let typ = Type.Subst.subst_typ theta typ in
+          is_singleton_case dctx typ
+      | Defined (_, `Struct _) -> false
+      | Defined (_, `Variant (typcases, _)) -> List.length typcases = 1
       | _ -> false)
   | _ -> false
 

--- a/p4spec/lib/pass/elaborate/elab.ml
+++ b/p4spec/lib/pass/elaborate/elab.ml
@@ -10,6 +10,7 @@ open Util.Checks
 open Util.Source
 module Xl = Lang.Xl
 module F = Format
+module Mixop = Runtime.Mixop
 
 (* Checks *)
 
@@ -56,10 +57,11 @@ let as_struct_typ (ctx : Ctx.t) (typ_il : Il.typ) : Il.typfield list attempt =
   | VarT (tid, _) -> (
       let td_opt = Ctx.find_typdef_opt ctx tid in
       match td_opt with
-      | Some (Defined (_, deftyp)) -> (
-          match deftyp.it with
-          | StructT typfields_il -> Ok typfields_il
-          | _ -> fail typ_il.at "cannot destruct type as a struct")
+      | Some (Defined (_, `Struct typfields_il)) -> Ok typfields_il
+      | Some (Defined (_, `Plain _)) ->
+          fail typ_il.at "cannot destruct plain type as a struct"
+      | Some (Defined (_, `Variant _)) ->
+          fail typ_il.at "cannot destruct variant type as a struct"
       | _ -> fail typ_il.at "cannot destruct type as a struct")
   | _ -> fail typ_il.at "cannot destruct type as a struct"
 
@@ -93,52 +95,66 @@ and elab_plaintyp' (ctx : Ctx.t) (plaintyp : plaintyp') : Il.typ' =
 
 (* Elaboration of notation types *)
 
-and elab_nottyp (ctx : Ctx.t) (typ : typ) : Il.nottyp =
+and elab_nottyp (ctx : Ctx.t) (typ : typ) : Mixop.t * Il.nottyp =
   match typ with
   | PlainT plaintyp ->
-      let mixop = Mixop.Arg in
       let typ_il = elab_plaintyp ctx plaintyp in
-      (mixop, [ typ_il ]) $ plaintyp.at
+      let mixop_el = Mixop.Arg in
+      let nottyp_il = (Mixop.to_flat mixop_el, [ typ_il ]) $ plaintyp.at in
+      (mixop_el, nottyp_il)
   | NotationT nottyp -> (
       match nottyp.it with
       | AtomT atom ->
-          let mixop = Mixop.Atom atom in
-          let typs_il = [] in
-          (mixop, typs_il) $ nottyp.at
+          let mixop_el = Mixop.Atom atom in
+          let nottyp_il = (Mixop.to_flat mixop_el, []) $ nottyp.at in
+          (mixop_el, nottyp_il)
       | SeqT [] ->
-          let mixop = Mixop.Seq [] in
-          let typs_il = [] in
-          (mixop, typs_il) $ nottyp.at
+          let mixop_el = Mixop.Seq [] in
+          let nottyp_il = (Mixop.to_flat mixop_el, []) $ nottyp.at in
+          (mixop_el, nottyp_il)
       | SeqT (typ_h :: typs_t) ->
-          let mixop_h, typs_il_h = elab_nottyp ctx typ_h |> it in
-          let mixop_t, typs_il_t =
-            elab_nottyp ctx (NotationT (SeqT typs_t $ nottyp.at)) |> it
+          let mixop_el_h, nottyp_il_h = elab_nottyp ctx typ_h in
+          let mixop_el_t, nottyp_il_t =
+            elab_nottyp ctx (NotationT (SeqT typs_t $ nottyp.at))
           in
-          let mixop =
-            match mixop_t with
-            | Mixop.Seq mixops_t -> Mixop.Seq (mixop_h :: mixops_t)
+          let _, typs_il_h = nottyp_il_h.it in
+          let _, typs_il_t = nottyp_il_t.it in
+          let mixop_el =
+            match mixop_el_t with
+            | Mixop.Seq mixops_t -> Mixop.Seq (mixop_el_h :: mixops_t)
             | _ -> assert false
           in
           let typs_il = typs_il_h @ typs_il_t in
-          (mixop, typs_il) $ nottyp.at
+          let nottyp_il = (Mixop.to_flat mixop_el, typs_il) $ nottyp.at in
+          (mixop_el, nottyp_il)
       | InfixT (typ_l, atom, typ_r) ->
-          let mixop_l, typs_il_l = elab_nottyp ctx typ_l |> it in
-          let mixop_r, typs_il_r = elab_nottyp ctx typ_r |> it in
-          let mixop = Mixop.Infix (mixop_l, atom, mixop_r) in
-          let typs_il = typs_il_l @ typs_il_r in
-          (mixop, typs_il) $ nottyp.at
+          let mixop_el_l, nottyp_il_l = elab_nottyp ctx typ_l in
+          let mixop_el_r, nottyp_il_r = elab_nottyp ctx typ_r in
+          let _, typs_il_l = nottyp_il_l.it in
+          let _, typs_il_r = nottyp_il_r.it in
+          let mixop_el = Mixop.Infix (mixop_el_l, atom, mixop_el_r) in
+          let nottyp_il =
+            (Mixop.to_flat mixop_el, typs_il_l @ typs_il_r) $ nottyp.at
+          in
+          (mixop_el, nottyp_il)
       | BrackT (atom_l, typ, atom_r) ->
-          let mixop, typs_il = elab_nottyp ctx typ |> it in
-          let mixop = Mixop.Brack (atom_l, mixop, atom_r) in
-          (mixop, typs_il) $ nottyp.at)
+          let mixop_el_inner, nottyp_il_inner = elab_nottyp ctx typ in
+          let _, typs_il = nottyp_il_inner.it in
+          let mixop_el = Mixop.Brack (atom_l, mixop_el_inner, atom_r) in
+          let nottyp_il = (Mixop.to_flat mixop_el, typs_il) $ nottyp.at in
+          (mixop_el, nottyp_il))
 
 (* Elaboration of definition types *)
 
 and elab_deftyp (ctx : Ctx.t) (id : id) (tparams : tparam list)
-    (deftyp : deftyp) : Typdef.t * Il.deftyp =
+    (deftyp : deftyp) : Ctx.t * Typdef.t * Il.deftyp =
   match deftyp.it with
-  | PlainTD plaintyp -> elab_deftyp_plain ctx tparams plaintyp
-  | StructTD typfields -> elab_deftyp_struct ctx deftyp.at tparams typfields
+  | PlainTD plaintyp ->
+      let td, deftyp_il = elab_deftyp_plain ctx tparams plaintyp in
+      (ctx, td, deftyp_il)
+  | StructTD typfields ->
+      let td, deftyp_il = elab_deftyp_struct ctx deftyp.at tparams typfields in
+      (ctx, td, deftyp_il)
   | VariantTD typcases -> elab_deftyp_variant ctx deftyp.at id tparams typcases
 
 (* Elaboration of plain type definitions *)
@@ -147,7 +163,7 @@ and elab_deftyp_plain (ctx : Ctx.t) (tparams : tparam list)
     (plaintyp : plaintyp) : Typdef.t * Il.deftyp =
   let typ_il = elab_plaintyp ctx plaintyp in
   let deftyp_il = Il.PlainT typ_il $ plaintyp.at in
-  let td = Typdef.Defined (tparams, deftyp_il) in
+  let td = Typdef.Defined (tparams, `Plain typ_il) in
   (td, deftyp_il)
 
 (* Elaboration of struct type definitions *)
@@ -161,55 +177,60 @@ and elab_deftyp_struct (ctx : Ctx.t) (at : region) (tparams : tparam list)
     (typfields : typfield list) : Typdef.t * Il.deftyp =
   let typfields_il = List.map (elab_typfield ctx) typfields in
   let deftyp_il = Il.StructT typfields_il $ at in
-  let td = Typdef.Defined (tparams, deftyp_il) in
+  let td = Typdef.Defined (tparams, `Struct typfields_il) in
   (td, deftyp_il)
 
 (* Elaboration of variant type definitions *)
 
-and elab_typcase_plain (ctx : Ctx.t) (typ_il : Il.typ) : Il.typcase list =
+and elab_typcase_plain (ctx : Ctx.t) (typ_il : Il.typ) :
+    Mixop.t list * Il.typcase list =
   let typ_il = Expand.expand_typ (Ctx.find_typdef_opt ctx) typ_il in
   match typ_il.it with
   | VarT (tid, targs_il) -> (
       let td = Ctx.find_typdef ctx tid in
       match td with
       | Defining _ -> error typ_il.at "cannot extend an incomplete type"
-      | Defined (tparams, deftyp) -> (
-          match deftyp.it with
-          | VariantT typcases_il ->
-              let theta = TIdMap.of_lists tparams targs_il in
-              List.map (Subst.subst_typcase theta) typcases_il
-          | _ -> error typ_il.at "cannot extend a non-variant type")
+      | Defined (tparams, `Plain typ_il') ->
+          let theta = TIdMap.of_lists tparams targs_il in
+          let typ_il' = Subst.subst_typ theta typ_il' in
+          elab_typcase_plain ctx typ_il'
+      | Defined (tparams, `Variant (typcases_il, mixops_el)) ->
+          let theta = TIdMap.of_lists tparams targs_il in
+          let typcases_il = List.map (Subst.subst_typcase theta) typcases_il in
+          (mixops_el, typcases_il)
+      | Defined (_, `Struct _) -> error typ_il.at "cannot extend a struct type"
       | _ -> error typ_il.at "cannot extend a non-variant type")
   | _ -> error typ_il.at "cannot extend a non-variant type"
 
 and elab_typcase (ctx : Ctx.t) (typorigin_il : Il.typorigin) (typcase : typcase)
-    : Il.typcase list =
+    : Mixop.t list * Il.typcase list =
   let typ, hints = typcase in
   match typ with
   | PlainT plaintyp ->
       let typ_il = elab_plaintyp ctx plaintyp in
       elab_typcase_plain ctx typ_il
   | NotationT _ ->
-      let nottyp_il = elab_nottyp ctx typ in
+      let mixop_el, nottyp_il = elab_nottyp ctx typ in
       let typcase_il = (nottyp_il, typorigin_il, hints) in
-      [ typcase_il ]
+      ([ mixop_el ], [ typcase_il ])
 
 and elab_deftyp_variant (ctx : Ctx.t) (at : region) (id : id)
-    (tparams : tparam list) (typcases : typcase list) : Typdef.t * Il.deftyp =
+    (tparams : tparam list) (typcases : typcase list) :
+    Ctx.t * Typdef.t * Il.deftyp =
   let typorigin_il =
     let targs_il =
       List.map (fun tparam -> Il.VarT (tparam, []) $ tparam.at) tparams
     in
     (id, targs_il) $ id.at
   in
-  let typcases_il = List.concat_map (elab_typcase ctx typorigin_il) typcases in
-  let mixops =
-    typcases_il
-    |> List.map (fun (nottyp_il, _, _) ->
-           let mixop, _ = nottyp_il.it in
-           mixop)
+  let mixops_el, typcases_il =
+    List.fold_left
+      (fun (mixops_acc, cases_acc) typcase ->
+        let mixops, cases = elab_typcase ctx typorigin_il typcase in
+        (mixops_acc @ mixops, cases_acc @ cases))
+      ([], []) typcases
   in
-  let mixop_groups = groupby Mixop.eq mixops in
+  let mixop_groups = groupby Mixop.eq mixops_el in
   let mixop_duplicates =
     List.filter (fun mixop_group -> List.length mixop_group > 1) mixop_groups
   in
@@ -222,8 +243,8 @@ and elab_deftyp_variant (ctx : Ctx.t) (at : region) (id : id)
            (fun mixop_group -> Mixop.string_of_mixop (List.hd mixop_group))
            mixop_duplicates));
   let deftyp_il = Il.VariantT typcases_il $ at in
-  let td = Typdef.Defined (tparams, deftyp_il) in
-  (td, deftyp_il)
+  let td = Typdef.Defined (tparams, `Variant (typcases_il, mixops_el)) in
+  (ctx, td, deftyp_il)
 
 (* Expressions *)
 
@@ -836,26 +857,26 @@ and elab_exp_normal (ctx : Ctx.t) (typ_il_expect : Il.typ) (exp : exp) :
               match td with
               | Param | Extern | Defining _ ->
                   elab_exp_plain ctx typ_il_expect exp
-              | Defined (tparams, deftyp_il) -> (
+              | Defined (tparams, `Plain typ_il) ->
                   let theta = TIdMap.of_lists tparams targs_il in
-                  match deftyp_il.it with
-                  | PlainT typ_il ->
-                      let typ_il = Subst.subst_typ theta typ_il in
-                      elab_exp_normal ctx typ_il exp
-                  | StructT typfields_il ->
-                      let typfields_il =
-                        List.map
-                          (fun (atom, typ_il) ->
-                            let typ_il = Subst.subst_typ theta typ_il in
-                            (atom, typ_il))
-                          typfields_il
-                      in
-                      elab_exp_struct ctx typ_il_expect typfields_il exp
-                  | VariantT typcases_il ->
-                      let typcases_il =
-                        List.map (Subst.subst_typcase theta) typcases_il
-                      in
-                      elab_exp_variant ctx typ_il_expect typcases_il exp))
+                  let typ_il = Subst.subst_typ theta typ_il in
+                  elab_exp_normal ctx typ_il exp
+              | Defined (tparams, `Struct typfields_il) ->
+                  let theta = TIdMap.of_lists tparams targs_il in
+                  let typfields_il =
+                    List.map
+                      (fun (atom, typ_il) ->
+                        let typ_il = Subst.subst_typ theta typ_il in
+                        (atom, typ_il))
+                      typfields_il
+                  in
+                  elab_exp_struct ctx typ_il_expect typfields_il exp
+              | Defined (tparams, `Variant (typcases_il, mixops_el)) ->
+                  let theta = TIdMap.of_lists tparams targs_il in
+                  let typcases_il =
+                    List.map (Subst.subst_typcase theta) typcases_il
+                  in
+                  elab_exp_variant ctx typ_il_expect mixops_el typcases_il exp)
           | _ -> elab_exp_plain ctx typ_il_expect exp))
 
 (* Elaboration of wildcard variable expressions *)
@@ -1067,13 +1088,13 @@ and elab_exp_not_inner (ctx : Ctx.t) (mixop : Mixop.t) (typs_il : Il.typ list)
 and fail_elab_not (at : region) (msg : string) : (Ctx.t * Il.notexp) attempt =
   fail at ("cannot elaborate notation expression because " ^ msg)
 
-and elab_exp_not (ctx : Ctx.t) (nottyp_il : Il.nottyp) (exp : exp) :
-    (Ctx.t * Il.notexp) attempt =
-  let mixop, typs_il = nottyp_il.it in
-  let* ctx, typs_il, exps_il = elab_exp_not_inner ctx mixop typs_il exp in
+and elab_exp_not (ctx : Ctx.t) (mixop_el : Mixop.t) (nottyp_il : Il.nottyp)
+    (exp : exp) : (Ctx.t * Il.notexp) attempt =
+  let mixop_il, typs_il = nottyp_il.it in
+  let* ctx, typs_il, exps_il = elab_exp_not_inner ctx mixop_el typs_il exp in
   match typs_il with
   | [] ->
-      let notexp_il = (mixop, exps_il) in
+      let notexp_il = (mixop_il, exps_il) in
       Ok (ctx, notexp_il)
   | _ -> fail_elab_not exp.at "too few arguments"
 
@@ -1123,12 +1144,13 @@ and fail_elab_variant (at : region) (msg : string) : (Ctx.t * Il.exp) attempt =
   fail at ("cannot elaborate variant case because " ^ msg)
 
 and elab_exp_variant (ctx : Ctx.t) (typ_il_expect : Il.typ)
-    (typcases_il : Il.typcase list) (exp : exp) : (Ctx.t * Il.exp) attempt =
+    (mixops_el : Mixop.t list) (typcases_il : Il.typcase list) (exp : exp) :
+    (Ctx.t * Il.exp) attempt =
   let ctx, exps_il =
-    List.fold_left
-      (fun (ctx, exps_il) typcase_il ->
+    List.fold_left2
+      (fun (ctx, exps_il) mixop_el typcase_il ->
         let nottyp_il, typorigin_il, _ = typcase_il in
-        match elab_exp_not ctx nottyp_il exp with
+        match elab_exp_not ctx mixop_el nottyp_il exp with
         | Ok (ctx, notexp_il) ->
             let typ_il =
               let id, targs_il = typorigin_il.it in
@@ -1136,7 +1158,7 @@ and elab_exp_variant (ctx : Ctx.t) (typ_il_expect : Il.typ)
             in
             let exp_il =
               let mixop, exps_il_inner = notexp_il in
-              let atoms = Mixop.atoms mixop in
+              let atoms = Domain.Mixop.atoms mixop in
               let at =
                 match atoms with
                 | [] -> exp_list_region exps_il_inner
@@ -1147,7 +1169,7 @@ and elab_exp_variant (ctx : Ctx.t) (typ_il_expect : Il.typ)
             let+ exp_il = cast_exp ctx typ_il_expect typ_il exp_il in
             (ctx, exps_il @ [ exp_il ])
         | Fail _ -> (ctx, exps_il))
-      (ctx, []) typcases_il
+      (ctx, []) mixops_el typcases_il
   in
   match exps_il with
   | [ exp_il ] -> Ok (ctx, exp_il)
@@ -1430,8 +1452,8 @@ and elab_var_prem (ctx : Ctx.t) (id : id) (plaintyp : plaintyp) : Ctx.t =
 (* Elaboration of rule premises *)
 
 and elab_rule_prem (ctx : Ctx.t) (id : id) (exp : exp) : Ctx.t * Il.prem' =
-  let nottyp_il, inputs = Ctx.find_rel_signature ctx id in
-  let+ ctx, notexp_il = elab_exp_not ctx nottyp_il exp in
+  let mixop_el, nottyp_il, inputs = Ctx.find_rel_signature ctx id in
+  let+ ctx, notexp_il = elab_exp_not ctx mixop_el nottyp_il exp in
   let _, exps_il = notexp_il in
   if Hints.Input.is_conditional inputs exps_il then
     let prem_il = Il.IfHoldPr (id, notexp_il) in
@@ -1443,8 +1465,8 @@ and elab_rule_prem (ctx : Ctx.t) (id : id) (exp : exp) : Ctx.t * Il.prem' =
 (* Elaboration of negated rule premises *)
 
 and elab_rule_not_prem (ctx : Ctx.t) (id : id) (exp : exp) : Ctx.t * Il.prem' =
-  let nottyp_il, inputs = Ctx.find_rel_signature ctx id in
-  let+ ctx, notexp_il = elab_exp_not ctx nottyp_il exp in
+  let mixop_el, nottyp_il, inputs = Ctx.find_rel_signature ctx id in
+  let+ ctx, notexp_il = elab_exp_not ctx mixop_el nottyp_il exp in
   let _, exps_il = notexp_il in
   check
     (Hints.Input.is_conditional inputs exps_il)
@@ -1598,7 +1620,7 @@ and elab_rulepaths (at : region) (ctxs_local : Ctx.t list)
 
 and elab_rulegroup (ctx : Ctx.t) (at : region) (id_rel : id) (id_rulegroup : id)
     (rules : rule list) : rulegroup_internal =
-  let nottyp_il, inputs, _, _ = Ctx.find_defined_rel ctx id_rel in
+  let mixop_el, nottyp_il, inputs, _, _ = Ctx.find_defined_rel ctx id_rel in
   let ctxs_local =
     List.map
       (fun rule ->
@@ -1621,7 +1643,9 @@ and elab_rulegroup (ctx : Ctx.t) (at : region) (id_rel : id) (id_rulegroup : id)
   let ctxs_local, notexps_il =
     List.map2
       (fun ctx_local exp ->
-        let+ ctx_local, notexp_il = elab_exp_not ctx_local nottyp_il exp in
+        let+ ctx_local, notexp_il =
+          elab_exp_not ctx_local mixop_el nottyp_il exp
+        in
         (ctx_local, notexp_il))
       ctxs_local exp_group
     |> List.split
@@ -1796,7 +1820,7 @@ and elab_typ_def (ctx : Ctx.t) (id : id) (tparams : tparam list)
   in
   check (List.for_all valid_tid tparams) id.at "invalid type parameter";
   let ctx_local = Ctx.add_tparams ctx tparams in
-  let td, deftyp_il = elab_deftyp ctx_local id tparams deftyp in
+  let _ctx_local, td, deftyp_il = elab_deftyp ctx_local id tparams deftyp in
   let def_il = Il.TypD (id, tparams, deftyp_il, hints) $ deftyp.at in
   let ctx = Ctx.update_typdef ctx id td in
   (ctx, def_il)
@@ -1844,17 +1868,17 @@ and fetch_rel_input_hint (at : region) (nottyp_il : Il.nottyp)
 
 and elab_extern_rel_def (ctx : Ctx.t) (at : region) (id : id) (nottyp : nottyp)
     (hints : hint list) : Ctx.t * Il.def =
-  let nottyp_il = elab_nottyp ctx (NotationT nottyp) in
+  let mixop_el, nottyp_il = elab_nottyp ctx (NotationT nottyp) in
   let inputs = fetch_rel_input_hint at nottyp_il hints in
-  let ctx = Ctx.add_extern_rel ctx id nottyp_il inputs in
+  let ctx = Ctx.add_extern_rel ctx id mixop_el nottyp_il inputs in
   let def_il = Il.ExternRelD (id, nottyp_il, inputs, hints) $ at in
   (ctx, def_il)
 
 and elab_rel_def (ctx : Ctx.t) (at : region) (id : id) (nottyp : nottyp)
     (hints : hint list) : Ctx.t * Il.def =
-  let nottyp_il = elab_nottyp ctx (NotationT nottyp) in
+  let mixop_el, nottyp_il = elab_nottyp ctx (NotationT nottyp) in
   let inputs = fetch_rel_input_hint at nottyp_il hints in
-  let ctx = Ctx.add_defined_rel ctx id nottyp_il inputs in
+  let ctx = Ctx.add_defined_rel ctx id mixop_el nottyp_il inputs in
   let def_il = Il.RelD (id, nottyp_il, inputs, [], None, hints) $ at in
   (ctx, def_il)
 
@@ -1983,16 +2007,14 @@ and pattern_set_covered_by_typ (ctx : Ctx.t) (typ_il : Il.typ) :
   | VarT (tid, _) -> (
       let td = Ctx.find_typdef ctx tid in
       match td with
-      | Defined (_, deftyp_il) -> (
-          match deftyp_il.it with
-          | VariantT typcases_il ->
-              typcases_il
-              |> List.map (fun (nottyp_il, _, _) -> nottyp_il)
-              |> Pattern.PatternSet.of_list
-          | _ ->
-              error typ_il.at
-                ("non-variant type not supported in patterns: "
-                ^ Il.Print.string_of_typ typ_il))
+      | Defined (_, `Variant (typcases_il, _)) ->
+          typcases_il
+          |> List.map (fun (nottyp_il, _, _) -> nottyp_il)
+          |> Pattern.PatternSet.of_list
+      | Defined _ ->
+          error typ_il.at
+            ("non-variant type not supported in patterns: "
+            ^ Il.Print.string_of_typ typ_il)
       | _ ->
           error typ_il.at
             ("non-variant type not supported in patterns: "
@@ -2119,7 +2141,9 @@ let populate_typs (ctx : Ctx.t) : unit =
 let populate_rule (ctx : Ctx.t) (def_il : Il.def) : Il.def =
   match def_il.it with
   | Il.RelD (id, nottyp_il, inputs, [], None, hints) ->
-      let _, _, rulegroups_il, elsegroup_il_opt = Ctx.find_defined_rel ctx id in
+      let _, _, _, rulegroups_il, elsegroup_il_opt =
+        Ctx.find_defined_rel ctx id
+      in
       Il.RelD (id, nottyp_il, inputs, rulegroups_il, elsegroup_il_opt, hints)
       $ def_il.at
   | Il.RelD _ -> error def_il.at "relation was already populated"

--- a/p4spec/lib/pass/prose/ctx.ml
+++ b/p4spec/lib/pass/prose/ctx.ml
@@ -234,7 +234,7 @@ let load_def (ctx : t) (def : def) : t =
           add_metavar ctx id typ
         else ctx
       in
-      let td = Typdef.Defined (tparams, deftyp) in
+      let td = Typdef.of_deftyp tparams deftyp in
       let ctx = add_typdef ctx id td in
       match deftyp.it with
       | VariantT typcases -> load_typcases ctx id typcases

--- a/p4spec/lib/pass/structure/ctx.ml
+++ b/p4spec/lib/pass/structure/ctx.ml
@@ -96,7 +96,7 @@ let load_def (ctx : t) (def : def) : t =
           add_metavar ctx id typ
         else ctx
       in
-      let td = Typdef.Defined (tparams, deftyp) in
+      let td = Typdef.of_deftyp tparams deftyp in
       add_typdef ctx id td
   | VarD (id, typ, _hints) -> add_metavar ctx id typ
   | _ -> ctx

--- a/p4spec/lib/pass/structure/opt/overlap.ml
+++ b/p4spec/lib/pass/structure/opt/overlap.ml
@@ -54,17 +54,15 @@ let typ_as_variant (tdenv : TDEnv.t) (typ : typ) : mixop list option =
       let td = TDEnv.find tid tdenv in
       match td with
       | Param | Extern | Defining _ -> None
-      | Defined (_, deftyp) -> (
-          match deftyp.it with
-          | VariantT typcases ->
-              let mixops =
-                typcases
-                |> List.map (fun (nottyp, _, _) ->
-                       let mixop, _ = nottyp.it in
-                       mixop)
-              in
-              Some mixops
-          | _ -> None))
+      | Defined (_, `Variant (typcases, _)) ->
+          let mixops =
+            typcases
+            |> List.map (fun (nottyp, _, _) ->
+                   let mixop, _ = nottyp.it in
+                   mixop)
+          in
+          Some mixops
+      | Defined _ -> None)
   | _ -> None
 
 (* Determine the overlapping guard of two conditions *)

--- a/p4spec/lib/pass/structure/opt/post/remove_match_singleton.ml
+++ b/p4spec/lib/pass/structure/opt/post/remove_match_singleton.ml
@@ -18,10 +18,8 @@ let is_singleton_case (tdenv : TDEnv.t) (typ : typ) : bool =
       let td = TDEnv.find tid tdenv in
       match td with
       | Param | Extern | Defining _ -> false
-      | Defined (_, deftyp) -> (
-          match deftyp.it with
-          | VariantT typcases -> List.length typcases = 1
-          | _ -> false))
+      | Defined (_, `Variant (typcases, _)) -> List.length typcases = 1
+      | Defined _ -> false)
   | _ -> false
 
 let is_singleton_match (tdenv : TDEnv.t) (exp : exp) : bool =

--- a/p4spec/lib/runtime/dune
+++ b/p4spec/lib/runtime/dune
@@ -3,6 +3,7 @@
  (public_name p4spectec.runtime)
  (libraries
   error_runtime
+  mixop
   type
   value
   static

--- a/p4spec/lib/runtime/dynamic/envs.ml
+++ b/p4spec/lib/runtime/dynamic/envs.ml
@@ -41,8 +41,8 @@ module TDEnv = struct
         | Param | Extern | Defining _ -> typ
         | Defined (tparams, deftyp) -> (
             let theta = TIdMap.of_lists tparams targs in
-            match deftyp.it with
-            | PlainT typ ->
+            match deftyp with
+            | `Plain typ ->
                 let typ = Type.Subst.subst_typ theta typ in
                 unroll tdenv typ
             | _ -> typ))

--- a/p4spec/lib/runtime/mixop/dune
+++ b/p4spec/lib/runtime/mixop/dune
@@ -1,0 +1,6 @@
+(library
+ (name mixop)
+ (public_name p4spectec.runtime.mixop)
+ (libraries util lang)
+ (preprocess
+  (pps ppx_deriving_yojson)))

--- a/p4spec/lib/runtime/mixop/mixop.ml
+++ b/p4spec/lib/runtime/mixop/mixop.ml
@@ -1,0 +1,153 @@
+open Util.Source
+module Atom = Domain.Atom
+
+(* Elaboration-time mixop: a tree representation used while building up
+   mixfix operators from the EL surface syntax. Converted to the flat IL
+   [Il.Mixop.t] form via [to_il] at the end of elaboration. *)
+
+type atom = Atom.t phrase
+
+type t =
+  | Arg
+  | Atom of atom
+  | Brack of atom * t * atom
+  | Infix of t * atom * t
+  | Seq of t list
+
+(* Normalization: flatten to list form. *)
+let rec flatten_to_list (mixop : t) : t list =
+  match mixop with
+  | Arg | Atom _ -> [ mixop ]
+  | Brack (al, inner, ar) -> (Atom al :: flatten_to_list inner) @ [ Atom ar ]
+  | Infix (ml, atom, mr) ->
+      flatten_to_list ml @ [ Atom atom ] @ flatten_to_list mr
+  | Seq parts -> List.concat_map flatten_to_list parts
+
+let normalize (mixop : t) : t list = flatten_to_list mixop
+
+(* Comparison: compares on the normalized form. *)
+let compare_atom (atom_a : atom) (atom_b : atom) =
+  Atom.compare atom_a.it atom_b.it
+
+let compare_primitive (a : t) (b : t) =
+  match (a, b) with
+  | Arg, Arg -> 0
+  | Arg, _ -> -1
+  | _, Arg -> 1
+  | Atom atom_a, Atom atom_b -> compare_atom atom_a atom_b
+  | _ -> assert false
+
+let compare (mixop_a : t) (mixop_b : t) =
+  if mixop_a == mixop_b then 0
+  else List.compare compare_primitive (normalize mixop_a) (normalize mixop_b)
+
+let eq (mixop_a : t) (mixop_b : t) = compare mixop_a mixop_b = 0
+
+(* Arity *)
+let rec arity = function
+  | Arg -> 1
+  | Atom _ -> 0
+  | Brack (_, mixop, _) -> arity mixop
+  | Infix (mixop_l, _, mixop_r) -> arity mixop_l + arity mixop_r
+  | Seq mixops -> List.fold_left (fun acc mixop -> acc + arity mixop) 0 mixops
+
+(* Extract atoms *)
+let rec atoms = function
+  | Arg -> []
+  | Atom atom -> [ atom ]
+  | Brack (atom_l, mixop, atom_r) -> (atom_l :: atoms mixop) @ [ atom_r ]
+  | Infix (mixop_l, atom, mixop_r) -> atoms mixop_l @ [ atom ] @ atoms mixop_r
+  | Seq mixops -> List.concat_map atoms mixops
+
+(* --- Constructors --- *)
+
+let arg : t = Arg
+let mk_atom (s : string) : t = Atom (Atom.Atom s $ no_region)
+let silent_atom (s : string) : t = Atom (Atom.SilentAtom s $ no_region)
+
+let brack (l : string) (inner : t) (r : string) : t =
+  Brack (Atom.Atom l $ no_region, inner, Atom.Atom r $ no_region)
+
+let seq (ts : t list) : t = Seq ts
+
+(* Assembler: interleave rendered atoms and argument strings *)
+
+let assemble ~(string_of_atom : atom -> string) (mixop : t) (args : string list)
+    : string =
+  let rec assemble (mixop : t) (args : string list) : string * string list =
+    match mixop with
+    | Arg -> (
+        match args with
+        | [] -> failwith "not enough arguments"
+        | arg :: args -> (arg, args))
+    | Atom atom ->
+        let smixop = string_of_atom atom in
+        (smixop, args)
+    | Brack (atom_l, mixop, atom_r) ->
+        let smixop, args = assemble mixop args in
+        let smixop =
+          [ string_of_atom atom_l; smixop; string_of_atom atom_r ]
+          |> List.filter (fun s -> s <> "")
+          |> String.concat " "
+        in
+        (smixop, args)
+    | Infix (mixop_l, atom, mixop_r) ->
+        let smixop_l, args = assemble mixop_l args in
+        let smixop_r, args = assemble mixop_r args in
+        let smixop =
+          [ smixop_l; string_of_atom atom; smixop_r ]
+          |> List.filter (fun s -> s <> "")
+          |> String.concat " "
+        in
+        (smixop, args)
+    | Seq mixops ->
+        let smixops, args =
+          List.fold_left
+            (fun (smixops, args) mixop ->
+              let smixop, args = assemble mixop args in
+              (smixops @ [ smixop ], args))
+            ([], args) mixops
+        in
+        let smixop =
+          smixops |> List.filter (fun s -> s <> "") |> String.concat " "
+        in
+        (smixop, args)
+  in
+  let smixop, args = assemble mixop args in
+  match args with [] -> smixop | _ -> failwith "too many arguments"
+
+(* Stringifier *)
+
+let string_of_mixop (mixop : t) =
+  let rec to_string = function
+    | Arg -> "%"
+    | Atom atom -> Atom.string_of_atom atom.it
+    | Brack (atom_l, mixop, atom_r) ->
+        Atom.string_of_atom atom_l.it
+        ^ to_string mixop
+        ^ Atom.string_of_atom atom_r.it
+    | Infix (mixop_l, atom, mixop_r) ->
+        to_string mixop_l ^ Atom.string_of_atom atom.it ^ to_string mixop_r
+    | Seq mixops -> String.concat " " (List.map to_string mixops)
+  in
+  "`" ^ to_string mixop ^ "`"
+
+(* Conversion to the flat representation *)
+
+let to_flat (mixop : t) : Domain.Mixop.t =
+  let rec flatten (mixop : t) (mixop_rev : Domain.Mixop.t) : Domain.Mixop.t =
+    match mixop with
+    | Arg -> Domain.Mixop.Arg :: mixop_rev
+    | Atom atom -> Domain.Mixop.Atom atom :: mixop_rev
+    | Brack (atom_left, inner, atom_right) ->
+        let mixop_rev = Domain.Mixop.Atom atom_left :: mixop_rev in
+        let mixop_rev = flatten inner mixop_rev in
+        Domain.Mixop.Atom atom_right :: mixop_rev
+    | Infix (mixop_left, atom, mixop_right) ->
+        let mixop_rev = flatten mixop_left mixop_rev in
+        let mixop_rev = Domain.Mixop.Atom atom :: mixop_rev in
+        flatten mixop_right mixop_rev
+    | Seq parts ->
+        List.fold_left (fun mixop_rev p -> flatten p mixop_rev) mixop_rev parts
+  in
+  List.rev (flatten mixop [])

--- a/p4spec/lib/runtime/runtime.ml
+++ b/p4spec/lib/runtime/runtime.ml
@@ -1,3 +1,4 @@
+module Mixop = Mixop
 module Type = Type
 module Value = Value
 module Static = Static

--- a/p4spec/lib/runtime/static/dune
+++ b/p4spec/lib/runtime/static/dune
@@ -1,4 +1,4 @@
 (library
  (name static)
  (public_name p4spectec.runtime.static)
- (libraries util lang type))
+ (libraries util lang type mixop))

--- a/p4spec/lib/runtime/static/rel.ml
+++ b/p4spec/lib/runtime/static/rel.ml
@@ -4,15 +4,16 @@ open Il
 (* Relation *)
 
 type t =
-  | Extern of nottyp * Hints.Input.t
-  | Defined of nottyp * Hints.Input.t * rulegroup list * elsegroup option
+  | Extern of Mixop.t * nottyp * Hints.Input.t
+  | Defined of
+      Mixop.t * nottyp * Hints.Input.t * rulegroup list * elsegroup option
 
 let to_string = function
-  | Extern (nottyp_il, inputs) ->
+  | Extern (_, nottyp_il, inputs) ->
       Hints.Input.to_string inputs
       ^ " = extern "
       ^ Il.Print.string_of_nottyp nottyp_il
-  | Defined (nottyp_il, inputs, rulegroups, elsegroup_opt) ->
+  | Defined (_, nottyp_il, inputs, rulegroups, elsegroup_opt) ->
       Hints.Input.to_string inputs
       ^ " =\n\n"
       ^ Il.Print.string_of_rulegroups nottyp_il inputs rulegroups

--- a/p4spec/lib/runtime/type/dune
+++ b/p4spec/lib/runtime/type/dune
@@ -1,6 +1,6 @@
 (library
  (name type)
  (public_name p4spectec.runtime.type)
- (libraries util lang error_runtime)
+ (libraries util lang mixop error_runtime)
  (preprocess
   (pps ppx_deriving_yojson)))

--- a/p4spec/lib/runtime/type/expand.ml
+++ b/p4spec/lib/runtime/type/expand.ml
@@ -13,10 +13,10 @@ let rec expand_typ (find_typdef_opt : TId.t -> Typdef.t option) (typ : typ) :
       let td_opt = find_typdef_opt tid in
       match td_opt with
       | Some (Defined (tparams, deftyp)) -> (
-          match deftyp.it with
-          | PlainT _ when List.length targs <> List.length tparams ->
+          match deftyp with
+          | `Plain _ when List.length targs <> List.length tparams ->
               error typ.at "type arguments do not match"
-          | PlainT typ ->
+          | `Plain typ ->
               let theta = TIdMap.of_lists tparams targs in
               let typ = Subst.subst_typ theta typ in
               expand_typ find_typdef_opt typ

--- a/p4spec/lib/runtime/type/sub.ml
+++ b/p4spec/lib/runtime/type/sub.ml
@@ -21,8 +21,8 @@ and sub_typ' (find_typdef_opt : TId.t -> Typdef.t option) (typ_a : typ)
       match (td_opt_a, td_opt_b) with
       | ( Some (Defined (tparams_a, deftyp_a)),
           Some (Defined (tparams_b, deftyp_b)) ) -> (
-          match (deftyp_a.it, deftyp_b.it) with
-          | VariantT typcases_a, VariantT typcases_b ->
+          match (deftyp_a, deftyp_b) with
+          | `Variant (typcases_a, _), `Variant (typcases_b, _) ->
               let theta_a = TIdMap.of_lists tparams_a targs_a in
               let theta_b = TIdMap.of_lists tparams_b targs_b in
               let nottyps_a =

--- a/p4spec/lib/runtime/type/typdef.ml
+++ b/p4spec/lib/runtime/type/typdef.ml
@@ -14,15 +14,43 @@ type t =
   (* Type being defined *)
   | Defining of tparam list
   (* Type that is completely defined *)
-  | Defined of tparam list * deftyp
+  | Defined of tparam list * [
+      | `Plain of typ
+      | `Struct of typfield list
+      | `Variant of typcase list * Mixop.t list
+    ]
 [@@@ocamlformat "enable"]
 
 let to_string = function
   | Param -> "Param"
   | Extern -> "Extern"
   | Defining tparams -> "Defining" ^ string_of_tparams tparams
-  | Defined (tparams, deftyp) ->
-      "Defined " ^ string_of_tparams tparams ^ " " ^ string_of_deftyp deftyp
+  | Defined (tparams, typdef) ->
+      let deftyp_str =
+        match typdef with
+        | `Plain typ -> string_of_typ typ
+        | `Struct typfields ->
+            "{ "
+            ^ String.concat ", "
+                (List.map
+                   (fun (atom, typ) ->
+                     string_of_atom atom ^ ": " ^ string_of_typ typ)
+                   typfields)
+            ^ " }"
+        | `Variant (typcases, _) ->
+            "| "
+            ^ String.concat " | "
+                (List.map
+                   (fun (nottyp, _, _) -> string_of_nottyp nottyp)
+                   typcases)
+      in
+      "Defined" ^ string_of_tparams tparams ^ " = " ^ deftyp_str
+
+let of_deftyp (tparams : tparam list) (deftyp : deftyp) : t =
+  match deftyp.it with
+  | PlainT typ -> Defined (tparams, `Plain typ)
+  | StructT typfields -> Defined (tparams, `Struct typfields)
+  | VariantT typcases -> Defined (tparams, `Variant (typcases, []))
 
 let get_tparams = function
   | Param | Extern -> []

--- a/p4spec/lib/runtime/value/match.ml
+++ b/p4spec/lib/runtime/value/match.ml
@@ -25,12 +25,12 @@ let rec sub_ (find_typdef_opt : TId.t -> Type.Typdef.t option)
       | Param | Defining _ -> error typ.at "unexpected type variable"
       | Extern -> ( match value.it with ExternV _ -> true | _ -> false)
       | Defined (tparams, deftyp) -> (
-          match (deftyp.it, value.it) with
-          | PlainT typ, _ ->
+          match (deftyp, value.it) with
+          | `Plain typ, _ ->
               let theta = TIdMap.of_lists tparams targs in
               let typ = Type.Subst.subst_typ theta typ in
               sub_ find_typdef_opt find_func typ value
-          | StructT typfields, StructV valuefields
+          | `Struct typfields, StructV valuefields
             when List.length typfields = List.length valuefields ->
               let theta = TIdMap.of_lists tparams targs in
               List.for_all2
@@ -40,7 +40,7 @@ let rec sub_ (find_typdef_opt : TId.t -> Type.Typdef.t option)
                   let typ = Type.Subst.subst_typ theta typ in
                   sub_ find_typdef_opt find_func typ value)
                 typfields valuefields
-          | VariantT typcases, CaseV (mixop_v, values_inner) ->
+          | `Variant (typcases, _), CaseV (mixop_v, values_inner) ->
               let theta = TIdMap.of_lists tparams targs in
               List.exists
                 (fun typcase ->


### PR DESCRIPTION
## Motivation
While porting #143 to downstream, I had several concerns surfaced regarding the Mixop design. I think I've come up with a rather satisfying solution , but being a substantial refactor, I wanted to try it out here as well and ask for thoughts before merging it downstream. Please read the Motivation section of the downstream PR first.

- **Original PR:** kaist-plrg/spectec-core#31

This is still a draft: only 1 of the three downstream commits are ported for now. Originally hoped to finish within the week, but there are several hurdles that we might want to discuss.

- **Runtime.Type.Typdef:** The same typedef representation is reused for elaboration, structuring and prose. However, this commit adds a `Mixop.t` to the variant case, that's only used for elaboration. The current commit does a workaround by constructing `Typdef.Defined` using `Typdef.of_deftyp` which inserts empty mixops. I think a more semantically accurate solution is having different `Typdef`s for the different passes, as even now, the `Param` and `Defining` variants are only used during elaboration.
- **Runtime.Mixop:** Due to the dependency graph, I had to place the elaboration-time mixop in `Runtime.Mixop`. Ideally it belongs in `Runtime.Static`, but `Typdef` currently depends on `Mixop`.
- **Domain.Mixop:** Similarly, `Domain.Mixop` (for IL and below) cannot be moved elsewhere because `Domain.Lib` depends on it. Again, the motivation is understood but I think it fits better in IL, as it's used in the layers after IL.