### PR TITLE
compile: compile generic meta-functions to callable OCaml

### DIFF
--- a/p4spec/lib/pass/compile/codegen.ml
+++ b/p4spec/lib/pass/compile/codegen.ml
@@ -61,7 +61,7 @@ let compile_spec ?(name = "") (path_out : string)
   in
   (* Marshal/unmarshal — one Ml.LetRec per SCC group *)
   let toplevels_interface_ml =
-    let const_decls, marshal_groups, unmarshal_groups =
+    let const_decls, marshal_groups, unmarshal_groups, registry_ml =
       Gen.Interface.compile ctx spec
     in
     let to_tops groups =
@@ -71,6 +71,7 @@ let compile_spec ?(name = "") (path_out : string)
         groups
     in
     const_decls @ to_tops marshal_groups @ to_tops unmarshal_groups
+    @ [ registry_ml ]
   in
   (* Logic groups — one Ml.LetRec per SCC group, in topo order. The heavy code
      lives at module top-level (no longer inside the functor), reading the
@@ -97,6 +98,7 @@ let compile_spec ?(name = "") (path_out : string)
     in
     let funcdef_eval_rel_ml = Gen.Dispatch.compile_eval_rel ctx spec in
     [
+      Ml.Raw Template.Split.interface_name_fn;
       Ml.LetRec [ funcdef_eval_func_ml; funcdef_eval_rel_ml ];
       Ml.Raw Template.Functor.eval_program;
     ]

--- a/p4spec/lib/pass/compile/ctx.ml
+++ b/p4spec/lib/pass/compile/ctx.ml
@@ -29,6 +29,7 @@ type t = {
   rels : Rels.t;
   bindings : Bindings.t;
   poly_sigs : (string * Il.tparam list) list;
+  extern_builtin_names : Mono.StringSet.t;
 }
 
 (* Adders *)
@@ -106,6 +107,9 @@ let find_rel (ctx : t) (rid : RId.t) : Input.t = Rels.find rid ctx.rels
 let find_poly_tparams (ctx : t) (name : string) : Il.tparam list option =
   List.assoc_opt name ctx.poly_sigs
 
+let find_extern_builtin_names (ctx : t) : Mono.StringSet.t =
+  ctx.extern_builtin_names
+
 (* Initialization *)
 
 let empty_lib = { splits = []; combines = []; folds = []; foralls = [] }
@@ -139,6 +143,15 @@ let poly_sig_of_def (def : Sl.def) : (string * Il.tparam list) option =
   | ExternDecD (id, tparams, _, _, _) when tparams <> [] -> Some (id.it, tparams)
   | _ -> None
 
+(* Extern/builtin decl names across the whole spec (ground and generic
+   alike) — the call targets [Gen.Func]'s boundary-crossing guard cares
+   about. Spec-wide, since an extern/builtin never shares an SCC with its
+   generic caller (it has no outgoing call-graph edges of its own). *)
+let extern_builtin_name_of_def (def : Sl.def) : string option =
+  match def.it with
+  | ExternDecD (id, _, _, _, _) | BuiltinDecD (id, _, _, _, _) -> Some id.it
+  | _ -> None
+
 let init (spec : Sl.spec) : t =
   let ctx =
     {
@@ -148,6 +161,8 @@ let init (spec : Sl.spec) : t =
       rels = Rels.empty;
       bindings = Bindings.empty;
       poly_sigs = List.filter_map poly_sig_of_def spec;
+      extern_builtin_names =
+        Mono.StringSet.of_list (List.filter_map extern_builtin_name_of_def spec);
     }
   in
   load_defs ctx spec

--- a/p4spec/lib/pass/compile/ctx.ml
+++ b/p4spec/lib/pass/compile/ctx.ml
@@ -143,10 +143,8 @@ let poly_sig_of_def (def : Sl.def) : (string * Il.tparam list) option =
   | ExternDecD (id, tparams, _, _, _) when tparams <> [] -> Some (id.it, tparams)
   | _ -> None
 
-(* Extern/builtin decl names across the whole spec (ground and generic
-   alike) — the call targets [Gen.Func]'s boundary-crossing guard cares
-   about. Spec-wide, since an extern/builtin never shares an SCC with its
-   generic caller (it has no outgoing call-graph edges of its own). *)
+(* Spec-wide extern/builtin names: an extern/builtin never shares an SCC
+   with its generic caller, so [Gen.Func]'s boundary guard needs this set. *)
 let extern_builtin_name_of_def (def : Sl.def) : string option =
   match def.it with
   | ExternDecD (id, _, _, _, _) | BuiltinDecD (id, _, _, _, _) -> Some id.it

--- a/p4spec/lib/pass/compile/ctx.ml
+++ b/p4spec/lib/pass/compile/ctx.ml
@@ -28,6 +28,7 @@ type t = {
   ctors : Ctors.t;
   rels : Rels.t;
   bindings : Bindings.t;
+  poly_sigs : (string * Il.tparam list) list;
 }
 
 (* Adders *)
@@ -102,6 +103,9 @@ let find_binding (ctx : t) (var : Var.t) : Ml.id =
 
 let find_rel (ctx : t) (rid : RId.t) : Input.t = Rels.find rid ctx.rels
 
+let find_poly_tparams (ctx : t) (name : string) : Il.tparam list option =
+  List.assoc_opt name ctx.poly_sigs
+
 (* Initialization *)
 
 let empty_lib = { splits = []; combines = []; folds = []; foralls = [] }
@@ -124,6 +128,17 @@ let load_def (ctx : t) (def : Sl.def) : t =
 let load_defs (ctx : t) (defs : Sl.def list) : t =
   List.fold_left load_def ctx defs
 
+(* Definitions still generic after monomorphization: name -> its own tparams. *)
+
+let poly_sig_of_def (def : Sl.def) : (string * Il.tparam list) option =
+  match def.it with
+  | FuncDecD (id, tparams, _, _, _, _, _) when tparams <> [] ->
+      Some (id.it, tparams)
+  | BuiltinDecD (id, tparams, _, _, _) when tparams <> [] ->
+      Some (id.it, tparams)
+  | ExternDecD (id, tparams, _, _, _) when tparams <> [] -> Some (id.it, tparams)
+  | _ -> None
+
 let init (spec : Sl.spec) : t =
   let ctx =
     {
@@ -132,6 +147,7 @@ let init (spec : Sl.spec) : t =
       ctors = Ctors.empty;
       rels = Rels.empty;
       bindings = Bindings.empty;
+      poly_sigs = List.filter_map poly_sig_of_def spec;
     }
   in
   load_defs ctx spec

--- a/p4spec/lib/pass/compile/ctx.ml
+++ b/p4spec/lib/pass/compile/ctx.ml
@@ -29,7 +29,6 @@ type t = {
   rels : Rels.t;
   bindings : Bindings.t;
   poly_sigs : (string * Il.tparam list) list;
-  extern_builtin_names : Mono.StringSet.t;
 }
 
 (* Adders *)
@@ -107,9 +106,6 @@ let find_rel (ctx : t) (rid : RId.t) : Input.t = Rels.find rid ctx.rels
 let find_poly_tparams (ctx : t) (name : string) : Il.tparam list option =
   List.assoc_opt name ctx.poly_sigs
 
-let find_extern_builtin_names (ctx : t) : Mono.StringSet.t =
-  ctx.extern_builtin_names
-
 (* Initialization *)
 
 let empty_lib = { splits = []; combines = []; folds = []; foralls = [] }
@@ -143,13 +139,6 @@ let poly_sig_of_def (def : Sl.def) : (string * Il.tparam list) option =
   | ExternDecD (id, tparams, _, _, _) when tparams <> [] -> Some (id.it, tparams)
   | _ -> None
 
-(* Spec-wide extern/builtin names: an extern/builtin never shares an SCC
-   with its generic caller, so [Gen.Func]'s boundary guard needs this set. *)
-let extern_builtin_name_of_def (def : Sl.def) : string option =
-  match def.it with
-  | ExternDecD (id, _, _, _, _) | BuiltinDecD (id, _, _, _, _) -> Some id.it
-  | _ -> None
-
 let init (spec : Sl.spec) : t =
   let ctx =
     {
@@ -159,8 +148,6 @@ let init (spec : Sl.spec) : t =
       rels = Rels.empty;
       bindings = Bindings.empty;
       poly_sigs = List.filter_map poly_sig_of_def spec;
-      extern_builtin_names =
-        Mono.StringSet.of_list (List.filter_map extern_builtin_name_of_def spec);
     }
   in
   load_defs ctx spec

--- a/p4spec/lib/pass/compile/gen/bind.ml
+++ b/p4spec/lib/pass/compile/gen/bind.ml
@@ -23,32 +23,37 @@ let compile_blk_footer (ctx_inner : Ctx.t) (ctx_outer : Ctx.t) (chain : Chain.t)
 
 (* Binding *)
 
-let rec compile_binding (ctx : Ctx.t) (expr_stub_ml : Ml.expr) (exp : exp) :
-    Ctx.t * Binding.t list * Chain.t =
+let rec compile_binding ~(tparams : string list) (ctx : Ctx.t)
+    (expr_stub_ml : Ml.expr) (exp : exp) : Ctx.t * Binding.t list * Chain.t =
   let typ_exp = exp.note $ exp.at in
   match exp.it with
-  | VarE id -> compile_var_binding ctx expr_stub_ml id typ_exp
-  | TupleE exps -> compile_tuple_binding ctx expr_stub_ml exps
-  | CaseE notexp -> compile_case_binding ctx typ_exp expr_stub_ml notexp
+  | VarE id -> compile_var_binding ~tparams ctx expr_stub_ml id typ_exp
+  | TupleE exps -> compile_tuple_binding ~tparams ctx expr_stub_ml exps
+  | CaseE notexp ->
+      compile_case_binding ~tparams ctx typ_exp expr_stub_ml notexp
   | StrE expfields -> compile_str_binding ctx expr_stub_ml expfields
-  | OptE exp_opt -> compile_opt_binding ctx expr_stub_ml exp_opt
-  | ListE exps -> compile_list_binding ctx expr_stub_ml exps
-  | ConsE (exp_h, exp_t) -> compile_cons_binding ctx expr_stub_ml exp_h exp_t
+  | OptE exp_opt -> compile_opt_binding ~tparams ctx expr_stub_ml exp_opt
+  | ListE exps -> compile_list_binding ~tparams ctx expr_stub_ml exps
+  | ConsE (exp_h, exp_t) ->
+      compile_cons_binding ~tparams ctx expr_stub_ml exp_h exp_t
   | IterE (exp, iterexp) ->
-      compile_iter_binding ctx typ_exp expr_stub_ml exp iterexp
+      compile_iter_binding ~tparams ctx typ_exp expr_stub_ml exp iterexp
   | _ ->
       error exp.at
         (Format.asprintf "unsupported binding expression: %s"
            (Sl.Print.string_of_exp exp))
 
-and compile_bindings (ctx : Ctx.t) (exprs_stub_ml : Ml.expr list)
-    (exps : exp list) : Ctx.t * Binding.t list * Chain.t =
+and compile_bindings ~(tparams : string list) (ctx : Ctx.t)
+    (exprs_stub_ml : Ml.expr list) (exps : exp list) :
+    Ctx.t * Binding.t list * Chain.t =
   match (exprs_stub_ml, exps) with
   | [], [] -> (ctx, [], fun expr -> expr)
   | expr_stub_h_ml :: exprs_stub_t_ml, exp_h :: exps_t ->
-      let ctx, bindings_h, chain_h = compile_binding ctx expr_stub_h_ml exp_h in
+      let ctx, bindings_h, chain_h =
+        compile_binding ~tparams ctx expr_stub_h_ml exp_h
+      in
       let ctx, bindings_t, chain_t =
-        compile_bindings ctx exprs_stub_t_ml exps_t
+        compile_bindings ~tparams ctx exprs_stub_t_ml exps_t
       in
       let bindings = bindings_h @ bindings_t in
       let chain = Chain.connect [ chain_h; chain_t ] in
@@ -60,8 +65,9 @@ and compile_bindings (ctx : Ctx.t) (exprs_stub_ml : Ml.expr list)
    Annotates struct-typed stubs so OCaml can resolve record fields unambiguously.
    Variant-typed bindings are left unannotated to preserve polymorphic-variant subtyping. *)
 
-and compile_var_binding (ctx : Ctx.t) (expr_stub_ml : Ml.expr) (id : id)
-    (typ : typ) : Ctx.t * Binding.t list * Chain.t =
+and compile_var_binding ~(tparams : string list) (ctx : Ctx.t)
+    (expr_stub_ml : Ml.expr) (id : id) (typ : typ) :
+    Ctx.t * Binding.t list * Chain.t =
   let id_ml = Names.var_of_id id in
   let binding = ((id, []), id_ml) in
   let is_struct_typ =
@@ -75,7 +81,7 @@ and compile_var_binding (ctx : Ctx.t) (expr_stub_ml : Ml.expr) (id : id)
   in
   let expr_final_ml =
     if is_struct_typ then
-      let typ_ml = Type.compile_typ ~tparams:[] typ in
+      let typ_ml = Type.compile_typ ~tparams typ in
       Ml.AnnotE (expr_stub_ml, typ_ml)
     else expr_stub_ml
   in
@@ -95,8 +101,9 @@ and compile_var_binding (ctx : Ctx.t) (expr_stub_ml : Ml.expr) (id : id)
       in
     ] *)
 
-and compile_tuple_binding (ctx : Ctx.t) (expr_stub_ml : Ml.expr)
-    (exps : exp list) : Ctx.t * Binding.t list * Chain.t =
+and compile_tuple_binding ~(tparams : string list) (ctx : Ctx.t)
+    (expr_stub_ml : Ml.expr) (exps : exp list) :
+    Ctx.t * Binding.t list * Chain.t =
   let ctx_outer = ctx in
   (* Create stub expressions for tuple elements *)
   let ctx, ids_stub_ml = Stub.OCaml.vars ctx "tup__" (List.length exps) in
@@ -110,7 +117,9 @@ and compile_tuple_binding (ctx : Ctx.t) (expr_stub_ml : Ml.expr)
     Chain.make_let pat_ml expr_stub_ml
   in
   (* Create chains for tuple elements *)
-  let ctx, bindings, chain_elems = compile_bindings ctx exprs_stub_ml exps in
+  let ctx, bindings, chain_elems =
+    compile_bindings ~tparams ctx exprs_stub_ml exps
+  in
   (* Connect chains *)
   let chain = Chain.connect [ chain_tuple; chain_elems ] in
   (* Finish nested block with bindings *)
@@ -140,8 +149,9 @@ and compile_tuple_binding (ctx : Ctx.t) (expr_stub_ml : Ml.expr)
       in
     ] *)
 
-and compile_case_binding (ctx : Ctx.t) (typ_exp : typ) (expr_stub_ml : Ml.expr)
-    (notexp : notexp) : Ctx.t * Binding.t list * Chain.t =
+and compile_case_binding ~(tparams : string list) (ctx : Ctx.t) (typ_exp : typ)
+    (expr_stub_ml : Ml.expr) (notexp : notexp) :
+    Ctx.t * Binding.t list * Chain.t =
   let mixop, exps = Mixfix.split notexp in
   let ctx_outer = ctx in
   (* Create stub expressions for case elements *)
@@ -157,7 +167,9 @@ and compile_case_binding (ctx : Ctx.t) (typ_exp : typ) (expr_stub_ml : Ml.expr)
     Chain.make_match expr_stub_ml pat_ml
   in
   (* Create chains for case elements *)
-  let ctx, bindings, chain_elems = compile_bindings ctx exprs_stub_ml exps in
+  let ctx, bindings, chain_elems =
+    compile_bindings ~tparams ctx exprs_stub_ml exps
+  in
   (* Connect chains *)
   let chain = Chain.connect [ chain_match; chain_elems ] in
   (* Finish nested block with bindings *)
@@ -198,8 +210,9 @@ and compile_str_binding (_ctx : Ctx.t) (_expr_stub_ml : Ml.expr)
       in
     ] *)
 
-and compile_opt_binding (ctx : Ctx.t) (expr_stub_ml : Ml.expr)
-    (exp_opt : exp option) : Ctx.t * Binding.t list * Chain.t =
+and compile_opt_binding ~(tparams : string list) (ctx : Ctx.t)
+    (expr_stub_ml : Ml.expr) (exp_opt : exp option) :
+    Ctx.t * Binding.t list * Chain.t =
   let ctx_outer = ctx in
   let ctx, bindings, expr_bind_ml =
     match exp_opt with
@@ -213,7 +226,9 @@ and compile_opt_binding (ctx : Ctx.t) (expr_stub_ml : Ml.expr)
           Chain.make_match expr_stub_ml pat_then_ml
         in
         (* Create chain for option element *)
-        let ctx, bindings, chain_then = compile_binding ctx expr_elem_ml exp in
+        let ctx, bindings, chain_then =
+          compile_binding ~tparams ctx expr_elem_ml exp
+        in
         (* Connect chains *)
         let chain = Chain.connect [ chain_some; chain_then ] in
         (* Finish nested block with bindings *)
@@ -257,8 +272,9 @@ and compile_opt_binding (ctx : Ctx.t) (expr_stub_ml : Ml.expr)
       in
     ] *)
 
-and compile_list_binding (ctx : Ctx.t) (expr_stub_ml : Ml.expr)
-    (exps : exp list) : Ctx.t * Binding.t list * Chain.t =
+and compile_list_binding ~(tparams : string list) (ctx : Ctx.t)
+    (expr_stub_ml : Ml.expr) (exps : exp list) :
+    Ctx.t * Binding.t list * Chain.t =
   let ctx_outer = ctx in
   (* Create stub expressions for list elements *)
   let ctx, ids_stub_ml = Stub.OCaml.vars ctx "elem_list__" (List.length exps) in
@@ -272,7 +288,9 @@ and compile_list_binding (ctx : Ctx.t) (expr_stub_ml : Ml.expr)
     Chain.make_let pat_ml expr_stub_ml
   in
   (* Create chains for list elements *)
-  let ctx, bindings, chain_elems = compile_bindings ctx exprs_stub_ml exps in
+  let ctx, bindings, chain_elems =
+    compile_bindings ~tparams ctx exprs_stub_ml exps
+  in
   (* Connect chains *)
   let chain = Chain.connect [ chain_list; chain_elems ] in
   (* Finish nested block with bindings *)
@@ -300,8 +318,9 @@ and compile_list_binding (ctx : Ctx.t) (expr_stub_ml : Ml.expr)
       in
     ] *)
 
-and compile_cons_binding (ctx : Ctx.t) (expr_stub_ml : Ml.expr) (exp_h : exp)
-    (exp_t : exp) : Ctx.t * Binding.t list * Chain.t =
+and compile_cons_binding ~(tparams : string list) (ctx : Ctx.t)
+    (expr_stub_ml : Ml.expr) (exp_h : exp) (exp_t : exp) :
+    Ctx.t * Binding.t list * Chain.t =
   let ctx_outer = ctx in
   (* Create stub expressions for head and tail *)
   let ctx, id_h_stub_ml = Stub.OCaml.var ctx "h__" in
@@ -315,7 +334,9 @@ and compile_cons_binding (ctx : Ctx.t) (expr_stub_ml : Ml.expr) (exp_h : exp)
   in
   (* Create chains for head and tail *)
   let ctx, bindings, chain_elems =
-    compile_bindings ctx [ expr_h_stub_ml; expr_t_stub_ml ] [ exp_h; exp_t ]
+    compile_bindings ~tparams ctx
+      [ expr_h_stub_ml; expr_t_stub_ml ]
+      [ exp_h; exp_t ]
   in
   (* Connect chains *)
   let chain = Chain.connect [ chain_cons; chain_elems ] in
@@ -347,8 +368,8 @@ and compile_cons_binding (ctx : Ctx.t) (expr_stub_ml : Ml.expr) (exp_h : exp)
     For M >= 2 this fuses [Option.map f expr |> Option.splitN] into a single
     [Option.fold_1_M]; M = 1 degenerates to a plain [Option.map]. *)
 
-and compile_iter_opt_binding (ctx : Ctx.t) (expr_stub_ml : Ml.expr) (exp : exp)
-    : Ctx.t * Binding.t list * Chain.t =
+and compile_iter_opt_binding ~(tparams : string list) (ctx : Ctx.t)
+    (expr_stub_ml : Ml.expr) (exp : exp) : Ctx.t * Binding.t list * Chain.t =
   let ctx_outer = ctx in
   (* Create stub expression for option element *)
   let ctx, id_stub_iter_ml = Stub.OCaml.var ctx "elem_opt__" in
@@ -356,7 +377,9 @@ and compile_iter_opt_binding (ctx : Ctx.t) (expr_stub_ml : Ml.expr) (exp : exp)
   (* Create [Option.map (fun expr_stub_inner -> ...) expr] *)
   let chain_map = Chain.make_option_map expr_stub_ml id_stub_iter_ml in
   (* Create chains for option element *)
-  let ctx, bindings, chain_elem = compile_binding ctx expr_stub_iter_ml exp in
+  let ctx, bindings, chain_elem =
+    compile_binding ~tparams ctx expr_stub_iter_ml exp
+  in
   (* Connect chains *)
   let chain = Chain.connect [ chain_map; chain_elem ] in
   (* Finish map block with bindings *)
@@ -413,8 +436,8 @@ and compile_iter_opt_binding (ctx : Ctx.t) (expr_stub_ml : Ml.expr) (exp : exp)
     For M >= 2 this fuses [List.map f expr |> List.splitN] into a single
     [List.fold_left_1_M]; M = 1 degenerates to a plain [List.map]. *)
 
-and compile_iter_list_binding (ctx : Ctx.t) (expr_stub_ml : Ml.expr) (exp : exp)
-    : Ctx.t * Binding.t list * Chain.t =
+and compile_iter_list_binding ~(tparams : string list) (ctx : Ctx.t)
+    (expr_stub_ml : Ml.expr) (exp : exp) : Ctx.t * Binding.t list * Chain.t =
   let ctx_outer = ctx in
   (* Create stub expression for list element *)
   let ctx, id_stub_iter_ml = Stub.OCaml.var ctx "elem_list__" in
@@ -422,7 +445,9 @@ and compile_iter_list_binding (ctx : Ctx.t) (expr_stub_ml : Ml.expr) (exp : exp)
   (* Create [List.map (fun expr_stub_inner -> ...) expr] *)
   let chain_map = Chain.make_list_map expr_stub_ml id_stub_iter_ml in
   (* Create chains for list element *)
-  let ctx, bindings, chain_elem = compile_binding ctx expr_stub_iter_ml exp in
+  let ctx, bindings, chain_elem =
+    compile_binding ~tparams ctx expr_stub_iter_ml exp
+  in
   (* Connect chains *)
   let chain = Chain.connect [ chain_map; chain_elem ] in
   (* Finish map block with bindings *)
@@ -464,8 +489,9 @@ and compile_iter_list_binding (ctx : Ctx.t) (expr_stub_ml : Ml.expr) (exp : exp)
   in
   (ctx, bindings_lift, chain)
 
-and compile_iter_binding (ctx : Ctx.t) (typ_exp : typ) (expr_stub_ml : Ml.expr)
-    (exp : exp) (iterexp : iterexp) : Ctx.t * Binding.t list * Chain.t =
+and compile_iter_binding ~(tparams : string list) (ctx : Ctx.t) (typ_exp : typ)
+    (expr_stub_ml : Ml.expr) (exp : exp) (iterexp : iterexp) :
+    Ctx.t * Binding.t list * Chain.t =
   match
     Common.is_iter_var_exp (Il.IterE (exp, iterexp) $$ (typ_exp.at, typ_exp.it))
   with
@@ -477,14 +503,14 @@ and compile_iter_binding (ctx : Ctx.t) (typ_exp : typ) (expr_stub_ml : Ml.expr)
   | None -> (
       let iter, _ = iterexp in
       match iter with
-      | Opt -> compile_iter_opt_binding ctx expr_stub_ml exp
-      | List -> compile_iter_list_binding ctx expr_stub_ml exp)
+      | Opt -> compile_iter_opt_binding ~tparams ctx expr_stub_ml exp
+      | List -> compile_iter_list_binding ~tparams ctx expr_stub_ml exp)
 
 (* Entry point *)
 
-let compile (ctx : Ctx.t) (expr_stub_ml : Ml.expr) (exp : exp) : Ctx.t * Chain.t
-    =
-  let ctx, bindings, chain = compile_binding ctx expr_stub_ml exp in
+let compile ~(tparams : string list) (ctx : Ctx.t) (expr_stub_ml : Ml.expr)
+    (exp : exp) : Ctx.t * Chain.t =
+  let ctx, bindings, chain = compile_binding ~tparams ctx expr_stub_ml exp in
   let vars, ids_ml = List.split bindings in
   let ctx = Ctx.add_bindings ctx vars ids_ml in
   (ctx, chain)

--- a/p4spec/lib/pass/compile/gen/dispatch.ml
+++ b/p4spec/lib/pass/compile/gen/dispatch.ml
@@ -4,7 +4,6 @@ open Util.Source
 
 let compile_eval_func (ctx : Ctx.t) (spec : Sl.spec)
     (dispatch_table : Mono.dispatch_table) : Ml.funcdef =
-  ignore ctx;
   (* Build func_sigs from monomorphized spec *)
   let func_sigs : (string, Sl.param list * Sl.typ) Hashtbl.t =
     Hashtbl.create 32
@@ -18,6 +17,21 @@ let compile_eval_func (ctx : Ctx.t) (spec : Sl.spec)
           Hashtbl.replace func_sigs id.it (params, typ_ret)
       | TableDecD (id, params, typ_ret, _, _) ->
           Hashtbl.replace func_sigs id.it (params, typ_ret)
+      | _ -> ())
+    spec;
+  (* Same, but for defs still generic (tparams <> []) — [func_sigs] above
+     skips these, so the generic arm (Task 6) needs its own signature table. *)
+  let poly_func_sigs : (string, Sl.param list * Sl.typ) Hashtbl.t =
+    Hashtbl.create 16
+  in
+  List.iter
+    (fun def ->
+      match def.it with
+      | FuncDecD (id, tparams, params, typ_ret, _, _, _)
+      | BuiltinDecD (id, tparams, params, typ_ret, _)
+      | ExternDecD (id, tparams, params, typ_ret, _)
+        when tparams <> [] ->
+          Hashtbl.replace poly_func_sigs id.it (params, typ_ret)
       | _ -> ())
     spec;
   (* Collect poly-instance original names *)
@@ -152,6 +166,122 @@ let compile_eval_func (ctx : Ctx.t) (spec : Sl.spec)
         | _ -> None)
       spec
   in
+  (* Arms for defs still generic: witnesses come from [interface_lookup_],
+     so no ground call site is needed. *)
+  let build_generic_arm (name : string) (tparams : Il.tparam list)
+      (params : Sl.param list) (typ_ret : Sl.typ) : Ml.arm option =
+    let has_defp =
+      List.exists
+        (fun p -> match p.it with DefP _ -> true | _ -> false)
+        params
+    in
+    if has_defp then None
+    else
+      let tvars = List.map (fun (tp : Il.tparam) -> tp.it) tparams in
+      let tparams_ml = List.map Names.tvar tparams in
+      let ocaml_name = "f__" ^ Names.sanitize name in
+      (* Bind [marshal__x]/[unmarshal__x] per tparam; the annotation is needed
+         or OCaml can't prove the later application principal ([-w 20]). *)
+      let witness_lets =
+        List.concat
+          (List.mapi
+             (fun i tv ->
+               let id_entry = "entry__" ^ string_of_int i in
+               let expr_lookup_ml =
+                 Ml.AppE
+                   ( Ml.LitE "interface_lookup_",
+                     [
+                       Ml.AppE
+                         ( Ml.LitE "List.nth",
+                           [ Ml.VarE "typs__"; Ml.LitE (string_of_int i) ] );
+                     ] )
+               in
+               let typ_marshal_ml =
+                 Ml.NameT (Printf.sprintf "('%s -> Value.t)" tv)
+               in
+               let typ_unmarshal_ml =
+                 Ml.NameT (Printf.sprintf "(Value.t -> '%s)" tv)
+               in
+               [
+                 (id_entry, expr_lookup_ml);
+                 ( Interface.witness_marshal_name tv,
+                   Ml.AnnotE
+                     ( Ml.AppE
+                         ( Ml.LitE "Obj.obj",
+                           [ Ml.AppE (Ml.LitE "fst", [ Ml.VarE id_entry ]) ] ),
+                       typ_marshal_ml ) );
+                 ( Interface.witness_unmarshal_name tv,
+                   Ml.AnnotE
+                     ( Ml.AppE
+                         ( Ml.LitE "Obj.obj",
+                           [ Ml.AppE (Ml.LitE "snd", [ Ml.VarE id_entry ]) ] ),
+                       typ_unmarshal_ml ) );
+               ])
+             tparams_ml)
+      in
+      let exprs_witness_ml =
+        List.concat_map
+          (fun tv ->
+            [
+              Ml.VarE (Interface.witness_marshal_name tv);
+              Ml.VarE (Interface.witness_unmarshal_name tv);
+            ])
+          tparams_ml
+      in
+      let exp_typs =
+        List.filter_map
+          (fun p -> match p.it with ExpP (typ, _) -> Some typ | _ -> None)
+          params
+      in
+      try
+        let vars_arg_ml, exprs_marshal_arg_ml =
+          List.mapi
+            (fun i typ ->
+              ( "a" ^ string_of_int i,
+                Func.apply_witness (string_of_int i)
+                  (Interface.resolve_unmarshal tvars typ)
+                  (Ml.AppE
+                     ( Ml.LitE "List.nth",
+                       [ Ml.VarE "args__"; Ml.LitE (string_of_int i) ] )) ))
+            exp_typs
+          |> List.split
+        in
+        let exprs_arg_ml = List.map (fun v -> Ml.VarE v) vars_arg_ml in
+        let expr_call_ml =
+          Ml.AppE (Ml.LitE ocaml_name, exprs_witness_ml @ exprs_arg_ml)
+        in
+        let expr_marshal_ret_ml =
+          Func.apply_witness "ret__"
+            (Interface.resolve_marshal tvars typ_ret)
+            expr_call_ml
+        in
+        let expr_run_pass_ml =
+          Ml.AppE (Ml.LitE "Run.Pass", [ expr_marshal_ret_ml ])
+        in
+        let expr_body_ml =
+          List.fold_right
+            (fun (var, rhs) acc -> Ml.LetE (Ml.VarP var, rhs, acc))
+            (witness_lets @ List.combine vars_arg_ml exprs_marshal_arg_ml)
+            expr_run_pass_ml
+        in
+        Some (Ml.LitP ("\"" ^ name ^ "\""), expr_body_ml)
+      with Failure msg ->
+        (* Same tuple/set/map boundary shapes Task 5's bridges skip (e.g. a
+           tuple-of-lists return) — skip this arm too. *)
+        Util.Error.warn_compile no_region
+          (Format.asprintf "generic function %s: %s — skipping eval_func arm"
+             name msg);
+        None
+  in
+  let arms_generic_ml =
+    List.filter_map
+      (fun (name, tparams) ->
+        match Hashtbl.find_opt poly_func_sigs name with
+        | None -> None
+        | Some (params, typ_ret) ->
+            build_generic_arm name tparams params typ_ret)
+      ctx.Ctx.poly_sigs
+  in
   (* Fallback wild arm *)
   let arm_wild_ml =
     ( Ml.WildP,
@@ -170,7 +300,9 @@ let compile_eval_func (ctx : Ctx.t) (spec : Sl.spec)
               ];
           ] ) )
   in
-  let arms_ml = arms_poly_ml @ arms_mono_ml @ [ arm_wild_ml ] in
+  let arms_ml =
+    arms_poly_ml @ arms_mono_ml @ arms_generic_ml @ [ arm_wild_ml ]
+  in
   let expr_match_ml = Ml.MatchE (Ml.VarE "name__", arms_ml) in
   (* Unmatch handler *)
   let expr_fail_unmatch_ml =
@@ -190,12 +322,32 @@ let compile_eval_func (ctx : Ctx.t) (spec : Sl.spec)
             ];
         ] )
   in
+  (* [interface_lookup_] raises this when a generic arm's witness type has
+     no ground call site anywhere in the spec. *)
+  let expr_fail_no_marshaller_ml =
+    Ml.AppE
+      ( Ml.LitE "Run.Fail",
+        [
+          Ml.TupleE
+            [
+              Ml.LitE "no_region";
+              Ml.AppE
+                ( Ml.LitE "Printf.sprintf",
+                  [
+                    Ml.StrE "eval_func: no marshaller registered for type %s";
+                    Ml.VarE "tyname__";
+                  ] );
+            ];
+        ] )
+  in
   let expr_try_ml =
     Ml.TryE
       ( expr_match_ml,
         [
           ( Ml.VariantP (`Mono ("Unmatch", [ Ml.VarP "msg_" ])),
             expr_fail_unmatch_ml );
+          ( Ml.VariantP (`Mono ("No_marshaller_", [ Ml.VarP "tyname__" ])),
+            expr_fail_no_marshaller_ml );
         ] )
   in
   let params_ml =

--- a/p4spec/lib/pass/compile/gen/dispatch.ml
+++ b/p4spec/lib/pass/compile/gen/dispatch.ml
@@ -233,6 +233,7 @@ let compile_eval_func (ctx : Ctx.t) (spec : Sl.spec)
           (fun p -> match p.it with ExpP (typ, _) -> Some typ | _ -> None)
           params
       in
+      let n_tparams = List.length tparams in
       try
         let vars_arg_ml, exprs_marshal_arg_ml =
           List.mapi
@@ -258,11 +259,42 @@ let compile_eval_func (ctx : Ctx.t) (spec : Sl.spec)
         let expr_run_pass_ml =
           Ml.AppE (Ml.LitE "Run.Pass", [ expr_marshal_ret_ml ])
         in
-        let expr_body_ml =
+        let expr_ok_ml =
           List.fold_right
             (fun (var, rhs) acc -> Ml.LetE (Ml.VarP var, rhs, acc))
             (witness_lets @ List.combine vars_arg_ml exprs_marshal_arg_ml)
             expr_run_pass_ml
+        in
+        (* Guard arity before any [List.nth typs__ i] below can crash. *)
+        let expr_fail_arity_ml =
+          Ml.AppE
+            ( Ml.LitE "Run.Fail",
+              [
+                Ml.TupleE
+                  [
+                    Ml.LitE "no_region";
+                    Ml.AppE
+                      ( Ml.LitE "Printf.sprintf",
+                        [
+                          Ml.StrE
+                            (Printf.sprintf
+                               "eval_func: %s expects %d type argument(s), \
+                                got %%d"
+                               name n_tparams);
+                          Ml.AppE
+                            (Ml.LitE "List.length", [ Ml.VarE "typs__" ]);
+                        ] );
+                  ];
+              ] )
+        in
+        let expr_body_ml =
+          Ml.IfE
+            ( Ml.BinopE
+                ( "=",
+                  Ml.AppE (Ml.LitE "List.length", [ Ml.VarE "typs__" ]),
+                  Ml.LitE (string_of_int n_tparams) ),
+              expr_ok_ml,
+              Some expr_fail_arity_ml )
         in
         Some (Ml.LitP ("\"" ^ name ^ "\""), expr_body_ml)
       with Failure msg ->
@@ -276,10 +308,14 @@ let compile_eval_func (ctx : Ctx.t) (spec : Sl.spec)
   let arms_generic_ml =
     List.filter_map
       (fun (name, tparams) ->
-        match Hashtbl.find_opt poly_func_sigs name with
-        | None -> None
-        | Some (params, typ_ret) ->
-            build_generic_arm name tparams params typ_ret)
+        (* A name with a recorded ground instance is already handled by
+           [arms_poly_ml] — don't shadow it with an unreachable arm here. *)
+        if Hashtbl.mem poly_names name then None
+        else
+          match Hashtbl.find_opt poly_func_sigs name with
+          | None -> None
+          | Some (params, typ_ret) ->
+              build_generic_arm name tparams params typ_ret)
       ctx.Ctx.poly_sigs
   in
   (* Fallback wild arm *)

--- a/p4spec/lib/pass/compile/gen/dispatch.ml
+++ b/p4spec/lib/pass/compile/gen/dispatch.ml
@@ -278,11 +278,10 @@ let compile_eval_func (ctx : Ctx.t) (spec : Sl.spec)
                         [
                           Ml.StrE
                             (Printf.sprintf
-                               "eval_func: %s expects %d type argument(s), \
-                                got %%d"
+                               "eval_func: %s expects %d type argument(s), got \
+                                %%d"
                                name n_tparams);
-                          Ml.AppE
-                            (Ml.LitE "List.length", [ Ml.VarE "typs__" ]);
+                          Ml.AppE (Ml.LitE "List.length", [ Ml.VarE "typs__" ]);
                         ] );
                   ];
               ] )

--- a/p4spec/lib/pass/compile/gen/dispatch.ml
+++ b/p4spec/lib/pass/compile/gen/dispatch.ml
@@ -205,7 +205,7 @@ let compile_eval_func (ctx : Ctx.t) (spec : Sl.spec)
       ("args__", Some (Ml.AppT ("list", [ Ml.NameT "Value.t" ])));
     ]
   in
-  ("eval_func", params_ml, Some (Ml.NameT "Run.func_result"), expr_try_ml)
+  ("eval_func", [], params_ml, Some (Ml.NameT "Run.func_result"), expr_try_ml)
 
 let compile_eval_rel (ctx : Ctx.t) (spec : Sl.spec) : Ml.funcdef =
   ignore ctx;
@@ -351,4 +351,4 @@ let compile_eval_rel (ctx : Ctx.t) (spec : Sl.spec) : Ml.funcdef =
       ("args__", Some (Ml.AppT ("list", [ Ml.NameT "Value.t" ])));
     ]
   in
-  ("eval_rel", params_ml, Some (Ml.NameT "Run.rel_result"), expr_try_ml)
+  ("eval_rel", [], params_ml, Some (Ml.NameT "Run.rel_result"), expr_try_ml)

--- a/p4spec/lib/pass/compile/gen/exp.ml
+++ b/p4spec/lib/pass/compile/gen/exp.ml
@@ -7,7 +7,8 @@ open Util.Source
 
 (* Compiling expressions *)
 
-let rec compile_exp (ctx : Ctx.t) (exp : exp) : Ctx.t * Ml.expr =
+let rec compile_exp ~(tparams : string list) (ctx : Ctx.t) (exp : exp) :
+    Ctx.t * Ml.expr =
   let wrap_ctx (expr_ml : Ml.expr) : Ctx.t * Ml.expr = (ctx, expr_ml) in
   let typ_exp = exp.note $ exp.at in
   match exp.it with
@@ -15,33 +16,37 @@ let rec compile_exp (ctx : Ctx.t) (exp : exp) : Ctx.t * Ml.expr =
   | NumE num -> compile_num_exp num |> wrap_ctx
   | TextE str -> compile_text_exp str |> wrap_ctx
   | VarE id -> compile_var_exp ctx id |> wrap_ctx
-  | UnE (op, optyp, exp) -> compile_unop_exp ctx op optyp exp
-  | BinE (op, optyp, exp_l, exp_r) -> compile_binop_exp ctx op optyp exp_l exp_r
-  | CmpE (op, optyp, exp_l, exp_r) -> compile_cmp_exp ctx op optyp exp_l exp_r
-  | UpCastE (typ, exp) -> compile_upcast_exp ctx typ exp
-  | DownCastE (typ, exp) -> compile_downcast_exp ctx typ exp
-  | SubE (exp, typ) -> compile_sub_exp ctx exp typ
-  | MatchE (exp, pattern) -> compile_match_exp ctx exp pattern
-  | TupleE exps -> compile_tuple_exp ctx exps
-  | CaseE notexp -> compile_case_exp ctx typ_exp notexp
-  | StrE expfields -> compile_str_exp ctx typ_exp expfields
-  | OptE exp_opt -> compile_opt_exp ctx exp_opt
-  | ListE exps -> compile_list_exp ctx exps
-  | ConsE (exp_h, exp_t) -> compile_cons_exp ctx exp_h exp_t
-  | CatE (exp_l, exp_r) -> compile_cat_exp ctx typ_exp exp_l exp_r
-  | MemE (exp_e, exp_s) -> compile_mem_exp ctx exp_e exp_s
-  | LenE exp -> compile_len_exp ctx exp
-  | DotE (exp_b, atom) -> compile_dot_exp ctx exp_b atom
-  | IdxE (exp_b, exp_i) -> compile_idx_exp ctx exp_b exp_i
-  | SliceE (exp_b, exp_l, exp_n) -> compile_slice_exp ctx exp_b exp_l exp_n
-  | UpdE (exp_b, path, exp_n) -> compile_upd_exp ctx exp_b path exp_n
-  | CallE (id, targs, args) -> compile_call_exp ctx id targs args
-  | IterE (exp, iterexp) -> compile_iter_exp ctx typ_exp exp iterexp
+  | UnE (op, optyp, exp) -> compile_unop_exp ~tparams ctx op optyp exp
+  | BinE (op, optyp, exp_l, exp_r) ->
+      compile_binop_exp ~tparams ctx op optyp exp_l exp_r
+  | CmpE (op, optyp, exp_l, exp_r) ->
+      compile_cmp_exp ~tparams ctx op optyp exp_l exp_r
+  | UpCastE (typ, exp) -> compile_upcast_exp ~tparams ctx typ exp
+  | DownCastE (typ, exp) -> compile_downcast_exp ~tparams ctx typ exp
+  | SubE (exp, typ) -> compile_sub_exp ~tparams ctx exp typ
+  | MatchE (exp, pattern) -> compile_match_exp ~tparams ctx exp pattern
+  | TupleE exps -> compile_tuple_exp ~tparams ctx exps
+  | CaseE notexp -> compile_case_exp ~tparams ctx typ_exp notexp
+  | StrE expfields -> compile_str_exp ~tparams ctx typ_exp expfields
+  | OptE exp_opt -> compile_opt_exp ~tparams ctx exp_opt
+  | ListE exps -> compile_list_exp ~tparams ctx exps
+  | ConsE (exp_h, exp_t) -> compile_cons_exp ~tparams ctx exp_h exp_t
+  | CatE (exp_l, exp_r) -> compile_cat_exp ~tparams ctx typ_exp exp_l exp_r
+  | MemE (exp_e, exp_s) -> compile_mem_exp ~tparams ctx exp_e exp_s
+  | LenE exp -> compile_len_exp ~tparams ctx exp
+  | DotE (exp_b, atom) -> compile_dot_exp ~tparams ctx exp_b atom
+  | IdxE (exp_b, exp_i) -> compile_idx_exp ~tparams ctx exp_b exp_i
+  | SliceE (exp_b, exp_l, exp_n) ->
+      compile_slice_exp ~tparams ctx exp_b exp_l exp_n
+  | UpdE (exp_b, path, exp_n) -> compile_upd_exp ~tparams ctx exp_b path exp_n
+  | CallE (id, targs, args) -> compile_call_exp ~tparams ctx id targs args
+  | IterE (exp, iterexp) -> compile_iter_exp ~tparams ctx typ_exp exp iterexp
 
-and compile_exps (ctx : Ctx.t) (exps : exp list) : Ctx.t * Ml.expr list =
+and compile_exps ~(tparams : string list) (ctx : Ctx.t) (exps : exp list) :
+    Ctx.t * Ml.expr list =
   List.fold_left
     (fun (ctx, exprs_ml) exp ->
-      let ctx, expr_ml = compile_exp ctx exp in
+      let ctx, expr_ml = compile_exp ~tparams ctx exp in
       (ctx, exprs_ml @ [ expr_ml ]))
     (ctx, []) exps
 
@@ -78,9 +83,9 @@ and compile_var_exp (ctx : Ctx.t) (id : id) : Ml.expr =
    +    ->  [expr]
    -    ->  [Bigint.neg expr] *)
 
-and compile_unop_exp (ctx : Ctx.t) (unop : unop) (_optyp : optyp) (exp : exp) :
-    Ctx.t * Ml.expr =
-  let ctx, expr_ml = compile_exp ctx exp in
+and compile_unop_exp ~(tparams : string list) (ctx : Ctx.t) (unop : unop)
+    (_optyp : optyp) (exp : exp) : Ctx.t * Ml.expr =
+  let ctx, expr_ml = compile_exp ~tparams ctx exp in
   let expr_ml =
     match unop with
     | `NotOp -> Ml.UnopE ("not", expr_ml)
@@ -114,10 +119,10 @@ and compile_binop_num (binop : Num.binop) : string =
    **         ->  [Bigint.( ** ) expr_l expr_r]
    +,-,*,/,%  ->  [Bigint.op expr_l expr_r] *)
 
-and compile_binop_exp (ctx : Ctx.t) (binop : binop) (_optyp : optyp)
-    (exp_l : exp) (exp_r : exp) : Ctx.t * Ml.expr =
-  let ctx, expr_ml_l = compile_exp ctx exp_l in
-  let ctx, expr_ml_r = compile_exp ctx exp_r in
+and compile_binop_exp ~(tparams : string list) (ctx : Ctx.t) (binop : binop)
+    (_optyp : optyp) (exp_l : exp) (exp_r : exp) : Ctx.t * Ml.expr =
+  let ctx, expr_ml_l = compile_exp ~tparams ctx exp_l in
+  let ctx, expr_ml_r = compile_exp ~tparams ctx exp_r in
   let expr_ml =
     match binop with
     | `ImplOp ->
@@ -150,10 +155,10 @@ and compile_cmpop_num (cmpop : Num.cmpop) : string =
   | `LeOp -> "Bigint.( <= )"
   | `GeOp -> "Bigint.( >= )"
 
-and compile_cmp_exp (ctx : Ctx.t) (cmpop : cmpop) (optyp : optyp) (exp_l : exp)
-    (exp_r : exp) : Ctx.t * Ml.expr =
-  let ctx, expr_ml_l = compile_exp ctx exp_l in
-  let ctx, expr_ml_r = compile_exp ctx exp_r in
+and compile_cmp_exp ~(tparams : string list) (ctx : Ctx.t) (cmpop : cmpop)
+    (optyp : optyp) (exp_l : exp) (exp_r : exp) : Ctx.t * Ml.expr =
+  let ctx, expr_ml_l = compile_exp ~tparams ctx exp_l in
+  let ctx, expr_ml_r = compile_exp ~tparams ctx exp_r in
   let expr_ml =
     match (cmpop, optyp) with
     | ((`EqOp | `NeOp) as cmpop), `BoolT ->
@@ -175,9 +180,10 @@ and compile_cmp_exp (ctx : Ctx.t) (cmpop : cmpop) (optyp : optyp) (exp_l : exp)
 
    [(expr :> T)] *)
 
-and compile_upcast_exp (ctx : Ctx.t) (typ : typ) (exp : exp) : Ctx.t * Ml.expr =
-  let ctx, expr_ml = compile_exp ctx exp in
-  let typ_ml = Type.compile_typ ~tparams:[] typ in
+and compile_upcast_exp ~(tparams : string list) (ctx : Ctx.t) (typ : typ)
+    (exp : exp) : Ctx.t * Ml.expr =
+  let ctx, expr_ml = compile_exp ~tparams ctx exp in
+  let typ_ml = Type.compile_typ ~tparams typ in
   let expr_ml = Ml.CoerceE (expr_ml, typ_ml) in
   (ctx, expr_ml)
 
@@ -192,12 +198,12 @@ and compile_upcast_exp (ctx : Ctx.t) (typ : typ) (exp : exp) : Ctx.t * Ml.expr =
    plain (expr :> T). Inside iter bodies, the SL type is narrowed post-SubG but
    the OCaml binding type is the wider guide type, so a plain coercion fails. *)
 
-and compile_downcast_exp_var (ctx : Ctx.t) (id : id) (targs : targ list)
-    (exp : exp) : Ctx.t * Ml.expr =
+and compile_downcast_exp_var ~(tparams : string list) (ctx : Ctx.t) (id : id)
+    (targs : targ list) (exp : exp) : Ctx.t * Ml.expr =
   let ctors_typ = Ctx.find_ctors ctx id in
-  let ctx, expr_ml = compile_exp ctx exp in
+  let ctx, expr_ml = compile_exp ~tparams ctx exp in
   let typ_target_ml =
-    Type.compile_typ ~tparams:[] (Il.VarT (id, targs) $ no_region)
+    Type.compile_typ ~tparams (Il.VarT (id, targs) $ no_region)
   in
   if ctors_typ = [] then (ctx, expr_ml)
   else
@@ -212,7 +218,7 @@ and compile_downcast_exp_var (ctx : Ctx.t) (id : id) (targs : targ list)
                 List.map (Mono.Subst.subst_typ theta) typs
             | _ -> typs
           in
-          (ctor_ml, Type.compile_typs ~tparams:[] typs_inst))
+          (ctor_ml, Type.compile_typs ~tparams typs_inst))
         ctors_typ
     in
     let expr_scrut_ml = Ml.AnnotE (expr_ml, Ml.OpenRowT typrows_ml) in
@@ -241,10 +247,10 @@ and compile_downcast_exp_var (ctx : Ctx.t) (id : id) (targs : targ list)
 
    [let (x1,..,xn) = expr in (dc(T1,x1), .., dc(Tn,xn))] *)
 
-and compile_downcast_exp_tuple (ctx : Ctx.t) (typs : typ list) (exp : exp) :
-    Ctx.t * Ml.expr =
+and compile_downcast_exp_tuple ~(tparams : string list) (ctx : Ctx.t)
+    (typs : typ list) (exp : exp) : Ctx.t * Ml.expr =
   (* Compile expression *)
-  let ctx, expr_ml = compile_exp ctx exp in
+  let ctx, expr_ml = compile_exp ~tparams ctx exp in
   let ctx_outer = ctx in
   (* Create stub expression for tuple elements *)
   let ctx, ids_stub_ml = Stub.OCaml.vars ctx "tup__" (List.length typs) in
@@ -254,7 +260,9 @@ and compile_downcast_exp_tuple (ctx : Ctx.t) (typs : typ list) (exp : exp) :
     List.combine exps_stub typs
     |> List.fold_left
          (fun (ctx, expr_elems_ml) (exp_stub, typ) ->
-           let ctx, expr_elem_ml = compile_downcast_exp ctx typ exp_stub in
+           let ctx, expr_elem_ml =
+             compile_downcast_exp ~tparams ctx typ exp_stub
+           in
            (ctx, expr_elems_ml @ [ expr_elem_ml ]))
          (ctx, [])
   in
@@ -273,18 +281,18 @@ and compile_downcast_exp_tuple (ctx : Ctx.t) (typs : typ list) (exp : exp) :
 
    [Option.map (fun x -> dc(T, x)) expr] *)
 
-and compile_downcast_exp_iter_opt (ctx : Ctx.t) (typ : typ) (exp : exp) :
-    Ctx.t * Ml.expr =
+and compile_downcast_exp_iter_opt ~(tparams : string list) (ctx : Ctx.t)
+    (typ : typ) (exp : exp) : Ctx.t * Ml.expr =
   (* Fetch source type *)
   let typ_src = match exp.note with IterT (typ, Opt) -> typ | _ -> typ in
   (* Compile expression *)
-  let ctx, expr_ml = compile_exp ctx exp in
+  let ctx, expr_ml = compile_exp ~tparams ctx exp in
   let ctx_outer = ctx in
   (* Create stub expression for option element *)
   let ctx, id_stub_ml = Stub.OCaml.var ctx "elem_opt__" in
   let exp_stub = Stub.SpecTec.var id_stub_ml typ_src in
   (* Compile downcast expression for iterated element *)
-  let ctx, expr_elem_ml = compile_downcast_exp ctx typ exp_stub in
+  let ctx, expr_elem_ml = compile_downcast_exp ~tparams ctx typ exp_stub in
   (* Promote preamble *)
   let ctx = Ctx.promote_preamble ctx ctx_outer in
   (* Create map on option *)
@@ -296,18 +304,18 @@ and compile_downcast_exp_iter_opt (ctx : Ctx.t) (typ : typ) (exp : exp) :
 
    [List.map (fun x -> dc(T, x)) expr] *)
 
-and compile_downcast_exp_iter_list (ctx : Ctx.t) (typ : typ) (exp : exp) :
-    Ctx.t * Ml.expr =
+and compile_downcast_exp_iter_list ~(tparams : string list) (ctx : Ctx.t)
+    (typ : typ) (exp : exp) : Ctx.t * Ml.expr =
   (* Fetch source type *)
   let typ_src = match exp.note with IterT (typ, List) -> typ | _ -> typ in
   (* Compile expression *)
-  let ctx, expr_ml = compile_exp ctx exp in
+  let ctx, expr_ml = compile_exp ~tparams ctx exp in
   let ctx_outer = ctx in
   (* Create stub expression for list element *)
   let ctx, id_stub_ml = Stub.OCaml.var ctx "elem_list__" in
   let exp_stub = Stub.SpecTec.var id_stub_ml typ_src in
   (* Compile downcast expression for iterated element *)
-  let ctx, expr_elem_ml = compile_downcast_exp ctx typ exp_stub in
+  let ctx, expr_elem_ml = compile_downcast_exp ~tparams ctx typ exp_stub in
   (* Promote preamble *)
   let ctx = Ctx.promote_preamble ctx ctx_outer in
   (* Create map on list *)
@@ -315,19 +323,19 @@ and compile_downcast_exp_iter_list (ctx : Ctx.t) (typ : typ) (exp : exp) :
   let expr_ml = Ml.AppE (Ml.VarE "List.map", [ expr_lambda_ml; expr_ml ]) in
   (ctx, expr_ml)
 
-and compile_downcast_exp_iter (ctx : Ctx.t) (typ : typ) (iter : iter)
-    (exp : exp) : Ctx.t * Ml.expr =
+and compile_downcast_exp_iter ~(tparams : string list) (ctx : Ctx.t) (typ : typ)
+    (iter : iter) (exp : exp) : Ctx.t * Ml.expr =
   match iter with
-  | Opt -> compile_downcast_exp_iter_opt ctx typ exp
-  | List -> compile_downcast_exp_iter_list ctx typ exp
+  | Opt -> compile_downcast_exp_iter_opt ~tparams ctx typ exp
+  | List -> compile_downcast_exp_iter_list ~tparams ctx typ exp
 
-and compile_downcast_exp (ctx : Ctx.t) (typ : typ) (exp : exp) : Ctx.t * Ml.expr
-    =
+and compile_downcast_exp ~(tparams : string list) (ctx : Ctx.t) (typ : typ)
+    (exp : exp) : Ctx.t * Ml.expr =
   match typ.it with
-  | VarT (id, targs) -> compile_downcast_exp_var ctx id targs exp
-  | TupleT typs -> compile_downcast_exp_tuple ctx typs exp
-  | IterT (typ, iter) -> compile_downcast_exp_iter ctx typ iter exp
-  | _ -> compile_exp ctx exp
+  | VarT (id, targs) -> compile_downcast_exp_var ~tparams ctx id targs exp
+  | TupleT typs -> compile_downcast_exp_tuple ~tparams ctx typs exp
+  | IterT (typ, iter) -> compile_downcast_exp_iter ~tparams ctx typ iter exp
+  | _ -> compile_exp ~tparams ctx exp
 
 (* Subtyping check expressions *)
 
@@ -335,8 +343,9 @@ and compile_downcast_exp (ctx : Ctx.t) (typ : typ) (exp : exp) : Ctx.t * Ml.expr
 
    [Bigint.( >= ) expr 0] *)
 
-and compile_sub_exp_num_nat (ctx : Ctx.t) (exp : exp) : Ctx.t * Ml.expr =
-  let ctx, expr_ml = compile_exp ctx exp in
+and compile_sub_exp_num_nat ~(tparams : string list) (ctx : Ctx.t) (exp : exp) :
+    Ctx.t * Ml.expr =
+  let ctx, expr_ml = compile_exp ~tparams ctx exp in
   let expr_zero_ml = Ml.BigintE "0" in
   let expr_ml = Ml.AppE (Ml.VarE "Bigint.( >= )", [ expr_ml; expr_zero_ml ]) in
   (ctx, expr_ml)
@@ -347,13 +356,13 @@ and compile_sub_exp_num_nat (ctx : Ctx.t) (exp : exp) : Ctx.t * Ml.expr =
    | `Ci pi.. -> sub(pi) && ..
    | _        -> false *)
 
-and compile_sub_match (ctx : Ctx.t) (exp : exp)
+and compile_sub_match ~(tparams : string list) (ctx : Ctx.t) (exp : exp)
     (ctors_inter : (Ml.ctor * Il.typ list) list) : Ctx.t * Ml.expr =
   (* Compile expression with type annotation *)
-  let ctx, expr_ml = compile_exp ctx exp in
+  let ctx, expr_ml = compile_exp ~tparams ctx exp in
   let typrows_ml =
     List.map
-      (fun (ctor_ml, typs) -> (ctor_ml, Type.compile_typs ~tparams:[] typs))
+      (fun (ctor_ml, typs) -> (ctor_ml, Type.compile_typs ~tparams typs))
       ctors_inter
   in
   let expr_scrut_ml = Ml.AnnotE (expr_ml, Ml.OpenRowT typrows_ml) in
@@ -371,7 +380,9 @@ and compile_sub_match (ctx : Ctx.t) (exp : exp)
           |> List.fold_left
                (fun (ctx, exprs_cond_ml) (id, typ) ->
                  let exp_stub = Stub.SpecTec.var id typ in
-                 let ctx, expr_cond_ml = compile_sub_exp ctx exp_stub typ in
+                 let ctx, expr_cond_ml =
+                   compile_sub_exp ~tparams ctx exp_stub typ
+                 in
                  (ctx, exprs_cond_ml @ [ expr_cond_ml ]))
                (ctx, [])
         in
@@ -412,8 +423,8 @@ and compile_sub_match (ctx : Ctx.t) (exp : exp)
    ctors(S) & ctors(T) = {} ->  false
    otherwise                ->  compile_sub_match on intersection *)
 
-and compile_sub_exp_var_irreflexive (ctx : Ctx.t) (exp : exp) (id : id)
-    (targs : targ list) : Ctx.t * Ml.expr =
+and compile_sub_exp_var_irreflexive ~(tparams : string list) (ctx : Ctx.t)
+    (exp : exp) (id : id) (targs : targ list) : Ctx.t * Ml.expr =
   let ctors_typ = Ctx.find_ctors ctx id in
   if ctors_typ = [] then (ctx, Ml.BoolE true)
   else
@@ -440,27 +451,27 @@ and compile_sub_exp_var_irreflexive (ctx : Ctx.t) (exp : exp) (id : id)
         ctors_typ
     in
     if ctors_inter = [] then (ctx, Ml.BoolE false)
-    else compile_sub_match ctx exp ctors_inter
+    else compile_sub_match ~tparams ctx exp ctors_inter
 
 (* Variable subtype check: [exp <: VarT T]
 
    exp : T  ->  true
    exp : S  ->  compile_sub_exp_var_irreflexive *)
 
-and compile_sub_exp_var (ctx : Ctx.t) (exp : exp) (id : id) (targs : targ list)
-    : Ctx.t * Ml.expr =
+and compile_sub_exp_var ~(tparams : string list) (ctx : Ctx.t) (exp : exp)
+    (id : id) (targs : targ list) : Ctx.t * Ml.expr =
   match exp.note with
   | VarT (id_exp_typ, _) when id_exp_typ.it = id.it -> (ctx, Ml.BoolE true)
-  | _ -> compile_sub_exp_var_irreflexive ctx exp id targs
+  | _ -> compile_sub_exp_var_irreflexive ~tparams ctx exp id targs
 
 (* Tuple subtype check: [exp <: (typ_1, ..., typ_n)]
 
    [let (x1,..,xn) = expr in sub(x1,T1) && .. && sub(xn,Tn)] *)
 
-and compile_sub_exp_tuple (ctx : Ctx.t) (exp : exp) (typs : typ list) :
-    Ctx.t * Ml.expr =
+and compile_sub_exp_tuple ~(tparams : string list) (ctx : Ctx.t) (exp : exp)
+    (typs : typ list) : Ctx.t * Ml.expr =
   (* Compile expression *)
-  let ctx, expr_ml = compile_exp ctx exp in
+  let ctx, expr_ml = compile_exp ~tparams ctx exp in
   (* Save context for promotion *)
   let ctx_outer = ctx in
   (* Create stub expression for tuple elements *)
@@ -471,7 +482,7 @@ and compile_sub_exp_tuple (ctx : Ctx.t) (exp : exp) (typs : typ list) :
     |> List.fold_left
          (fun (ctx, exprs_elem_ml) (id_stub, typ) ->
            let exp_stub = Stub.SpecTec.var id_stub typ in
-           let ctx, expr_ml = compile_sub_exp ctx exp_stub typ in
+           let ctx, expr_ml = compile_sub_exp ~tparams ctx exp_stub typ in
            (ctx, exprs_elem_ml @ [ expr_ml ]))
          (ctx, [])
   in
@@ -501,17 +512,17 @@ and compile_sub_exp_tuple (ctx : Ctx.t) (exp : exp) (typs : typ list) :
 
    [match expr with None -> true | Some x -> sub(x, T)] *)
 
-and compile_sub_exp_opt (ctx : Ctx.t) (exp : exp) (typ : typ) : Ctx.t * Ml.expr
-    =
+and compile_sub_exp_opt ~(tparams : string list) (ctx : Ctx.t) (exp : exp)
+    (typ : typ) : Ctx.t * Ml.expr =
   (* Compile expression *)
-  let ctx, expr_ml = compile_exp ctx exp in
+  let ctx, expr_ml = compile_exp ~tparams ctx exp in
   (* Save context for promotion *)
   let ctx_outer = ctx in
   (* Create stub expression for option element *)
   let ctx, id_stub_ml = Stub.OCaml.var ctx "elem_opt__" in
   let exp_stub = Stub.SpecTec.var id_stub_ml typ in
   (* Compile subtype check for option element *)
-  let ctx, expr_cond_ml = compile_sub_exp ctx exp_stub typ in
+  let ctx, expr_cond_ml = compile_sub_exp ~tparams ctx exp_stub typ in
   (* Promote preamble *)
   let ctx = Ctx.promote_preamble ctx ctx_outer in
   (* Create match expression *)
@@ -529,17 +540,17 @@ and compile_sub_exp_opt (ctx : Ctx.t) (exp : exp) (typ : typ) : Ctx.t * Ml.expr
 
    [List.for_all (fun x -> sub(x, T)) expr] *)
 
-and compile_sub_exp_list (ctx : Ctx.t) (exp : exp) (typ : typ) : Ctx.t * Ml.expr
-    =
+and compile_sub_exp_list ~(tparams : string list) (ctx : Ctx.t) (exp : exp)
+    (typ : typ) : Ctx.t * Ml.expr =
   (* Compile expression *)
-  let ctx, expr_ml = compile_exp ctx exp in
+  let ctx, expr_ml = compile_exp ~tparams ctx exp in
   (* Save context for promotion *)
   let ctx_outer = ctx in
   (* Create stub expression for list element *)
   let ctx, id_stub_ml = Stub.OCaml.var ctx "elem_list__" in
   let exp_stub = Stub.SpecTec.var id_stub_ml typ in
   (* Compile subtype check for list element *)
-  let ctx, expr_cond_ml = compile_sub_exp ctx exp_stub typ in
+  let ctx, expr_cond_ml = compile_sub_exp ~tparams ctx exp_stub typ in
   (* Promote preamble *)
   let ctx = Ctx.promote_preamble ctx ctx_outer in
   (* Create result expression *)
@@ -552,18 +563,19 @@ and compile_sub_exp_list (ctx : Ctx.t) (exp : exp) (typ : typ) : Ctx.t * Ml.expr
   in
   (ctx, expr_ml)
 
-and compile_sub_exp_iter (ctx : Ctx.t) (exp : exp) (typ : typ) (iter : iter) :
-    Ctx.t * Ml.expr =
+and compile_sub_exp_iter ~(tparams : string list) (ctx : Ctx.t) (exp : exp)
+    (typ : typ) (iter : iter) : Ctx.t * Ml.expr =
   match iter with
-  | Opt -> compile_sub_exp_opt ctx exp typ
-  | List -> compile_sub_exp_list ctx exp typ
+  | Opt -> compile_sub_exp_opt ~tparams ctx exp typ
+  | List -> compile_sub_exp_list ~tparams ctx exp typ
 
-and compile_sub_exp (ctx : Ctx.t) (exp : exp) (typ : typ) : Ctx.t * Ml.expr =
+and compile_sub_exp ~(tparams : string list) (ctx : Ctx.t) (exp : exp)
+    (typ : typ) : Ctx.t * Ml.expr =
   match typ.it with
-  | NumT `NatT -> compile_sub_exp_num_nat ctx exp
-  | VarT (id, targs) -> compile_sub_exp_var ctx exp id targs
-  | TupleT typs -> compile_sub_exp_tuple ctx exp typs
-  | IterT (typ, iter) -> compile_sub_exp_iter ctx exp typ iter
+  | NumT `NatT -> compile_sub_exp_num_nat ~tparams ctx exp
+  | VarT (id, targs) -> compile_sub_exp_var ~tparams ctx exp id targs
+  | TupleT typs -> compile_sub_exp_tuple ~tparams ctx exp typs
+  | IterT (typ, iter) -> compile_sub_exp_iter ~tparams ctx exp typ iter
   | _ -> (ctx, Ml.BoolE true)
 
 (* Pattern match expression: [exp matches pattern]
@@ -575,9 +587,9 @@ and compile_sub_exp (ctx : Ctx.t) (exp : exp) (typ : typ) : Ctx.t * Ml.expr =
    OptP Some       ->  [Option.is_some expr]
    OptP None       ->  [Option.is_none expr] *)
 
-and compile_match_exp (ctx : Ctx.t) (exp : exp) (pattern : pattern) :
-    Ctx.t * Ml.expr =
-  let ctx, expr_ml = compile_exp ctx exp in
+and compile_match_exp ~(tparams : string list) (ctx : Ctx.t) (exp : exp)
+    (pattern : pattern) : Ctx.t * Ml.expr =
+  let ctx, expr_ml = compile_exp ~tparams ctx exp in
   let expr_ml =
     match pattern with
     | CaseP mixop ->
@@ -607,8 +619,9 @@ and compile_match_exp (ctx : Ctx.t) (exp : exp) (pattern : pattern) :
 
    [(expr1, .., exprn)] *)
 
-and compile_tuple_exp (ctx : Ctx.t) (exps : exp list) : Ctx.t * Ml.expr =
-  let ctx, exprs_ml = compile_exps ctx exps in
+and compile_tuple_exp ~(tparams : string list) (ctx : Ctx.t) (exps : exp list) :
+    Ctx.t * Ml.expr =
+  let ctx, exprs_ml = compile_exps ~tparams ctx exps in
   let expr_ml = Ml.TupleE exprs_ml in
   (ctx, expr_ml)
 
@@ -616,11 +629,11 @@ and compile_tuple_exp (ctx : Ctx.t) (exps : exp list) : Ctx.t * Ml.expr =
 
    [`Ctor(expr1, .., exprn)] *)
 
-and compile_case_exp (ctx : Ctx.t) (typ_exp : typ) (notexp : notexp) :
-    Ctx.t * Ml.expr =
+and compile_case_exp ~(tparams : string list) (ctx : Ctx.t) (typ_exp : typ)
+    (notexp : notexp) : Ctx.t * Ml.expr =
   let mixop, exps = Mixfix.split notexp in
   let ctor_ml = Ctx.find_ctor ctx typ_exp mixop in
-  let ctx, exprs_ml = compile_exps ctx exps in
+  let ctx, exprs_ml = compile_exps ~tparams ctx exps in
   let expr_ml = Ml.VariantE (ctor_ml, exprs_ml) in
   (ctx, expr_ml)
 
@@ -628,19 +641,19 @@ and compile_case_exp (ctx : Ctx.t) (typ_exp : typ) (notexp : notexp) :
 
    [({field1=expr1; ..; fieldn=exprn} : T)] *)
 
-and compile_str_exp (ctx : Ctx.t) (typ_exp : typ)
+and compile_str_exp ~(tparams : string list) (ctx : Ctx.t) (typ_exp : typ)
     (expfields : (atom * exp) list) : Ctx.t * Ml.expr =
   let ctx, exprfields_ml =
     List.fold_left
       (fun (ctx, exprfields_ml) (atom, exp) ->
         let field_ml = Names.field atom in
-        let ctx, expr_ml = compile_exp ctx exp in
+        let ctx, expr_ml = compile_exp ~tparams ctx exp in
         let exprfield_ml = (field_ml, expr_ml) in
         (ctx, exprfields_ml @ [ exprfield_ml ]))
       (ctx, []) expfields
   in
   let expr_ml = Ml.RecordE exprfields_ml in
-  let typ_ml = Type.compile_typ ~tparams:[] typ_exp in
+  let typ_ml = Type.compile_typ ~tparams typ_exp in
   let expr_ml = Ml.AnnotE (expr_ml, typ_ml) in
   (ctx, expr_ml)
 
@@ -649,13 +662,14 @@ and compile_str_exp (ctx : Ctx.t) (typ_exp : typ)
    None    ->  [None]
    Some e  ->  [Some expr] *)
 
-and compile_opt_exp (ctx : Ctx.t) (exp_opt : exp option) : Ctx.t * Ml.expr =
+and compile_opt_exp ~(tparams : string list) (ctx : Ctx.t)
+    (exp_opt : exp option) : Ctx.t * Ml.expr =
   match exp_opt with
   | None ->
       let expr_ml = Ml.OptE None in
       (ctx, expr_ml)
   | Some exp ->
-      let ctx, expr_ml = compile_exp ctx exp in
+      let ctx, expr_ml = compile_exp ~tparams ctx exp in
       let expr_ml = Ml.OptE (Some expr_ml) in
       (ctx, expr_ml)
 
@@ -663,8 +677,9 @@ and compile_opt_exp (ctx : Ctx.t) (exp_opt : exp option) : Ctx.t * Ml.expr =
 
    [[expr1; ..; exprn]] *)
 
-and compile_list_exp (ctx : Ctx.t) (exps : exp list) : Ctx.t * Ml.expr =
-  let ctx, exprs_ml = compile_exps ctx exps in
+and compile_list_exp ~(tparams : string list) (ctx : Ctx.t) (exps : exp list) :
+    Ctx.t * Ml.expr =
+  let ctx, exprs_ml = compile_exps ~tparams ctx exps in
   let expr_ml = Ml.ListE exprs_ml in
   (ctx, expr_ml)
 
@@ -672,10 +687,10 @@ and compile_list_exp (ctx : Ctx.t) (exps : exp list) : Ctx.t * Ml.expr =
 
    [expr_h :: expr_t] *)
 
-and compile_cons_exp (ctx : Ctx.t) (exp_h : exp) (exp_t : exp) : Ctx.t * Ml.expr
-    =
-  let ctx, expr_h_ml = compile_exp ctx exp_h in
-  let ctx, expr_t_ml = compile_exp ctx exp_t in
+and compile_cons_exp ~(tparams : string list) (ctx : Ctx.t) (exp_h : exp)
+    (exp_t : exp) : Ctx.t * Ml.expr =
+  let ctx, expr_h_ml = compile_exp ~tparams ctx exp_h in
+  let ctx, expr_t_ml = compile_exp ~tparams ctx exp_t in
   let expr_ml = Ml.ConsE (expr_h_ml, expr_t_ml) in
   (ctx, expr_ml)
 
@@ -684,11 +699,11 @@ and compile_cons_exp (ctx : Ctx.t) (exp_h : exp) (exp_t : exp) : Ctx.t * Ml.expr
    text  ->  [expr_l ^ expr_r]
    list  ->  [expr_l @ expr_r] *)
 
-and compile_cat_exp (ctx : Ctx.t) (typ_exp : typ) (exp_l : exp) (exp_r : exp) :
-    Ctx.t * Ml.expr =
+and compile_cat_exp ~(tparams : string list) (ctx : Ctx.t) (typ_exp : typ)
+    (exp_l : exp) (exp_r : exp) : Ctx.t * Ml.expr =
   let binop_ml = match typ_exp.it with TextT -> "^" | _ -> "@" in
-  let ctx, expr_l_ml = compile_exp ctx exp_l in
-  let ctx, expr_r_ml = compile_exp ctx exp_r in
+  let ctx, expr_l_ml = compile_exp ~tparams ctx exp_l in
+  let ctx, expr_r_ml = compile_exp ~tparams ctx exp_r in
   let expr_ml = Ml.BinopE (binop_ml, expr_l_ml, expr_r_ml) in
   (ctx, expr_ml)
 
@@ -696,10 +711,10 @@ and compile_cat_exp (ctx : Ctx.t) (typ_exp : typ) (exp_l : exp) (exp_r : exp) :
 
    [List.mem expr_e expr_s] *)
 
-and compile_mem_exp (ctx : Ctx.t) (exp_e : exp) (exp_s : exp) : Ctx.t * Ml.expr
-    =
-  let ctx, expr_e_ml = compile_exp ctx exp_e in
-  let ctx, expr_s_ml = compile_exp ctx exp_s in
+and compile_mem_exp ~(tparams : string list) (ctx : Ctx.t) (exp_e : exp)
+    (exp_s : exp) : Ctx.t * Ml.expr =
+  let ctx, expr_e_ml = compile_exp ~tparams ctx exp_e in
+  let ctx, expr_s_ml = compile_exp ~tparams ctx exp_s in
   let expr_ml = Ml.AppE (Ml.VarE "List.mem", [ expr_e_ml; expr_s_ml ]) in
   (ctx, expr_ml)
 
@@ -708,8 +723,9 @@ and compile_mem_exp (ctx : Ctx.t) (exp_e : exp) (exp_s : exp) : Ctx.t * Ml.expr
    text  ->  [Bigint.of_int (String.length expr)]
    list  ->  [Bigint.of_int (List.length expr)] *)
 
-and compile_len_exp (ctx : Ctx.t) (exp : exp) : Ctx.t * Ml.expr =
-  let ctx, expr_ml = compile_exp ctx exp in
+and compile_len_exp ~(tparams : string list) (ctx : Ctx.t) (exp : exp) :
+    Ctx.t * Ml.expr =
+  let ctx, expr_ml = compile_exp ~tparams ctx exp in
   let id_len_ml =
     match exp.note with TextT -> "String.length" | _ -> "List.length"
   in
@@ -723,10 +739,10 @@ and compile_len_exp (ctx : Ctx.t) (exp : exp) : Ctx.t * Ml.expr =
 
    [expr_b.field] *)
 
-and compile_dot_exp (ctx : Ctx.t) (exp_b : exp) (atom : atom) : Ctx.t * Ml.expr
-    =
+and compile_dot_exp ~(tparams : string list) (ctx : Ctx.t) (exp_b : exp)
+    (atom : atom) : Ctx.t * Ml.expr =
   let field_ml = Names.field atom in
-  let ctx, expr_b_ml = compile_exp ctx exp_b in
+  let ctx, expr_b_ml = compile_exp ~tparams ctx exp_b in
   let expr_ml = Ml.FieldE (expr_b_ml, field_ml) in
   (ctx, expr_ml)
 
@@ -735,10 +751,10 @@ and compile_dot_exp (ctx : Ctx.t) (exp_b : exp) (atom : atom) : Ctx.t * Ml.expr
    text  ->  [String.sub expr_b (to_int i) 1]
    list  ->  [List.nth expr_b (to_int i)] *)
 
-and compile_idx_exp (ctx : Ctx.t) (exp_b : exp) (exp_i : exp) : Ctx.t * Ml.expr
-    =
-  let ctx, expr_b_ml = compile_exp ctx exp_b in
-  let ctx, expr_i_ml = compile_exp ctx exp_i in
+and compile_idx_exp ~(tparams : string list) (ctx : Ctx.t) (exp_b : exp)
+    (exp_i : exp) : Ctx.t * Ml.expr =
+  let ctx, expr_b_ml = compile_exp ~tparams ctx exp_b in
+  let ctx, expr_i_ml = compile_exp ~tparams ctx exp_i in
   let expr_i_ml = Ml.AppE (Ml.VarE "Bigint.to_int_exn", [ expr_i_ml ]) in
   let expr_ml =
     match exp_b.note with
@@ -753,12 +769,12 @@ and compile_idx_exp (ctx : Ctx.t) (exp_b : exp) (exp_i : exp) : Ctx.t * Ml.expr
    text  ->  [String.sub expr_b (to_int i) (to_int n)]
    list  ->  [List.filteri (fun j _ -> i <= j && j < i+n) expr_b] *)
 
-and compile_slice_exp (ctx : Ctx.t) (exp_b : exp) (exp_i : exp) (exp_n : exp) :
-    Ctx.t * Ml.expr =
-  let ctx, expr_b_ml = compile_exp ctx exp_b in
-  let ctx, expr_i_ml = compile_exp ctx exp_i in
+and compile_slice_exp ~(tparams : string list) (ctx : Ctx.t) (exp_b : exp)
+    (exp_i : exp) (exp_n : exp) : Ctx.t * Ml.expr =
+  let ctx, expr_b_ml = compile_exp ~tparams ctx exp_b in
+  let ctx, expr_i_ml = compile_exp ~tparams ctx exp_i in
   let expr_i_ml = Ml.AppE (Ml.VarE "Bigint.to_int_exn", [ expr_i_ml ]) in
-  let ctx, expr_n_ml = compile_exp ctx exp_n in
+  let ctx, expr_n_ml = compile_exp ~tparams ctx exp_n in
   let expr_n_ml = Ml.AppE (Ml.VarE "Bigint.to_int_exn", [ expr_n_ml ]) in
   match exp_b.note with
   | TextT ->
@@ -797,10 +813,10 @@ and compile_slice_exp (ctx : Ctx.t) (exp_b : exp) (exp_i : exp) (exp_n : exp) :
    IdxP(p, i)    ->  [access(p, expr_b)[i]]
    SliceP(p,i,n) ->  [access(p, expr_b)[i..i+n-1]] *)
 
-and compile_access_path_idx (ctx : Ctx.t) (path : path) (exp_i : exp)
-    (expr_b_ml : Ml.expr) : Ctx.t * Ml.expr =
-  let ctx, expr_inner_ml = compile_access_path ctx path expr_b_ml in
-  let ctx, expr_i_ml = compile_exp ctx exp_i in
+and compile_access_path_idx ~(tparams : string list) (ctx : Ctx.t) (path : path)
+    (exp_i : exp) (expr_b_ml : Ml.expr) : Ctx.t * Ml.expr =
+  let ctx, expr_inner_ml = compile_access_path ~tparams ctx path expr_b_ml in
+  let ctx, expr_i_ml = compile_exp ~tparams ctx exp_i in
   let expr_i_ml = Ml.AppE (Ml.VarE "Bigint.to_int_exn", [ expr_i_ml ]) in
   let expr_ml =
     match path.note with
@@ -810,12 +826,13 @@ and compile_access_path_idx (ctx : Ctx.t) (path : path) (exp_i : exp)
   in
   (ctx, expr_ml)
 
-and compile_access_path_slice (ctx : Ctx.t) (path : path) (exp_i : exp)
-    (exp_n : exp) (expr_b_ml : Ml.expr) : Ctx.t * Ml.expr =
-  let ctx, expr_inner_ml = compile_access_path ctx path expr_b_ml in
-  let ctx, expr_i_ml = compile_exp ctx exp_i in
+and compile_access_path_slice ~(tparams : string list) (ctx : Ctx.t)
+    (path : path) (exp_i : exp) (exp_n : exp) (expr_b_ml : Ml.expr) :
+    Ctx.t * Ml.expr =
+  let ctx, expr_inner_ml = compile_access_path ~tparams ctx path expr_b_ml in
+  let ctx, expr_i_ml = compile_exp ~tparams ctx exp_i in
   let expr_i_ml = Ml.AppE (Ml.VarE "Bigint.to_int_exn", [ expr_i_ml ]) in
-  let ctx, expr_n_ml = compile_exp ctx exp_n in
+  let ctx, expr_n_ml = compile_exp ~tparams ctx exp_n in
   let expr_n_ml = Ml.AppE (Ml.VarE "Bigint.to_int_exn", [ expr_n_ml ]) in
   match path.note with
   | Il.TextT ->
@@ -844,18 +861,19 @@ and compile_access_path_slice (ctx : Ctx.t) (path : path) (exp_i : exp)
       in
       (ctx, expr_ml)
 
-and compile_access_path (ctx : Ctx.t) (path : path) (expr_b_ml : Ml.expr) :
-    Ctx.t * Ml.expr =
+and compile_access_path ~(tparams : string list) (ctx : Ctx.t) (path : path)
+    (expr_b_ml : Ml.expr) : Ctx.t * Ml.expr =
   match path.it with
   | RootP -> (ctx, expr_b_ml)
   | DotP (path, atom) ->
-      let ctx, expr_ml = compile_access_path ctx path expr_b_ml in
+      let ctx, expr_ml = compile_access_path ~tparams ctx path expr_b_ml in
       let field_ml = Names.field atom in
       let expr_ml = Ml.FieldE (expr_ml, field_ml) in
       (ctx, expr_ml)
-  | IdxP (path, exp_i) -> compile_access_path_idx ctx path exp_i expr_b_ml
+  | IdxP (path, exp_i) ->
+      compile_access_path_idx ~tparams ctx path exp_i expr_b_ml
   | SliceP (path, exp_i, exp_n) ->
-      compile_access_path_slice ctx path exp_i exp_n expr_b_ml
+      compile_access_path_slice ~tparams ctx path exp_i exp_n expr_b_ml
 
 (* Path write helper: [update(path, expr_b, expr_n)]
 
@@ -910,17 +928,18 @@ and compile_upd_idx_list (ctx : Ctx.t) (expr_ml : Ml.expr) (expr_i_ml : Ml.expr)
   in
   (ctx, expr_ml)
 
-and compile_upd_idx (ctx : Ctx.t) (path : path) (exp_i : exp)
-    (expr_b_ml : Ml.expr) (expr_n_ml : Ml.expr) : Ctx.t * Ml.expr =
-  let ctx, expr_ml = compile_access_path ctx path expr_b_ml in
-  let ctx, expr_i_ml = compile_exp ctx exp_i in
+and compile_upd_idx ~(tparams : string list) (ctx : Ctx.t) (path : path)
+    (exp_i : exp) (expr_b_ml : Ml.expr) (expr_n_ml : Ml.expr) : Ctx.t * Ml.expr
+    =
+  let ctx, expr_ml = compile_access_path ~tparams ctx path expr_b_ml in
+  let ctx, expr_i_ml = compile_exp ~tparams ctx exp_i in
   let expr_i_ml = Ml.AppE (Ml.VarE "Bigint.to_int_exn", [ expr_i_ml ]) in
   let ctx, expr_ml =
     match path.note with
     | Il.TextT -> compile_upd_idx_text ctx expr_ml expr_i_ml expr_n_ml
     | _ -> compile_upd_idx_list ctx expr_ml expr_i_ml expr_n_ml
   in
-  compile_upd ctx path expr_b_ml expr_ml
+  compile_upd ~tparams ctx path expr_b_ml expr_ml
 
 (* Slice update: [exp_b[i : n] <- exp_n]
 
@@ -977,13 +996,13 @@ and compile_upd_slice_list (ctx : Ctx.t) (expr_ml : Ml.expr)
   in
   (ctx, expr_ml)
 
-and compile_upd_slice (ctx : Ctx.t) (path : path) (exp_i : exp)
-    (exp_n_len : exp) (expr_b_ml : Ml.expr) (expr_n_ml : Ml.expr) :
-    Ctx.t * Ml.expr =
-  let ctx, expr_ml = compile_access_path ctx path expr_b_ml in
-  let ctx, expr_i_ml = compile_exp ctx exp_i in
+and compile_upd_slice ~(tparams : string list) (ctx : Ctx.t) (path : path)
+    (exp_i : exp) (exp_n_len : exp) (expr_b_ml : Ml.expr) (expr_n_ml : Ml.expr)
+    : Ctx.t * Ml.expr =
+  let ctx, expr_ml = compile_access_path ~tparams ctx path expr_b_ml in
+  let ctx, expr_i_ml = compile_exp ~tparams ctx exp_i in
   let expr_i_ml = Ml.AppE (Ml.VarE "Bigint.to_int_exn", [ expr_i_ml ]) in
-  let ctx, expr_n_len_ml = compile_exp ctx exp_n_len in
+  let ctx, expr_n_len_ml = compile_exp ~tparams ctx exp_n_len in
   let expr_n_len_ml =
     Ml.AppE (Ml.VarE "Bigint.to_int_exn", [ expr_n_len_ml ])
   in
@@ -993,61 +1012,66 @@ and compile_upd_slice (ctx : Ctx.t) (path : path) (exp_i : exp)
         compile_upd_slice_text ctx expr_ml expr_i_ml expr_n_len_ml expr_n_ml
     | _ -> compile_upd_slice_list ctx expr_ml expr_i_ml expr_n_len_ml expr_n_ml
   in
-  compile_upd ctx path expr_b_ml expr_ml
+  compile_upd ~tparams ctx path expr_b_ml expr_ml
 
 (* Record field update: [exp_b.atom <- exp_n]
 
    [update(p, expr_b, {access(p, expr_b) with field = expr_n})] *)
 
-and compile_upd_dot (ctx : Ctx.t) (path : path) (atom : atom)
-    (expr_b_ml : Ml.expr) (expr_n_ml : Ml.expr) : Ctx.t * Ml.expr =
-  let ctx, expr_ml = compile_access_path ctx path expr_b_ml in
+and compile_upd_dot ~(tparams : string list) (ctx : Ctx.t) (path : path)
+    (atom : atom) (expr_b_ml : Ml.expr) (expr_n_ml : Ml.expr) : Ctx.t * Ml.expr
+    =
+  let ctx, expr_ml = compile_access_path ~tparams ctx path expr_b_ml in
   let expr_ml =
     let field_ml = Names.field atom in
     Ml.RecordUpdateE (expr_ml, [ (field_ml, expr_n_ml) ])
   in
-  compile_upd ctx path expr_b_ml expr_ml
+  compile_upd ~tparams ctx path expr_b_ml expr_ml
 
-and compile_upd (ctx : Ctx.t) (path : path) (expr_b_ml : Ml.expr)
-    (expr_n_ml : Ml.expr) : Ctx.t * Ml.expr =
+and compile_upd ~(tparams : string list) (ctx : Ctx.t) (path : path)
+    (expr_b_ml : Ml.expr) (expr_n_ml : Ml.expr) : Ctx.t * Ml.expr =
   match path.it with
   | RootP -> (ctx, expr_n_ml)
-  | DotP (path, atom) -> compile_upd_dot ctx path atom expr_b_ml expr_n_ml
-  | IdxP (path, exp_i) -> compile_upd_idx ctx path exp_i expr_b_ml expr_n_ml
+  | DotP (path, atom) ->
+      compile_upd_dot ~tparams ctx path atom expr_b_ml expr_n_ml
+  | IdxP (path, exp_i) ->
+      compile_upd_idx ~tparams ctx path exp_i expr_b_ml expr_n_ml
   | SliceP (path, exp_i, exp_n_len) ->
-      compile_upd_slice ctx path exp_i exp_n_len expr_b_ml expr_n_ml
+      compile_upd_slice ~tparams ctx path exp_i exp_n_len expr_b_ml expr_n_ml
 
-and compile_upd_exp (ctx : Ctx.t) (exp_b : exp) (path : path) (exp_n : exp) :
-    Ctx.t * Ml.expr =
-  let ctx, expr_b_ml = compile_exp ctx exp_b in
-  let ctx, expr_n_ml = compile_exp ctx exp_n in
-  compile_upd ctx path expr_b_ml expr_n_ml
+and compile_upd_exp ~(tparams : string list) (ctx : Ctx.t) (exp_b : exp)
+    (path : path) (exp_n : exp) : Ctx.t * Ml.expr =
+  let ctx, expr_b_ml = compile_exp ~tparams ctx exp_b in
+  let ctx, expr_n_ml = compile_exp ~tparams ctx exp_n in
+  compile_upd ~tparams ctx path expr_b_ml expr_n_ml
 
 (* Call expressions: [id(args)]
 
    [f_id expr_args] *)
 
-and compile_arg (ctx : Ctx.t) (arg : arg) : Ctx.t * Ml.expr =
+and compile_arg ~(tparams : string list) (ctx : Ctx.t) (arg : arg) :
+    Ctx.t * Ml.expr =
   match arg.it with
   | ExpA exp ->
-      let ctx, expr_ml = compile_exp ctx exp in
+      let ctx, expr_ml = compile_exp ~tparams ctx exp in
       (ctx, expr_ml)
   | DefA id ->
       let id_ml = Names.func id in
       let expr_ml = Ml.VarE id_ml in
       (ctx, expr_ml)
 
-and compile_args (ctx : Ctx.t) (args : arg list) : Ctx.t * Ml.expr list =
+and compile_args ~(tparams : string list) (ctx : Ctx.t) (args : arg list) :
+    Ctx.t * Ml.expr list =
   List.fold_left
     (fun (ctx, exprs_ml) arg ->
-      let ctx, expr_ml = compile_arg ctx arg in
+      let ctx, expr_ml = compile_arg ~tparams ctx arg in
       (ctx, exprs_ml @ [ expr_ml ]))
     (ctx, []) args
 
-and compile_call_exp (ctx : Ctx.t) (id : id) (_targs : targ list)
-    (args : arg list) : Ctx.t * Ml.expr =
+and compile_call_exp ~(tparams : string list) (ctx : Ctx.t) (id : id)
+    (_targs : targ list) (args : arg list) : Ctx.t * Ml.expr =
   let id_func_ml = Names.func id in
-  let ctx, exprs_arg_ml = compile_args ctx args in
+  let ctx, exprs_arg_ml = compile_args ~tparams ctx args in
   let expr_ml = Ml.AppE (Ml.VarE id_func_ml, exprs_arg_ml) in
   (ctx, expr_ml)
 
@@ -1059,8 +1083,8 @@ and compile_call_exp (ctx : Ctx.t) (id : id) (_targs : targ list)
    multi-var   ->  [Option.fold_N_1 (fun x .. -> expr) x? y? ..]
                    (fuses [Option.map f (Option.combineN x? y? ..)]) *)
 
-and compile_iter_exp_opt (ctx : Ctx.t) (exp : exp) (vars : var list) :
-    Ctx.t * Ml.expr =
+and compile_iter_exp_opt ~(tparams : string list) (ctx : Ctx.t) (exp : exp)
+    (vars : var list) : Ctx.t * Ml.expr =
   (* Fetch iteration target variables *)
   let ids_opt_ml =
     List.map
@@ -1072,7 +1096,7 @@ and compile_iter_exp_opt (ctx : Ctx.t) (exp : exp) (vars : var list) :
   let ctx, ids_stub_ml = Stub.OCaml.iterator ~prefix:"elem_opt__" ctx vars in
   let n = List.length ids_opt_ml in
   (* Compile body expression *)
-  let ctx, expr_body_ml = compile_exp ctx exp in
+  let ctx, expr_body_ml = compile_exp ~tparams ctx exp in
   let ctx, expr_ml =
     if n >= 2 then
       (* Fuse [Option.map f (combineN o0 ..)] into [Option.fold_N_1 f o0 ..] *)
@@ -1108,8 +1132,8 @@ and compile_iter_exp_opt (ctx : Ctx.t) (exp : exp) (vars : var list) :
    multi-var   ->  [List.fold_left_N_1 (fun x .. -> expr) x* y* ..]
                    (fuses [List.map f (List.combineN x* y* ..)]) *)
 
-and compile_iter_exp_list (ctx : Ctx.t) (exp : exp) (vars : var list) :
-    Ctx.t * Ml.expr =
+and compile_iter_exp_list ~(tparams : string list) (ctx : Ctx.t) (exp : exp)
+    (vars : var list) : Ctx.t * Ml.expr =
   (* Save outer context for promotion *)
   let ctx_outer = ctx in
   (* Fetch iteration target variables *)
@@ -1122,7 +1146,7 @@ and compile_iter_exp_list (ctx : Ctx.t) (exp : exp) (vars : var list) :
   let ctx, ids_stub_ml = Stub.OCaml.iterator ~prefix:"elem_list__" ctx vars in
   let n = List.length ids_list_ml in
   (* Compile body expression *)
-  let ctx, expr_body_ml = compile_exp ctx exp in
+  let ctx, expr_body_ml = compile_exp ~tparams ctx exp in
   let ctx, expr_ml =
     if n >= 2 then
       (* Fuse [List.map f (combineN l0 ..)] into a single [fold_left_N_1 f l0 ..] *)
@@ -1152,8 +1176,8 @@ and compile_iter_exp_list (ctx : Ctx.t) (exp : exp) (vars : var list) :
   let ctx = Ctx.promote_preamble ctx ctx_outer in
   (ctx, expr_ml)
 
-and compile_iter_exp (ctx : Ctx.t) (typ_exp : typ) (exp : exp)
-    (iterexp : iterexp) : Ctx.t * Ml.expr =
+and compile_iter_exp ~(tparams : string list) (ctx : Ctx.t) (typ_exp : typ)
+    (exp : exp) (iterexp : iterexp) : Ctx.t * Ml.expr =
   match
     Common.is_iter_var_exp (Il.IterE (exp, iterexp) $$ (typ_exp.at, typ_exp.it))
   with
@@ -1164,5 +1188,5 @@ and compile_iter_exp (ctx : Ctx.t) (typ_exp : typ) (exp : exp)
   | None -> (
       let iter, vars = iterexp in
       match iter with
-      | Opt -> compile_iter_exp_opt ctx exp vars
-      | List -> compile_iter_exp_list ctx exp vars)
+      | Opt -> compile_iter_exp_opt ~tparams ctx exp vars
+      | List -> compile_iter_exp_list ~tparams ctx exp vars)

--- a/p4spec/lib/pass/compile/gen/exp.ml
+++ b/p4spec/lib/pass/compile/gen/exp.ml
@@ -1068,12 +1068,27 @@ and compile_args ~(tparams : string list) (ctx : Ctx.t) (args : arg list) :
       (ctx, exprs_ml @ [ expr_ml ]))
     (ctx, []) args
 
+(* If [id] is still generic (found in [poly_sigs]), forward the caller's own
+   witnesses for its targs, resolved against the caller's [tparams]. Mangled
+   ground-specialized names are never in [poly_sigs], so this is a no-op for
+   the entire monomorphized path — only symbolic calls hit the [Some] arm. *)
 and compile_call_exp ~(tparams : string list) (ctx : Ctx.t) (id : id)
-    (_targs : targ list) (args : arg list) : Ctx.t * Ml.expr =
+    (targs : targ list) (args : arg list) : Ctx.t * Ml.expr =
   let id_func_ml = Names.func id in
   let ctx, exprs_arg_ml = compile_args ~tparams ctx args in
-  let expr_ml = Ml.AppE (Ml.VarE id_func_ml, exprs_arg_ml) in
-  (ctx, expr_ml)
+  match Ctx.find_poly_tparams ctx id.it with
+  | Some callee_tparams when List.length callee_tparams = List.length targs ->
+      let exprs_witness_ml =
+        List.concat_map
+          (fun targ ->
+            [
+              Interface.resolve_marshal tparams targ;
+              Interface.resolve_unmarshal tparams targ;
+            ])
+          targs
+      in
+      (ctx, Ml.AppE (Ml.VarE id_func_ml, exprs_witness_ml @ exprs_arg_ml))
+  | _ -> (ctx, Ml.AppE (Ml.VarE id_func_ml, exprs_arg_ml))
 
 (* Iterator expressions *)
 

--- a/p4spec/lib/pass/compile/gen/exp.ml
+++ b/p4spec/lib/pass/compile/gen/exp.ml
@@ -1068,10 +1068,8 @@ and compile_args ~(tparams : string list) (ctx : Ctx.t) (args : arg list) :
       (ctx, exprs_ml @ [ expr_ml ]))
     (ctx, []) args
 
-(* If [id] is still generic (found in [poly_sigs]), forward the caller's own
-   witnesses for its targs, resolved against the caller's [tparams]. Mangled
-   ground-specialized names are never in [poly_sigs], so this is a no-op for
-   the entire monomorphized path — only symbolic calls hit the [Some] arm. *)
+(* Forward the caller's witnesses if [id] is still generic — a no-op for
+   mangled ground names, which are never in [poly_sigs]. *)
 and compile_call_exp ~(tparams : string list) (ctx : Ctx.t) (id : id)
     (targs : targ list) (args : arg list) : Ctx.t * Ml.expr =
   let id_func_ml = Names.func id in

--- a/p4spec/lib/pass/compile/gen/func.ml
+++ b/p4spec/lib/pass/compile/gen/func.ml
@@ -130,6 +130,102 @@ let compile_extern_func (ctx : Ctx.t) (reverse_dispatch : reverse_dispatch)
   in
   (ctx, [ funcdef_ml ])
 
+(* Witness parameters for a generic extern/builtin bridge: for each of the
+   function's own tparams, a marshal/unmarshal pair the caller must supply. *)
+let compile_witness_params (tparams_ml : string list) : Ml.param list =
+  List.concat_map
+    (fun tv ->
+      [
+        ( Interface.witness_marshal_name tv,
+          Some (Ml.NameT (Printf.sprintf "('%s -> Value.t)" tv)) );
+        ( Interface.witness_unmarshal_name tv,
+          Some (Ml.NameT (Printf.sprintf "(Value.t -> '%s)" tv)) );
+      ])
+    tparams_ml
+
+let compile_targ_reify (tvars : string list) : Ml.expr =
+  Ml.ListE
+    (List.map
+       (fun tv -> Ml.AppE (Ml.LitE "make_typ_var_", [ Ml.StrE tv; Ml.ListE [] ]))
+       tvars)
+
+(* [resolve_expr] may itself be a lambda (List/Opt witnesses build one) —
+   bind it to a name before applying, since Ml's printer never parenthesizes
+   an [AppE]'s function-position expression. *)
+let apply_witness (tag : string) (resolve_expr : Ml.expr) (arg_expr : Ml.expr)
+    : Ml.expr =
+  let w_id = "w__" ^ tag in
+  Ml.LetE (Ml.VarP w_id, resolve_expr, Ml.AppE (Ml.VarE w_id, [ arg_expr ]))
+
+(* Extern functions, still generic: forward the enclosing tparams' witnesses
+   to marshal/unmarshal at the boundary, and reify the tparams themselves as
+   the call's runtime targs (they're the callee's own, still unresolved). *)
+
+let compile_extern_func_generic (ctx : Ctx.t) (id : id)
+    (tparams : Il.tparam list) (params : param list) (typ_ret : typ) :
+    Ctx.t * Ml.funcdef list =
+  let id_ml = Names.func id in
+  let tvars = List.map (fun (tp : Il.tparam) -> tp.it) tparams in
+  let tparams_ml = List.map Names.tvar tparams in
+  let typ_ret_ml = Type.compile_typ ~tparams:tvars typ_ret in
+  let typs_param =
+    List.filter_map
+      (fun (param : param) ->
+        match param.it with ExpP (typ, _) -> Some typ | _ -> None)
+      params
+  in
+  let n = List.length typs_param in
+  let params_ml =
+    compile_witness_params tparams_ml
+    @ List.mapi
+        (fun i typ ->
+          ("p__" ^ string_of_int i, Some (Type.compile_typ ~tparams:tvars typ)))
+        typs_param
+  in
+  let vars_marshal_ml, exprs_marshal_ml =
+    List.mapi
+      (fun i typ ->
+        ( "v__" ^ string_of_int i,
+          apply_witness (string_of_int i) (Interface.resolve_marshal tvars typ)
+            (Ml.VarE ("p__" ^ string_of_int i)) ))
+      typs_param
+    |> List.split
+  in
+  let exprs_arg_ml =
+    Ml.ListE (List.init n (fun i -> Ml.VarE ("v__" ^ string_of_int i)))
+  in
+  let exprs_targ_ml = compile_targ_reify tvars in
+  let expr_call_ml =
+    Ml.AppE
+      ( Common.extern_field "eval_extern_func",
+        [ Ml.StrE id.it; exprs_targ_ml; exprs_arg_ml ] )
+  in
+  let expr_result_ml =
+    Ml.MatchE
+      ( expr_call_ml,
+        [
+          ( Ml.VariantP (`Mono ("Run.Pass", [ Ml.VarP "v_out__" ])),
+            apply_witness "ret__"
+              (Interface.resolve_unmarshal tvars typ_ret)
+              (Ml.VarE "v_out__") );
+          ( Ml.VariantP (`Mono ("Run.Fail", [ Ml.WildP; Ml.VarP "msg__" ])),
+            Ml.AppE
+              ( Ml.LitE "raise",
+                [ Ml.AppE (Ml.LitE "Unmatch", [ Ml.VarE "msg__" ]) ] ) );
+        ] )
+  in
+  let expr_body_ml =
+    List.fold_right
+      (fun (var_marshal_ml, expr_marshal_ml) expr_body_ml ->
+        Ml.LetE (Ml.VarP var_marshal_ml, expr_marshal_ml, expr_body_ml))
+      (List.combine vars_marshal_ml exprs_marshal_ml)
+      expr_result_ml
+  in
+  let funcdef_ml =
+    (id_ml, tparams_ml, params_ml, Some typ_ret_ml, Common.deref_ctx expr_body_ml)
+  in
+  (ctx, [ funcdef_ml ])
+
 (* Builtin functions *)
 
 let compile_builtin_func (ctx : Ctx.t) (reverse_dispatch : reverse_dispatch)
@@ -206,23 +302,107 @@ let compile_builtin_func (ctx : Ctx.t) (reverse_dispatch : reverse_dispatch)
   in
   (ctx, [ funcdef_ml ])
 
+(* Builtin functions, still generic — mirrors [compile_extern_func_generic]
+   but for [call_builtin]'s calling convention. *)
+
+let compile_builtin_func_generic (ctx : Ctx.t) (id : id)
+    (tparams : Il.tparam list) (params : param list) (typ_ret : typ) :
+    Ctx.t * Ml.funcdef list =
+  let id_ml = Names.func id in
+  let tvars = List.map (fun (tp : Il.tparam) -> tp.it) tparams in
+  let tparams_ml = List.map Names.tvar tparams in
+  let typ_ret_ml = Type.compile_typ ~tparams:tvars typ_ret in
+  let typs_param =
+    List.filter_map
+      (fun (param : param) ->
+        match param.it with ExpP (typ, _) -> Some typ | _ -> None)
+      params
+  in
+  let n = List.length typs_param in
+  let params_ml =
+    compile_witness_params tparams_ml
+    @ List.mapi
+        (fun i typ ->
+          ("p__" ^ string_of_int i, Some (Type.compile_typ ~tparams:tvars typ)))
+        typs_param
+  in
+  let vars_marshal_ml, exprs_marshal_ml =
+    List.mapi
+      (fun i typ ->
+        ( "v__" ^ string_of_int i,
+          apply_witness (string_of_int i) (Interface.resolve_marshal tvars typ)
+            (Ml.VarE ("p__" ^ string_of_int i)) ))
+      typs_param
+    |> List.split
+  in
+  let exprs_arg_ml =
+    Ml.ListE (List.init n (fun i -> Ml.VarE ("v__" ^ string_of_int i)))
+  in
+  let exprs_targ_ml = compile_targ_reify tvars in
+  let name_orig_lit_ml =
+    Ml.LitE (Printf.sprintf "(\"%s\" $ no_region)" (String.escaped id.it))
+  in
+  let expr_call_ml =
+    Ml.AppE
+      ( Common.iface_field "call_builtin",
+        [ Ml.LitE "(fun _ -> ())"; name_orig_lit_ml; exprs_targ_ml; exprs_arg_ml ]
+      )
+  in
+  let expr_try_ml =
+    Ml.TryE
+      ( expr_call_ml,
+        [
+          ( Ml.VariantP
+              (`Mono ("Util.Error.BuiltinError", [ Ml.WildP; Ml.VarP "msg__" ])),
+            Ml.AppE
+              ( Ml.LitE "raise",
+                [ Ml.AppE (Ml.LitE "Unmatch", [ Ml.VarE "msg__" ]) ] ) );
+        ] )
+  in
+  let expr_result_ml =
+    Ml.LetE
+      ( Ml.VarP "v_out__",
+        expr_try_ml,
+        apply_witness "ret__"
+          (Interface.resolve_unmarshal tvars typ_ret)
+          (Ml.VarE "v_out__") )
+  in
+  let expr_body_ml =
+    List.fold_right
+      (fun (var_marshal_ml, expr_marshal_ml) expr_body_ml ->
+        Ml.LetE (Ml.VarP var_marshal_ml, expr_marshal_ml, expr_body_ml))
+      (List.combine vars_marshal_ml exprs_marshal_ml)
+      expr_result_ml
+  in
+  let funcdef_ml =
+    (id_ml, tparams_ml, params_ml, Some typ_ret_ml, Common.deref_ctx expr_body_ml)
+  in
+  (ctx, [ funcdef_ml ])
+
 (* Table functions *)
 
 let rec compile_table_func (ctx : Ctx.t) (id : id) (params : param list)
     (typ_ret : typ) (tablerows : tablerow list) : Ctx.t * Ml.funcdef list =
   let block = List.concat_map (fun (_, _, block_row) -> block_row) tablerows in
-  compile_defined_func_mono ~tparams:[] ctx id params typ_ret block None
+  compile_defined_func_mono ~tparams:[] ~tparams_ml:[] ctx id params typ_ret
+    block None
 
 (* Defined functions *)
 
-and compile_defined_func_mono ~(tparams : string list) (ctx : Ctx.t) (id : id)
-    (params : param list) (typ_ret : typ) (block_main : block)
-    (elseblock_opt : block option) : Ctx.t * Ml.funcdef list =
+(* A generic function forwards its own witnesses to sibling/boundary calls
+   inside its body (see [compile_call_exp]), so its own signature — and its
+   internal main__/else__/dispatcher helpers — must accept them too. *)
+and compile_defined_func_mono ~(tparams : string list)
+    ~(tparams_ml : string list) (ctx : Ctx.t) (id : id) (params : param list)
+    (typ_ret : typ) (block_main : block) (elseblock_opt : block option) :
+    Ctx.t * Ml.funcdef list =
   let id_ml = Names.func id in
   let typ_ret_ml = Type.compile_typ ~tparams typ_ret in
   let ctx_outer = ctx in
   (* Compile parameters *)
+  let witness_params_ml = compile_witness_params tparams_ml in
   let ctx, params_ml, chain = compile_params ~tparams ctx params in
+  let params_ml = witness_params_ml @ params_ml in
   let ids_param_ml = List.map (fun (id_param_ml, _) -> id_param_ml) params_ml in
   (* Compile main block *)
   let id_main_ml = "main__" ^ id_ml in
@@ -274,15 +454,6 @@ and compile_defined_func_mono ~(tparams : string list) (ctx : Ctx.t) (id : id)
   in
   (ctx, funcdefs_ml)
 
-(* Only extern/builtin calls cross the Value.t boundary — a plain
-   self/mutual call with a bare tparam is ordinary polymorphic recursion. *)
-let block_crosses_boundary_with (scope : Mono.StringSet.t)
-    (extern_builtin_names : Mono.StringSet.t) (block : block) : bool =
-  Mono.Collect.collect_all_calls_in_block block
-  |> List.exists (fun (callee, targs) ->
-         Mono.StringSet.mem callee extern_builtin_names
-         && List.exists (Mono.typ_mentions_any scope) targs)
-
 (* DefP (callback) params have no Ml.typ, so the generic-tparams printer
    path can't build an explicit forall signature for them. *)
 let has_callback_param (params : param list) : bool =
@@ -297,52 +468,55 @@ let compile_defined_func (ctx : Ctx.t) (definedfunc : definedfunc) :
     definedfunc
   in
   if tparams = [] then
-    compile_defined_func_mono ~tparams:[] ctx id params typ_ret block_main
-      elseblock_opt
+    compile_defined_func_mono ~tparams:[] ~tparams_ml:[] ctx id params
+      typ_ret block_main elseblock_opt
+  (* Unsupported-but-preexisting (e.g. $match_overloaded_named<V>): warn and
+     skip, same as pre-Task-4 behavior, instead of failing the build. *)
+  else if has_callback_param params then (
+    Util.Error.warn_compile id.at
+      (Format.asprintf
+         "generic function %s has a callback parameter — not yet supported \
+          for generic compilation, skipping"
+         id.it);
+    (ctx, []))
   else
     let tparams_str = List.map (fun (tp : Il.tparam) -> tp.it) tparams in
-    let scope = Mono.StringSet.of_list tparams_str in
-    let all_blocks = block_main @ Option.value ~default:[] elseblock_opt in
-    (* Unsupported-but-preexisting (e.g. $match_overloaded_named<V>): warn
-       and skip, same as pre-Task-4 behavior, instead of failing the build. *)
-    if has_callback_param params then (
-      Util.Error.warn_compile id.at
-        (Format.asprintf
-           "generic function %s has a callback parameter — not yet \
-            supported for generic compilation, skipping"
-           id.it);
-      (ctx, []))
-    else if
-      block_crosses_boundary_with scope
-        (Ctx.find_extern_builtin_names ctx)
-        all_blocks
-    then
-      Error.error id.at
-        (Format.asprintf
-           "generic function %s crosses the Value.t boundary via its own \
-            type parameter — not yet supported (see Task 5)"
-           id.it)
-    else
-      let tparams_ml = List.map Names.tvar tparams in
-      let ctx, funcdefs =
-        compile_defined_func_mono ~tparams:tparams_str ctx id params typ_ret
-          block_main elseblock_opt
-      in
-      ( ctx,
-        List.map
-          (fun (name, _tparams, params, ret, body) ->
-            (name, tparams_ml, params, ret, body))
-          funcdefs )
+    let tparams_ml = List.map Names.tvar tparams in
+    let ctx, funcdefs =
+      compile_defined_func_mono ~tparams:tparams_str ~tparams_ml ctx id params
+        typ_ret block_main elseblock_opt
+    in
+    ( ctx,
+      List.map
+        (fun (name, _tparams, params, ret, body) ->
+          (name, tparams_ml, params, ret, body))
+        funcdefs )
 
 (* Defs *)
+
+(* Pre-existing generic externs/builtins with an unsupported boundary shape
+   (e.g. a tuple-of-lists return) warn and skip, not fail the whole build. *)
+let try_compile_generic_bridge (ctx : Ctx.t) (id : id)
+    (f : unit -> Ctx.t * Ml.funcdef list) : Ctx.t * Ml.funcdef list =
+  try f ()
+  with Failure msg ->
+    Util.Error.warn_compile id.at
+      (Format.asprintf "generic extern/builtin %s: %s — skipping" id.it msg);
+    (ctx, [])
 
 let compile_def (ctx : Ctx.t) (reverse_dispatch : reverse_dispatch)
     (def : def) : Ctx.t * Ml.funcdef list =
   match def.it with
   | ExternDecD (id, [], params, typ_ret, _) ->
       compile_extern_func ctx reverse_dispatch id params typ_ret
+  | ExternDecD (id, tparams, params, typ_ret, _) ->
+      try_compile_generic_bridge ctx id (fun () ->
+          compile_extern_func_generic ctx id tparams params typ_ret)
   | BuiltinDecD (id, [], params, typ_ret, _) ->
       compile_builtin_func ctx reverse_dispatch id params typ_ret
+  | BuiltinDecD (id, tparams, params, typ_ret, _) ->
+      try_compile_generic_bridge ctx id (fun () ->
+          compile_builtin_func_generic ctx id tparams params typ_ret)
   | TableDecD (id, params, typ_ret, tablerows, _) ->
       compile_table_func ctx id params typ_ret tablerows
   | FuncDecD definedfunc -> compile_defined_func ctx definedfunc

--- a/p4spec/lib/pass/compile/gen/func.ml
+++ b/p4spec/lib/pass/compile/gen/func.ml
@@ -124,7 +124,7 @@ let compile_extern_func (ctx : Ctx.t) (reverse_dispatch : reverse_dispatch)
       expr_result_ml
   in
   let funcdef_ml =
-    (id_ml, params_ml, Some typ_ret_ml, Common.deref_ctx expr_body_ml)
+    (id_ml, [], params_ml, Some typ_ret_ml, Common.deref_ctx expr_body_ml)
   in
   (ctx, [ funcdef_ml ])
 
@@ -200,7 +200,7 @@ let compile_builtin_func (ctx : Ctx.t) (reverse_dispatch : reverse_dispatch)
       expr_result_ml
   in
   let funcdef_ml =
-    (id_ml, params_ml, Some typ_ret_ml, Common.deref_ctx expr_body_ml)
+    (id_ml, [], params_ml, Some typ_ret_ml, Common.deref_ctx expr_body_ml)
   in
   (ctx, [ funcdef_ml ])
 
@@ -227,7 +227,7 @@ and compile_defined_func_mono (ctx : Ctx.t) (id : id) (params : param list)
   let ctx, funcdef_main_ml =
     let ctx, expr_block_ml = Instr.compile_block ctx block_main in
     let expr_ml = Chain.apply chain expr_block_ml in
-    let funcdef_main_ml = (id_main_ml, params_ml, Some typ_ret_ml, expr_ml) in
+    let funcdef_main_ml = (id_main_ml, [], params_ml, Some typ_ret_ml, expr_ml) in
     (ctx, funcdef_main_ml)
   in
   (* Compile else block *)
@@ -238,7 +238,7 @@ and compile_defined_func_mono (ctx : Ctx.t) (id : id) (params : param list)
         let ctx, expr_else_ml = Instr.compile_block ctx elseblock in
         let expr_ml = Chain.apply chain expr_else_ml in
         let funcdef_else_ml =
-          (id_else_ml, params_ml, Some typ_ret_ml, expr_ml)
+          (id_else_ml, [], params_ml, Some typ_ret_ml, expr_ml)
         in
         (ctx, Some funcdef_else_ml)
     | None -> (ctx, None)
@@ -261,7 +261,7 @@ and compile_defined_func_mono (ctx : Ctx.t) (id : id) (params : param list)
     | None -> Ml.AppE (Ml.VarE id_main_ml, exprs_param_ml)
   in
   let funcdef_dispatcher_ml =
-    (id_ml, params_ml, Some typ_ret_ml, dispatch_ml)
+    (id_ml, [], params_ml, Some typ_ret_ml, dispatch_ml)
   in
   (* Collect function definitions *)
   let funcdefs_ml =

--- a/p4spec/lib/pass/compile/gen/func.ml
+++ b/p4spec/lib/pass/compile/gen/func.ml
@@ -149,17 +149,15 @@ let compile_targ_reify (tvars : string list) : Ml.expr =
        (fun tv -> Ml.AppE (Ml.LitE "make_typ_var_", [ Ml.StrE tv; Ml.ListE [] ]))
        tvars)
 
-(* [resolve_expr] may itself be a lambda (List/Opt witnesses build one) —
-   bind it to a name before applying, since Ml's printer never parenthesizes
-   an [AppE]'s function-position expression. *)
+(* Bind [resolve_expr] before applying — it may be a bare lambda, and Ml's
+   printer never parenthesizes an [AppE]'s function-position expression. *)
 let apply_witness (tag : string) (resolve_expr : Ml.expr) (arg_expr : Ml.expr)
     : Ml.expr =
   let w_id = "w__" ^ tag in
   Ml.LetE (Ml.VarP w_id, resolve_expr, Ml.AppE (Ml.VarE w_id, [ arg_expr ]))
 
-(* Extern functions, still generic: forward the enclosing tparams' witnesses
-   to marshal/unmarshal at the boundary, and reify the tparams themselves as
-   the call's runtime targs (they're the callee's own, still unresolved). *)
+(* Generic extern: forward tparam witnesses to marshal/unmarshal at the
+   boundary, and reify the tparams as the call's own runtime targs. *)
 
 let compile_extern_func_generic (ctx : Ctx.t) (id : id)
     (tparams : Il.tparam list) (params : param list) (typ_ret : typ) :
@@ -389,9 +387,8 @@ let rec compile_table_func (ctx : Ctx.t) (id : id) (params : param list)
 
 (* Defined functions *)
 
-(* A generic function forwards its own witnesses to sibling/boundary calls
-   inside its body (see [compile_call_exp]), so its own signature — and its
-   internal main__/else__/dispatcher helpers — must accept them too. *)
+(* A generic function's body forwards its own witnesses to sibling/boundary
+   calls, so its main__/else__/dispatcher helpers must accept them too. *)
 and compile_defined_func_mono ~(tparams : string list)
     ~(tparams_ml : string list) (ctx : Ctx.t) (id : id) (params : param list)
     (typ_ret : typ) (block_main : block) (elseblock_opt : block option) :

--- a/p4spec/lib/pass/compile/gen/func.ml
+++ b/p4spec/lib/pass/compile/gen/func.ml
@@ -274,20 +274,81 @@ and compile_defined_func_mono ~(tparams : string list) (ctx : Ctx.t) (id : id)
   in
   (ctx, funcdefs_ml)
 
-let compile_defined_func (ctx : Ctx.t) (definedfunc : definedfunc) :
+(* Only extern/builtin calls cross the Value.t boundary — a plain
+   self/mutual call with a bare tparam is ordinary polymorphic recursion. *)
+let block_crosses_boundary_with (scope : Mono.StringSet.t)
+    (extern_builtin_names : Mono.StringSet.t) (block : block) : bool =
+  Mono.Collect.collect_all_calls_in_block block
+  |> List.exists (fun (callee, targs) ->
+         Mono.StringSet.mem callee extern_builtin_names
+         && List.exists (Mono.typ_mentions_any scope) targs)
+
+(* DefP (callback) params have no Ml.typ, so the generic-tparams printer
+   path can't build an explicit forall signature for them. *)
+let has_callback_param (params : param list) : bool =
+  List.exists
+    (fun (param : param) ->
+      match param.it with DefP _ -> true | ExpP _ -> false)
+    params
+
+let compile_defined_func (ctx : Ctx.t)
+    (extern_builtin_names : Mono.StringSet.t) (definedfunc : definedfunc) :
     Ctx.t * Ml.funcdef list =
   let id, tparams, params, typ_ret, block_main, elseblock_opt, _ =
     definedfunc
   in
-  if tparams <> [] then (ctx, [])
-  else
+  if tparams = [] then
     compile_defined_func_mono ~tparams:[] ctx id params typ_ret block_main
       elseblock_opt
+  else
+    let tparams_str = List.map (fun (tp : Il.tparam) -> tp.it) tparams in
+    let scope = Mono.StringSet.of_list tparams_str in
+    let all_blocks = block_main @ Option.value ~default:[] elseblock_opt in
+    (* Unsupported-but-preexisting (e.g. $match_overloaded_named<V>): warn
+       and skip, same as pre-Task-4 behavior, instead of failing the build. *)
+    if has_callback_param params then (
+      Util.Error.warn_compile id.at
+        (Format.asprintf
+           "generic function %s has a callback parameter — not yet \
+            supported for generic compilation, skipping"
+           id.it);
+      (ctx, []))
+    else if block_crosses_boundary_with scope extern_builtin_names all_blocks
+    then
+      Error.error id.at
+        (Format.asprintf
+           "generic function %s crosses the Value.t boundary via its own \
+            type parameter — not yet supported (see Task 5)"
+           id.it)
+    else
+      let tparams_ml = List.map Names.tvar tparams in
+      let ctx, funcdefs =
+        compile_defined_func_mono ~tparams:tparams_str ctx id params typ_ret
+          block_main elseblock_opt
+      in
+      ( ctx,
+        List.map
+          (fun (name, _tparams, params, ret, body) ->
+            (name, tparams_ml, params, ret, body))
+          funcdefs )
 
 (* Defs *)
 
-let compile_def (ctx : Ctx.t) (reverse_dispatch : reverse_dispatch) (def : def)
-    : Ctx.t * Ml.funcdef list =
+(* Names of extern/builtin decls — the call targets that matter to
+   [block_crosses_boundary_with]. *)
+let collect_extern_builtin_names (defs : def list) : Mono.StringSet.t =
+  List.filter_map
+    (fun (def : def) ->
+      match def.it with
+      | ExternDecD (id, _, _, _, _) | BuiltinDecD (id, _, _, _, _) ->
+          Some id.it
+      | _ -> None)
+    defs
+  |> Mono.StringSet.of_list
+
+let compile_def (ctx : Ctx.t) (reverse_dispatch : reverse_dispatch)
+    (extern_builtin_names : Mono.StringSet.t) (def : def) :
+    Ctx.t * Ml.funcdef list =
   match def.it with
   | ExternDecD (id, [], params, typ_ret, _) ->
       compile_extern_func ctx reverse_dispatch id params typ_ret
@@ -295,14 +356,18 @@ let compile_def (ctx : Ctx.t) (reverse_dispatch : reverse_dispatch) (def : def)
       compile_builtin_func ctx reverse_dispatch id params typ_ret
   | TableDecD (id, params, typ_ret, tablerows, _) ->
       compile_table_func ctx id params typ_ret tablerows
-  | FuncDecD definedfunc -> compile_defined_func ctx definedfunc
+  | FuncDecD definedfunc ->
+      compile_defined_func ctx extern_builtin_names definedfunc
   | _ -> (ctx, [])
 
 let compile_defs (ctx : Ctx.t) (defs : def list)
     (reverse_dispatch : reverse_dispatch) : Ctx.t * Ml.funcdef list =
+  let extern_builtin_names = collect_extern_builtin_names defs in
   List.fold_left
     (fun (ctx, funcdefs_ml_acc) def ->
-      let ctx, funcdefs_ml = compile_def ctx reverse_dispatch def in
+      let ctx, funcdefs_ml =
+        compile_def ctx reverse_dispatch extern_builtin_names def
+      in
       (ctx, funcdefs_ml_acc @ funcdefs_ml))
     (ctx, []) defs
 

--- a/p4spec/lib/pass/compile/gen/func.ml
+++ b/p4spec/lib/pass/compile/gen/func.ml
@@ -291,8 +291,7 @@ let has_callback_param (params : param list) : bool =
       match param.it with DefP _ -> true | ExpP _ -> false)
     params
 
-let compile_defined_func (ctx : Ctx.t)
-    (extern_builtin_names : Mono.StringSet.t) (definedfunc : definedfunc) :
+let compile_defined_func (ctx : Ctx.t) (definedfunc : definedfunc) :
     Ctx.t * Ml.funcdef list =
   let id, tparams, params, typ_ret, block_main, elseblock_opt, _ =
     definedfunc
@@ -313,7 +312,10 @@ let compile_defined_func (ctx : Ctx.t)
             supported for generic compilation, skipping"
            id.it);
       (ctx, []))
-    else if block_crosses_boundary_with scope extern_builtin_names all_blocks
+    else if
+      block_crosses_boundary_with scope
+        (Ctx.find_extern_builtin_names ctx)
+        all_blocks
     then
       Error.error id.at
         (Format.asprintf
@@ -334,21 +336,8 @@ let compile_defined_func (ctx : Ctx.t)
 
 (* Defs *)
 
-(* Names of extern/builtin decls — the call targets that matter to
-   [block_crosses_boundary_with]. *)
-let collect_extern_builtin_names (defs : def list) : Mono.StringSet.t =
-  List.filter_map
-    (fun (def : def) ->
-      match def.it with
-      | ExternDecD (id, _, _, _, _) | BuiltinDecD (id, _, _, _, _) ->
-          Some id.it
-      | _ -> None)
-    defs
-  |> Mono.StringSet.of_list
-
 let compile_def (ctx : Ctx.t) (reverse_dispatch : reverse_dispatch)
-    (extern_builtin_names : Mono.StringSet.t) (def : def) :
-    Ctx.t * Ml.funcdef list =
+    (def : def) : Ctx.t * Ml.funcdef list =
   match def.it with
   | ExternDecD (id, [], params, typ_ret, _) ->
       compile_extern_func ctx reverse_dispatch id params typ_ret
@@ -356,18 +345,14 @@ let compile_def (ctx : Ctx.t) (reverse_dispatch : reverse_dispatch)
       compile_builtin_func ctx reverse_dispatch id params typ_ret
   | TableDecD (id, params, typ_ret, tablerows, _) ->
       compile_table_func ctx id params typ_ret tablerows
-  | FuncDecD definedfunc ->
-      compile_defined_func ctx extern_builtin_names definedfunc
+  | FuncDecD definedfunc -> compile_defined_func ctx definedfunc
   | _ -> (ctx, [])
 
 let compile_defs (ctx : Ctx.t) (defs : def list)
     (reverse_dispatch : reverse_dispatch) : Ctx.t * Ml.funcdef list =
-  let extern_builtin_names = collect_extern_builtin_names defs in
   List.fold_left
     (fun (ctx, funcdefs_ml_acc) def ->
-      let ctx, funcdefs_ml =
-        compile_def ctx reverse_dispatch extern_builtin_names def
-      in
+      let ctx, funcdefs_ml = compile_def ctx reverse_dispatch def in
       (ctx, funcdefs_ml_acc @ funcdefs_ml))
     (ctx, []) defs
 

--- a/p4spec/lib/pass/compile/gen/func.ml
+++ b/p4spec/lib/pass/compile/gen/func.ml
@@ -26,15 +26,15 @@ let lookup_dispatch_info (reverse_dispatch : reverse_dispatch) (id : id) :
 
 (* Parameters *)
 
-let compile_exp_param ~(index : int option) (ctx : Ctx.t) (typ : typ)
-    (exp : exp) : Ctx.t * Ml.param * Chain.t =
+let compile_exp_param ~(index : int option) ~(tparams : string list)
+    (ctx : Ctx.t) (typ : typ) (exp : exp) : Ctx.t * Ml.param * Chain.t =
   let id_stub_ml =
     "param__" ^ (index |> Option.map string_of_int |> Option.value ~default:"")
   in
   let expr_stub_ml = Ml.VarE id_stub_ml in
-  let typ_ml = Type.compile_typ ~tparams:[] typ in
+  let typ_ml = Type.compile_typ ~tparams typ in
   let param_ml = (id_stub_ml, Some typ_ml) in
-  let ctx, chain = Bind.compile ctx expr_stub_ml exp in
+  let ctx, chain = Bind.compile ~tparams ctx expr_stub_ml exp in
   (ctx, param_ml, chain)
 
 let compile_def_param (ctx : Ctx.t) (id : id) : Ctx.t * Ml.param * Chain.t =
@@ -44,19 +44,21 @@ let compile_def_param (ctx : Ctx.t) (id : id) : Ctx.t * Ml.param * Chain.t =
   let chain = Chain.nop in
   (ctx, param_ml, chain)
 
-let compile_param ~(index : int option) (ctx : Ctx.t) (param : param) :
-    Ctx.t * Ml.param * Chain.t =
+let compile_param ~(index : int option) ~(tparams : string list) (ctx : Ctx.t)
+    (param : param) : Ctx.t * Ml.param * Chain.t =
   match param.it with
-  | ExpP (typ, exp) -> compile_exp_param ~index ctx typ exp
+  | ExpP (typ, exp) -> compile_exp_param ~index ~tparams ctx typ exp
   | DefP (id, _, _, _) -> compile_def_param ctx id
 
-let compile_params (ctx : Ctx.t) (params : param list) :
-    Ctx.t * Ml.param list * Chain.t =
+let compile_params ~(tparams : string list) (ctx : Ctx.t) (params : param list)
+    : Ctx.t * Ml.param list * Chain.t =
   params
   |> List.mapi (fun idx param -> (idx, param))
   |> List.fold_left
        (fun (ctx, params_ml, chain_acc) (idx, param) ->
-         let ctx, param_ml, chain = compile_param ~index:(Some idx) ctx param in
+         let ctx, param_ml, chain =
+           compile_param ~index:(Some idx) ~tparams ctx param
+         in
          let params_ml = params_ml @ [ param_ml ] in
          let chain = Chain.connect [ chain_acc; chain ] in
          (ctx, params_ml, chain))
@@ -209,25 +211,27 @@ let compile_builtin_func (ctx : Ctx.t) (reverse_dispatch : reverse_dispatch)
 let rec compile_table_func (ctx : Ctx.t) (id : id) (params : param list)
     (typ_ret : typ) (tablerows : tablerow list) : Ctx.t * Ml.funcdef list =
   let block = List.concat_map (fun (_, _, block_row) -> block_row) tablerows in
-  compile_defined_func_mono ctx id params typ_ret block None
+  compile_defined_func_mono ~tparams:[] ctx id params typ_ret block None
 
 (* Defined functions *)
 
-and compile_defined_func_mono (ctx : Ctx.t) (id : id) (params : param list)
-    (typ_ret : typ) (block_main : block) (elseblock_opt : block option) :
-    Ctx.t * Ml.funcdef list =
+and compile_defined_func_mono ~(tparams : string list) (ctx : Ctx.t) (id : id)
+    (params : param list) (typ_ret : typ) (block_main : block)
+    (elseblock_opt : block option) : Ctx.t * Ml.funcdef list =
   let id_ml = Names.func id in
-  let typ_ret_ml = Type.compile_typ ~tparams:[] typ_ret in
+  let typ_ret_ml = Type.compile_typ ~tparams typ_ret in
   let ctx_outer = ctx in
   (* Compile parameters *)
-  let ctx, params_ml, chain = compile_params ctx params in
+  let ctx, params_ml, chain = compile_params ~tparams ctx params in
   let ids_param_ml = List.map (fun (id_param_ml, _) -> id_param_ml) params_ml in
   (* Compile main block *)
   let id_main_ml = "main__" ^ id_ml in
   let ctx, funcdef_main_ml =
-    let ctx, expr_block_ml = Instr.compile_block ctx block_main in
+    let ctx, expr_block_ml = Instr.compile_block ~tparams ctx block_main in
     let expr_ml = Chain.apply chain expr_block_ml in
-    let funcdef_main_ml = (id_main_ml, [], params_ml, Some typ_ret_ml, expr_ml) in
+    let funcdef_main_ml =
+      (id_main_ml, [], params_ml, Some typ_ret_ml, expr_ml)
+    in
     (ctx, funcdef_main_ml)
   in
   (* Compile else block *)
@@ -235,7 +239,7 @@ and compile_defined_func_mono (ctx : Ctx.t) (id : id) (params : param list)
   let ctx, funcdef_else_ml_opt =
     match elseblock_opt with
     | Some elseblock ->
-        let ctx, expr_else_ml = Instr.compile_block ctx elseblock in
+        let ctx, expr_else_ml = Instr.compile_block ~tparams ctx elseblock in
         let expr_ml = Chain.apply chain expr_else_ml in
         let funcdef_else_ml =
           (id_else_ml, [], params_ml, Some typ_ret_ml, expr_ml)
@@ -276,7 +280,9 @@ let compile_defined_func (ctx : Ctx.t) (definedfunc : definedfunc) :
     definedfunc
   in
   if tparams <> [] then (ctx, [])
-  else compile_defined_func_mono ctx id params typ_ret block_main elseblock_opt
+  else
+    compile_defined_func_mono ~tparams:[] ctx id params typ_ret block_main
+      elseblock_opt
 
 (* Defs *)
 

--- a/p4spec/lib/pass/compile/gen/func.ml
+++ b/p4spec/lib/pass/compile/gen/func.ml
@@ -146,13 +146,14 @@ let compile_witness_params (tparams_ml : string list) : Ml.param list =
 let compile_targ_reify (tvars : string list) : Ml.expr =
   Ml.ListE
     (List.map
-       (fun tv -> Ml.AppE (Ml.LitE "make_typ_var_", [ Ml.StrE tv; Ml.ListE [] ]))
+       (fun tv ->
+         Ml.AppE (Ml.LitE "make_typ_var_", [ Ml.StrE tv; Ml.ListE [] ]))
        tvars)
 
 (* Bind [resolve_expr] before applying — it may be a bare lambda, and Ml's
    printer never parenthesizes an [AppE]'s function-position expression. *)
-let apply_witness (tag : string) (resolve_expr : Ml.expr) (arg_expr : Ml.expr)
-    : Ml.expr =
+let apply_witness (tag : string) (resolve_expr : Ml.expr) (arg_expr : Ml.expr) :
+    Ml.expr =
   let w_id = "w__" ^ tag in
   Ml.LetE (Ml.VarP w_id, resolve_expr, Ml.AppE (Ml.VarE w_id, [ arg_expr ]))
 
@@ -184,7 +185,8 @@ let compile_extern_func_generic (ctx : Ctx.t) (id : id)
     List.mapi
       (fun i typ ->
         ( "v__" ^ string_of_int i,
-          apply_witness (string_of_int i) (Interface.resolve_marshal tvars typ)
+          apply_witness (string_of_int i)
+            (Interface.resolve_marshal tvars typ)
             (Ml.VarE ("p__" ^ string_of_int i)) ))
       typs_param
     |> List.split
@@ -220,7 +222,11 @@ let compile_extern_func_generic (ctx : Ctx.t) (id : id)
       expr_result_ml
   in
   let funcdef_ml =
-    (id_ml, tparams_ml, params_ml, Some typ_ret_ml, Common.deref_ctx expr_body_ml)
+    ( id_ml,
+      tparams_ml,
+      params_ml,
+      Some typ_ret_ml,
+      Common.deref_ctx expr_body_ml )
   in
   (ctx, [ funcdef_ml ])
 
@@ -328,7 +334,8 @@ let compile_builtin_func_generic (ctx : Ctx.t) (id : id)
     List.mapi
       (fun i typ ->
         ( "v__" ^ string_of_int i,
-          apply_witness (string_of_int i) (Interface.resolve_marshal tvars typ)
+          apply_witness (string_of_int i)
+            (Interface.resolve_marshal tvars typ)
             (Ml.VarE ("p__" ^ string_of_int i)) ))
       typs_param
     |> List.split
@@ -343,8 +350,9 @@ let compile_builtin_func_generic (ctx : Ctx.t) (id : id)
   let expr_call_ml =
     Ml.AppE
       ( Common.iface_field "call_builtin",
-        [ Ml.LitE "(fun _ -> ())"; name_orig_lit_ml; exprs_targ_ml; exprs_arg_ml ]
-      )
+        [
+          Ml.LitE "(fun _ -> ())"; name_orig_lit_ml; exprs_targ_ml; exprs_arg_ml;
+        ] )
   in
   let expr_try_ml =
     Ml.TryE
@@ -373,7 +381,11 @@ let compile_builtin_func_generic (ctx : Ctx.t) (id : id)
       expr_result_ml
   in
   let funcdef_ml =
-    (id_ml, tparams_ml, params_ml, Some typ_ret_ml, Common.deref_ctx expr_body_ml)
+    ( id_ml,
+      tparams_ml,
+      params_ml,
+      Some typ_ret_ml,
+      Common.deref_ctx expr_body_ml )
   in
   (ctx, [ funcdef_ml ])
 
@@ -451,6 +463,16 @@ and compile_defined_func_mono ~(tparams : string list)
   in
   (ctx, funcdefs_ml)
 
+(* Pre-existing generic externs/builtins with an unsupported boundary shape
+   (e.g. a tuple-of-lists return) warn and skip, not fail the whole build. *)
+let try_compile_generic_bridge (ctx : Ctx.t) (id : id)
+    (f : unit -> Ctx.t * Ml.funcdef list) : Ctx.t * Ml.funcdef list =
+  try f ()
+  with Failure msg ->
+    Util.Error.warn_compile id.at
+      (Format.asprintf "generic extern/builtin %s: %s — skipping" id.it msg);
+    (ctx, [])
+
 (* DefP (callback) params have no Ml.typ, so the generic-tparams printer
    path can't build an explicit forall signature for them. *)
 let has_callback_param (params : param list) : bool =
@@ -465,23 +487,24 @@ let compile_defined_func (ctx : Ctx.t) (definedfunc : definedfunc) :
     definedfunc
   in
   if tparams = [] then
-    compile_defined_func_mono ~tparams:[] ~tparams_ml:[] ctx id params
-      typ_ret block_main elseblock_opt
-  (* Unsupported-but-preexisting (e.g. $match_overloaded_named<V>): warn and
-     skip, same as pre-Task-4 behavior, instead of failing the build. *)
+    compile_defined_func_mono ~tparams:[] ~tparams_ml:[] ctx id params typ_ret
+      block_main elseblock_opt
+    (* Unsupported-but-preexisting (e.g. $match_overloaded_named<V>): warn and
+       skip, same as pre-Task-4 behavior, instead of failing the build. *)
   else if has_callback_param params then (
     Util.Error.warn_compile id.at
       (Format.asprintf
-         "generic function %s has a callback parameter — not yet supported \
-          for generic compilation, skipping"
+         "generic function %s has a callback parameter — not yet supported for \
+          generic compilation, skipping"
          id.it);
     (ctx, []))
   else
     let tparams_str = List.map (fun (tp : Il.tparam) -> tp.it) tparams in
     let tparams_ml = List.map Names.tvar tparams in
     let ctx, funcdefs =
-      compile_defined_func_mono ~tparams:tparams_str ~tparams_ml ctx id params
-        typ_ret block_main elseblock_opt
+      try_compile_generic_bridge ctx id (fun () ->
+          compile_defined_func_mono ~tparams:tparams_str ~tparams_ml ctx id
+            params typ_ret block_main elseblock_opt)
     in
     ( ctx,
       List.map
@@ -491,18 +514,8 @@ let compile_defined_func (ctx : Ctx.t) (definedfunc : definedfunc) :
 
 (* Defs *)
 
-(* Pre-existing generic externs/builtins with an unsupported boundary shape
-   (e.g. a tuple-of-lists return) warn and skip, not fail the whole build. *)
-let try_compile_generic_bridge (ctx : Ctx.t) (id : id)
-    (f : unit -> Ctx.t * Ml.funcdef list) : Ctx.t * Ml.funcdef list =
-  try f ()
-  with Failure msg ->
-    Util.Error.warn_compile id.at
-      (Format.asprintf "generic extern/builtin %s: %s — skipping" id.it msg);
-    (ctx, [])
-
-let compile_def (ctx : Ctx.t) (reverse_dispatch : reverse_dispatch)
-    (def : def) : Ctx.t * Ml.funcdef list =
+let compile_def (ctx : Ctx.t) (reverse_dispatch : reverse_dispatch) (def : def)
+    : Ctx.t * Ml.funcdef list =
   match def.it with
   | ExternDecD (id, [], params, typ_ret, _) ->
       compile_extern_func ctx reverse_dispatch id params typ_ret

--- a/p4spec/lib/pass/compile/gen/instr.ml
+++ b/p4spec/lib/pass/compile/gen/instr.ml
@@ -4,20 +4,21 @@ open Util.Source
 
 (* Instructions *)
 
-let rec compile_instr (ctx : Ctx.t) (instr : instr) : Ctx.t * Ml.expr =
+let rec compile_instr ~(tparams : string list) (ctx : Ctx.t) (instr : instr) :
+    Ctx.t * Ml.expr =
   match instr.it with
   | IfI (exp_cond, iterexps, block, _) ->
-      compile_if_instr ctx exp_cond iterexps block
+      compile_if_instr ~tparams ctx exp_cond iterexps block
   | HoldI (id, notexp, iterexps, holdcase) ->
-      compile_hold_instr ctx id notexp iterexps holdcase
-  | CaseI (exp, cases, _) -> compile_case_instr ctx exp cases
-  | GroupI (_, _, _, block) -> compile_group_instr ctx block
+      compile_hold_instr ~tparams ctx id notexp iterexps holdcase
+  | CaseI (exp, cases, _) -> compile_case_instr ~tparams ctx exp cases
+  | GroupI (_, _, _, block) -> compile_group_instr ~tparams ctx block
   | LetI (exp_l, exp_r, iterinstrs, block) ->
-      compile_let_instr ctx exp_l exp_r iterinstrs block
+      compile_let_instr ~tparams ctx exp_l exp_r iterinstrs block
   | RuleI (id, notexp, inputs, iterinstrs, block) ->
-      compile_rule_instr ctx id notexp inputs iterinstrs block
-  | ResultI (_, exps) -> compile_result_instr ctx exps
-  | ReturnI exp -> compile_return_instr ctx exp
+      compile_rule_instr ~tparams ctx id notexp inputs iterinstrs block
+  | ResultI (_, exps) -> compile_result_instr ~tparams ctx exps
+  | ReturnI exp -> compile_return_instr ~tparams ctx exp
   | DebugI exp -> compile_debug_instr ctx exp
 
 (* If instruction (no iterexps): [if exp_cond then block]
@@ -30,12 +31,13 @@ let rec compile_instr (ctx : Ctx.t) (instr : instr) : Ctx.t * Ml.expr =
    Opt iter:  [match guide__quest with None -> true | Some elem -> <inner cond>]
               (multi-guide fuses into [Option.for_all_N]) *)
 
-and compile_if_cond (ctx : Ctx.t) (exp_cond : exp) : Ctx.t * Ml.expr =
+and compile_if_cond ~(tparams : string list) (ctx : Ctx.t) (exp_cond : exp) :
+    Ctx.t * Ml.expr =
   (* Base case: compile condition expression directly *)
-  Exp.compile_exp ctx exp_cond
+  Exp.compile_exp ~tparams ctx exp_cond
 
-and compile_if_cond_list (ctx : Ctx.t) (exp_cond : exp) (vars : var list)
-    (iterexps_t : iterexp list) : Ctx.t * Ml.expr =
+and compile_if_cond_list ~(tparams : string list) (ctx : Ctx.t) (exp_cond : exp)
+    (vars : var list) (iterexps_t : iterexp list) : Ctx.t * Ml.expr =
   let ctx_outer = ctx in
   let n = List.length vars in
   (* Fetch guiding list variables *)
@@ -47,7 +49,9 @@ and compile_if_cond_list (ctx : Ctx.t) (exp_cond : exp) (vars : var list)
   (* Create stubs for element vars *)
   let ctx, ids_elem_ml = Stub.OCaml.iterator ~prefix:"iter_cond__" ctx vars in
   (* Compile inner condition with element vars bound *)
-  let ctx_inner, expr_inner_ml = compile_if_cond_iter ctx exp_cond iterexps_t in
+  let ctx_inner, expr_inner_ml =
+    compile_if_cond_iter ~tparams ctx exp_cond iterexps_t
+  in
   (* Promote preamble from inner scope *)
   let ctx = Ctx.promote_preamble ctx_inner ctx_outer in
   (* Fuse [List.for_all f (combineN ..)] into [List.for_all_N f ..] when there
@@ -73,8 +77,8 @@ and compile_if_cond_list (ctx : Ctx.t) (exp_cond : exp) (vars : var list)
   in
   (ctx, expr_ml)
 
-and compile_if_cond_opt (ctx : Ctx.t) (exp_cond : exp) (vars : var list)
-    (iterexps_t : iterexp list) : Ctx.t * Ml.expr =
+and compile_if_cond_opt ~(tparams : string list) (ctx : Ctx.t) (exp_cond : exp)
+    (vars : var list) (iterexps_t : iterexp list) : Ctx.t * Ml.expr =
   let ctx_outer = ctx in
   let n = List.length vars in
   (* Fetch guiding option variables *)
@@ -86,7 +90,9 @@ and compile_if_cond_opt (ctx : Ctx.t) (exp_cond : exp) (vars : var list)
   (* Create stubs for element vars *)
   let ctx, ids_elem_ml = Stub.OCaml.iterator ~prefix:"iter_cond__" ctx vars in
   (* Compile inner condition with element vars bound *)
-  let ctx_inner, expr_inner_ml = compile_if_cond_iter ctx exp_cond iterexps_t in
+  let ctx_inner, expr_inner_ml =
+    compile_if_cond_iter ~tparams ctx exp_cond iterexps_t
+  in
   (* Promote preamble from inner scope *)
   let ctx = Ctx.promote_preamble ctx_inner ctx_outer in
   (* Fuse [match combineN .. with None -> true | Some (..) -> f ..] into
@@ -116,21 +122,23 @@ and compile_if_cond_opt (ctx : Ctx.t) (exp_cond : exp) (vars : var list)
   in
   (ctx, expr_ml)
 
-and compile_if_cond_iter (ctx : Ctx.t) (exp_cond : exp)
+and compile_if_cond_iter ~(tparams : string list) (ctx : Ctx.t) (exp_cond : exp)
     (iterexps_rev : iterexp list) : Ctx.t * Ml.expr =
   match iterexps_rev with
-  | [] -> compile_if_cond ctx exp_cond
+  | [] -> compile_if_cond ~tparams ctx exp_cond
   | (iter, vars) :: iterexps_t -> (
       match iter with
-      | Il.List -> compile_if_cond_list ctx exp_cond vars iterexps_t
-      | Il.Opt -> compile_if_cond_opt ctx exp_cond vars iterexps_t)
+      | Il.List -> compile_if_cond_list ~tparams ctx exp_cond vars iterexps_t
+      | Il.Opt -> compile_if_cond_opt ~tparams ctx exp_cond vars iterexps_t)
 
-and compile_if_instr (ctx : Ctx.t) (exp_cond : exp) (iterexps : iterexp list)
-    (block_then : block) : Ctx.t * Ml.expr =
+and compile_if_instr ~(tparams : string list) (ctx : Ctx.t) (exp_cond : exp)
+    (iterexps : iterexp list) (block_then : block) : Ctx.t * Ml.expr =
   let iterexps_rev = List.rev iterexps in
   (* Compile condition, wrapping iterexps from innermost outward *)
-  let ctx, expr_cond_ml = compile_if_cond_iter ctx exp_cond iterexps_rev in
-  let ctx, expr_then_ml = compile_block ctx block_then in
+  let ctx, expr_cond_ml =
+    compile_if_cond_iter ~tparams ctx exp_cond iterexps_rev
+  in
+  let ctx, expr_then_ml = compile_block ~tparams ctx block_then in
   ( ctx,
     Ml.IfE (expr_cond_ml, expr_then_ml, Some (Common.raise_unmatch "if failed"))
   )
@@ -150,10 +158,10 @@ and compile_if_instr (ctx : Ctx.t) (exp_cond : exp) (iterexps : iterexp list)
    Opt iter:  [match guide__quest with None -> true | Some elem -> <inner_hold>]
    (None -> true: vacuously holds when element is absent, same as IfI) *)
 
-and compile_hold_cond (ctx : Ctx.t) (id : id) (notexp : notexp) :
-    Ctx.t * Ml.expr =
+and compile_hold_cond ~(tparams : string list) (ctx : Ctx.t) (id : id)
+    (notexp : notexp) : Ctx.t * Ml.expr =
   let exps_input = Domain.Mixfix.args notexp in
-  let ctx, exprs_input_ml = Exp.compile_exps ctx exps_input in
+  let ctx, exprs_input_ml = Exp.compile_exps ~tparams ctx exps_input in
   let id_rel_ml = Names.rel id in
   let expr_call_ml = Ml.AppE (Ml.VarE id_rel_ml, exprs_input_ml) in
   let expr_hold_ml =
@@ -163,8 +171,9 @@ and compile_hold_cond (ctx : Ctx.t) (id : id) (notexp : notexp) :
   in
   (ctx, expr_hold_ml)
 
-and compile_hold_cond_list (ctx : Ctx.t) (id : id) (notexp : notexp)
-    (vars : var list) (iterexps_t : iterexp list) : Ctx.t * Ml.expr =
+and compile_hold_cond_list ~(tparams : string list) (ctx : Ctx.t) (id : id)
+    (notexp : notexp) (vars : var list) (iterexps_t : iterexp list) :
+    Ctx.t * Ml.expr =
   let ctx_outer = ctx in
   let n = List.length vars in
   (* Fetch guiding list variables *)
@@ -176,7 +185,9 @@ and compile_hold_cond_list (ctx : Ctx.t) (id : id) (notexp : notexp)
   (* Create stubs for element vars *)
   let ctx, ids_elem_ml = Stub.OCaml.iterator ~prefix:"iter_hold__" ctx vars in
   (* Compile inner hold condition with element vars bound *)
-  let ctx, expr_inner_ml = compile_hold_cond_iter ctx id notexp iterexps_t in
+  let ctx, expr_inner_ml =
+    compile_hold_cond_iter ~tparams ctx id notexp iterexps_t
+  in
   (* Promote preamble from inner scope *)
   let ctx = Ctx.promote_preamble ctx ctx_outer in
   (* Hold holds iff it holds for all list elements. Fuse the combine when there
@@ -202,8 +213,9 @@ and compile_hold_cond_list (ctx : Ctx.t) (id : id) (notexp : notexp)
   in
   (ctx, expr_ml)
 
-and compile_hold_cond_opt (ctx : Ctx.t) (id : id) (notexp : notexp)
-    (vars : var list) (iterexps_t : iterexp list) : Ctx.t * Ml.expr =
+and compile_hold_cond_opt ~(tparams : string list) (ctx : Ctx.t) (id : id)
+    (notexp : notexp) (vars : var list) (iterexps_t : iterexp list) :
+    Ctx.t * Ml.expr =
   let ctx_outer = ctx in
   let n = List.length vars in
   (* Fetch guiding option variables *)
@@ -215,7 +227,9 @@ and compile_hold_cond_opt (ctx : Ctx.t) (id : id) (notexp : notexp)
   (* Create stubs for element vars *)
   let ctx, ids_elem_ml = Stub.OCaml.iterator ~prefix:"iter_hold__" ctx vars in
   (* Compile inner hold condition with element vars bound *)
-  let ctx, expr_inner_ml = compile_hold_cond_iter ctx id notexp iterexps_t in
+  let ctx, expr_inner_ml =
+    compile_hold_cond_iter ~tparams ctx id notexp iterexps_t
+  in
   (* Promote preamble from inner scope *)
   let ctx = Ctx.promote_preamble ctx ctx_outer in
   (* Build match: None -> true (vacuous), Some -> inner hold condition. Fuse the
@@ -244,26 +258,26 @@ and compile_hold_cond_opt (ctx : Ctx.t) (id : id) (notexp : notexp)
   in
   (ctx, expr_ml)
 
-and compile_hold_cond_iter (ctx : Ctx.t) (id : id) (notexp : notexp)
-    (iterexps_rev : iterexp list) : Ctx.t * Ml.expr =
+and compile_hold_cond_iter ~(tparams : string list) (ctx : Ctx.t) (id : id)
+    (notexp : notexp) (iterexps_rev : iterexp list) : Ctx.t * Ml.expr =
   match iterexps_rev with
-  | [] -> compile_hold_cond ctx id notexp
+  | [] -> compile_hold_cond ~tparams ctx id notexp
   | (iter, vars) :: iterexps_t -> (
       match iter with
-      | Il.List -> compile_hold_cond_list ctx id notexp vars iterexps_t
-      | Il.Opt -> compile_hold_cond_opt ctx id notexp vars iterexps_t)
+      | Il.List -> compile_hold_cond_list ~tparams ctx id notexp vars iterexps_t
+      | Il.Opt -> compile_hold_cond_opt ~tparams ctx id notexp vars iterexps_t)
 
-and compile_hold_case (ctx : Ctx.t) (holdcase : holdcase) (id_hold_ml : string)
-    : Ctx.t * Ml.expr =
+and compile_hold_case ~(tparams : string list) (ctx : Ctx.t)
+    (holdcase : holdcase) (id_hold_ml : string) : Ctx.t * Ml.expr =
   match holdcase with
   | BothH (block_hold, block_nothold) ->
       (* Both branches reachable; no Unmatch on either path *)
-      let ctx, expr_hold_ml = compile_block ctx block_hold in
-      let ctx, expr_nothold_ml = compile_block ctx block_nothold in
+      let ctx, expr_hold_ml = compile_block ~tparams ctx block_hold in
+      let ctx, expr_nothold_ml = compile_block ~tparams ctx block_nothold in
       (ctx, Ml.IfE (Ml.VarE id_hold_ml, expr_hold_ml, Some expr_nothold_ml))
   | HoldH (block_hold, _) ->
       (* If condition does not hold: Unmatch -> fall through to next sibling *)
-      let ctx, expr_hold_ml = compile_block ctx block_hold in
+      let ctx, expr_hold_ml = compile_block ~tparams ctx block_hold in
       ( ctx,
         Ml.IfE
           ( Ml.VarE id_hold_ml,
@@ -271,22 +285,25 @@ and compile_hold_case (ctx : Ctx.t) (holdcase : holdcase) (id_hold_ml : string)
             Some (Common.raise_unmatch "hold failed") ) )
   | NotHoldH (block_nothold, _) ->
       (* If condition holds: Unmatch -> fall through to next sibling *)
-      let ctx, expr_nothold_ml = compile_block ctx block_nothold in
+      let ctx, expr_nothold_ml = compile_block ~tparams ctx block_nothold in
       ( ctx,
         Ml.IfE
           ( Ml.UnopE ("not", Ml.VarE id_hold_ml),
             expr_nothold_ml,
             Some (Common.raise_unmatch "not-hold failed") ) )
 
-and compile_hold_instr (ctx : Ctx.t) (id : id) (notexp : notexp)
-    (iterexps : iterexp list) (holdcase : holdcase) : Ctx.t * Ml.expr =
+and compile_hold_instr ~(tparams : string list) (ctx : Ctx.t) (id : id)
+    (notexp : notexp) (iterexps : iterexp list) (holdcase : holdcase) :
+    Ctx.t * Ml.expr =
   let ctx_outer = ctx in
   (* Process iterexps innermost-first, matching interpreter's List.rev *)
   let iterexps_rev = List.rev iterexps in
-  let ctx, expr_hold_ml = compile_hold_cond_iter ctx id notexp iterexps_rev in
+  let ctx, expr_hold_ml =
+    compile_hold_cond_iter ~tparams ctx id notexp iterexps_rev
+  in
   (* Bind hold__ so holdcase branches can reference it *)
   let ctx, id_hold_ml = Stub.OCaml.var ctx "hold__" in
-  let ctx, expr_body_ml = compile_hold_case ctx holdcase id_hold_ml in
+  let ctx, expr_body_ml = compile_hold_case ~tparams ctx holdcase id_hold_ml in
   let ctx = Ctx.promote_preamble ctx ctx_outer in
   (ctx, Ml.LetE (Ml.VarP id_hold_ml, expr_hold_ml, expr_body_ml))
 
@@ -308,24 +325,24 @@ and compile_hold_instr (ctx : Ctx.t) (id : id) (notexp : notexp)
      MatchG pat  ->  case__ matches pat
      MemG exp_s  ->  case__ in exp_s *)
 
-and compile_guard (ctx : Ctx.t) (exp_scrut : exp) (guard : guard) :
-    Ctx.t * Ml.expr =
+and compile_guard ~(tparams : string list) (ctx : Ctx.t) (exp_scrut : exp)
+    (guard : guard) : Ctx.t * Ml.expr =
   match guard with
   | BoolG b ->
-      let ctx, expr_ml = Exp.compile_exp ctx exp_scrut in
+      let ctx, expr_ml = Exp.compile_exp ~tparams ctx exp_scrut in
       let expr_ml = if b then expr_ml else Ml.UnopE ("not", expr_ml) in
       (ctx, expr_ml)
   | CmpG (cmpop, optyp, exp_r) ->
-      Exp.compile_cmp_exp ctx cmpop optyp exp_scrut exp_r
-  | SubG typ -> Exp.compile_sub_exp ctx exp_scrut typ
-  | MatchG pattern -> Exp.compile_match_exp ctx exp_scrut pattern
-  | MemG exp_s -> Exp.compile_mem_exp ctx exp_scrut exp_s
+      Exp.compile_cmp_exp ~tparams ctx cmpop optyp exp_scrut exp_r
+  | SubG typ -> Exp.compile_sub_exp ~tparams ctx exp_scrut typ
+  | MatchG pattern -> Exp.compile_match_exp ~tparams ctx exp_scrut pattern
+  | MemG exp_s -> Exp.compile_mem_exp ~tparams ctx exp_scrut exp_s
 
-and compile_case_instr (ctx : Ctx.t) (exp : exp) (cases : case list) :
-    Ctx.t * Ml.expr =
+and compile_case_instr ~(tparams : string list) (ctx : Ctx.t) (exp : exp)
+    (cases : case list) : Ctx.t * Ml.expr =
   let ctx_outer = ctx in
   (* Compile scrutinee and bind to a fresh variable so it is evaluated once *)
-  let ctx, expr_scrut_ml = Exp.compile_exp ctx exp in
+  let ctx, expr_scrut_ml = Exp.compile_exp ~tparams ctx exp in
   let ctx, id_scrut_ml = Stub.OCaml.var ctx "case__" in
   let exp_scrut = Stub.SpecTec.var id_scrut_ml (exp.note $ exp.at) in
   (* Build nested if-else chain: first case is outermost, last is innermost *)
@@ -333,8 +350,8 @@ and compile_case_instr (ctx : Ctx.t) (exp : exp) (cases : case list) :
     List.fold_right
       (fun (guard, block) (ctx, expr_else_ml) ->
         (* Compile guard condition against the bound scrutinee *)
-        let ctx, expr_cond_ml = compile_guard ctx exp_scrut guard in
-        let ctx, expr_block_ml = compile_block ctx block in
+        let ctx, expr_cond_ml = compile_guard ~tparams ctx exp_scrut guard in
+        let ctx, expr_block_ml = compile_block ~tparams ctx block in
         let expr_body_ml =
           Ml.IfE (expr_cond_ml, expr_block_ml, Some expr_else_ml)
         in
@@ -352,8 +369,9 @@ and compile_case_instr (ctx : Ctx.t) (exp : exp) (cases : case list) :
 
    [compile_block block] *)
 
-and compile_group_instr (ctx : Ctx.t) (block : block) : Ctx.t * Ml.expr =
-  compile_block ctx block
+and compile_group_instr ~(tparams : string list) (ctx : Ctx.t) (block : block) :
+    Ctx.t * Ml.expr =
+  compile_block ~tparams ctx block
 
 (* Let instruction (no iterinstrs): [let exp_l = exp_r in cont]
 
@@ -375,17 +393,18 @@ and compile_group_instr (ctx : Ctx.t) (block : block) : Ctx.t * Ml.expr =
 
    Opt iterinstrs: analogous with Option.fold_N_M *)
 
-and compile_let (ctx : Ctx.t) (exp_l : exp) (exp_r : exp)
-    (cont : Ctx.t -> Ctx.t * Ml.expr) : Ctx.t * Ml.expr =
-  let ctx, expr_r_ml = Exp.compile_exp ctx exp_r in
-  let ctx, chain = Bind.compile ctx expr_r_ml exp_l in
+and compile_let ~(tparams : string list) (ctx : Ctx.t) (exp_l : exp)
+    (exp_r : exp) (cont : Ctx.t -> Ctx.t * Ml.expr) : Ctx.t * Ml.expr =
+  let ctx, expr_r_ml = Exp.compile_exp ~tparams ctx exp_r in
+  let ctx, chain = Bind.compile ~tparams ctx expr_r_ml exp_l in
   let ctx, expr_result_ml = cont ctx in
   let expr_ml = Chain.apply chain expr_result_ml in
   (ctx, expr_ml)
 
-and compile_let_opt (ctx : Ctx.t) (exp_l : exp) (exp_r : exp)
-    (vars_bound : var list) (vars_bind : var list) (iterinstrs : iterinstr list)
-    (cont : Ctx.t -> Ctx.t * Ml.expr) : Ctx.t * Ml.expr =
+and compile_let_opt ~(tparams : string list) (ctx : Ctx.t) (exp_l : exp)
+    (exp_r : exp) (vars_bound : var list) (vars_bind : var list)
+    (iterinstrs : iterinstr list) (cont : Ctx.t -> Ctx.t * Ml.expr) :
+    Ctx.t * Ml.expr =
   let ctx_outer = ctx in
   let n_bound = List.length vars_bound in
   let n_bind = List.length vars_bind in
@@ -416,7 +435,7 @@ and compile_let_opt (ctx : Ctx.t) (exp_l : exp) (exp_r : exp)
   in
   (* Compile inner body *)
   let ctx, expr_inner_ml =
-    compile_let_iter ctx exp_l exp_r iterinstrs cont_inner
+    compile_let_iter ~tparams ctx exp_l exp_r iterinstrs cont_inner
   in
   (* Build bound RHS. Fuse [combineN |> Option.map f |> splitM] into a single
      match [Option.fold_N_M] when there is a real combine or split to eliminate;
@@ -483,9 +502,10 @@ and compile_let_opt (ctx : Ctx.t) (exp_l : exp) (exp_r : exp)
   let expr_ml = Ml.LetE (pat_out_ml, expr_rhs_ml, expr_cont_ml) in
   (ctx, expr_ml)
 
-and compile_let_list (ctx : Ctx.t) (exp_l : exp) (exp_r : exp)
-    (vars_bound : var list) (vars_bind : var list) (iterinstrs : iterinstr list)
-    (cont : Ctx.t -> Ctx.t * Ml.expr) : Ctx.t * Ml.expr =
+and compile_let_list ~(tparams : string list) (ctx : Ctx.t) (exp_l : exp)
+    (exp_r : exp) (vars_bound : var list) (vars_bind : var list)
+    (iterinstrs : iterinstr list) (cont : Ctx.t -> Ctx.t * Ml.expr) :
+    Ctx.t * Ml.expr =
   let ctx_outer = ctx in
   let n_bound = List.length vars_bound in
   let n_bind = List.length vars_bind in
@@ -516,7 +536,7 @@ and compile_let_list (ctx : Ctx.t) (exp_l : exp) (exp_r : exp)
   in
   (* Compile inner body *)
   let ctx, expr_inner_ml =
-    compile_let_iter ctx exp_l exp_r iterinstrs cont_inner
+    compile_let_iter ~tparams ctx exp_l exp_r iterinstrs cont_inner
   in
   (* Build bound RHS. Fuse [combineN |> List.map f |> splitM] into a single
      tail-recursive [fold_left_N_M] when there is a real combine or split to
@@ -582,25 +602,27 @@ and compile_let_list (ctx : Ctx.t) (exp_l : exp) (exp_r : exp)
   let expr_ml = Ml.LetE (pat_out_ml, expr_rhs_ml, expr_cont_ml) in
   (ctx, expr_ml)
 
-and compile_let_iter (ctx : Ctx.t) (exp_l : exp) (exp_r : exp)
-    (iterinstrs_rev : iterinstr list) (cont : Ctx.t -> Ctx.t * Ml.expr) :
-    Ctx.t * Ml.expr =
+and compile_let_iter ~(tparams : string list) (ctx : Ctx.t) (exp_l : exp)
+    (exp_r : exp) (iterinstrs_rev : iterinstr list)
+    (cont : Ctx.t -> Ctx.t * Ml.expr) : Ctx.t * Ml.expr =
   match iterinstrs_rev with
-  | [] -> compile_let ctx exp_l exp_r cont
+  | [] -> compile_let ~tparams ctx exp_l exp_r cont
   | iterinstr_h :: iterinstrs_t -> (
       let iter, vars_bound, vars_bind = iterinstr_h in
       match iter with
       | Il.Opt ->
-          compile_let_opt ctx exp_l exp_r vars_bound vars_bind iterinstrs_t cont
+          compile_let_opt ~tparams ctx exp_l exp_r vars_bound vars_bind
+            iterinstrs_t cont
       | Il.List ->
-          compile_let_list ctx exp_l exp_r vars_bound vars_bind iterinstrs_t
-            cont)
+          compile_let_list ~tparams ctx exp_l exp_r vars_bound vars_bind
+            iterinstrs_t cont)
 
-and compile_let_instr (ctx : Ctx.t) (exp_l : exp) (exp_r : exp)
-    (iterinstrs : iterinstr list) (block_cont_ml : block) : Ctx.t * Ml.expr =
+and compile_let_instr ~(tparams : string list) (ctx : Ctx.t) (exp_l : exp)
+    (exp_r : exp) (iterinstrs : iterinstr list) (block_cont_ml : block) :
+    Ctx.t * Ml.expr =
   let iterinstrs_rev = List.rev iterinstrs in
-  let cont ctx = compile_block ctx block_cont_ml in
-  compile_let_iter ctx exp_l exp_r iterinstrs_rev cont
+  let cont ctx = compile_block ~tparams ctx block_cont_ml in
+  compile_let_iter ~tparams ctx exp_l exp_r iterinstrs_rev cont
 
 (* Rule instruction (no iterinstrs): [relation(inputs) ~~ outputs in cont]
 
@@ -622,19 +644,19 @@ and compile_let_instr (ctx : Ctx.t) (exp_l : exp) (exp_r : exp)
 
    Opt iterinstrs: analogous with Option.fold_N_M *)
 
-and compile_rule (ctx : Ctx.t) (rel_id : id) (notexp : notexp)
-    (inputs : Hints.Input.t) (cont : Ctx.t -> Ctx.t * Ml.expr) : Ctx.t * Ml.expr
-    =
+and compile_rule ~(tparams : string list) (ctx : Ctx.t) (rel_id : id)
+    (notexp : notexp) (inputs : Hints.Input.t) (cont : Ctx.t -> Ctx.t * Ml.expr)
+    : Ctx.t * Ml.expr =
   let ctx_outer = ctx in
   let exps = Domain.Mixfix.args notexp in
   let exps_input, exps_output = Hints.Input.split inputs exps in
-  let ctx, exprs_input_ml = Exp.compile_exps ctx exps_input in
+  let ctx, exprs_input_ml = Exp.compile_exps ~tparams ctx exps_input in
   let id_rel_ml = Names.rel rel_id in
   let expr_call_ml = Ml.AppE (Ml.VarE id_rel_ml, exprs_input_ml) in
   let ctx, chain =
     match exps_output with
     | [] -> (ctx, Chain.make_let Ml.WildP expr_call_ml)
-    | [ exp_out ] -> Bind.compile ctx expr_call_ml exp_out
+    | [ exp_out ] -> Bind.compile ~tparams ctx expr_call_ml exp_out
     | exps_out ->
         let n = List.length exps_out in
         let ctx, ids_stub_ml = Stub.OCaml.vars ctx "tup__" n in
@@ -645,7 +667,9 @@ and compile_rule (ctx : Ctx.t) (rel_id : id) (notexp : notexp)
         let ctx, chain_binds =
           List.fold_left2
             (fun (ctx, chain_acc) id_s_ml exp_out ->
-              let ctx, chain_b = Bind.compile ctx (Ml.VarE id_s_ml) exp_out in
+              let ctx, chain_b =
+                Bind.compile ~tparams ctx (Ml.VarE id_s_ml) exp_out
+              in
               (ctx, Chain.connect [ chain_acc; chain_b ]))
             (ctx, Chain.nop) ids_stub_ml exps_out
         in
@@ -656,10 +680,10 @@ and compile_rule (ctx : Ctx.t) (rel_id : id) (notexp : notexp)
   let expr_ml = Chain.apply chain expr_cont_ml in
   (ctx, expr_ml)
 
-and compile_rule_opt (ctx : Ctx.t) (rel_id : id) (notexp : notexp)
-    (inputs : Hints.Input.t) (vars_bound : var list) (vars_bind : var list)
-    (iterinstrs : iterinstr list) (cont : Ctx.t -> Ctx.t * Ml.expr) :
-    Ctx.t * Ml.expr =
+and compile_rule_opt ~(tparams : string list) (ctx : Ctx.t) (rel_id : id)
+    (notexp : notexp) (inputs : Hints.Input.t) (vars_bound : var list)
+    (vars_bind : var list) (iterinstrs : iterinstr list)
+    (cont : Ctx.t -> Ctx.t * Ml.expr) : Ctx.t * Ml.expr =
   let ctx_outer = ctx in
   let n_bound = List.length vars_bound in
   let n_bind = List.length vars_bind in
@@ -690,7 +714,7 @@ and compile_rule_opt (ctx : Ctx.t) (rel_id : id) (notexp : notexp)
   in
   (* Compile inner body *)
   let ctx, expr_inner_ml =
-    compile_rule_iter ctx rel_id notexp inputs iterinstrs cont_inner
+    compile_rule_iter ~tparams ctx rel_id notexp inputs iterinstrs cont_inner
   in
   (* Build bound RHS. Fuse [combineN |> Option.map f |> splitM] into a single
      match [Option.fold_N_M] when there is a real combine or split to eliminate;
@@ -755,10 +779,10 @@ and compile_rule_opt (ctx : Ctx.t) (rel_id : id) (notexp : notexp)
   let expr_ml = Ml.LetE (pat_out_ml, expr_rhs_ml, expr_cont_ml) in
   (ctx, expr_ml)
 
-and compile_rule_list (ctx : Ctx.t) (rel_id : id) (notexp : notexp)
-    (inputs : Hints.Input.t) (vars_bound : var list) (vars_bind : var list)
-    (iterinstrs : iterinstr list) (cont : Ctx.t -> Ctx.t * Ml.expr) :
-    Ctx.t * Ml.expr =
+and compile_rule_list ~(tparams : string list) (ctx : Ctx.t) (rel_id : id)
+    (notexp : notexp) (inputs : Hints.Input.t) (vars_bound : var list)
+    (vars_bind : var list) (iterinstrs : iterinstr list)
+    (cont : Ctx.t -> Ctx.t * Ml.expr) : Ctx.t * Ml.expr =
   let ctx_outer = ctx in
   let n_bound = List.length vars_bound in
   let n_bind = List.length vars_bind in
@@ -789,7 +813,7 @@ and compile_rule_list (ctx : Ctx.t) (rel_id : id) (notexp : notexp)
   in
   (* Compile inner body *)
   let ctx, expr_inner_ml =
-    compile_rule_iter ctx rel_id notexp inputs iterinstrs cont_inner
+    compile_rule_iter ~tparams ctx rel_id notexp inputs iterinstrs cont_inner
   in
   (* Build bound RHS. Fuse [combineN |> List.map f |> splitM] into a single
      tail-recursive [fold_left_N_M] when there is a real combine or split to
@@ -853,32 +877,33 @@ and compile_rule_list (ctx : Ctx.t) (rel_id : id) (notexp : notexp)
   let expr_ml = Ml.LetE (pat_out_ml, expr_rhs_ml, expr_cont_ml) in
   (ctx, expr_ml)
 
-and compile_rule_iter (ctx : Ctx.t) (rel_id : id) (notexp : notexp)
-    (inputs : Hints.Input.t) (iterinstrs_rev : iterinstr list)
+and compile_rule_iter ~(tparams : string list) (ctx : Ctx.t) (rel_id : id)
+    (notexp : notexp) (inputs : Hints.Input.t) (iterinstrs_rev : iterinstr list)
     (cont : Ctx.t -> Ctx.t * Ml.expr) : Ctx.t * Ml.expr =
   match iterinstrs_rev with
-  | [] -> compile_rule ctx rel_id notexp inputs cont
+  | [] -> compile_rule ~tparams ctx rel_id notexp inputs cont
   | iterinstr_h :: iterinstrs_t -> (
       let iter, vars_bound, vars_bind = iterinstr_h in
       match iter with
       | Il.Opt ->
-          compile_rule_opt ctx rel_id notexp inputs vars_bound vars_bind
-            iterinstrs_t cont
+          compile_rule_opt ~tparams ctx rel_id notexp inputs vars_bound
+            vars_bind iterinstrs_t cont
       | Il.List ->
-          compile_rule_list ctx rel_id notexp inputs vars_bound vars_bind
-            iterinstrs_t cont)
+          compile_rule_list ~tparams ctx rel_id notexp inputs vars_bound
+            vars_bind iterinstrs_t cont)
 
-and compile_rule_instr (ctx : Ctx.t) (id : id) (notexp : notexp)
-    (inputs : Hints.Input.t) (iterinstrs : iterinstr list) (block_cont : block)
-    : Ctx.t * Ml.expr =
+and compile_rule_instr ~(tparams : string list) (ctx : Ctx.t) (id : id)
+    (notexp : notexp) (inputs : Hints.Input.t) (iterinstrs : iterinstr list)
+    (block_cont : block) : Ctx.t * Ml.expr =
   let iterinstrs_rev = List.rev iterinstrs in
-  let cont ctx = compile_block ctx block_cont in
-  compile_rule_iter ctx id notexp inputs iterinstrs_rev cont
+  let cont ctx = compile_block ~tparams ctx block_cont in
+  compile_rule_iter ~tparams ctx id notexp inputs iterinstrs_rev cont
 
 (* Result instruction *)
 
-and compile_result_instr (ctx : Ctx.t) (exps : exp list) : Ctx.t * Ml.expr =
-  let ctx, exprs_ml = Exp.compile_exps ctx exps in
+and compile_result_instr ~(tparams : string list) (ctx : Ctx.t)
+    (exps : exp list) : Ctx.t * Ml.expr =
+  let ctx, exprs_ml = Exp.compile_exps ~tparams ctx exps in
   let expr_ml =
     match exprs_ml with
     | [] -> Ml.UnitE
@@ -889,8 +914,9 @@ and compile_result_instr (ctx : Ctx.t) (exps : exp list) : Ctx.t * Ml.expr =
 
 (* Return instruction *)
 
-and compile_return_instr (ctx : Ctx.t) (exp : exp) : Ctx.t * Ml.expr =
-  let ctx, expr_ml = Exp.compile_exp ctx exp in
+and compile_return_instr ~(tparams : string list) (ctx : Ctx.t) (exp : exp) :
+    Ctx.t * Ml.expr =
+  let ctx, expr_ml = Exp.compile_exp ~tparams ctx exp in
   (ctx, expr_ml)
 
 (* Debug instruction: [debug exp]
@@ -906,13 +932,14 @@ and compile_debug_instr (ctx : Ctx.t) (_exp : exp) : Ctx.t * Ml.expr =
    [instr]               ->  [compile_instr instr]
    [instr_h :: instrs_t] ->  [try compile_instr instr_h with Unmatch _ -> compile_block instrs_t] *)
 
-and compile_block (ctx : Ctx.t) (block : block) : Ctx.t * Ml.expr =
+and compile_block ~(tparams : string list) (ctx : Ctx.t) (block : block) :
+    Ctx.t * Ml.expr =
   match block with
   | [] -> (ctx, Common.raise_unmatch "empty block")
-  | [ instr ] -> compile_instr ctx instr
+  | [ instr ] -> compile_instr ~tparams ctx instr
   | instr_h :: instrs_t ->
-      let ctx, expr_h_ml = compile_instr ctx instr_h in
-      let ctx, expr_t_ml = compile_block ctx instrs_t in
+      let ctx, expr_h_ml = compile_instr ~tparams ctx instr_h in
+      let ctx, expr_t_ml = compile_block ~tparams ctx instrs_t in
       let arm_ml = (Ml.VariantP (`Mono ("Unmatch", [ Ml.WildP ])), expr_t_ml) in
       let expr_ml = Ml.TryE (expr_h_ml, [ arm_ml ]) in
       (ctx, expr_ml)

--- a/p4spec/lib/pass/compile/gen/interface.ml
+++ b/p4spec/lib/pass/compile/gen/interface.ml
@@ -641,6 +641,90 @@ module Unmarshal = struct
     (name, [], [ ("v", Some (Ml.NameT "Value.t")) ], Some ml_typ, body)
 end
 
+(* Dictionary-passing witnesses: a generic function's own boundary calls
+   (extern/builtin) marshal/unmarshal at its still-unresolved tparams via
+   witness functions the caller passes in, instead of a named top-level
+   marshal_T/unmarshal_T (which only exists for closed/ground T). *)
+
+let witness_marshal_name (tvar : string) = "marshal__" ^ tvar
+let witness_unmarshal_name (tvar : string) = "unmarshal__" ^ tvar
+
+(* [resolve_marshal tparams typ] / [resolve_unmarshal tparams typ] build an
+   expr of OCaml type ['t -> Value.t] / [Value.t -> 't] for [typ], where
+   ['t] is [typ]'s compiled OCaml type. Scope: bare tparam, or List/Opt of
+   one; anything else mentioning a tparam raises (see plan doc). *)
+let rec resolve_marshal (tparams : string list) (typ : Sl.typ) : Ml.expr =
+  match typ.it with
+  | Il.VarT (id, []) when List.mem id.it tparams ->
+      Ml.VarE (witness_marshal_name (Names.tvar id))
+  | Il.IterT (t, Il.List) when typ_mentions tparams t ->
+      Ml.FunE
+        ( [ Ml.VarP "x__" ],
+          Ml.AppE
+            ( Ml.LitE "Value.Make.list",
+              [
+                typ_make_expr typ;
+                Ml.AppE
+                  ( Ml.LitE "List.map",
+                    [ resolve_marshal tparams t; Ml.VarE "x__" ] );
+              ] ) )
+  | Il.IterT (t, Il.Opt) when typ_mentions tparams t ->
+      Ml.FunE
+        ( [ Ml.VarP "x__" ],
+          Ml.AppE
+            ( Ml.LitE "Value.Make.opt",
+              [
+                typ_make_expr typ;
+                Ml.AppE
+                  ( Ml.LitE "Option.map",
+                    [ resolve_marshal tparams t; Ml.VarE "x__" ] );
+              ] ) )
+  | _ when typ_mentions tparams typ ->
+      failwith
+        (Printf.sprintf
+           "resolve_marshal: %s: type parameter used inside an unsupported \
+            container at a boundary call (only bare/List/Opt supported)"
+           (Sl.Print.string_of_typ typ))
+  | _ -> Ml.VarE ("marshal_" ^ interface_name typ)
+
+and resolve_unmarshal (tparams : string list) (typ : Sl.typ) : Ml.expr =
+  match typ.it with
+  | Il.VarT (id, []) when List.mem id.it tparams ->
+      Ml.VarE (witness_unmarshal_name (Names.tvar id))
+  | Il.IterT (t, Il.List) when typ_mentions tparams t ->
+      Ml.FunE
+        ( [ Ml.VarP "v__" ],
+          Ml.AppE
+            ( Ml.LitE "List.map",
+              [
+                resolve_unmarshal tparams t;
+                Ml.AppE (Ml.LitE "Value.Get.list", [ Ml.VarE "v__" ]);
+              ] ) )
+  | Il.IterT (t, Il.Opt) when typ_mentions tparams t ->
+      Ml.FunE
+        ( [ Ml.VarP "v__" ],
+          Ml.AppE
+            ( Ml.LitE "Option.map",
+              [
+                resolve_unmarshal tparams t;
+                Ml.AppE (Ml.LitE "Value.Get.opt", [ Ml.VarE "v__" ]);
+              ] ) )
+  | _ when typ_mentions tparams typ ->
+      failwith
+        (Printf.sprintf
+           "resolve_unmarshal: %s: type parameter used inside an \
+            unsupported container at a boundary call"
+           (Sl.Print.string_of_typ typ))
+  | _ -> Ml.VarE ("unmarshal_" ^ interface_name typ)
+
+and typ_mentions (tparams : string list) (typ : Sl.typ) : bool =
+  match typ.it with
+  | Il.BoolT | Il.NumT _ | Il.TextT | Il.FuncT _ -> false
+  | Il.VarT (id, targs) ->
+      List.mem id.it tparams || List.exists (typ_mentions tparams) targs
+  | Il.TupleT typs -> List.exists (typ_mentions tparams) typs
+  | Il.IterT (t, _) -> typ_mentions tparams t
+
 (* Direct dependencies of marshal/unmarshal for a given type:
    the sub-types that marshal_T calls marshal_S for. *)
 let interface_typ_deps (ctx : Ctx.t) (typ : Sl.typ) : Sl.typ list =

--- a/p4spec/lib/pass/compile/gen/interface.ml
+++ b/p4spec/lib/pass/compile/gen/interface.ml
@@ -641,18 +641,14 @@ module Unmarshal = struct
     (name, [], [ ("v", Some (Ml.NameT "Value.t")) ], Some ml_typ, body)
 end
 
-(* Dictionary-passing witnesses: a generic function's own boundary calls
-   (extern/builtin) marshal/unmarshal at its still-unresolved tparams via
-   witness functions the caller passes in, instead of a named top-level
-   marshal_T/unmarshal_T (which only exists for closed/ground T). *)
+(* Dictionary-passing: a boundary call at a still-unresolved tparam
+   marshals/unmarshals via a caller-supplied witness, not a named marshal_T. *)
 
 let witness_marshal_name (tvar : string) = "marshal__" ^ tvar
 let witness_unmarshal_name (tvar : string) = "unmarshal__" ^ tvar
 
-(* [resolve_marshal tparams typ] / [resolve_unmarshal tparams typ] build an
-   expr of OCaml type ['t -> Value.t] / [Value.t -> 't] for [typ], where
-   ['t] is [typ]'s compiled OCaml type. Scope: bare tparam, or List/Opt of
-   one; anything else mentioning a tparam raises (see plan doc). *)
+(* Builds an expr of type ['t -> Value.t] / [Value.t -> 't] for [typ].
+   Scope: bare tparam, or List/Opt of one; else raises (see plan doc). *)
 let rec resolve_marshal (tparams : string list) (typ : Sl.typ) : Ml.expr =
   match typ.it with
   | Il.VarT (id, []) when List.mem id.it tparams ->

--- a/p4spec/lib/pass/compile/gen/interface.ml
+++ b/p4spec/lib/pass/compile/gen/interface.ml
@@ -708,8 +708,8 @@ and resolve_unmarshal (tparams : string list) (typ : Sl.typ) : Ml.expr =
   | _ when typ_mentions tparams typ ->
       failwith
         (Printf.sprintf
-           "resolve_unmarshal: %s: type parameter used inside an \
-            unsupported container at a boundary call"
+           "resolve_unmarshal: %s: type parameter used inside an unsupported \
+            container at a boundary call"
            (Sl.Print.string_of_typ typ))
   | _ -> Ml.VarE ("unmarshal_" ^ interface_name typ)
 
@@ -771,12 +771,38 @@ let compute_groups (ctx : Ctx.t) (typs : Sl.typ list) : Sl.typ list list =
     let sccs = Scc.Tarjan.tarjan n adj in
     List.map (fun scc -> List.map (fun i -> typs_arr.(i)) scc) sccs
 
+(* name -> [Obj.t]-erased marshal_<name>/unmarshal_<name> pair, used by
+   [eval_func]'s generic arm. *)
+let compile_registry (typs : Sl.typ list) : Ml.toplevel =
+  let entries_ml =
+    List.map
+      (fun typ ->
+        let name = interface_name typ in
+        Ml.TupleE
+          [
+            Ml.StrE name;
+            Ml.TupleE
+              [
+                Ml.AppE (Ml.LitE "Obj.repr", [ Ml.VarE ("marshal_" ^ name) ]);
+                Ml.AppE (Ml.LitE "Obj.repr", [ Ml.VarE ("unmarshal_" ^ name) ]);
+              ];
+          ])
+      typs
+  in
+  Ml.Let
+    ( "interface_registry_",
+      Ml.AppE
+        ( Ml.LitE "Hashtbl.of_seq",
+          [ Ml.AppE (Ml.LitE "List.to_seq", [ Ml.ListE entries_ml ]) ] ) )
+
 let compile (ctx : Ctx.t) (spec : Sl.spec) :
-    Ml.toplevel list * Ml.funcdef list list * Ml.funcdef list list =
+    Ml.toplevel list * Ml.funcdef list list * Ml.funcdef list list * Ml.toplevel
+    =
   let typs = collect_types ctx spec in
   let groups = compute_groups ctx typs in
   let pool = make_pool () in
   let marshal_groups = List.map (List.map (Marshal.compile ctx pool)) groups in
   let unmarshal_groups = List.map (List.map (Unmarshal.compile ctx)) groups in
   let const_decls = List.rev_map (fun (n, e) -> Ml.Let (n, e)) pool.consts in
-  (const_decls, marshal_groups, unmarshal_groups)
+  let registry_ml = compile_registry typs in
+  (const_decls, marshal_groups, unmarshal_groups, registry_ml)

--- a/p4spec/lib/pass/compile/gen/interface.ml
+++ b/p4spec/lib/pass/compile/gen/interface.ml
@@ -474,7 +474,7 @@ module Marshal = struct
     let name = "marshal_" ^ interface_name typ in
     let ml_typ = Type.compile_typ ~tparams:[] typ in
     let body = compile_body ctx pool typ in
-    (name, [ ("x", Some ml_typ) ], Some (Ml.NameT "Value.t"), body)
+    (name, [], [ ("x", Some ml_typ) ], Some (Ml.NameT "Value.t"), body)
 end
 
 (* Unmarshalling *)
@@ -638,7 +638,7 @@ module Unmarshal = struct
     let name = "unmarshal_" ^ interface_name typ in
     let ml_typ = Type.compile_typ ~tparams:[] typ in
     let body = compile_body ctx typ in
-    (name, [ ("v", Some (Ml.NameT "Value.t")) ], Some ml_typ, body)
+    (name, [], [ ("v", Some (Ml.NameT "Value.t")) ], Some ml_typ, body)
 end
 
 (* Direct dependencies of marshal/unmarshal for a given type:

--- a/p4spec/lib/pass/compile/gen/interface.ml
+++ b/p4spec/lib/pass/compile/gen/interface.ml
@@ -5,6 +5,8 @@ open Util.Source
 
 (* Type-to-name mapping for generated function suffixes *)
 
+(* Mirrored at runtime by [interface_name_] in [Template.Split.interface_name_fn]
+   — keep both in sync; see that function's own cross-reference comment. *)
 let rec interface_name (typ : Sl.typ) : string =
   match typ.it with
   | BoolT -> "bool"

--- a/p4spec/lib/pass/compile/gen/rel.ml
+++ b/p4spec/lib/pass/compile/gen/rel.ml
@@ -26,7 +26,9 @@ let compile_defined_rel (ctx : Ctx.t) (id : id)
     |> List.fold_left
          (fun (ctx, chain_acc) (i, exp_in) ->
            let ctx, ch =
-             Bind.compile ctx (Ml.VarE ("param__" ^ string_of_int i)) exp_in
+             Bind.compile ~tparams:[] ctx
+               (Ml.VarE ("param__" ^ string_of_int i))
+               exp_in
            in
            (ctx, Chain.connect [ chain_acc; ch ]))
          (ctx, Chain.nop)
@@ -34,7 +36,7 @@ let compile_defined_rel (ctx : Ctx.t) (id : id)
   (* Compile main block *)
   let id_main_ml = "main__" ^ id_ml in
   let ctx, funcdef_main_ml =
-    let ctx, expr_block_ml = Instr.compile_block ctx block_main in
+    let ctx, expr_block_ml = Instr.compile_block ~tparams:[] ctx block_main in
     let expr_ml = Chain.apply chain expr_block_ml in
     (ctx, (id_main_ml, [], params_ml, None, expr_ml))
   in
@@ -43,7 +45,7 @@ let compile_defined_rel (ctx : Ctx.t) (id : id)
   let ctx, funcdef_else_ml_opt =
     match elseblock_opt with
     | Some elseblock ->
-        let ctx, expr_else_ml = Instr.compile_block ctx elseblock in
+        let ctx, expr_else_ml = Instr.compile_block ~tparams:[] ctx elseblock in
         let expr_ml = Chain.apply chain expr_else_ml in
         (ctx, Some (id_else_ml, [], params_ml, None, expr_ml))
     | None -> (ctx, None)

--- a/p4spec/lib/pass/compile/gen/rel.ml
+++ b/p4spec/lib/pass/compile/gen/rel.ml
@@ -36,7 +36,7 @@ let compile_defined_rel (ctx : Ctx.t) (id : id)
   let ctx, funcdef_main_ml =
     let ctx, expr_block_ml = Instr.compile_block ctx block_main in
     let expr_ml = Chain.apply chain expr_block_ml in
-    (ctx, (id_main_ml, params_ml, None, expr_ml))
+    (ctx, (id_main_ml, [], params_ml, None, expr_ml))
   in
   (* Compile else block *)
   let id_else_ml = "else__" ^ id_ml in
@@ -45,7 +45,7 @@ let compile_defined_rel (ctx : Ctx.t) (id : id)
     | Some elseblock ->
         let ctx, expr_else_ml = Instr.compile_block ctx elseblock in
         let expr_ml = Chain.apply chain expr_else_ml in
-        (ctx, Some (id_else_ml, params_ml, None, expr_ml))
+        (ctx, Some (id_else_ml, [], params_ml, None, expr_ml))
     | None -> (ctx, None)
   in
   (* Promote preamble to outer context *)
@@ -63,7 +63,7 @@ let compile_defined_rel (ctx : Ctx.t) (id : id)
             ] )
     | None -> Ml.AppE (Ml.VarE id_main_ml, exprs_param_ml)
   in
-  let funcdef_dispatcher_ml = (id_ml, params_ml, None, dispatch_ml) in
+  let funcdef_dispatcher_ml = (id_ml, [], params_ml, None, dispatch_ml) in
   let funcdefs_ml =
     (funcdef_main_ml :: Option.to_list funcdef_else_ml_opt)
     @ [ funcdef_dispatcher_ml ]
@@ -143,7 +143,7 @@ let compile_extern_rel (ctx : Ctx.t) (id : id)
       (List.combine vars_marshal_ml exprs_marshal_ml)
       expr_result_ml
   in
-  (ctx, [ (id_ml, params_ml, None, Common.deref_ctx expr_body_ml) ])
+  (ctx, [ (id_ml, [], params_ml, None, Common.deref_ctx expr_body_ml) ])
 
 (* Defs *)
 

--- a/p4spec/lib/pass/compile/ml/ast.ml
+++ b/p4spec/lib/pass/compile/ml/ast.ml
@@ -147,7 +147,7 @@ type param = id * typ option
 
 (* Function definitions *)
 
-type funcdef = id * param list * typ option * expr
+type funcdef = id * tparam list * param list * typ option * expr
 
 (* Top-level items *)
 

--- a/p4spec/lib/pass/compile/ml/print.ml
+++ b/p4spec/lib/pass/compile/ml/print.ml
@@ -312,7 +312,10 @@ let print_funcdef (id, tparams, params, typ_ret_opt, expr_body) =
       let ret_typ_str =
         match typ_ret_opt with
         | Some typ -> print_typ typ
-        | None -> failwith (Printf.sprintf "print_funcdef: generic function %s: missing return type" id)
+        | None ->
+            failwith
+              (Printf.sprintf
+                 "print_funcdef: generic function %s: missing return type" id)
       in
       let arrow_typ_str =
         match param_typ_strs with

--- a/p4spec/lib/pass/compile/ml/print.ml
+++ b/p4spec/lib/pass/compile/ml/print.ml
@@ -293,10 +293,8 @@ let print_funcdef (id, tparams, params, typ_ret_opt, expr_body) =
       print_id id ^ " " ^ str_params ^ str_ret ^ " =\n  "
       ^ print_expr ~level:1 expr_body
   | _ ->
-      (* Explicit forall, spelled out — required for mutual/self-recursive
-         generic calls that instantiate at a different type than the
-         member's own parameters (OCaml won't infer this inside a
-         [let rec]). *)
+      (* Explicit forall: OCaml can't infer instantiation at a different
+         type than the member's own params inside a [let rec]. *)
       let quantifier = String.concat " " (List.map (fun t -> "'" ^ t) tparams) in
       let param_typ_strs =
         List.map

--- a/p4spec/lib/pass/compile/ml/print.ml
+++ b/p4spec/lib/pass/compile/ml/print.ml
@@ -279,17 +279,51 @@ let print_param (id, typ_opt) =
 
 (* Function definitions *)
 
-let print_funcdef (id, params, typ_ret_opt, expr_body) =
-  let str_params =
-    match params with
-    | [] -> "()"
-    | _ -> String.concat " " (List.map print_param params)
-  in
-  let str_ret =
-    match typ_ret_opt with None -> "" | Some typ -> " : " ^ print_typ typ
-  in
-  print_id id ^ " " ^ str_params ^ str_ret ^ " =\n  "
-  ^ print_expr ~level:1 expr_body
+let print_funcdef (id, tparams, params, typ_ret_opt, expr_body) =
+  match tparams with
+  | [] ->
+      let str_params =
+        match params with
+        | [] -> "()"
+        | _ -> String.concat " " (List.map print_param params)
+      in
+      let str_ret =
+        match typ_ret_opt with None -> "" | Some typ -> " : " ^ print_typ typ
+      in
+      print_id id ^ " " ^ str_params ^ str_ret ^ " =\n  "
+      ^ print_expr ~level:1 expr_body
+  | _ ->
+      (* Explicit forall, spelled out — required for mutual/self-recursive
+         generic calls that instantiate at a different type than the
+         member's own parameters (OCaml won't infer this inside a
+         [let rec]). *)
+      let quantifier = String.concat " " (List.map (fun t -> "'" ^ t) tparams) in
+      let param_typ_strs =
+        List.map
+          (fun (id, typ_opt) ->
+            match typ_opt with
+            | Some typ -> print_typ typ
+            | None ->
+                failwith
+                  (Printf.sprintf
+                     "print_funcdef: generic function %s: untyped param %s \
+                      (higher-order params not supported)"
+                     id id))
+          params
+      in
+      let ret_typ_str =
+        match typ_ret_opt with
+        | Some typ -> print_typ typ
+        | None -> failwith (Printf.sprintf "print_funcdef: generic function %s: missing return type" id)
+      in
+      let arrow_typ_str = String.concat " -> " (param_typ_strs @ [ ret_typ_str ]) in
+      let str_params =
+        match params with
+        | [] -> "()"
+        | _ -> String.concat " " (List.map (fun (id, _) -> print_id id) params)
+      in
+      print_id id ^ " : " ^ quantifier ^ ". " ^ arrow_typ_str ^ " =\n  fun "
+      ^ str_params ^ " ->\n  " ^ print_expr ~level:1 expr_body
 
 (* Top-level items *)
 

--- a/p4spec/lib/pass/compile/ml/print.ml
+++ b/p4spec/lib/pass/compile/ml/print.ml
@@ -314,7 +314,11 @@ let print_funcdef (id, tparams, params, typ_ret_opt, expr_body) =
         | Some typ -> print_typ typ
         | None -> failwith (Printf.sprintf "print_funcdef: generic function %s: missing return type" id)
       in
-      let arrow_typ_str = String.concat " -> " (param_typ_strs @ [ ret_typ_str ]) in
+      let arrow_typ_str =
+        match param_typ_strs with
+        | [] -> "unit -> " ^ ret_typ_str
+        | _ -> String.concat " -> " (param_typ_strs @ [ ret_typ_str ])
+      in
       let str_params =
         match params with
         | [] -> "()"

--- a/p4spec/lib/pass/compile/mono/collect.ml
+++ b/p4spec/lib/pass/compile/mono/collect.ml
@@ -19,6 +19,20 @@ let make_poly_call_collector (poly_funcs : StringSet.t) :
   in
   { (Collect.make_base ~default:[] ~compose:( @ )) with collect_exp }
 
+(* ===== All-call collector ===== *)
+
+(* Every (callee, targs) pair in a block, regardless of polymorphism —
+   used to detect a generic function's own boundary crossings. *)
+let make_all_call_collector () : (string * Il.typ list) list Collect.collector
+    =
+  let collect_exp c exp =
+    let sub = Collect.default_collect_exp c exp in
+    match exp.it with
+    | Il.CallE (id, targs, _) -> c.compose sub [ (id.it, targs) ]
+    | _ -> sub
+  in
+  { (Collect.make_base ~default:[] ~compose:( @ )) with collect_exp }
+
 (* ===== Collecting from SL blocks ===== *)
 
 let collect_from_exp (c : (string * Il.typ list) list Collect.collector)
@@ -113,3 +127,10 @@ let collect_call_sites ~(poly_funcs : StringSet.t) (spec : Sl.spec) :
       let cmp_id = String.compare id_a id_b in
       if cmp_id <> 0 then cmp_id else compare targs_a targs_b)
     raw
+
+(* All (callee, targs) call sites in a block; feeds [Gen.Func]'s boundary
+   check. *)
+let collect_all_calls_in_block (block : Sl.block) : (string * Il.typ list) list
+    =
+  let c = make_all_call_collector () in
+  collect_in_block c block

--- a/p4spec/lib/pass/compile/mono/mono.ml
+++ b/p4spec/lib/pass/compile/mono/mono.ml
@@ -43,16 +43,28 @@ let add_instance (tbl : dispatch_table) ~(original : string) ~(mangled : string)
 
 (* ===== Call-site rewriting ===== *)
 
+(* True if [typ] mentions a VarT bound in [scope] — distinguishes a
+   still-symbolic call from a ground one, so we don't mangle the former. *)
+let rec typ_mentions_any (scope : StringSet.t) (typ : Il.typ) : bool =
+  match typ.it with
+  | Il.BoolT | Il.NumT _ | Il.TextT | Il.FuncT _ -> false
+  | Il.VarT (id, targs) ->
+      StringSet.mem id.it scope || List.exists (typ_mentions_any scope) targs
+  | Il.TupleT typs -> List.exists (typ_mentions_any scope) typs
+  | Il.IterT (typ, _) -> typ_mentions_any scope typ
+
 (* Rewrite all CallE nodes in an expression tree:
    - CallE(id, targs, args) where id.it ∈ poly_funcs and targs ≠ []
      → CallE({id with it = mangled_name}, [], args)
    - All other nodes are left unchanged (types are not substituted here). *)
 
-let rec rewrite_exp (poly_funcs : StringSet.t) (exp : Il.exp) : Il.exp =
-  { exp with it = rewrite_exp' poly_funcs exp.it }
+let rec rewrite_exp (poly_funcs : StringSet.t) (tparams_scope : StringSet.t)
+    (exp : Il.exp) : Il.exp =
+  { exp with it = rewrite_exp' poly_funcs tparams_scope exp.it }
 
-and rewrite_exp' (poly_funcs : StringSet.t) (exp' : Il.exp') : Il.exp' =
-  let re = rewrite_exp poly_funcs in
+and rewrite_exp' (poly_funcs : StringSet.t) (tparams_scope : StringSet.t)
+    (exp' : Il.exp') : Il.exp' =
+  let re = rewrite_exp poly_funcs tparams_scope in
   match exp' with
   | Il.BoolE _ | Il.NumE _ | Il.TextE _ | Il.VarE _ -> exp'
   | Il.UnE (op, ot, exp) -> Il.UnE (op, ot, re exp)
@@ -77,63 +89,81 @@ and rewrite_exp' (poly_funcs : StringSet.t) (exp' : Il.exp') : Il.exp' =
   | Il.IdxE (exp_l, exp_r) -> Il.IdxE (re exp_l, re exp_r)
   | Il.SliceE (exp_l, exp_m, exp_r) -> Il.SliceE (re exp_l, re exp_m, re exp_r)
   | Il.UpdE (exp_b, path, exp_u) ->
-      Il.UpdE (re exp_b, rewrite_path poly_funcs path, re exp_u)
+      Il.UpdE (re exp_b, rewrite_path poly_funcs tparams_scope path, re exp_u)
   | Il.CallE (id, targs, args)
-    when targs <> [] && StringSet.mem id.it poly_funcs ->
+    when targs <> []
+         && StringSet.mem id.it poly_funcs
+         && not (List.exists (typ_mentions_any tparams_scope) targs) ->
       let mangled = Name.mangle id.it targs in
       Il.CallE
-        ({ id with it = mangled }, [], List.map (rewrite_arg poly_funcs) args)
+        ( { id with it = mangled },
+          [],
+          List.map (rewrite_arg poly_funcs tparams_scope) args )
   | Il.CallE (id, targs, args) ->
-      Il.CallE (id, targs, List.map (rewrite_arg poly_funcs) args)
+      (* Non-poly callee, or poly callee called with still-symbolic targs —
+         leave targs untouched; Task 5 compiles these calls directly. *)
+      Il.CallE
+        (id, targs, List.map (rewrite_arg poly_funcs tparams_scope) args)
   | Il.IterE (exp, iterexp) -> Il.IterE (re exp, iterexp)
 
-and rewrite_path (poly_funcs : StringSet.t) (path : Il.path) : Il.path =
-  { path with it = rewrite_path' poly_funcs path.it }
+and rewrite_path (poly_funcs : StringSet.t) (tparams_scope : StringSet.t)
+    (path : Il.path) : Il.path =
+  { path with it = rewrite_path' poly_funcs tparams_scope path.it }
 
-and rewrite_path' (poly_funcs : StringSet.t) (path' : Il.path') : Il.path' =
-  let re = rewrite_exp poly_funcs in
+and rewrite_path' (poly_funcs : StringSet.t) (tparams_scope : StringSet.t)
+    (path' : Il.path') : Il.path' =
+  let re = rewrite_exp poly_funcs tparams_scope in
   match path' with
   | Il.RootP -> Il.RootP
-  | Il.IdxP (path, exp) -> Il.IdxP (rewrite_path poly_funcs path, re exp)
+  | Il.IdxP (path, exp) ->
+      Il.IdxP (rewrite_path poly_funcs tparams_scope path, re exp)
   | Il.SliceP (path, exp_l, exp_r) ->
-      Il.SliceP (rewrite_path poly_funcs path, re exp_l, re exp_r)
-  | Il.DotP (path, atom) -> Il.DotP (rewrite_path poly_funcs path, atom)
+      Il.SliceP (rewrite_path poly_funcs tparams_scope path, re exp_l, re exp_r)
+  | Il.DotP (path, atom) ->
+      Il.DotP (rewrite_path poly_funcs tparams_scope path, atom)
 
-and rewrite_arg (poly_funcs : StringSet.t) (arg : Il.arg) : Il.arg =
+and rewrite_arg (poly_funcs : StringSet.t) (tparams_scope : StringSet.t)
+    (arg : Il.arg) : Il.arg =
   match arg.it with
-  | Il.ExpA exp -> Il.ExpA (rewrite_exp poly_funcs exp) $ arg.at
+  | Il.ExpA exp -> Il.ExpA (rewrite_exp poly_funcs tparams_scope exp) $ arg.at
   | Il.DefA _ -> arg
 
-let rewrite_notexp (poly_funcs : StringSet.t) (notexp : Sl.notexp) : Sl.notexp =
-  Mixfix.map (rewrite_exp poly_funcs) notexp
+let rewrite_notexp (poly_funcs : StringSet.t) (tparams_scope : StringSet.t)
+    (notexp : Sl.notexp) : Sl.notexp =
+  Mixfix.map (rewrite_exp poly_funcs tparams_scope) notexp
 
-let rewrite_guard (poly_funcs : StringSet.t) (guard : Sl.guard) : Sl.guard =
+let rewrite_guard (poly_funcs : StringSet.t) (tparams_scope : StringSet.t)
+    (guard : Sl.guard) : Sl.guard =
   match guard with
   | Sl.BoolG _ | Sl.MatchG _ -> guard
-  | Sl.CmpG (op, ot, exp) -> Sl.CmpG (op, ot, rewrite_exp poly_funcs exp)
+  | Sl.CmpG (op, ot, exp) ->
+      Sl.CmpG (op, ot, rewrite_exp poly_funcs tparams_scope exp)
   | Sl.SubG _ -> guard
-  | Sl.MemG exp -> Sl.MemG (rewrite_exp poly_funcs exp)
+  | Sl.MemG exp -> Sl.MemG (rewrite_exp poly_funcs tparams_scope exp)
 
-let rec rewrite_instr (poly_funcs : StringSet.t) (instr : Sl.instr) : Sl.instr =
-  { instr with it = rewrite_instr' poly_funcs instr.it }
+let rec rewrite_instr (poly_funcs : StringSet.t) (tparams_scope : StringSet.t)
+    (instr : Sl.instr) : Sl.instr =
+  { instr with it = rewrite_instr' poly_funcs tparams_scope instr.it }
 
-and rewrite_instr' (poly_funcs : StringSet.t) (instr' : Sl.instr') : Sl.instr' =
-  let re = rewrite_exp poly_funcs in
-  let rb = rewrite_block poly_funcs in
+and rewrite_instr' (poly_funcs : StringSet.t) (tparams_scope : StringSet.t)
+    (instr' : Sl.instr') : Sl.instr' =
+  let re = rewrite_exp poly_funcs tparams_scope in
+  let rb = rewrite_block poly_funcs tparams_scope in
   match instr' with
   | Sl.IfI (exp, iterexps, block, dangle) ->
       Sl.IfI (re exp, iterexps, rb block, dangle)
   | Sl.HoldI (id, notexp, iterexps, holdcase) ->
       Sl.HoldI
         ( id,
-          rewrite_notexp poly_funcs notexp,
+          rewrite_notexp poly_funcs tparams_scope notexp,
           iterexps,
-          rewrite_holdcase poly_funcs holdcase )
+          rewrite_holdcase poly_funcs tparams_scope holdcase )
   | Sl.CaseI (exp, cases, dangle) ->
       Sl.CaseI
         ( re exp,
           List.map
-            (fun (guard, block) -> (rewrite_guard poly_funcs guard, rb block))
+            (fun (guard, block) ->
+              (rewrite_guard poly_funcs tparams_scope guard, rb block))
             cases,
           dangle )
   | Sl.GroupI (id, rel_sig, exps, block) ->
@@ -142,17 +172,22 @@ and rewrite_instr' (poly_funcs : StringSet.t) (instr' : Sl.instr') : Sl.instr' =
       Sl.LetI (re lhs_exp, re rhs_exp, iterinstrs, rb block)
   | Sl.RuleI (id, notexp, hints, iterinstrs, block) ->
       Sl.RuleI
-        (id, rewrite_notexp poly_funcs notexp, hints, iterinstrs, rb block)
+        ( id,
+          rewrite_notexp poly_funcs tparams_scope notexp,
+          hints,
+          iterinstrs,
+          rb block )
   | Sl.ResultI (rel_sig, exps) -> Sl.ResultI (rel_sig, List.map re exps)
   | Sl.ReturnI exp -> Sl.ReturnI (re exp)
   | Sl.DebugI exp -> Sl.DebugI (re exp)
 
-and rewrite_block (poly_funcs : StringSet.t) (block : Sl.block) : Sl.block =
-  List.map (rewrite_instr poly_funcs) block
+and rewrite_block (poly_funcs : StringSet.t) (tparams_scope : StringSet.t)
+    (block : Sl.block) : Sl.block =
+  List.map (rewrite_instr poly_funcs tparams_scope) block
 
-and rewrite_holdcase (poly_funcs : StringSet.t) (holdcase : Sl.holdcase) :
-    Sl.holdcase =
-  let rb = rewrite_block poly_funcs in
+and rewrite_holdcase (poly_funcs : StringSet.t) (tparams_scope : StringSet.t)
+    (holdcase : Sl.holdcase) : Sl.holdcase =
+  let rb = rewrite_block poly_funcs tparams_scope in
   match holdcase with
   | Sl.BothH (block_hold, block_nhold) ->
       Sl.BothH (rb block_hold, rb block_nhold)
@@ -160,29 +195,28 @@ and rewrite_holdcase (poly_funcs : StringSet.t) (holdcase : Sl.holdcase) :
   | Sl.NotHoldH (block, dangle) -> Sl.NotHoldH (rb block, dangle)
 
 let rewrite_def (poly_funcs : StringSet.t) (def : Sl.def) : Sl.def =
-  let rb = rewrite_block poly_funcs in
   match def.it with
   | Sl.FuncDecD (id, tparams, params, typ_ret, block, elseblock, hints) ->
+      let scope =
+        StringSet.of_list (List.map (fun (tp : Il.tparam) -> tp.it) tparams)
+      in
+      let rb = rewrite_block poly_funcs scope in
       {
         def with
         it =
           Sl.FuncDecD
-            ( id,
-              tparams,
-              params,
-              typ_ret,
-              rb block,
-              Option.map rb elseblock,
-              hints );
+            (id, tparams, params, typ_ret, rb block, Option.map rb elseblock, hints);
       }
   | Sl.RelD (id, rel_sig, exps, block, elseblock, hints) ->
+      (* RelD has no tparams of its own — always ground scope. *)
+      let rb = rewrite_block poly_funcs StringSet.empty in
       {
         def with
         it =
           Sl.RelD
             ( id,
               rel_sig,
-              List.map (rewrite_exp poly_funcs) exps,
+              List.map (rewrite_exp poly_funcs StringSet.empty) exps,
               rb block,
               Option.map rb elseblock,
               hints );
@@ -281,18 +315,6 @@ let monomorphize (spec : Sl.spec) : Sl.spec * dispatch_table =
     (* Step 5: rewrite all call sites in the full spec (including new defs) *)
     let combined_spec = spec @ List.rev !new_defs in
     let rewritten = rewrite_spec poly_funcs combined_spec in
-    (* Step 6: remove original poly FuncDecDs/BuiltinDecDs/ExternDecDs *)
-    let filtered =
-      List.filter
-        (fun def ->
-          match def.it with
-          | Sl.FuncDecD (id, tparams, _, _, _, _, _) ->
-              not (tparams <> [] && StringSet.mem id.it poly_funcs)
-          | Sl.BuiltinDecD (id, tparams, _, _, _) ->
-              not (tparams <> [] && StringSet.mem id.it poly_funcs)
-          | Sl.ExternDecD (id, tparams, _, _, _) ->
-              not (tparams <> [] && StringSet.mem id.it poly_funcs)
-          | _ -> true)
-        rewritten
-    in
-    (filtered, dispatch_table)
+    (* Step 6: keep generic originals alive — Task 4/5 compile them,
+       Task 6 makes them reachable from eval_func. *)
+    (rewritten, dispatch_table)

--- a/p4spec/lib/pass/compile/mono/mono.ml
+++ b/p4spec/lib/pass/compile/mono/mono.ml
@@ -4,6 +4,7 @@ module Mixfix = Domain.Mixfix
 module StringSet = Collect.StringSet
 module Specialize = Specialize
 module Subst = Subst
+module Collect = Collect
 
 (* ===== Dispatch table types ===== *)
 

--- a/p4spec/lib/pass/compile/scc/call.ml
+++ b/p4spec/lib/pass/compile/scc/call.ml
@@ -123,12 +123,10 @@ let collect_refs_def (def : def) : string list * int list =
 
 (* ── Node classification ── *)
 
-(* True for defs that compile to OCaml let-bindings (func or rel, concrete) *)
+(* True for defs that are graph nodes: funcs (ground or generic) and rels. *)
 let is_entity (def : def) : bool =
   match def.it with
-  | FuncDecD (_, tparams, _, _, _, _, _) -> tparams = []
-  | ExternDecD (_, tparams, _, _, _) -> tparams = []
-  | BuiltinDecD (_, tparams, _, _, _) -> tparams = []
+  | FuncDecD _ | ExternDecD _ | BuiltinDecD _ -> true
   | TableDecD _ | RelD _ | ExternRelD _ -> true
   | _ -> false
 

--- a/p4spec/lib/pass/compile/template/split.ml
+++ b/p4spec/lib/pass/compile/template/split.ml
@@ -43,8 +43,8 @@ let dispatch_header (n_parts : int) : string =
   in
   if opens = "" then common_opens ^ "\n" else common_opens ^ "\n" ^ opens ^ "\n"
 
-(* [interface_name]/[Names.sanitize] (interface.ml) re-emitted as fixed
-   source, since [Typ.t = Il.typ] but the compiler isn't linked into the artifact. *)
+(* [interface_name]/[Names.sanitize] re-emitted as fixed source, since the
+   compiler itself isn't linked into the generated artifact. *)
 let interface_name_fn : string =
   {|
 let interface_keywords_ =

--- a/p4spec/lib/pass/compile/template/split.ml
+++ b/p4spec/lib/pass/compile/template/split.ml
@@ -45,6 +45,7 @@ let dispatch_header (n_parts : int) : string =
 
 (* [interface_name]/[Names.sanitize] re-emitted as fixed source, since the
    compiler itself isn't linked into the generated artifact. *)
+(* Must stay in sync with [Interface.interface_name] (gen/interface.ml). *)
 let interface_name_fn : string =
   {|
 let interface_keywords_ =

--- a/p4spec/lib/pass/compile/template/split.ml
+++ b/p4spec/lib/pass/compile/template/split.ml
@@ -43,6 +43,76 @@ let dispatch_header (n_parts : int) : string =
   in
   if opens = "" then common_opens ^ "\n" else common_opens ^ "\n" ^ opens ^ "\n"
 
+(* [interface_name]/[Names.sanitize] (interface.ml) re-emitted as fixed
+   source, since [Typ.t = Il.typ] but the compiler isn't linked into the artifact. *)
+let interface_name_fn : string =
+  {|
+let interface_keywords_ =
+  [ "and"; "as"; "assert"; "asr"; "begin"; "class"; "constraint"; "do"; "done";
+    "downto"; "else"; "end"; "exception"; "external"; "false"; "for"; "fun";
+    "function"; "functor"; "if"; "in"; "include"; "inherit"; "initializer";
+    "land"; "lazy"; "let"; "lor"; "lsl"; "lsr"; "lxor"; "match"; "method";
+    "mod"; "module"; "mutable"; "new"; "nonrec"; "object"; "of"; "open"; "or";
+    "private"; "rec"; "sig"; "struct"; "then"; "to"; "true"; "try"; "type";
+    "val"; "virtual"; "when"; "while"; "with" ]
+
+let interface_snake_case_ (name : string) : string =
+  let len = String.length name in
+  let buf = Buffer.create (len + 4) in
+  String.iteri
+    (fun idx c ->
+      (if idx > 0 then
+         let prev = name.[idx - 1] in
+         let is_upper = c >= 'A' && c <= 'Z' in
+         let prev_lower = prev >= 'a' && prev <= 'z' in
+         let prev_upper = prev >= 'A' && prev <= 'Z' in
+         let next_lower =
+           idx + 1 < len && name.[idx + 1] >= 'a' && name.[idx + 1] <= 'z'
+         in
+         if is_upper && (prev_lower || (prev_upper && next_lower)) then
+           Buffer.add_char buf '_');
+      Buffer.add_char buf (Char.lowercase_ascii c))
+    name;
+  Buffer.contents buf
+
+let interface_escape_non_alnum_ (name : string) : string =
+  let buf = Buffer.create (String.length name) in
+  String.iter
+    (fun c ->
+      if (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9')
+      then Buffer.add_char buf c
+      else Buffer.add_char buf '_')
+    name;
+  Buffer.contents buf
+
+let interface_sanitize_ (name : string) : string =
+  let name = interface_escape_non_alnum_ (interface_snake_case_ name) in
+  if List.mem name interface_keywords_ then name ^ "_" else name
+
+let rec interface_name_ (typ : Typ.t) : string =
+  match typ.it with
+  | Il.BoolT -> "bool"
+  | Il.NumT `NatT -> "nat"
+  | Il.NumT `IntT -> "int"
+  | Il.TextT -> "text"
+  | Il.VarT (id, []) -> interface_sanitize_ id.it
+  | Il.VarT (id, targs) ->
+      interface_sanitize_ id.it ^ "__"
+      ^ String.concat "__" (List.map interface_name_ targs)
+  | Il.TupleT typs -> String.concat "_" (List.map interface_name_ typs) ^ "_tup"
+  | Il.IterT (t, Il.Opt) -> interface_name_ t ^ "__opt"
+  | Il.IterT (t, Il.List) -> interface_name_ t ^ "__list"
+  | Il.FuncT _ -> "func"
+
+exception No_marshaller_ of string
+
+let interface_lookup_ (typ : Typ.t) : Obj.t * Obj.t =
+  let name = interface_name_ typ in
+  match Hashtbl.find_opt interface_registry_ name with
+  | Some entry -> entry
+  | None -> raise (No_marshaller_ name)
+|}
+
 (* Generated [compiled/dune]. [-opaque] keeps the [.cmx] jobs parallel despite
    the linear cmi chain. *)
 let dune (name : string) : string =

--- a/p4spec/test/run/dune
+++ b/p4spec/test/run/dune
@@ -340,6 +340,14 @@
      ../../../../../p4c/testdata/p4_16_errors
      -neg)))))
 
+;; Direct eval_func test (Task 6) — no expected/actual diffing, the command
+;; itself fails (nonzero exit) if eval_func doesn't return the right result.
+
+(rule
+ (alias eval-func-ml)
+ (action
+  (run ./test.exe eval-func)))
+
 ;; Rules to generate outputs (ML compiled interpreter)
 
 (rule

--- a/p4spec/test/run/dune
+++ b/p4spec/test/run/dune
@@ -61,7 +61,8 @@
    (ignore-outputs
     (diff run_pos_sl.expected run_pos_ml.actual))
    (ignore-outputs
-    (diff run_neg_sl.expected run_neg_ml.actual)))))
+    (diff run_neg_sl.expected run_neg_ml.actual))
+   (run ./test.exe eval-func))))
 
 (rule
  (alias run-sl-mono)

--- a/p4spec/test/run/test.ml
+++ b/p4spec/test/run/test.ml
@@ -209,6 +209,45 @@ let eval_func_has_dup_test () : unit =
   | Fail (_, msg) ->
       failwith
         (Printf.sprintf "eval_func_has_dup_test: eval_func failed: %s" msg));
+  (* [interface_name]/[interface_name_] registry-key agreement: a mismatch
+     for a registered witness type surfaces as [No_marshaller_] below. *)
+  let check_has_dup (label : string) (typ_x : Runtime.Type.Typ.t)
+      (value_dup : Runtime.Value.t) : unit =
+    let value_args =
+      Runtime.Value.Make.list
+        (Runtime.Type.Typ.Make.list typ_x)
+        [ value_dup; value_dup ]
+    in
+    match Interp.eval_func "has_dup_" [ typ_x ] [ value_args ] with
+    | Pass value ->
+        if Runtime.Value.Get.bool value then
+          print_endline
+            (Printf.sprintf "[PASS] eval_func \"has_dup_\" at %s" label)
+        else
+          failwith
+            (Printf.sprintf
+               "eval_func_has_dup_test: %s: expected true, got false" label)
+    | Fail (_, msg) ->
+        failwith (Printf.sprintf "eval_func_has_dup_test: %s: %s" label msg)
+  in
+  (* [name]'s [`TYPE] case — a VarT with a plain id (no sanitizing needed). *)
+  let typ_name =
+    Util.Source.(Runtime.Type.Typ.Make.var ("name" $ no_region) [])
+  in
+  let value_name = Runtime.Value.Make.(("TYPE" <| []) <<| "name") in
+  check_has_dup "name (VarT, plain id)" typ_name value_name;
+  (* Witness itself is [text list] — exercises the [IterT (_, List)] arm. *)
+  let typ_text_list = Runtime.Type.Typ.Make.list typ_text in
+  let value_text_list =
+    Runtime.Value.Make.list typ_text_list [ Runtime.Value.Make.text "a" ]
+  in
+  check_has_dup "text list (IterT List)" typ_text_list value_text_list;
+  (* Witness itself is [text opt] — exercises the [IterT (_, Opt)] arm. *)
+  let typ_text_opt = Runtime.Type.Typ.Make.opt typ_text in
+  let value_text_opt =
+    Runtime.Value.Make.opt typ_text_opt (Some (Runtime.Value.Make.text "a"))
+  in
+  check_has_dup "text opt (IterT Opt)" typ_text_opt value_text_opt;
   (* Wrong arity (missing the [X] witness type) must fail cleanly, not crash. *)
   match Interp.eval_func "has_dup_" [] [ value_args ] with
   | Pass _ ->
@@ -217,9 +256,48 @@ let eval_func_has_dup_test () : unit =
       print_endline
         "[PASS] eval_func \"has_dup_\" with wrong arity failed cleanly"
 
+(* [split.ml]'s embedded keyword list must match [Names.keywords], or a
+   keyword-colliding type name sanitizes differently at runtime vs compile. *)
+
+let extract_bracketed_list (s : string) (marker : string) : string list =
+  let n = String.length s and m = String.length marker in
+  let rec find i =
+    if i + m > n then failwith "extract_bracketed_list: marker not found"
+    else if String.sub s i m = marker then i
+    else find (i + 1)
+  in
+  let marker_idx = find 0 in
+  let open_idx = String.index_from s marker_idx '[' in
+  let close_idx = String.index_from s open_idx ']' in
+  String.sub s (open_idx + 1) (close_idx - open_idx - 1)
+  |> String.split_on_char ';'
+  |> List.filter_map (fun tok ->
+         match String.trim tok with
+         | "" -> None
+         | tok -> Some (String.sub tok 1 (String.length tok - 2)))
+
+let interface_name_keywords_test () : unit =
+  let embedded =
+    extract_bracketed_list Pass.Compile.Template.Split.interface_name_fn
+      "interface_keywords_ ="
+  in
+  let expected = Pass.Compile.Gen.Names.keywords in
+  if List.sort compare embedded <> List.sort compare expected then
+    failwith
+      "interface_name_keywords_test: split.ml's interface_keywords_ has \
+       drifted from Names.keywords"
+  else
+    print_endline
+      "[PASS] interface_name_fn's embedded keyword list matches \
+       Names.keywords"
+
+let eval_func_has_dup_and_keywords_test () : unit =
+  eval_func_has_dup_test ();
+  interface_name_keywords_test ()
+
 let eval_func_command =
   Core.Command.basic ~summary:"direct eval_func test (Task 6)"
-    (Core.Command.Param.return eval_func_has_dup_test)
+    (Core.Command.Param.return eval_func_has_dup_and_keywords_test)
 
 let command =
   Core.Command.group ~summary:"p4spec-test-run"

--- a/p4spec/test/run/test.ml
+++ b/p4spec/test/run/test.ml
@@ -165,8 +165,62 @@ let cover_run_command =
      fun () ->
        cover_run mode path_spec relname includes_p4 excludes_p4 testdirs_p4)
 
+(* Direct [eval_func] test (Task 6): [has_dup_<X>] is generic and is never
+   instantiated at [text] by any ground call site in spec/p4-comp, so this
+   only succeeds if [eval_func] can build [text]'s witnesses at runtime. *)
+
+let eval_func_has_dup_test () : unit =
+  let module Extern_stub = struct
+    module Cache = struct
+      let cache_on () = ()
+      let cache_off () = ()
+    end
+
+    let eval_extern_rel (_ : string) (_ : Runtime.Value.t list) : rel_result =
+      failwith "eval_func_has_dup_test: unexpected extern relation call"
+
+    let eval_extern_func (_ : string) (_ : Runtime.Type.Typ.t list)
+        (_ : Runtime.Value.t list) : func_result =
+      failwith "eval_func_has_dup_test: unexpected extern function call"
+
+    let checkpoint () : int = 0
+    let seff (_ : int) (_ : int) : bool = false
+    let clear () : unit = ()
+    let init_mode (_ : mode) : unit = ()
+  end in
+  let module Interp =
+    Backend_ocaml.Interp_ml.Make (Interface.P4) (Extern_stub) ()
+  in
+  Interp.init ~cache:false ~det:false ~guard:false ();
+  let typ_text = Runtime.Type.Typ.Make.text in
+  let value_dup = Runtime.Value.Make.text "dup" in
+  let value_args =
+    Runtime.Value.Make.list
+      (Runtime.Type.Typ.Make.list typ_text)
+      [ value_dup; value_dup ]
+  in
+  match Interp.eval_func "has_dup_" [ typ_text ] [ value_args ] with
+  | Pass value ->
+      if Runtime.Value.Get.bool value then
+        print_endline
+          "[PASS] eval_func \"has_dup_\" at text (no ground call site) \
+           returned true"
+      else
+        failwith "eval_func_has_dup_test: expected true (duplicate), got false"
+  | Fail (_, msg) ->
+      failwith
+        (Printf.sprintf "eval_func_has_dup_test: eval_func failed: %s" msg)
+
+let eval_func_command =
+  Core.Command.basic ~summary:"direct eval_func test (Task 6)"
+    (Core.Command.Param.return eval_func_has_dup_test)
+
 let command =
   Core.Command.group ~summary:"p4spec-test-run"
-    [ ("run", run_command); ("cover-run", cover_run_command) ]
+    [
+      ("run", run_command);
+      ("cover-run", cover_run_command);
+      ("eval-func", eval_func_command);
+    ]
 
 let () = Command_unix.run ~version command

--- a/p4spec/test/run/test.ml
+++ b/p4spec/test/run/test.ml
@@ -165,9 +165,8 @@ let cover_run_command =
      fun () ->
        cover_run mode path_spec relname includes_p4 excludes_p4 testdirs_p4)
 
-(* Direct [eval_func] test (Task 6): [has_dup_<X>] is generic and is never
-   instantiated at [text] by any ground call site in spec/p4-comp, so this
-   only succeeds if [eval_func] can build [text]'s witnesses at runtime. *)
+(* [has_dup_<X>] is generic, never instantiated at [text] anywhere — only
+   succeeds if [eval_func] can build [text]'s witnesses at runtime. *)
 
 let eval_func_has_dup_test () : unit =
   let module Extern_stub = struct
@@ -199,7 +198,7 @@ let eval_func_has_dup_test () : unit =
       (Runtime.Type.Typ.Make.list typ_text)
       [ value_dup; value_dup ]
   in
-  match Interp.eval_func "has_dup_" [ typ_text ] [ value_args ] with
+  (match Interp.eval_func "has_dup_" [ typ_text ] [ value_args ] with
   | Pass value ->
       if Runtime.Value.Get.bool value then
         print_endline
@@ -209,7 +208,14 @@ let eval_func_has_dup_test () : unit =
         failwith "eval_func_has_dup_test: expected true (duplicate), got false"
   | Fail (_, msg) ->
       failwith
-        (Printf.sprintf "eval_func_has_dup_test: eval_func failed: %s" msg)
+        (Printf.sprintf "eval_func_has_dup_test: eval_func failed: %s" msg));
+  (* Wrong arity (missing the [X] witness type) must fail cleanly, not crash. *)
+  match Interp.eval_func "has_dup_" [] [ value_args ] with
+  | Pass _ ->
+      failwith "eval_func_has_dup_test: expected arity failure, got Pass"
+  | Fail (_, _) ->
+      print_endline
+        "[PASS] eval_func \"has_dup_\" with wrong arity failed cleanly"
 
 let eval_func_command =
   Core.Command.basic ~summary:"direct eval_func test (Task 6)"

--- a/spec/p4/0-aux/0.0-stdlib.watsup
+++ b/spec/p4/0-aux/0.0-stdlib.watsup
@@ -217,6 +217,19 @@ builtin dec $distinct_<K>(K*) : bool
   hint(prose_true "the elements of" %0 "are distinct")
   hint(prose_false "the elements of" %0 "are not distinct")
 
+dec $has_dup_<X>(X*) : bool
+  hint(prose_true "some element of" %0 "occurs more than once")
+dec $has_dup_from_<X>(X, X*) : bool
+
+def $has_dup_<X>(eps) = false
+def $has_dup_<X>(X_h :: X_t*) = $has_dup_from_<X>(X_h, X_t*)
+
+def $has_dup_from_<X>(X_h, eps) = false
+def $has_dup_from_<X>(X_h, X_h2 :: X_t*) = true
+  -- if ~$distinct_<X>(X_h :: X_h2 :: eps)
+def $has_dup_from_<X>(X_h, X_h2 :: X_t*) = $has_dup_<X>(X_h2 :: X_t*)
+  -- if $distinct_<X>(X_h :: X_h2 :: eps)
+
 ;;
 ;; General set functions
 ;;

--- a/spec/p4/0-aux/0.0-stdlib.watsup
+++ b/spec/p4/0-aux/0.0-stdlib.watsup
@@ -202,6 +202,15 @@ def $filter_<X>(X_h :: X_t*, b_h :: b_t*)
   = $filter_<X>(X_t*, b_t*)
   -- if ~b_h
 
+dec $evens_<X>(X*) : X*
+  hint(prose_in "every other element of" %0 "starting from the first")
+dec $odds_<X>(X*) : X*
+  hint(prose_in "every other element of" %0 "starting from the second")
+def $evens_<X>(eps) = eps
+def $evens_<X>(X_h :: X_t*) = X_h :: $odds_<X>(X_t*)
+def $odds_<X>(eps) = eps
+def $odds_<X>(X_h :: X_t*) = $evens_<X>(X_t*)
+
 builtin dec $sort_<X>((nat, X)*) : (nat, X)*
 
 builtin dec $distinct_<K>(K*) : bool


### PR DESCRIPTION
## What this does

Today, if a meta-function in the spec still has a type parameter after monomorphization (`dec $f<X>(...)`), the compiler just deletes it. `eval_func` (the entry point that calls a function by name at runtime) can only reach an instance `f<T>` if some call site in the compiled spec already wrote `f<T>(...)` with a concrete `T` — monomorphization only ever builds the instances it actually sees written down.

This PR makes those still-generic functions compile to real, callable OCaml, so `eval_func` can call `f<T>` for *any* `T` supplied at runtime, including a `T` that no code in the spec ever mentions literally.

Ground/monomorphized code paths are untouched — same dispatch tables, same mangled-instance mechanism, same performance. This adds a second, parallel path for the generic case only.

## How it works

Two mechanisms, layered:

**1. Real OCaml polymorphism for the pure-computation part.**

A generic function now compiles with an explicit `forall`, e.g.:

```ocaml
let rec f__evens_ : 'x. 'x list -> 'x list = fun param__0 -> ...
and f__odds_       : 'x. 'x list -> 'x list = fun param__0 -> ...
```

This has to be written out explicitly (not left to OCaml's inference) because `evens_`/`odds_` call each other mutually recursively, and OCaml won't infer polymorphic recursion inside a `let rec` on its own.

**2. Dictionary-passing at the boundary where a value has to become a `Value.t`.**

Everywhere else in the interpreter, values are dynamically-typed `Value.t` (a runtime-tagged variant). A generic OCaml function working on a real `'x` doesn't know at compile time how to turn an `'x` into a `Value.t` or back. So whenever a generic function's body calls an extern or builtin (the only place this conversion is needed) using its own unresolved type parameter, the function accepts two extra arguments per type parameter — the marshaller and unmarshaller for whatever type it eventually gets called with — and the caller supplies them:

```ocaml
let rec f__has_dup_from_ : 'x. ('x -> Value.t) -> (Value.t -> 'x) -> 'x -> 'x list -> bool =
  fun marshal__x unmarshal__x param__0 param__1 ->
  ...
  f__distinct_ (marshal__x) (unmarshal__x) ((x_h :: (x_h2 :: [])))
```

Where do the actual `marshal__x`/`unmarshal__x` functions come from when *nothing* in the spec ever called `has_dup_` at a concrete type? A small runtime registry, built once at compile time from every type the compiler already generates a marshaller for, keyed by the type's name:

```ocaml
let interface_registry_ = Hashtbl.of_seq (List.to_seq [
  ("text", (Obj.repr marshal_text, Obj.repr unmarshal_text));
  ("text__list", (Obj.repr marshal_text__list, Obj.repr unmarshal_text__list));
  ...
])
```

`eval_func`'s new arm looks up the caller-supplied runtime type in this table, unerases the pair, and calls the generic function with them. If a type isn't in the registry (nothing in the whole spec was ever compiled at that type), it fails cleanly with `Run.Fail "no marshaller registered for type X"` — it never crashes.

## Scope

Only supports a type parameter appearing bare (`X`), or as a list/option of bare (`X*`/`X?`), at a boundary call. Anything more (`set<X>`, `(X, Y)`, a struct/variant parametric in `X`) raises a clear "not yet supported" error at compile time instead of miscompiling. Also out of scope: generic functions with callback parameters, and calling a generic function at a type that's reachable from *no* ground call site anywhere in the spec (the registry only covers what the compiler already builds marshallers for — a fully general runtime dispatcher is a separate, larger effort on a different branch).

Both restrictions degrade gracefully: a handful of pre-existing generic functions in the spec hit one of these (`set<K>`/`map<K,V>` builtins, functions with callback params) and are skipped with a compile-time warning, not a hard failure.

## Being upfront about the rough edges

- **One place uses unsafe type erasure (`Obj.repr`/`Obj.magic`), and it's the first place in this codebase that does.** It's scoped as narrowly as I could make it: each registry entry is a single `(marshal, unmarshal)` tuple for the *same* type, so the two can never get mixed up, and only the two witness *functions* are erased — actual argument/return values always go through the real (typed) marshal/unmarshal functions, never `Obj.magic` directly. Still, this is the one part of the change that bypasses the type checker, so it deserves extra scrutiny on review.
- **The runtime type-naming logic is duplicated, not shared.** `eval_func`'s new arm needs to compute the same "type → registry key" string the compiler itself computes at compile time, but the compiler binary isn't linked into the generated artifact — so that naming logic (and the identifier-sanitizing rules it depends on) is copy-pasted into the generated code as a fixed string template. If the compiler's naming logic ever changes without updating this copy, lookups silently start failing (a type that *is* registered would wrongly report "no marshaller registered"). I added a cross-reference comment on both sides plus a test that checks the copy's keyword list against the real one, but this is a real maintenance hazard, not eliminated, just flagged.
- **A couple of design choices in the original plan turned out not to work as drafted** and needed fixing during implementation/review: a compile-time guard that was supposed to catch "this generic function calls an extern/builtin with its own type parameter" was checking the wrong scope and never actually fired; a zero-argument generic function's generated type signature didn't match its generated body and failed to type-check; and `eval_func`'s new arm crashed instead of failing cleanly when called with the wrong number of type arguments. All three are fixed and covered by tests now, but flagging them since they're the kind of thing worth a second look.

## Interface / signature changes

- `Ml.funcdef` (the compiler's internal AST node for a generated OCaml function) gained a type-parameter list: `id * tparam list * param list * typ option * expr` (was `id * param list * typ option * expr`). Every existing (ground) call site passes `[]` and is unaffected.
- `Ctx.t` (the compiler's global context) gained `poly_sigs`, a table of which function/extern/builtin names are still generic and their type parameters — purely additive.
- Several internal `compile_*` functions in the codegen pipeline gained a `~tparams : string list` labeled argument (the enclosing generic function's own type parameters, needed to resolve marshal/unmarshal witnesses). Existing callers all pass `[]`.
- `Interface.compile` (builds the marshal/unmarshal codegen) now returns a 4-tuple instead of 3, with the new registry as the last element.

None of this changes behavior for any function that doesn't have type parameters — every signature change is either purely additive or has `[]`/no-op as the value every existing call site passes.

## Testing

- `make build-compiled` (a real `dune build` type-check of the freshly generated OCaml) passes clean.
- `make test-run-ml` and `make test-sim-ml` (the full compiled-backend test suites) both pass clean.
- New direct tests exercise `eval_func` calling a generic function at a type with zero ground call sites anywhere in the spec — the actual goal of this PR — at several witness shapes (plain type, list, option), plus a wrong-arity call to confirm it fails cleanly instead of crashing.
- `make test-fast` (the interpreter-mode suite) is unaffected by this change and wasn't part of this PR's own verification loop, since it exercises a code path this PR doesn't touch.
