### PR TITLE
Thread real type args through compiled builtin/extern calls

### DIFF
--- a/p4spec/lib/pass/compile/gen/ast/exp.ml
+++ b/p4spec/lib/pass/compile/gen/ast/exp.ml
@@ -1077,7 +1077,10 @@ and compile_arg ~(tparams : string list) (ctx : Ctx.t) (arg : arg) :
                 (fun (tp : Il.tparam) ->
                   let typ_tp = Il.VarT (tp, []) $ no_region in
                   let conv = Interface.Converter.resolve ctx tparams typ_tp in
-                  [ conv.marshal; conv.unmarshal ])
+                  let expr_typ_ml =
+                    Interface.Dynamic_gen.make_typ_expr ~tparams typ_tp
+                  in
+                  [ conv.marshal; conv.unmarshal; expr_typ_ml ])
                 callee_tparams
             in
             Ml.AppE (Ml.VarE id_ml, exprs_converter_ml)
@@ -1107,7 +1110,8 @@ and compile_call_exp ~(tparams : string list) (ctx : Ctx.t) (id : id)
         List.concat_map
           (fun targ ->
             let conv = Interface.Converter.resolve ctx tparams targ in
-            [ conv.marshal; conv.unmarshal ])
+            let expr_typ_ml = Interface.Dynamic_gen.make_typ_expr ~tparams targ in
+            [ conv.marshal; conv.unmarshal; expr_typ_ml ])
           targs
       in
       (ctx, Ml.AppE (Ml.VarE id_func_ml, exprs_converter_ml @ exprs_arg_ml))

--- a/p4spec/lib/pass/compile/gen/ast/exp.ml
+++ b/p4spec/lib/pass/compile/gen/ast/exp.ml
@@ -1064,23 +1064,25 @@ and compile_arg ~(tparams : string list) (ctx : Ctx.t) (arg : arg) :
         match Ctx.find_func_tparams ctx id.it with
         | Some callee_tparams when callee_tparams <> [] ->
             List.iter
-              (fun (tp : Il.tparam) ->
-                if not (List.mem tp.it tparams) then
+              (fun (tparam : Il.tparam) ->
+                if not (List.mem tparam.it tparams) then
                   failwith
                     (Printf.sprintf
                        "compile_arg: %s: callee type parameter %s is not among \
                         the caller's type parameters"
-                       id.it tp.it))
+                       id.it tparam.it))
               callee_tparams;
             let exprs_converter_ml =
               List.concat_map
-                (fun (tp : Il.tparam) ->
-                  let typ_tp = Il.VarT (tp, []) $ no_region in
-                  let conv = Interface.Converter.resolve ctx tparams typ_tp in
-                  let expr_typ_ml =
-                    Interface.Dynamic_gen.make_typ_expr ~tparams typ_tp
+                (fun (tparam : Il.tparam) ->
+                  let typ_tparam = Il.VarT (tparam, []) $ no_region in
+                  let converter =
+                    Interface.Converter.resolve ctx tparams typ_tparam
                   in
-                  [ conv.marshal; conv.unmarshal; expr_typ_ml ])
+                  let expr_typ_ml =
+                    Interface.Dynamic_gen.make_typ_expr ~tparams typ_tparam
+                  in
+                  [ converter.marshal; converter.unmarshal; expr_typ_ml ])
                 callee_tparams
             in
             Ml.AppE (Ml.VarE id_ml, exprs_converter_ml)
@@ -1096,8 +1098,6 @@ and compile_args ~(tparams : string list) (ctx : Ctx.t) (args : arg list) :
       (ctx, exprs_ml @ [ expr_ml ]))
     (ctx, []) args
 
-(* Forward the caller's converters if [id] has its own tparams — a no-op
-   for a ground callee, per [Ctx.find_func_tparams]. *)
 and compile_call_exp ~(tparams : string list) (ctx : Ctx.t) (id : id)
     (targs : targ list) (args : arg list) : Ctx.t * Ml.expr =
   let id_func_ml = Names.func id in
@@ -1109,11 +1109,11 @@ and compile_call_exp ~(tparams : string list) (ctx : Ctx.t) (id : id)
       let exprs_converter_ml =
         List.concat_map
           (fun targ ->
-            let conv = Interface.Converter.resolve ctx tparams targ in
+            let converter = Interface.Converter.resolve ctx tparams targ in
             let expr_typ_ml =
               Interface.Dynamic_gen.make_typ_expr ~tparams targ
             in
-            [ conv.marshal; conv.unmarshal; expr_typ_ml ])
+            [ converter.marshal; converter.unmarshal; expr_typ_ml ])
           targs
       in
       (ctx, Ml.AppE (Ml.VarE id_func_ml, exprs_converter_ml @ exprs_arg_ml))

--- a/p4spec/lib/pass/compile/gen/ast/exp.ml
+++ b/p4spec/lib/pass/compile/gen/ast/exp.ml
@@ -1110,7 +1110,9 @@ and compile_call_exp ~(tparams : string list) (ctx : Ctx.t) (id : id)
         List.concat_map
           (fun targ ->
             let conv = Interface.Converter.resolve ctx tparams targ in
-            let expr_typ_ml = Interface.Dynamic_gen.make_typ_expr ~tparams targ in
+            let expr_typ_ml =
+              Interface.Dynamic_gen.make_typ_expr ~tparams targ
+            in
             [ conv.marshal; conv.unmarshal; expr_typ_ml ])
           targs
       in

--- a/p4spec/lib/pass/compile/gen/ast/func.ml
+++ b/p4spec/lib/pass/compile/gen/ast/func.ml
@@ -1,6 +1,5 @@
 open Lang
 open Sl
-module Typ = Runtime.Type.Typ
 open Util.Source
 
 (* Parameters *)
@@ -90,7 +89,7 @@ let compile_tparams (tparams_ml : Ml.tparam list) : Ml.param list =
           Some (Ml.FuncT (Ml.VarT tparam_ml, Ml.NameT "Value.t")) );
         ( Interface.Converter.name_unmarshal tparam_ml,
           Some (Ml.FuncT (Ml.NameT "Value.t", Ml.VarT tparam_ml)) );
-        ( Interface.Dynamic_gen.name_typ tparam_ml, Some (Ml.NameT "Typ.t") );
+        (Interface.Dynamic_gen.name_typ tparam_ml, Some (Ml.NameT "Typ.t"));
       ])
     tparams_ml
 

--- a/p4spec/lib/pass/compile/gen/ast/func.ml
+++ b/p4spec/lib/pass/compile/gen/ast/func.ml
@@ -90,21 +90,18 @@ let compile_tparams (tparams_ml : Ml.tparam list) : Ml.param list =
           Some (Ml.FuncT (Ml.VarT tparam_ml, Ml.NameT "Value.t")) );
         ( Interface.Converter.name_unmarshal tparam_ml,
           Some (Ml.FuncT (Ml.NameT "Value.t", Ml.VarT tparam_ml)) );
+        ( Interface.Dynamic_gen.name_typ tparam_ml, Some (Ml.NameT "Typ.t") );
       ])
     tparams_ml
 
-(* Type arguments
+(* Type arguments: [<X, ..>]
 
-   Reifies a generic call's own tparams as runtime targs: [<X, ..>]
-
-   [[Typ.Make.var ("X" $ no_region) []; ..]] *)
+   [[typ__x; ..]] *)
 
 let compile_targs (tparams : string list) : Ml.expr =
   let exprs_targs_ml =
     List.map
-      (fun tparam ->
-        let typ = Typ.Make.var (tparam $ no_region) [] in
-        Interface.Dynamic_gen.make_typ_expr typ)
+      (fun tparam -> Ml.VarE (Interface.Dynamic_gen.name_typ tparam))
       tparams
   in
   Ml.ListE exprs_targs_ml

--- a/p4spec/lib/pass/compile/gen/ast/func.ml
+++ b/p4spec/lib/pass/compile/gen/ast/func.ml
@@ -158,7 +158,7 @@ let compile_extern_func (ctx : Ctx.t) (id : id) (tparams : Il.tparam list)
   let exprs_arg_ml =
     Ml.ListE (List.init n (fun i -> Ml.VarE ("v__" ^ string_of_int i)))
   in
-  let exprs_targ_ml = compile_targs tparams in
+  let exprs_targ_ml = compile_targs tparams_ml in
   (* Call the extern, unmarshal its result *)
   let expr_call_ml =
     Ml.AppE
@@ -241,7 +241,7 @@ let compile_builtin_func (ctx : Ctx.t) (id : id) (tparams : Il.tparam list)
   let exprs_arg_ml =
     Ml.ListE (List.init n (fun i -> Ml.VarE ("v__" ^ string_of_int i)))
   in
-  let exprs_targ_ml = compile_targs tparams in
+  let exprs_targ_ml = compile_targs tparams_ml in
   (* Call the builtin, catching a builtin error as [Unmatch] *)
   let name_orig_lit_ml =
     Ml.LitE (Printf.sprintf "(\"%s\" $ no_region)" (String.escaped id.it))

--- a/p4spec/lib/pass/compile/gen/ast/func.ml
+++ b/p4spec/lib/pass/compile/gen/ast/func.ml
@@ -89,7 +89,7 @@ let compile_tparams (tparams_ml : Ml.tparam list) : Ml.param list =
           Some (Ml.FuncT (Ml.VarT tparam_ml, Ml.NameT "Value.t")) );
         ( Interface.Converter.name_unmarshal tparam_ml,
           Some (Ml.FuncT (Ml.NameT "Value.t", Ml.VarT tparam_ml)) );
-        (Interface.Dynamic_gen.name_typ tparam_ml, Some (Ml.NameT "Typ.t"));
+        (Interface.Naming.name_typ tparam_ml, Some (Ml.NameT "Typ.t"));
       ])
     tparams_ml
 
@@ -97,11 +97,11 @@ let compile_tparams (tparams_ml : Ml.tparam list) : Ml.param list =
 
    [[typ__x; ..]] *)
 
-let compile_targs (tparams : string list) : Ml.expr =
+let compile_targs (tparams_ml : Ml.tparam list) : Ml.expr =
   let exprs_targs_ml =
     List.map
-      (fun tparam -> Ml.VarE (Interface.Dynamic_gen.name_typ tparam))
-      tparams
+      (fun tparam_ml -> Ml.VarE (Interface.Naming.name_typ tparam_ml))
+      tparams_ml
   in
   Ml.ListE exprs_targs_ml
 

--- a/p4spec/lib/pass/compile/gen/ast/func.ml
+++ b/p4spec/lib/pass/compile/gen/ast/func.ml
@@ -84,12 +84,15 @@ let compile_params ~(tparams : string list) (ctx : Ctx.t) (params : param list)
 let compile_tparams (tparams_ml : Ml.tparam list) : Ml.param list =
   List.concat_map
     (fun tparam_ml ->
+      let id_marshal_ml = Interface.Converter.name_marshal tparam_ml in
+      let typ_marshal_ml = Ml.FuncT (Ml.VarT tparam_ml, Ml.NameT "Value.t") in
+      let id_unmarshal_ml = Interface.Converter.name_unmarshal tparam_ml in
+      let typ_unmarshal_ml = Ml.FuncT (Ml.NameT "Value.t", Ml.VarT tparam_ml) in
+      let id_typ_ml = Interface.Naming.name_typ tparam_ml in
       [
-        ( Interface.Converter.name_marshal tparam_ml,
-          Some (Ml.FuncT (Ml.VarT tparam_ml, Ml.NameT "Value.t")) );
-        ( Interface.Converter.name_unmarshal tparam_ml,
-          Some (Ml.FuncT (Ml.NameT "Value.t", Ml.VarT tparam_ml)) );
-        (Interface.Naming.name_typ tparam_ml, Some (Ml.NameT "Typ.t"));
+        (id_marshal_ml, Some typ_marshal_ml);
+        (id_unmarshal_ml, Some typ_unmarshal_ml);
+        (id_typ_ml, Some (Ml.NameT "Typ.t"));
       ])
     tparams_ml
 

--- a/p4spec/lib/pass/compile/gen/dispatch.ml
+++ b/p4spec/lib/pass/compile/gen/dispatch.ml
@@ -94,7 +94,20 @@ let compile_converter_binding (tparams_ml : string list) :
                typ_unmarshal_ml )
          in
          let binding_unmarshal_ml = (id_unmarshal_ml, expr_unmarshal_ml) in
-         [ binding_converter_ml; binding_marshal_ml; binding_unmarshal_ml ])
+         (* [let typ__x = List.nth typs__ i] *)
+         let id_typ_ml = Interface.Dynamic_gen.name_typ tparam_ml in
+         let expr_typ_ml =
+           Ml.AppE
+             ( Ml.LitE "List.nth",
+               [ Ml.VarE "typs__"; Ml.LitE (string_of_int i) ] )
+         in
+         let binding_typ_ml = (id_typ_ml, expr_typ_ml) in
+         [
+           binding_converter_ml;
+           binding_marshal_ml;
+           binding_unmarshal_ml;
+           binding_typ_ml;
+         ])
   |> List.concat
 
 let compile_func_arm_body (ctx : Ctx.t) (name : string) (tparams : string list)
@@ -109,6 +122,7 @@ let compile_func_arm_body (ctx : Ctx.t) (name : string) (tparams : string list)
         [
           Ml.VarE (Interface.Converter.name_marshal tparam);
           Ml.VarE (Interface.Converter.name_unmarshal tparam);
+          Ml.VarE (Interface.Dynamic_gen.name_typ tparam);
         ])
       tparams_ml
   in

--- a/p4spec/lib/pass/compile/gen/dispatch.ml
+++ b/p4spec/lib/pass/compile/gen/dispatch.ml
@@ -95,18 +95,18 @@ let compile_converter_binding (tparams_ml : string list) :
          in
          let binding_unmarshal_ml = (id_unmarshal_ml, expr_unmarshal_ml) in
          (* [let typ__x = List.nth typs__ i] *)
-         let id_typ_ml = Interface.Dynamic_gen.name_typ tparam_ml in
+         let id_typ_ml = Interface.Naming.name_typ tparam_ml in
          let expr_typ_ml =
            Ml.AppE
              ( Ml.LitE "List.nth",
                [ Ml.VarE "typs__"; Ml.LitE (string_of_int i) ] )
          in
-         let binding_typ_ml = (id_typ_ml, expr_typ_ml) in
+         let binding_targs_ml = (id_typ_ml, expr_typ_ml) in
          [
            binding_converter_ml;
            binding_marshal_ml;
            binding_unmarshal_ml;
-           binding_typ_ml;
+           binding_targs_ml;
          ])
   |> List.concat
 
@@ -122,7 +122,7 @@ let compile_func_arm_body (ctx : Ctx.t) (name : string) (tparams : string list)
         [
           Ml.VarE (Interface.Converter.name_marshal tparam);
           Ml.VarE (Interface.Converter.name_unmarshal tparam);
-          Ml.VarE (Interface.Dynamic_gen.name_typ tparam);
+          Ml.VarE (Interface.Naming.name_typ tparam);
         ])
       tparams_ml
   in

--- a/p4spec/lib/pass/compile/gen/interface/converter.ml
+++ b/p4spec/lib/pass/compile/gen/interface/converter.ml
@@ -138,11 +138,10 @@ and resolve_tuple_typ ~(visiting : string list) (ctx : Ctx.t)
   in
   let expr_marshal_ml =
     let pat_vars_ml = Ml.TupleP (List.map (fun var -> Ml.VarP var) vars_m) in
+    let expr_typ_ml = Dynamic_gen.make_typ_expr ~tparams typ in
     let expr_tuple_ml =
       Ml.AppE
-        ( Ml.LitE "Value.Make.tuple",
-          [ Dynamic_gen.make_typ_expr ~tparams typ; Ml.ListE marshal_calls_ml ]
-        )
+        (Ml.LitE "Value.Make.tuple", [ expr_typ_ml; Ml.ListE marshal_calls_ml ])
     in
     let expr_let_ml = Ml.LetE (pat_vars_ml, Ml.VarE "x__", expr_tuple_ml) in
     Ml.FunE ([ Ml.VarP "x__" ], expr_let_ml)
@@ -166,10 +165,9 @@ and resolve_opt_typ ~(visiting : string list) (ctx : Ctx.t)
     let expr_map_ml =
       Ml.AppE (Ml.LitE "Option.map", [ conv.marshal; Ml.VarE "x__" ])
     in
+    let expr_typ_ml = Dynamic_gen.make_typ_expr ~tparams typ in
     let expr_opt_ml =
-      Ml.AppE
-        ( Ml.LitE "Value.Make.opt",
-          [ Dynamic_gen.make_typ_expr ~tparams typ; expr_map_ml ] )
+      Ml.AppE (Ml.LitE "Value.Make.opt", [ expr_typ_ml; expr_map_ml ])
     in
     Ml.FunE ([ Ml.VarP "x__" ], expr_opt_ml)
   in
@@ -191,10 +189,9 @@ and resolve_list_typ ~(visiting : string list) (ctx : Ctx.t)
     let expr_map_ml =
       Ml.AppE (Ml.LitE "List.map", [ conv.marshal; Ml.VarE "x__" ])
     in
+    let expr_typ_ml = Dynamic_gen.make_typ_expr ~tparams typ in
     let expr_list_ml =
-      Ml.AppE
-        ( Ml.LitE "Value.Make.list",
-          [ Dynamic_gen.make_typ_expr ~tparams typ; expr_map_ml ] )
+      Ml.AppE (Ml.LitE "Value.Make.list", [ expr_typ_ml; expr_map_ml ])
     in
     Ml.FunE ([ Ml.VarP "x__" ], expr_list_ml)
   in
@@ -272,10 +269,10 @@ and resolve_struct_typdef ~(visiting : string list) (ctx : Ctx.t)
           Ml.TupleE [ expr_atom_ml; expr_conv_ml ])
         field_convs
     in
+    let expr_typ_ml = Dynamic_gen.make_typ_expr ~tparams typ in
     let expr_str_ml =
       Ml.AppE
-        ( Ml.LitE "Value.Make.str",
-          [ Dynamic_gen.make_typ_expr ~tparams typ; Ml.ListE field_exprs_ml ] )
+        (Ml.LitE "Value.Make.str", [ expr_typ_ml; Ml.ListE field_exprs_ml ])
     in
     Ml.FunE ([ Ml.VarP "x__" ], expr_str_ml)
   in
@@ -329,11 +326,11 @@ and resolve_variant_typdef ~(visiting : string list) (ctx : Ctx.t)
                 apply_converter "resolved_" conv.marshal (Ml.VarE pvar))
               convs pvars
           in
+          let expr_mixop_ml = Dynamic_gen.make_mixop_expr mixop in
+          let expr_typ_ml = Dynamic_gen.make_typ_expr ~tparams typ in
           let expr_case_ml =
-            compile_case_value
-              (Dynamic_gen.make_mixop_expr mixop)
-              (Ml.ListE marshal_calls_ml)
-              (Dynamic_gen.make_typ_expr ~tparams typ)
+            compile_case_value expr_mixop_ml (Ml.ListE marshal_calls_ml)
+              expr_typ_ml
           in
           (pat_ml, expr_case_ml))
         per_ctor

--- a/p4spec/lib/pass/compile/gen/interface/converter.ml
+++ b/p4spec/lib/pass/compile/gen/interface/converter.ml
@@ -141,7 +141,7 @@ and resolve_tuple_typ ~(visiting : string list) (ctx : Ctx.t)
     let expr_tuple_ml =
       Ml.AppE
         ( Ml.LitE "Value.Make.tuple",
-          [ Dynamic_gen.make_typ_expr typ; Ml.ListE marshal_calls_ml ] )
+          [ Dynamic_gen.make_typ_expr ~tparams typ; Ml.ListE marshal_calls_ml ] )
     in
     let expr_let_ml = Ml.LetE (pat_vars_ml, Ml.VarE "x__", expr_tuple_ml) in
     Ml.FunE ([ Ml.VarP "x__" ], expr_let_ml)
@@ -168,7 +168,7 @@ and resolve_opt_typ ~(visiting : string list) (ctx : Ctx.t)
     let expr_opt_ml =
       Ml.AppE
         ( Ml.LitE "Value.Make.opt",
-          [ Dynamic_gen.make_typ_expr typ; expr_map_ml ] )
+          [ Dynamic_gen.make_typ_expr ~tparams typ; expr_map_ml ] )
     in
     Ml.FunE ([ Ml.VarP "x__" ], expr_opt_ml)
   in
@@ -193,7 +193,7 @@ and resolve_list_typ ~(visiting : string list) (ctx : Ctx.t)
     let expr_list_ml =
       Ml.AppE
         ( Ml.LitE "Value.Make.list",
-          [ Dynamic_gen.make_typ_expr typ; expr_map_ml ] )
+          [ Dynamic_gen.make_typ_expr ~tparams typ; expr_map_ml ] )
     in
     Ml.FunE ([ Ml.VarP "x__" ], expr_list_ml)
   in
@@ -274,7 +274,7 @@ and resolve_struct_typdef ~(visiting : string list) (ctx : Ctx.t)
     let expr_str_ml =
       Ml.AppE
         ( Ml.LitE "Value.Make.str",
-          [ Dynamic_gen.make_typ_expr typ; Ml.ListE field_exprs_ml ] )
+          [ Dynamic_gen.make_typ_expr ~tparams typ; Ml.ListE field_exprs_ml ] )
     in
     Ml.FunE ([ Ml.VarP "x__" ], expr_str_ml)
   in
@@ -332,7 +332,7 @@ and resolve_variant_typdef ~(visiting : string list) (ctx : Ctx.t)
             compile_case_value
               (Dynamic_gen.make_mixop_expr mixop)
               (Ml.ListE marshal_calls_ml)
-              (Dynamic_gen.make_typ_expr typ)
+              (Dynamic_gen.make_typ_expr ~tparams typ)
           in
           (pat_ml, expr_case_ml))
         per_ctor

--- a/p4spec/lib/pass/compile/gen/interface/converter.ml
+++ b/p4spec/lib/pass/compile/gen/interface/converter.ml
@@ -141,7 +141,8 @@ and resolve_tuple_typ ~(visiting : string list) (ctx : Ctx.t)
     let expr_tuple_ml =
       Ml.AppE
         ( Ml.LitE "Value.Make.tuple",
-          [ Dynamic_gen.make_typ_expr ~tparams typ; Ml.ListE marshal_calls_ml ] )
+          [ Dynamic_gen.make_typ_expr ~tparams typ; Ml.ListE marshal_calls_ml ]
+        )
     in
     let expr_let_ml = Ml.LetE (pat_vars_ml, Ml.VarE "x__", expr_tuple_ml) in
     Ml.FunE ([ Ml.VarP "x__" ], expr_let_ml)

--- a/p4spec/lib/pass/compile/gen/interface/dynamic_gen.ml
+++ b/p4spec/lib/pass/compile/gen/interface/dynamic_gen.ml
@@ -4,10 +4,6 @@ open Util.Source
 
 (* Runtime Typ.t codegen *)
 
-(* Naming *)
-
-let name_typ (tvar : string) = "typ__" ^ tvar
-
 let rec make_typ_expr ?(tparams : string list = []) (typ : Sl.typ) : Ml.expr =
   match typ.it with
   | BoolT -> Ml.LitE "Typ.Make.bool"
@@ -15,7 +11,7 @@ let rec make_typ_expr ?(tparams : string list = []) (typ : Sl.typ) : Ml.expr =
   | NumT `IntT -> Ml.LitE "Typ.Make.int"
   | TextT -> Ml.LitE "Typ.Make.text"
   | VarT (id, []) when List.mem id.it tparams ->
-      Ml.VarE (name_typ (Names.tvar id))
+      Ml.VarE (Naming.name_typ (Names.tvar id))
   | VarT (id, targs) ->
       Ml.AppE
         ( Ml.LitE "Typ.Make.var",

--- a/p4spec/lib/pass/compile/gen/interface/dynamic_gen.ml
+++ b/p4spec/lib/pass/compile/gen/interface/dynamic_gen.ml
@@ -4,26 +4,33 @@ open Util.Source
 
 (* Runtime Typ.t codegen *)
 
-let rec make_typ_expr (typ : Sl.typ) : Ml.expr =
+(* Naming *)
+
+let name_typ (tvar : string) = "typ__" ^ tvar
+
+let rec make_typ_expr ?(tparams : string list = []) (typ : Sl.typ) : Ml.expr =
   match typ.it with
   | BoolT -> Ml.LitE "Typ.Make.bool"
   | NumT `NatT -> Ml.LitE "Typ.Make.nat"
   | NumT `IntT -> Ml.LitE "Typ.Make.int"
   | TextT -> Ml.LitE "Typ.Make.text"
+  | VarT (id, []) when List.mem id.it tparams ->
+      Ml.VarE (name_typ (Names.tvar id))
   | VarT (id, targs) ->
       Ml.AppE
         ( Ml.LitE "Typ.Make.var",
           [
             Common.make_phrase (Printf.sprintf "\"%s\"" (String.escaped id.it));
-            Ml.ListE (List.map make_typ_expr targs);
+            Ml.ListE (List.map (make_typ_expr ~tparams) targs);
           ] )
   | TupleT typs ->
       Ml.AppE
-        (Ml.LitE "Typ.Make.tuple", [ Ml.ListE (List.map make_typ_expr typs) ])
+        ( Ml.LitE "Typ.Make.tuple",
+          [ Ml.ListE (List.map (make_typ_expr ~tparams) typs) ] )
   | IterT (typ, Il.Opt) ->
-      Ml.AppE (Ml.LitE "Typ.Make.opt", [ make_typ_expr typ ])
+      Ml.AppE (Ml.LitE "Typ.Make.opt", [ make_typ_expr ~tparams typ ])
   | IterT (typ, Il.List) ->
-      Ml.AppE (Ml.LitE "Typ.Make.list", [ make_typ_expr typ ])
+      Ml.AppE (Ml.LitE "Typ.Make.list", [ make_typ_expr ~tparams typ ])
   | FuncT _ -> Ml.LitE "Typ.Make.bool"
 
 (* Runtime Atom.t codegen *)

--- a/p4spec/lib/pass/compile/gen/interface/naming.ml
+++ b/p4spec/lib/pass/compile/gen/interface/naming.ml
@@ -19,3 +19,8 @@ let rec name (typ : Sl.typ) : string =
   | IterT (t, Il.Opt) -> name t ^ "__opt"
   | IterT (t, Il.List) -> name t ^ "__list"
   | FuncT _ -> "func"
+
+(* OCaml binding name for a type parameter's runtime [Typ.t] dictionary
+   entry: [x] -> [typ__x] *)
+
+let name_typ (tvar : string) = "typ__" ^ tvar

--- a/p4spec/lib/pass/compile/gen/interface/naming.ml
+++ b/p4spec/lib/pass/compile/gen/interface/naming.ml
@@ -20,7 +20,7 @@ let rec name (typ : Sl.typ) : string =
   | IterT (t, Il.List) -> name t ^ "__list"
   | FuncT _ -> "func"
 
-(* OCaml binding name for a type parameter's runtime [Typ.t] dictionary
-   entry: [x] -> [typ__x] *)
+(* OCaml binding name for a type parameter's runtime [Typ.t] entry
+   [x] -> [typ__x] *)
 
 let name_typ (tvar : string) = "typ__" ^ tvar


### PR DESCRIPTION
## What this does

A compiled generic function (e.g. `builtin dec $f<X>(X) : text`) needs to tell the builtin's OCaml implementation what type `X` actually is when it's called. Before this change, it always passed a fake placeholder instead — literally the string `"X"`, the type parameter's own name, never the real type the caller used. This worked by accident: no builtin in this repo's spec currently looks at its type argument, so nobody noticed it was fake.

Fix: alongside the pair of conversion functions each generic function already receives per type parameter (one turning `X` into `Value.t`, one turning `Value.t` back into `X`), it now also receives the real type itself, as a plain value. That real type is threaded through from wherever it's actually known: a caller compiled from spec text that names the concrete type directly, or the interpreter's own runtime dispatcher, which already had the real type on hand but was throwing it away after using it once.

## Example

A generic builtin, and a caller that uses it at a concrete type:

```
builtin dec $describe_<X>(X) : text

dec $describe_nat(nat) : text
def $describe_nat(n) = $describe_<nat>(n)
```

Before, `$describe_` compiled to a function that always told the builtin its argument's type was `"X"`:

```ocaml
let rec f__describe_ : 'x. ('x -> Value.t) -> (Value.t -> 'x) -> 'x -> string =
  fun marshal__x unmarshal__x p__0 ->
  ...
  trampoline__.interface.call_builtin (fun _ -> ()) ("describe_" $ no_region)
    [ Typ.Make.var ("X" $ no_region) [] ] [ v__0 ]
```

After this change, it takes the real type as a third argument and passes that along instead:

```ocaml
let rec f__describe_ : 'x. ('x -> Value.t) -> (Value.t -> 'x) -> Typ.t -> 'x -> string =
  fun marshal__x unmarshal__x typ__x p__0 ->
  ...
  trampoline__.interface.call_builtin (fun _ -> ()) ("describe_" $ no_region)
    [ typ__x ] [ v__0 ]

let rec main__f__describe_nat (param__0 : Bigint.t) : string =
  let n = param__0 in
  f__describe_ (marshal_nat) (unmarshal_nat) (Typ.Make.nat) (n)
```

`$describe_nat`, which calls `$describe_` at type `nat`, now passes `Typ.Make.nat` — the actual type — as that third argument, so `$describe_`'s implementation can see what it's really working with.

## Changes

- **`dynamic_gen.ml`**: the function that turns a spec-level type into a runtime `Typ.t` value now knows about type parameters — for one, it emits a reference to that parameter's real-type argument instead of fabricating a name.

  ```diff
  -let rec make_typ_expr (typ : Sl.typ) : Ml.expr =
  +let name_typ (tvar : string) = "typ__" ^ tvar
  +
  +let rec make_typ_expr ?(tparams : string list = []) (typ : Sl.typ) : Ml.expr =
     match typ.it with
     ...
  +  | VarT (id, []) when List.mem id.it tparams ->
  +      Ml.VarE (name_typ (Names.tvar id))
     | VarT (id, targs) ->
         ...
  ```

- **`func.ml`**: every generic function's parameter list gains a `Typ.t` slot per type parameter, and the code that builds the type-argument list for a builtin/extern call reads it back instead of making one up.

  ```diff
     let compile_tparams (tparams_ml : Ml.tparam list) : Ml.param list =
       List.concat_map
         (fun tparam_ml ->
           [
             ( Interface.Converter.name_marshal tparam_ml, ... );
             ( Interface.Converter.name_unmarshal tparam_ml, ... );
  +          (Interface.Dynamic_gen.name_typ tparam_ml, Some (Ml.NameT "Typ.t"));
           ])
         tparams_ml

   let compile_targs (tparams : string list) : Ml.expr =
     let exprs_targs_ml =
       List.map
  -      (fun tparam ->
  -        let typ = Typ.Make.var (tparam $ no_region) [] in
  -        Interface.Dynamic_gen.make_typ_expr typ)
  +      (fun tparam -> Ml.VarE (Interface.Dynamic_gen.name_typ tparam))
         tparams
     in
     Ml.ListE exprs_targs_ml
  ```

- **`exp.ml`**: every place that calls into a generic function now also passes the real type alongside the two conversion functions.

  ```diff
       (fun (tp : Il.tparam) ->
         let typ_tp = Il.VarT (tp, []) $ no_region in
         let conv = Interface.Converter.resolve ctx tparams typ_tp in
  -      [ conv.marshal; conv.unmarshal ])
  +      let expr_typ_ml = Interface.Dynamic_gen.make_typ_expr ~tparams typ_tp in
  +      [ conv.marshal; conv.unmarshal; expr_typ_ml ])
  ```

- **`dispatch.ml`**: the interpreter's own dynamic dispatcher (`eval_func`) already receives the caller's real type at runtime — it now keeps a copy and forwards it instead of discarding it.

  ```diff
         let binding_unmarshal_ml = (id_unmarshal_ml, expr_unmarshal_ml) in
  -      [ binding_converter_ml; binding_marshal_ml; binding_unmarshal_ml ])
  +      let id_typ_ml = Interface.Dynamic_gen.name_typ tparam_ml in
  +      let expr_typ_ml =
  +        Ml.AppE (Ml.LitE "List.nth", [ Ml.VarE "typs__"; Ml.LitE (string_of_int i) ])
  +      in
  +      let binding_typ_ml = (id_typ_ml, expr_typ_ml) in
  +      [ binding_converter_ml; binding_marshal_ml; binding_unmarshal_ml; binding_typ_ml ])
  ```

- **`converter.ml`**: five call sites that build a `Value.t` for a generic-shaped value (e.g. a `List<X>`) had the same bug tagging the value with its type — same fix, threading `~tparams` through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
