### PR TITLE
Defer SL/PL interpreter error-message construction until rendered, for perf

### DIFF
--- a/p4spec/lib/interp/inst/hook.ml
+++ b/p4spec/lib/interp/inst/hook.ml
@@ -16,6 +16,11 @@ let is_cache_on () = !cache
 let handlers : (module HANDLER) list ref = ref []
 let register (handlers_ : (module HANDLER) list) = handlers := handlers_
 
+(* Fast-path guard: instrumentation is only needed when a handler is active.
+   Lets hot interpreter paths skip building dependency-edge arguments and
+   driving per-input loops when no handler is registered. *)
+let is_active () : bool = !handlers <> []
+
 (* Initialization and finalization *)
 
 let init_spec (spec : spec) : unit =

--- a/p4spec/lib/interp/inst/hook.ml
+++ b/p4spec/lib/interp/inst/hook.ml
@@ -16,9 +16,8 @@ let is_cache_on () = !cache
 let handlers : (module HANDLER) list ref = ref []
 let register (handlers_ : (module HANDLER) list) = handlers := handlers_
 
-(* Fast-path guard: instrumentation is only needed when a handler is active.
-   Lets hot interpreter paths skip building dependency-edge arguments and
-   driving per-input loops when no handler is registered. *)
+(* Activity *)
+
 let is_active () : bool = !handlers <> []
 
 (* Initialization and finalization *)

--- a/p4spec/lib/interp/interp-common/backtrace.ml
+++ b/p4spec/lib/interp/interp-common/backtrace.ml
@@ -3,7 +3,11 @@ open Util.Source
 
 (* Backtraces *)
 
-type trace = region * string
+(* Trace messages are deferred as thunks. On the hot backtracking path
+   (Unmatch used as control flow) the trace is discarded without ever being
+   forced, so its message string is never built. It is forced only when a
+   backtrace is actually rendered as a failtrace at error-report time. *)
+type trace = region * (unit -> string)
 type backtrace = Err of trace list | Unmatch of trace list
 
 exception Backtrace of backtrace
@@ -16,7 +20,7 @@ let back_failtraces (backtrace : backtrace) : failtrace list =
     | [] -> []
     | (at, msg) :: traces_t ->
         let failtraces = back_failtraces traces_t in
-        [ Failtrace (at, msg, failtraces) ]
+        [ Failtrace (at, msg (), failtraces) ]
   in
   match backtrace with Err traces | Unmatch traces -> back_failtraces traces
 
@@ -25,14 +29,16 @@ let back_failtraces (backtrace : backtrace) : failtrace list =
 let back (backtrace : backtrace) = raise (Backtrace backtrace)
 
 let back_err (at : region) (msg : string) =
-  let traces = [ (at, msg) ] in
+  let traces = [ (at, fun () -> msg) ] in
   raise (Backtrace (Err traces))
 
 let back_unmatch (at : region) (msg : string) =
-  let traces = [ (at, msg) ] in
+  let traces = [ (at, fun () -> msg) ] in
   raise (Backtrace (Unmatch traces))
 
-let back_nest (at : region) (msg : string) (backtrace : backtrace) =
+(* Nesting a descriptive frame; the message is a thunk so it is only built if
+   the resulting backtrace is ever rendered. *)
+let back_nest (at : region) (msg : unit -> string) (backtrace : backtrace) =
   let trace = (at, msg) in
   match backtrace with
   | Err traces -> raise (Backtrace (Err (trace :: traces)))

--- a/p4spec/lib/interp/interp-common/backtrace.ml
+++ b/p4spec/lib/interp/interp-common/backtrace.ml
@@ -3,10 +3,6 @@ open Util.Source
 
 (* Backtraces *)
 
-(* Trace messages are deferred as thunks. On the hot backtracking path
-   (Unmatch used as control flow) the trace is discarded without ever being
-   forced, so its message string is never built. It is forced only when a
-   backtrace is actually rendered as a failtrace at error-report time. *)
 type trace = region * (unit -> string)
 type backtrace = Err of trace list | Unmatch of trace list
 
@@ -36,8 +32,6 @@ let back_unmatch (at : region) (msg : string) =
   let traces = [ (at, fun () -> msg) ] in
   raise (Backtrace (Unmatch traces))
 
-(* Nesting a descriptive frame; the message is a thunk so it is only built if
-   the resulting backtrace is ever rendered. *)
 let back_nest (at : region) (msg : unit -> string) (backtrace : backtrace) =
   let trace = (at, msg) in
   match backtrace with

--- a/p4spec/lib/interp/interp-pl/interp.ml
+++ b/p4spec/lib/interp/interp-pl/interp.ml
@@ -1822,7 +1822,9 @@ module Make (Arch : Sim.ARCH) : Sim.INTERP_PL = struct
       values_output
     with Backtrace backtrace ->
       Hook.on_rel_exit id;
-      back_nest id.at (fun () -> F.asprintf "relation %s failed" id.it) backtrace
+      back_nest id.at
+        (fun () -> F.asprintf "relation %s failed" id.it)
+        backtrace
 
   and invoke_rel' ~(internal : bool) (ctx : Ctx.t) (id : id)
       (values_input : value list) : value list =
@@ -1981,7 +1983,9 @@ module Make (Arch : Sim.ARCH) : Sim.INTERP_PL = struct
       value_output
     with Backtrace backtrace ->
       Hook.on_func_exit id;
-      back_nest id.at (fun () -> F.asprintf "function %s failed" id.it) backtrace
+      back_nest id.at
+        (fun () -> F.asprintf "function %s failed" id.it)
+        backtrace
 
   and invoke_extern_func (ctx : Ctx.t) (id : id) (tparams : tparam list)
       (targs : targ list) (values_input : value list) (typ_output : typ) : value

--- a/p4spec/lib/interp/interp-pl/interp.ml
+++ b/p4spec/lib/interp/interp-pl/interp.ml
@@ -202,13 +202,13 @@ module Make (Arch : Sim.ARCH) : Sim.INTERP_PL = struct
 
   and assign_exps (ctx : Ctx.t) (exps : exp list) (values : value list) : Ctx.t
       =
-    check_back_err
-      (List.length exps = List.length values)
-      (over_region (List.map (fun e -> e.Annot.node.at) exps))
-      (F.asprintf
-         "mismatch in number of expressions and values while assigning, \
-          expected %d value(s) but got %d"
-         (List.length exps) (List.length values));
+    if List.length exps <> List.length values then
+      back_err
+        (over_region (List.map (fun e -> e.Annot.node.at) exps))
+        (F.asprintf
+           "mismatch in number of expressions and values while assigning, \
+            expected %d value(s) but got %d"
+           (List.length exps) (List.length values));
     List.fold_left2 assign_exp ctx exps values
 
   (* Assigning a value to a parameter *)
@@ -221,13 +221,13 @@ module Make (Arch : Sim.ARCH) : Sim.INTERP_PL = struct
 
   and assign_params (ctx_caller : Ctx.t) (ctx_callee : Ctx.t)
       (params : param list) (values : value list) : Ctx.t =
-    check_back_err
-      (List.length params = List.length values)
-      (over_region (List.map at params))
-      (F.asprintf
-         "mismatch in number of parameters and values while assigning, \
-          expected %d value(s) but got %d"
-         (List.length params) (List.length values));
+    if List.length params <> List.length values then
+      back_err
+        (over_region (List.map at params))
+        (F.asprintf
+           "mismatch in number of parameters and values while assigning, \
+            expected %d value(s) but got %d"
+           (List.length params) (List.length values));
     List.fold_left2 (assign_param ctx_caller) ctx_callee params values
 
   and assign_param_exp (ctx : Ctx.t) (exp : exp) (value : value) : Ctx.t =
@@ -263,7 +263,7 @@ module Make (Arch : Sim.ARCH) : Sim.INTERP_PL = struct
     try eval_exp' ctx exp
     with Backtrace backtrace ->
       back_nest exp.node.at
-        (F.asprintf "%s failed" (Pl.Print.string_of_exp exp))
+        (fun () -> F.asprintf "%s failed" (Pl.Print.string_of_exp exp))
         backtrace
 
   and eval_exp' (ctx : Ctx.t) (exp : exp) : value =
@@ -307,10 +307,11 @@ module Make (Arch : Sim.ARCH) : Sim.INTERP_PL = struct
   and eval_bool_exp (_typ_note : typ) (ctx : Ctx.t) (b : bool) : value =
     let value_res = Value.Make.bool b in
     Hook.on_value value_res;
-    List.iter
-      (fun value_input ->
-        Hook.on_value_dependency value_res value_input Dep.Edges.Control)
-      (Ctx.find_values_input ctx);
+    if Hook.is_active () then
+      List.iter
+        (fun value_input ->
+          Hook.on_value_dependency value_res value_input Dep.Edges.Control)
+        (Ctx.find_values_input ctx);
     value_res
 
   (* Numeric expression evaluation *)
@@ -318,10 +319,11 @@ module Make (Arch : Sim.ARCH) : Sim.INTERP_PL = struct
   and eval_num_exp (_typ_note : typ) (ctx : Ctx.t) (n : Num.t) : value =
     let value_res = Value.Make.num n in
     Hook.on_value value_res;
-    List.iter
-      (fun value_input ->
-        Hook.on_value_dependency value_res value_input Dep.Edges.Control)
-      (Ctx.find_values_input ctx);
+    if Hook.is_active () then
+      List.iter
+        (fun value_input ->
+          Hook.on_value_dependency value_res value_input Dep.Edges.Control)
+        (Ctx.find_values_input ctx);
     value_res
 
   (* Text expression evaluation *)
@@ -329,10 +331,11 @@ module Make (Arch : Sim.ARCH) : Sim.INTERP_PL = struct
   and eval_text_exp (_typ_note : typ) (ctx : Ctx.t) (s : string) : value =
     let value_res = Value.Make.text s in
     Hook.on_value value_res;
-    List.iter
-      (fun value_input ->
-        Hook.on_value_dependency value_res value_input Dep.Edges.Control)
-      (Ctx.find_values_input ctx);
+    if Hook.is_active () then
+      List.iter
+        (fun value_input ->
+          Hook.on_value_dependency value_res value_input Dep.Edges.Control)
+        (Ctx.find_values_input ctx);
     value_res
 
   (* Variable expression evaluation *)
@@ -1024,7 +1027,7 @@ module Make (Arch : Sim.ARCH) : Sim.INTERP_PL = struct
     try eval_arg' ctx arg
     with Backtrace backtrace ->
       back_nest arg.at
-        (F.asprintf "%s failed" (Pl.Print.string_of_arg arg))
+        (fun () -> F.asprintf "%s failed" (Pl.Print.string_of_arg arg))
         backtrace
 
   and eval_arg' (ctx : Ctx.t) (arg : arg) : value =
@@ -1045,8 +1048,8 @@ module Make (Arch : Sim.ARCH) : Sim.INTERP_PL = struct
     try eval_instr' ctx instr
     with Backtrace backtrace ->
       backtrace
-      |> back_nest instr.node.at
-           (F.asprintf "%s failed" (Pl.Print.string_of_instr instr))
+      |> back_nest instr.node.at (fun () ->
+             F.asprintf "%s failed" (Pl.Print.string_of_instr instr))
 
   and eval_instr' (ctx : Ctx.t) (instr : instr) : Ctx.t * Flow.t =
     let iid = instr.node.note.iid in
@@ -1193,7 +1196,9 @@ module Make (Arch : Sim.ARCH) : Sim.INTERP_PL = struct
       with
       | Backtrace (Unmatch _) -> false
       | Backtrace backtrace ->
-          back_nest id.at "hold condition evaluation failed" backtrace
+          back_nest id.at
+            (fun () -> "hold condition evaluation failed")
+            backtrace
     in
     let value_res = Value.Make.bool hold in
     Hook.on_value value_res;
@@ -1817,7 +1822,7 @@ module Make (Arch : Sim.ARCH) : Sim.INTERP_PL = struct
       values_output
     with Backtrace backtrace ->
       Hook.on_rel_exit id;
-      back_nest id.at (F.asprintf "relation %s failed" id.it) backtrace
+      back_nest id.at (fun () -> F.asprintf "relation %s failed" id.it) backtrace
 
   and invoke_rel' ~(internal : bool) (ctx : Ctx.t) (id : id)
       (values_input : value list) : value list =
@@ -1976,7 +1981,7 @@ module Make (Arch : Sim.ARCH) : Sim.INTERP_PL = struct
       value_output
     with Backtrace backtrace ->
       Hook.on_func_exit id;
-      back_nest id.at (F.asprintf "function %s failed" id.it) backtrace
+      back_nest id.at (fun () -> F.asprintf "function %s failed" id.it) backtrace
 
   and invoke_extern_func (ctx : Ctx.t) (id : id) (tparams : tparam list)
       (targs : targ list) (values_input : value list) (typ_output : typ) : value

--- a/p4spec/lib/interp/interp-sl/interp.ml
+++ b/p4spec/lib/interp/interp-sl/interp.ml
@@ -1691,7 +1691,9 @@ module Make (Arch : Sim.ARCH) : Sim.INTERP_SL = struct
       values_output
     with Backtrace backtrace ->
       Hook.on_rel_exit id;
-      back_nest id.at (fun () -> F.asprintf "relation %s failed" id.it) backtrace
+      back_nest id.at
+        (fun () -> F.asprintf "relation %s failed" id.it)
+        backtrace
 
   and invoke_rel' ~(internal : bool) (ctx : Ctx.t) (id : id)
       (values_input : value list) : value list =
@@ -1845,7 +1847,9 @@ module Make (Arch : Sim.ARCH) : Sim.INTERP_SL = struct
       value_output
     with Backtrace backtrace ->
       Hook.on_func_exit id;
-      back_nest id.at (fun () -> F.asprintf "function %s failed" id.it) backtrace
+      back_nest id.at
+        (fun () -> F.asprintf "function %s failed" id.it)
+        backtrace
 
   and invoke_extern_func (ctx : Ctx.t) (id : id) (tparams : tparam list)
       (targs : targ list) (values_input : value list) (typ_output : typ) : value

--- a/p4spec/lib/interp/interp-sl/interp.ml
+++ b/p4spec/lib/interp/interp-sl/interp.ml
@@ -207,13 +207,13 @@ module Make (Arch : Sim.ARCH) : Sim.INTERP_SL = struct
 
   and assign_exps (ctx : Ctx.t) (exps : exp list) (values : value list) : Ctx.t
       =
-    check_back_err
-      (List.length exps = List.length values)
-      (over_region (List.map at exps))
-      (F.asprintf
-         "mismatch in number of expressions and values while assigning, \
-          expected %d value(s) but got %d"
-         (List.length exps) (List.length values));
+    if List.length exps <> List.length values then
+      back_err
+        (over_region (List.map at exps))
+        (F.asprintf
+           "mismatch in number of expressions and values while assigning, \
+            expected %d value(s) but got %d"
+           (List.length exps) (List.length values));
     List.fold_left2 assign_exp ctx exps values
 
   (* Assigning a value to a parameter *)
@@ -226,13 +226,13 @@ module Make (Arch : Sim.ARCH) : Sim.INTERP_SL = struct
 
   and assign_params (ctx_caller : Ctx.t) (ctx_callee : Ctx.t)
       (params : param list) (values : value list) : Ctx.t =
-    check_back_err
-      (List.length params = List.length values)
-      (over_region (List.map at params))
-      (F.asprintf
-         "mismatch in number of parameters and values while assigning, \
-          expected %d value(s) but got %d"
-         (List.length params) (List.length values));
+    if List.length params <> List.length values then
+      back_err
+        (over_region (List.map at params))
+        (F.asprintf
+           "mismatch in number of parameters and values while assigning, \
+            expected %d value(s) but got %d"
+           (List.length params) (List.length values));
     List.fold_left2 (assign_param ctx_caller) ctx_callee params values
 
   and assign_param_exp (ctx : Ctx.t) (exp : exp) (value : value) : Ctx.t =
@@ -268,7 +268,7 @@ module Make (Arch : Sim.ARCH) : Sim.INTERP_SL = struct
     try eval_exp' ctx exp
     with Backtrace backtrace ->
       back_nest exp.at
-        (F.asprintf "%s failed" (Sl.Print.string_of_exp exp))
+        (fun () -> F.asprintf "%s failed" (Sl.Print.string_of_exp exp))
         backtrace
 
   and eval_exp' (ctx : Ctx.t) (exp : exp) : value =
@@ -312,10 +312,11 @@ module Make (Arch : Sim.ARCH) : Sim.INTERP_SL = struct
   and eval_bool_exp (_typ_note : typ) (ctx : Ctx.t) (b : bool) : value =
     let value_res = Value.Make.bool b in
     Hook.on_value value_res;
-    List.iter
-      (fun value_input ->
-        Hook.on_value_dependency value_res value_input Dep.Edges.Control)
-      (Ctx.find_values_input ctx);
+    if Hook.is_active () then
+      List.iter
+        (fun value_input ->
+          Hook.on_value_dependency value_res value_input Dep.Edges.Control)
+        (Ctx.find_values_input ctx);
     value_res
 
   (* Numeric expression evaluation *)
@@ -323,10 +324,11 @@ module Make (Arch : Sim.ARCH) : Sim.INTERP_SL = struct
   and eval_num_exp (_typ_note : typ) (ctx : Ctx.t) (n : Num.t) : value =
     let value_res = Value.Make.num n in
     Hook.on_value value_res;
-    List.iter
-      (fun value_input ->
-        Hook.on_value_dependency value_res value_input Dep.Edges.Control)
-      (Ctx.find_values_input ctx);
+    if Hook.is_active () then
+      List.iter
+        (fun value_input ->
+          Hook.on_value_dependency value_res value_input Dep.Edges.Control)
+        (Ctx.find_values_input ctx);
     value_res
 
   (* Text expression evaluation *)
@@ -334,10 +336,11 @@ module Make (Arch : Sim.ARCH) : Sim.INTERP_SL = struct
   and eval_text_exp (_typ_note : typ) (ctx : Ctx.t) (s : string) : value =
     let value_res = Value.Make.text s in
     Hook.on_value value_res;
-    List.iter
-      (fun value_input ->
-        Hook.on_value_dependency value_res value_input Dep.Edges.Control)
-      (Ctx.find_values_input ctx);
+    if Hook.is_active () then
+      List.iter
+        (fun value_input ->
+          Hook.on_value_dependency value_res value_input Dep.Edges.Control)
+        (Ctx.find_values_input ctx);
     value_res
 
   (* Variable expression evaluation *)
@@ -1029,7 +1032,7 @@ module Make (Arch : Sim.ARCH) : Sim.INTERP_SL = struct
     try eval_arg' ctx arg
     with Backtrace backtrace ->
       back_nest arg.at
-        (F.asprintf "%s failed" (Sl.Print.string_of_arg arg))
+        (fun () -> F.asprintf "%s failed" (Sl.Print.string_of_arg arg))
         backtrace
 
   and eval_arg' (ctx : Ctx.t) (arg : arg) : value =
@@ -1051,8 +1054,8 @@ module Make (Arch : Sim.ARCH) : Sim.INTERP_SL = struct
     try eval_instr' ctx instr
     with Backtrace backtrace ->
       backtrace
-      |> back_nest instr.at
-           (F.asprintf "%s failed" (Sl.Print.string_of_instr ~short:true instr))
+      |> back_nest instr.at (fun () ->
+             F.asprintf "%s failed" (Sl.Print.string_of_instr ~short:true instr))
 
   and eval_instr' (ctx : Ctx.t) (instr : instr) : Flow.t =
     let iid = instr.note.iid in
@@ -1215,7 +1218,9 @@ module Make (Arch : Sim.ARCH) : Sim.INTERP_SL = struct
       with
       | Backtrace (Unmatch _) -> false
       | Backtrace backtrace ->
-          back_nest id.at "hold condition evaluation failed" backtrace
+          back_nest id.at
+            (fun () -> "hold condition evaluation failed")
+            backtrace
     in
     let value_res = Value.Make.bool hold in
     Hook.on_value value_res;
@@ -1686,7 +1691,7 @@ module Make (Arch : Sim.ARCH) : Sim.INTERP_SL = struct
       values_output
     with Backtrace backtrace ->
       Hook.on_rel_exit id;
-      back_nest id.at (F.asprintf "relation %s failed" id.it) backtrace
+      back_nest id.at (fun () -> F.asprintf "relation %s failed" id.it) backtrace
 
   and invoke_rel' ~(internal : bool) (ctx : Ctx.t) (id : id)
       (values_input : value list) : value list =
@@ -1840,7 +1845,7 @@ module Make (Arch : Sim.ARCH) : Sim.INTERP_SL = struct
       value_output
     with Backtrace backtrace ->
       Hook.on_func_exit id;
-      back_nest id.at (F.asprintf "function %s failed" id.it) backtrace
+      back_nest id.at (fun () -> F.asprintf "function %s failed" id.it) backtrace
 
   and invoke_extern_func (ctx : Ctx.t) (id : id) (tparams : tparam list)
       (targs : targ list) (values_input : value list) (typ_output : typ) : value


### PR DESCRIPTION
## What this does

The SL/PL interpreters do rule-match backtracking with exceptions: a failed premise raises `Unmatch`, which is caught as ordinary control flow. On the way up, every frame (`eval_exp`, `eval_arg`, `eval_instr`, `invoke_rel`, `invoke_func`) eagerly built a `string_of_exp`/`string_of_instr` message — a string that, on the success path, is never read. Type-checking a valid program backtracks constantly (overload resolution, subtyping, variant dispatch), so a lot of work went into discarded strings.

This makes those messages lazy: they are built only if a backtrace is actually rendered for the user.

## Key changes

Trace messages become thunks, forced only at render time (`interp-common/backtrace.ml`):

```diff
-type trace = region * string
+type trace = region * (unit -> string)

-let back_nest (at : region) (msg : string) (backtrace : backtrace) =
+let back_nest (at : region) (msg : unit -> string) (backtrace : backtrace) =
```

The `back_nest` handlers pass thunks instead of pre-built strings (`interp-sl`, `interp-pl`; six sites each):

```diff
     with Backtrace backtrace ->
-      back_nest instr.at
-        (F.asprintf "%s failed" (Sl.Print.string_of_instr ~short:true instr))
-        backtrace
+      back_nest instr.at
+        (fun () -> F.asprintf "%s failed" (Sl.Print.string_of_instr ~short:true instr))
+        backtrace
```

The two hot `check_back_err` in `assign_exps`/`assign_params` become an inline `if`, so the message is built only on an actual arity mismatch:

```diff
-    check_back_err
-      (List.length exps = List.length values)
-      (over_region (List.map at exps))
-      (F.asprintf "mismatch ... expected %d value(s) but got %d" ...);
+    if List.length exps <> List.length values then
+      back_err (over_region (List.map at exps))
+        (F.asprintf "mismatch ... expected %d value(s) but got %d" ...);
```

Instrumentation driver loops in `eval_bool/num/text_exp` are guarded so they do nothing when no handler is registered (`inst/hook.ml` adds `is_active`):

```diff
     Hook.on_value value_res;
-    List.iter
-      (fun vi -> Hook.on_value_dependency value_res vi Dep.Edges.Control)
-      (Ctx.find_values_input ctx);
+    if Hook.is_active () then
+      List.iter
+        (fun vi -> Hook.on_value_dependency value_res vi Dep.Edges.Control)
+        (Ctx.find_values_input ctx);
```

`interp-pl` is touched only because it shares `interp-common/backtrace.ml`; `interp-al` has its own backtrack module and is untouched. No caching added.

## Perf

`make test-run-sl` in one process; per-program interpreter time summed from its `>>> took` lines; base = branch tip, interleaved on an idle machine:

| set | programs | base | this PR | Δ |
|---|---|---|---|---|
| positive (`Program_inst`, valid) | 1243 | 294.81s | 268.65s | **−8.9%** |
| negative (`Program_ok`, ill-typed) | 520 | 26.53s | 27.26s | ~0 |

The gain is on the success path. The negative set is unchanged by design — those programs report a type error, so the failtrace renders and the thunks are forced anyway.

## Correctness

`make test-run-sl` passes; diagnostics unchanged. A genuine type error still prints the full failtrace (`relation Program_ok failed` → `Decls_ok failed` → …).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
