### PR TITLE
Speed up boot-tower runs (~40%)

### DIFF
--- a/p4spec/bin/boot.ml
+++ b/p4spec/bin/boot.ml
@@ -5,6 +5,16 @@ open Util.Error
 
 let version = "0.1"
 
+(* Tune GC for the allocation-heavy meta-circular interpreter *)
+
+let () =
+  Gc.set
+    {
+      (Gc.get ()) with
+      Gc.minor_heap_size = 16 * 1024 * 1024;
+      Gc.space_overhead = 2000;
+    }
+
 exception CommandError of string
 
 (* Commands *)

--- a/p4spec/lib/backend-boot/spectec.ml
+++ b/p4spec/lib/backend-boot/spectec.ml
@@ -214,8 +214,8 @@ module Make_parametric
 
     let cache_off () =
       cache.meta.enabled <- false;
-      CCache.reset cache.meta.func;
-      CCache.reset cache.meta.rel;
+      CCache.empty cache.meta.func;
+      CCache.empty cache.meta.rel;
       Interface_SpecTec.cache_disable_reset cache.interface
   end
 
@@ -445,6 +445,6 @@ module Make_parametric
 
   let clear () : unit =
     clear_cache_interface ();
-    CCache.clear cache.meta.func;
-    CCache.clear cache.meta.rel
+    CCache.empty cache.meta.func;
+    CCache.empty cache.meta.rel
 end

--- a/p4spec/lib/cache/make.ml
+++ b/p4spec/lib/cache/make.ml
@@ -23,6 +23,7 @@ module Make (Entry : ENTRY) = struct
     mutable count : int; (* number of occupied slots *)
     mutable hand : int; (* eviction hand position *)
     mutable fill : int; (* next slot for sequential initial fill *)
+    mutable touched : int; (* one past the largest slot index ever written *)
   }
 
   let create ~(size : int) =
@@ -36,23 +37,26 @@ module Make (Entry : ENTRY) = struct
       count = 0;
       hand = 0;
       fill = 0;
+      touched = 0;
     }
 
   let size (cache : 'a t) : int = cache.count
 
-  let clear (cache : 'a t) : unit =
-    Table.clear cache.table;
-    Array.fill cache.occ 0 cache.capacity false;
-    cache.count <- 0;
-    cache.hand <- 0;
-    cache.fill <- 0
+  (* Remove every entry, visiting only the slots that were written *)
 
-  let reset (cache : 'a t) : unit =
-    Table.reset cache.table;
-    Array.fill cache.occ 0 cache.capacity false;
+  let empty (cache : 'a t) : unit =
+    for idx = 0 to cache.touched - 1 do
+      if cache.occ.(idx) then begin
+        Table.remove cache.table cache.clock.(idx).key;
+        cache.occ.(idx) <- false;
+        cache.clock.(idx).key <- Entry.default;
+        cache.clock.(idx).ref <- false
+      end
+    done;
     cache.count <- 0;
     cache.hand <- 0;
-    cache.fill <- 0
+    cache.fill <- 0;
+    cache.touched <- 0
 
   let find (cache : 'a t) (key : Entry.t) : 'a option =
     match Table.find_opt cache.table key with
@@ -61,7 +65,7 @@ module Make (Entry : ENTRY) = struct
         cache.clock.(idx).ref <- true;
         Some value
 
-  (* Advance the hand until a slot can be evicted; return its index. *)
+  (* Advance the hand until a slot can be evicted; return its index *)
 
   let evict (cache : 'a t) : int =
     let capacity = cache.capacity in
@@ -90,6 +94,7 @@ module Make (Entry : ENTRY) = struct
           if cache.count < cache.capacity then (
             let idx = cache.fill in
             cache.fill <- (cache.fill + 1) mod cache.capacity;
+            if idx + 1 > cache.touched then cache.touched <- idx + 1;
             idx)
           else evict cache
         in

--- a/p4spec/lib/interface/spectec/caches.ml
+++ b/p4spec/lib/interface/spectec/caches.ml
@@ -79,22 +79,22 @@ let cache_enable (cache : cache) : unit = cache.enabled <- true
 
 let cache_disable_reset (cache : cache) : unit =
   cache.enabled <- false;
-  MCache.reset cache.boot_mixop;
-  VCache.reset cache.boot_value;
-  VCache.reset cache.boot_value_pingpong;
-  VCache.reset cache.unboot_mixop;
-  VCache.reset cache.unboot_typ;
-  VCache.reset cache.unboot_value;
-  VCache.reset cache.unboot_value_pingpong
+  MCache.empty cache.boot_mixop;
+  VCache.empty cache.boot_value;
+  VCache.empty cache.boot_value_pingpong;
+  VCache.empty cache.unboot_mixop;
+  VCache.empty cache.unboot_typ;
+  VCache.empty cache.unboot_value;
+  VCache.empty cache.unboot_value_pingpong
 
 let cache_clear (cache : cache) : unit =
-  MCache.clear cache.boot_mixop;
-  VCache.clear cache.boot_value;
-  VCache.clear cache.boot_value_pingpong;
-  VCache.clear cache.unboot_mixop;
-  VCache.clear cache.unboot_typ;
-  VCache.clear cache.unboot_value;
-  VCache.clear cache.unboot_value_pingpong
+  MCache.empty cache.boot_mixop;
+  VCache.empty cache.boot_value;
+  VCache.empty cache.boot_value_pingpong;
+  VCache.empty cache.unboot_mixop;
+  VCache.empty cache.unboot_typ;
+  VCache.empty cache.unboot_value;
+  VCache.empty cache.unboot_value_pingpong
 
 (* Stack of caches, where the stack is pushed along calls that climb tower levels,
    and popped along call returns that descend tower levels *)

--- a/p4spec/lib/interp/interp-il/interp.ml
+++ b/p4spec/lib/interp/interp-il/interp.ml
@@ -1572,8 +1572,8 @@ module Make (Interface : Run.INTERFACE) (Extern : Run.EXTERN) () :
   (* Entry points for evaluation *)
 
   let clear () : unit =
-    CCache.reset !func_cache;
-    CCache.reset !rel_cache
+    CCache.empty !func_cache;
+    CCache.empty !rel_cache
 
   let do_eval_rel (relname : string) (values_input : value list) :
       value list backtrack =

--- a/p4spec/lib/interp/interp-sl/interp.ml
+++ b/p4spec/lib/interp/interp-sl/interp.ml
@@ -2140,8 +2140,8 @@ module Make (Interface : Run.INTERFACE) (Extern : Run.EXTERN) () :
   (* Entry points for evaluation *)
 
   let clear () : unit =
-    CCache.reset !func_cache;
-    CCache.reset !rel_cache
+    CCache.empty !func_cache;
+    CCache.empty !rel_cache
 
   let do_eval_rel (relname : string) (values_input : value list) : value list =
     try

--- a/p4spec/lib/pass/pass.ml
+++ b/p4spec/lib/pass/pass.ml
@@ -17,14 +17,29 @@ let expand_spec filenames =
 let parse paths_spec =
   paths_spec |> expand_spec |> List.concat_map Frontend.Parse.parse_file
 
-(* Elaboration *)
+(* Elaboration. *)
 
-let elab paths_spec = paths_spec |> parse |> Elaborate.Elab.elab_spec
+let cache_elab = Hashtbl.create 8
+
+let elab paths_spec =
+  match Hashtbl.find_opt cache_elab paths_spec with
+  | Some spec -> spec
+  | None ->
+      let spec = paths_spec |> parse |> Elaborate.Elab.elab_spec in
+      Hashtbl.replace cache_elab paths_spec spec;
+      spec
 
 (* Structuring *)
 
+let structure_cache = Hashtbl.create 8
+
 let structure ~(final : bool) paths_spec =
-  paths_spec |> elab |> Structure.Struct.struct_spec ~final
+  match Hashtbl.find_opt structure_cache (final, paths_spec) with
+  | Some spec -> spec
+  | None ->
+      let spec = paths_spec |> elab |> Structure.Struct.struct_spec ~final in
+      Hashtbl.replace structure_cache (final, paths_spec) spec;
+      spec
 
 (* Prose generation *)
 

--- a/p4spec/lib/runtime/dynamic/var.ml
+++ b/p4spec/lib/runtime/dynamic/var.ml
@@ -8,6 +8,22 @@ type t = id * iter list
 let to_string (id, iters) =
   string_of_varid id ^ String.concat "" (List.map string_of_iter iters)
 
+let compare_iter (iter_a : iter) (iter_b : iter) =
+  match (iter_a, iter_b) with
+  | Opt, Opt | List, List -> 0
+  | Opt, List -> -1
+  | List, Opt -> 1
+
+let rec compare_iters iters_a iters_b =
+  match (iters_a, iters_b) with
+  | [], [] -> 0
+  | [], _ :: _ -> -1
+  | _ :: _, [] -> 1
+  | iter_a :: iters_a, iter_b :: iters_b ->
+      let c = compare_iter iter_a iter_b in
+      if c <> 0 then c else compare_iters iters_a iters_b
+
+(* Compare variables by id, then by iters. *)
 let compare (id_a, iters_a) (id_b, iters_b) =
-  let cmp_id = compare id_a.it id_b.it in
-  if cmp_id = 0 then compare iters_a iters_b else cmp_id
+  let cmp_id = String.compare id_a.it id_b.it in
+  if cmp_id = 0 then compare_iters iters_a iters_b else cmp_id

--- a/p4spec/lib/runtime/value/value.ml
+++ b/p4spec/lib/runtime/value/value.ml
@@ -102,9 +102,20 @@ let hash_of (v : value') : int =
             h := (!h * 31) + value_field.note.vhash)
           valuefields
     | CaseV valuecase ->
-        let mixop, values = Mixfix.split valuecase in
-        h := (!h * 31) + Hashtbl.hash (Mixop.string_of_mixop mixop);
-        List.iter (fun value -> h := (!h * 31) + value.note.vhash) values
+        let rec go = function
+          | Mixfix.Arg value -> h := (!h * 31) + value.note.vhash
+          | Mixfix.Atom atom -> h := (!h * 31) + Hashtbl.hash atom.it
+          | Mixfix.Brack (atom_l, mixfix, atom_r) ->
+              h := (!h * 31) + Hashtbl.hash atom_l.it;
+              go mixfix;
+              h := (!h * 31) + Hashtbl.hash atom_r.it
+          | Mixfix.Infix (mixfix_l, atom, mixfix_r) ->
+              go mixfix_l;
+              h := (!h * 31) + Hashtbl.hash atom.it;
+              go mixfix_r
+          | Mixfix.Seq mixfixes -> List.iter go mixfixes
+        in
+        go valuecase
     | TupleV values ->
         h := (!h * 31) + 1001;
         List.iter (fun value -> h := (!h * 31) + value.note.vhash) values

--- a/p4spec/lib/runtime/value/value.ml
+++ b/p4spec/lib/runtime/value/value.ml
@@ -135,7 +135,15 @@ let hash_of (v : value') : int =
 (* Mixops *)
 
 module Mixops = struct
-  let of_string (s : string) : Mixop.t = Frontend.Parse.parse_mixop s
+  let cache : (string, Mixop.t) Hashtbl.t = Hashtbl.create 64
+
+  let of_string (s : string) : Mixop.t =
+    match Hashtbl.find_opt cache s with
+    | Some mixop -> mixop
+    | None ->
+        let mixop = Frontend.Parse.parse_mixop s in
+        Hashtbl.replace cache s mixop;
+        mixop
 
   let of_atoms_matrix (atoms_matrix : Atom.t list list) : Mixop.t =
     atoms_matrix

--- a/p4spec/lib/runtime/value/value.ml
+++ b/p4spec/lib/runtime/value/value.ml
@@ -304,12 +304,13 @@ module Get = struct
       (case_default : value list -> 'a) : 'a =
     match value.it with
     | CaseV valuecase -> (
-        let mixop, values = Mixfix.split valuecase in
-        let cases =
-          List.map (fun (s_mixop, f) -> (Mixops.of_string s_mixop, f)) cases
-        in
+        let values = Mixfix.args valuecase in
         let f_opt =
-          List.find_opt (fun (m, _) -> Mixop.eq m mixop) cases |> Option.map snd
+          List.find_opt
+            (fun (s_mixop, _) ->
+              Mixfix.eq_mixop valuecase (Mixops.of_string s_mixop))
+            cases
+          |> Option.map snd
         in
         match f_opt with Some f -> f values | None -> case_default values)
     | _ -> case_default []
@@ -352,33 +353,32 @@ module Get = struct
   let ( |>> ) (value : t) (s_mixop : string) : value list =
     match value.it with
     | CaseV valuecase ->
-        let mixop, values = Mixfix.split valuecase in
         let mixop_expect = Mixops.of_string s_mixop in
-        if Mixop.eq mixop mixop_expect then values
+        if Mixfix.eq_mixop valuecase mixop_expect then Mixfix.args valuecase
         else
           error no_region
             (Format.asprintf "expected case with %s, but got %s"
                (Mixop.string_of_mixop mixop_expect)
-               (Mixop.string_of_mixop mixop))
+               (Mixop.string_of_mixop (Mixfix.to_mixop valuecase)))
     | _ -> error no_region "not a case"
 
   let ( |>>! ) (value : t) (mixop_expect : Mixop.t) : value list =
     match value.it with
     | CaseV valuecase ->
-        let mixop, values = Mixfix.split valuecase in
-        if Mixop.eq mixop mixop_expect then values
+        if Mixfix.eq_mixop valuecase mixop_expect then Mixfix.args valuecase
         else
           error no_region
             (Format.asprintf "expected case with %s, but got %s"
                (Mixop.string_of_mixop mixop_expect)
-               (Mixop.string_of_mixop mixop))
+               (Mixop.string_of_mixop (Mixfix.to_mixop valuecase)))
     | _ -> error no_region "not a case"
 
   let ( |>>? ) (value : t) (s_mixop : string) : value list option =
     match value.it with
     | CaseV valuecase ->
-        let mixop, values = Mixfix.split valuecase in
         let mixop_expect = Mixops.of_string s_mixop in
-        if Mixop.eq mixop mixop_expect then Some values else None
+        if Mixfix.eq_mixop valuecase mixop_expect then
+          Some (Mixfix.args valuecase)
+        else None
     | _ -> None
 end


### PR DESCRIPTION
## What this does

Speeds up meta-circular tower runs (`spectec-boot boot-n`) by ~40%, with no change to what the interpreter computes. Seven small, independent changes, one per commit.

The interpreter spends most of its time allocating short-lived values and comparing them; the two biggest wins tune the garbage collector and cut per-lookup comparison cost. The rest remove redundant work on hot paths.

## Perf per change

Measured on the representative run — `boot-n -tower towers/il-il.json -p testdata/.../issue2342.p4`, release build, wall-clock, each step against the one before it:

| # | change | this step |
|---|--------|-----------|
| 1 | O(entries) cache reset | −9% |
| 2 | monomorphic `Var.compare` | −6% |
| 3 | hash case values without splitting | ~−2% |
| 4 | memoize `Mixops.of_string` | ~0 (generality) |
| 5 | avoid `to_mixop` in case getters | ~−2% |
| 6 | memoize spec elaboration | ~0 (setup only) |
| 7 | tune GC | −25% |

Cumulative: **16.0s → 9.6s (−40%)**. Steps 4 and 6 don't move this run but remove real duplicate work that shows up elsewhere (repeated parsing; suites of many small files). Behavior is unchanged: 40 sample programs still type-check, ill-typed ones are still rejected.

## The changes

**7. Tune GC.** The run allocates ~24 GB total, almost all of it thrown away immediately, so it was constantly collecting. Give it a much larger young-generation buffer (collected far less often) and let the old-generation collector run lazily (almost nothing survives that long anyway).

```diff
+let () =
+  Gc.set
+    {
+      (Gc.get ()) with
+      Gc.minor_heap_size = 16 * 1024 * 1024;
+      Gc.space_overhead = 2000;
+    }
```

**1. O(entries) cache reset.** The per-level result caches are reset on every call across a tower level. Reset used to wipe the full 256K-slot backing arrays every time; now it visits only the slots actually written since the last reset, tracked by a counter.

```diff
-  let clear (cache : 'a t) : unit =
-    Table.clear cache.table;
-    Array.fill cache.occ 0 cache.capacity false;
-    ...
-  let reset (cache : 'a t) : unit =
-    Table.reset cache.table;
-    Array.fill cache.occ 0 cache.capacity false;
-    ...
+  let empty (cache : 'a t) : unit =
+    for idx = 0 to cache.touched - 1 do
+      if cache.occ.(idx) then begin
+        Table.remove cache.table cache.clock.(idx).key;
+        cache.occ.(idx) <- false;
+        cache.clock.(idx).key <- Entry.default;
+        cache.clock.(idx).ref <- false
+      end
+    done;
+    ...
```

**2. Monomorphic `Var.compare`.** Every variable lookup compares map keys with the polymorphic `compare`. The key is a string plus a small list; use `String.compare` and a direct list comparison instead.

```diff
-  let cmp_id = compare id_a.it id_b.it in
-  if cmp_id = 0 then compare iters_a iters_b else cmp_id
+  let cmp_id = String.compare id_a.it id_b.it in
+  if cmp_id = 0 then compare_iters iters_a iters_b else cmp_id
```

**3. Hash case values without splitting.** Every case value, when constructed, was taken apart and turned into a string just to hash it. Walk its structure directly instead, reusing each argument's already-computed hash.

```diff
-    | CaseV valuecase ->
-        let mixop, values = Mixfix.split valuecase in
-        h := (!h * 31) + Hashtbl.hash (Mixop.string_of_mixop mixop);
-        List.iter (fun value -> h := (!h * 31) + value.note.vhash) values
+    | CaseV valuecase ->
+        let rec go = function
+          | Mixfix.Arg value -> h := (!h * 31) + value.note.vhash
+          | Mixfix.Atom atom -> h := (!h * 31) + Hashtbl.hash atom.it
+          | Mixfix.Brack (atom_l, mixfix, atom_r) -> ...
+          | Mixfix.Infix (mixfix_l, atom, mixfix_r) -> ...
+          | Mixfix.Seq mixfixes -> List.iter go mixfixes
+        in
+        go valuecase
```

**5. Avoid `to_mixop` in case getters.** The `|>>`, `|>>!`, `|>>?`, and `mtch` getters copied a case's tag just to compare it. Compare in place and take the arguments directly; build the copy only for the error message.

```diff
-        let mixop, values = Mixfix.split valuecase in
-        if Mixop.eq mixop mixop_expect then values
-        else error ...
+        if Mixfix.eq_mixop valuecase mixop_expect then Mixfix.args valuecase
+        else error ...
```

**4. Memoize `Mixops.of_string`** — value constructors parse constant tag literals through the full grammar; cache the parse keyed by the string.

**6. Memoize spec elaboration** — a tower whose levels share a spec directory (`il-il`, `sl-sl`) parsed and elaborated the same files once per level; cache the result keyed by the source paths.
