### PR TITLE
Speed up SL interpreter subtyping and hot-path comparisons

### DIFF
--- a/p4spec/lib/domain/atom.ml
+++ b/p4spec/lib/domain/atom.ml
@@ -79,7 +79,12 @@ type t =
 [@@@ocamlformat "enable"]
 
 let compare atom_a atom_b = compare atom_a atom_b
-let eq atom_a atom_b = atom_a = atom_b
+
+let eq (atom_a : t) (atom_b : t) : bool =
+  match (atom_a, atom_b) with
+  | Atom id_a, Atom id_b | SilentAtom id_a, SilentAtom id_b ->
+      String.equal id_a id_b
+  | _ -> atom_a = atom_b
 
 let string_of_atom = function
   | Atom id -> id

--- a/p4spec/lib/domain/lib.ml
+++ b/p4spec/lib/domain/lib.ml
@@ -35,8 +35,8 @@ module VId = struct
   type t = int
 
   let to_string t = string_of_int t
-  let compare t_a t_b = compare t_a t_b
-  let eq t_a t_b = compare t_a t_b = 0
+  let compare t_a t_b = Int.compare t_a t_b
+  let eq t_a t_b = Int.equal t_a t_b
   let hash t = Hashtbl.hash t
 end
 
@@ -109,8 +109,8 @@ module Id = struct
   type t = string phrase
 
   let to_string t = t.it
-  let compare t_a t_b = compare t_a.it t_b.it
-  let eq t_a t_b = compare t_a t_b = 0
+  let compare t_a t_b = String.compare t_a.it t_b.it
+  let eq t_a t_b = String.equal t_a.it t_b.it
   let hash t = Hashtbl.hash t.it
   let is_underscored t = String.starts_with ~prefix:"_" t.it
 

--- a/p4spec/lib/domain/mixfix.ml
+++ b/p4spec/lib/domain/mixfix.ml
@@ -123,17 +123,38 @@ let rec compare : type a b. compare_arg:(a -> b -> int) -> a t -> b t -> int =
         compare_mixfixes mixfixes_a mixfixes_b
     | _ -> Int.compare (tag mixfix_a) (tag mixfix_b)
 
-let eq ~(eq_arg : 'a -> 'b -> bool) (mixfix_a : 'a t) (mixfix_b : 'b t) =
-  compare
-    ~compare_arg:(fun arg_a arg_b -> if eq_arg arg_a arg_b then 0 else -1)
-    mixfix_a mixfix_b
-  = 0
+let rec eq : type a b. eq_arg:(a -> b -> bool) -> a t -> b t -> bool =
+ fun ~eq_arg mixfix_a mixfix_b ->
+  Obj.repr mixfix_a == Obj.repr mixfix_b
+  ||
+  match (mixfix_a, mixfix_b) with
+  | Arg arg_a, Arg arg_b -> eq_arg arg_a arg_b
+  | Atom atom_a, Atom atom_b -> Atom.eq atom_a.it atom_b.it
+  | Brack (atom_a_l, mixfix_a, atom_a_r), Brack (atom_b_l, mixfix_b, atom_b_r) ->
+      Atom.eq atom_a_l.it atom_b_l.it
+      && eq ~eq_arg mixfix_a mixfix_b
+      && Atom.eq atom_a_r.it atom_b_r.it
+  | ( Infix (mixfix_a_l, atom_a, mixfix_a_r),
+      Infix (mixfix_b_l, atom_b, mixfix_b_r) ) ->
+      Atom.eq atom_a.it atom_b.it
+      && eq ~eq_arg mixfix_a_l mixfix_b_l
+      && eq ~eq_arg mixfix_a_r mixfix_b_r
+  | Seq mixfixes_a, Seq mixfixes_b -> eqs ~eq_arg mixfixes_a mixfixes_b
+  | _ -> false
+
+and eqs : type a b. eq_arg:(a -> b -> bool) -> a t list -> b t list -> bool =
+ fun ~eq_arg mixfixes_a mixfixes_b ->
+  match (mixfixes_a, mixfixes_b) with
+  | [], [] -> true
+  | mixfix_a :: mixfixes_a, mixfix_b :: mixfixes_b ->
+      eq ~eq_arg mixfix_a mixfix_b && eqs ~eq_arg mixfixes_a mixfixes_b
+  | _ -> false
 
 let compare_mixop (mixfix_a : 'a t) (mixfix_b : 'b t) =
   compare ~compare_arg:(fun _ _ -> 0) mixfix_a mixfix_b
 
 let eq_mixop (mixfix_a : 'a t) (mixfix_b : 'b t) =
-  compare_mixop mixfix_a mixfix_b = 0
+  eq ~eq_arg:(fun _ _ -> true) mixfix_a mixfix_b
 
 (* Fold, map, and iter *)
 

--- a/p4spec/lib/lang/hints/input.ml
+++ b/p4spec/lib/lang/hints/input.ml
@@ -45,17 +45,20 @@ let validate (hint : t) (arity : int) : (unit, string) result =
 (* Splitting and combining expressions based on input hints *)
 
 let split (hint : t) (items : 'a list) : 'a list * 'a list =
-  items
-  |> List.mapi (fun idx item -> (idx, item))
-  |> List.partition (fun (idx, _) -> List.mem idx hint)
-  |> fun (item_input, item_output) ->
-  (List.map snd item_input, List.map snd item_output)
+  let rec go idx items_input_rev items_output_rev = function
+    | [] -> (List.rev items_input_rev, List.rev items_output_rev)
+    | item :: items ->
+        if List.memq idx hint then
+          go (idx + 1) (item :: items_input_rev) items_output_rev items
+        else go (idx + 1) items_input_rev (item :: items_output_rev) items
+  in
+  go 0 [] [] items
 
 let combine (hint : t) (items_input : 'a list) (items_output : 'a list) :
     'a list =
   let len = List.length items_input + List.length items_output in
   let idxs_input, idxs_output =
-    List.init len Fun.id |> List.partition (fun idx -> List.mem idx hint)
+    List.init len Fun.id |> List.partition (fun idx -> List.memq idx hint)
   in
   let items_input_indexed = List.combine idxs_input items_input in
   let items_output_indexed = List.combine idxs_output items_output in

--- a/p4spec/lib/runtime/dynamic/caches.ml
+++ b/p4spec/lib/runtime/dynamic/caches.ml
@@ -28,7 +28,8 @@ module CallEntry = struct
     | _ -> false
 
   let equal ((id_a, values_a) : t) ((id_b, values_b) : t) : bool =
-    if id_a <> id_b then false else equal_values values_a values_b
+    if not (String.equal id_a id_b) then false
+    else equal_values values_a values_b
 
   let hash ((id, values) : t) : int =
     let h = ref ((Hashtbl.hash id * 31) + 17) in

--- a/p4spec/lib/runtime/type/subst.ml
+++ b/p4spec/lib/runtime/type/subst.ml
@@ -60,7 +60,8 @@ let subst_typs (theta : theta) (typs : typ list) : typ list =
 (* Variant types *)
 
 let subst_nottyp (theta : theta) (nottyp : nottyp) : nottyp =
-  Mixfix.map (subst_typ theta) nottyp.it $ nottyp.at
+  if TIdMap.is_empty theta then nottyp
+  else Mixfix.map (subst_typ theta) nottyp.it $ nottyp.at
 
 let subst_typcase (theta : theta) (typcase : typcase) : typcase =
   let nottyp, typorigin, hints = typcase in

--- a/p4spec/lib/runtime/value/match.ml
+++ b/p4spec/lib/runtime/value/match.ml
@@ -43,14 +43,14 @@ let rec sub_ (find_typdef_opt : TId.t -> Type.Typdef.t option)
                 typfields valuefields
           | VariantT typcases, CaseV valuecase ->
               let theta = TIdMap.of_lists tparams targs in
-              let mixop_v, values = Mixfix.split valuecase in
+              let values = Mixfix.args valuecase in
               List.exists
-                (fun typcase ->
-                  let nottyp, _, _ = typcase in
+                (fun (nottyp, _, _) ->
+                  Mixfix.eq_mixop nottyp.it valuecase
+                  &&
                   let nottyp = Type.Subst.subst_nottyp theta nottyp in
-                  let mixop_t, typs = Mixfix.split nottyp.it in
-                  Mixop.eq mixop_t mixop_v
-                  && subs_ find_typdef_opt find_func typs values)
+                  let typs = Mixfix.args nottyp.it in
+                  subs_ find_typdef_opt find_func typs values)
                 typcases
           | _ -> false))
   | TupleT typs -> (


### PR DESCRIPTION
## What this does

Follow-up to #181, continuing to speed up meta-circular tower runs (`spectec-boot boot-n`) with no change to what the interpreter computes. Five small, independent changes, one per commit.

After #181 the remaining hot spots are value **subtyping** (done on every relation call and every variant dispatch) and the **polymorphic comparisons** still left on lookup paths. These changes remove that work: match variant tags without copying them, skip identity type-substitution, and replace polymorphic `compare`/`=`/`List.mem` on ids, atoms, and hint indices with monomorphic equivalents.

## Perf per change

The `action-bind.p4` / `il-il.json` benchmark is nondeterministic at two tower levels (search depth varies run to run) and the machine drifts between load regimes, so its wall-clock is not a reliable steady-state signal — across batches the distributions often overlap. The dependable measurement is profile self-time (`/usr/bin/sample`), where each change zeroes or sharply cuts its target. On the stable `issue2342.p4` proxy the whole set is ~5% faster and noticeably more consistent (tighter distribution, from lower GC-timing jitter).

For reference, one low-noise batch of `action-bind.p4` on `il-il.json` (release, user-time, 3 runs each, pre-PR = base, post-PR = branch tip) separated cleanly:

| | run 1 | run 2 | run 3 | mean |
|---|---|---|---|---|
| pre-PR | 6.94 | 6.22 | 6.70 | 6.62 |
| post-PR | 5.88 | 5.66 | 5.49 | 5.68 |

~14% here with no overlap — but, per the nondeterminism above, treat this as one favorable batch rather than a guaranteed number.

| # | change | profile self-time (action-bind, il-il) |
|---|--------|-----------------------------------------|
| 1 | monomorphic equality for atoms, mixops, ids | `Mixfix.compare_atom` (eq path) 834 → 0, `Lib.compare` 657 → 0 |
| 2 | match subtyping without copying case tags | `Value.Match.sub` 823 → 0, `Mixfix.map` (`to_mixop`) 543 → 102 |
| 3 | skip identity `subst_nottyp` | `Mixfix.map` 102 → 18, `subst_nottyp` → 0 |
| 4 | cheaper input-hint splitting | `List.mem` 571 → 0 |
| 5 | monomorphic id comparison in the call cache | drops polymorphic `<>` on cache probes |

Behavior is unchanged: 7 sample programs still type-check, an ill-typed program is still rejected (`VarDecl_ok failed`), and the `action-bind`/`issue47`/`issue2342` boot towers still pass.

## The changes

**1. Monomorphic equality for atoms, mixops, and identifiers.** Case-value matching, spec map/set builtins, and context lookups compare atoms, mixops, and ids constantly, all through polymorphic `compare`/`=` that dispatches through the C runtime even for the common nullary and string cases. `Atom.eq` is hand-written (`String.equal` for the two string-carrying atoms, structural equality for the rest); `Mixfix.eq`/`eq_mixop` do a direct structural recursion instead of running the ordering `compare` and testing `= 0`; `Lib.Id`/`Lib.VId` use `String.compare`/`Int.compare` and their `equal`s. `Atom.compare` (ordering) is left untouched — it backs `Set.Make(Value)`, whose element order is observable in spec output.

**2. Match value subtyping without copying case tags.** `Value.Match.sub` on a variant split the value's tag and every candidate's tag into unit-mixops via `Mixfix.split` — which calls `to_mixop`, a full tag-tree copy — just to compare them, and substituted every candidate's argument types before checking whether it even matched.

```diff
-              let mixop_v, values = Mixfix.split valuecase in
+              let values = Mixfix.args valuecase in
               List.exists
-                (fun typcase ->
-                  let nottyp, _, _ = typcase in
-                  let nottyp = Type.Subst.subst_nottyp theta nottyp in
-                  let mixop_t, typs = Mixfix.split nottyp.it in
-                  Mixop.eq mixop_t mixop_v
-                  && subs_ find_typdef_opt find_func typs values)
+                (fun (nottyp, _, _) ->
+                  Mixfix.eq_mixop nottyp.it valuecase
+                  &&
+                  let nottyp = Type.Subst.subst_nottyp theta nottyp in
+                  let typs = Mixfix.args nottyp.it in
+                  subs_ find_typdef_opt find_func typs values)
```

`Mixfix.eq_mixop` compares a tag against a value-case directly (ignoring the arguments), so no copy is needed; and a tag is invariant under substitution (theta only rewrites argument types), so matching it first lets us substitute and extract argument types for the one matching case only. Same result as before.

**3. Skip identity `subst_nottyp`.** `subst_nottyp` always rebuilt the whole tag tree with `Mixfix.map`, even for an empty substitution — the case for every variant with no type parameters. Guard it, matching `subst_typ`/`subst_typs`.

```diff
 let subst_nottyp (theta : theta) (nottyp : nottyp) : nottyp =
-  Mixfix.map (subst_typ theta) nottyp.it $ nottyp.at
+  if TIdMap.is_empty theta then nottyp
+  else Mixfix.map (subst_typ theta) nottyp.it $ nottyp.at
```

**4. Cheaper input-hint splitting.** `Hints.Input.split` runs on every rule and relation evaluation. It built five intermediate lists (`List.mapi` + `List.partition` + two `List.map snd`) and tested membership with `List.mem`, whose polymorphic `=` on the `int` hint indices calls into the C runtime per comparison. Fold once into two accumulators, and use `List.memq` — physical equality is exact for the immediate `int` indices.

```diff
-let split (hint : t) (items : 'a list) : 'a list * 'a list =
-  items
-  |> List.mapi (fun idx item -> (idx, item))
-  |> List.partition (fun (idx, _) -> List.mem idx hint)
-  |> fun (item_input, item_output) ->
-  (List.map snd item_input, List.map snd item_output)
+let split (hint : t) (items : 'a list) : 'a list * 'a list =
+  let rec go idx items_input_rev items_output_rev = function
+    | [] -> (List.rev items_input_rev, List.rev items_output_rev)
+    | item :: items ->
+        if List.memq idx hint then
+          go (idx + 1) (item :: items_input_rev) items_output_rev items
+        else go (idx + 1) items_input_rev (item :: items_output_rev) items
+  in
+  go 0 [] [] items
```

**5. Monomorphic id comparison in the call cache.** `CallEntry.equal`, run on every relation/function memo-cache probe collision, compared the id with polymorphic `<>`; use `String.equal`.
