### PR TITLE
Fix region propagation across passes

### DIFF
--- a/p4spec/lib/lang/il/fresh.ml
+++ b/p4spec/lib/lang/il/fresh.ml
@@ -25,7 +25,7 @@ let var_from_typ ?(wildcard = false) (metavars : typ TIdMap.t) (ids : IdSet.t)
              if
                Eq.eq_typ typ typ_alias
                && not (String.equal (Print.string_of_typ typ) tid.it)
-             then Some (tid, typ_alias, [])
+             then Some (tid.it $ at, typ_alias, [])
              else None)
     in
     match vars_alias with [ var_alias ] -> var_alias | _ -> var_from_typ'' typ

--- a/p4spec/lib/pass/algo/binding/antiunify.ml
+++ b/p4spec/lib/pass/algo/binding/antiunify.ml
@@ -142,7 +142,8 @@ let rec populate_exp (unifiers : IdSet.t) (exp_template : exp) (exp : exp) :
     match (exp_template.it, exp.it) with
     | VarE id_template, _ when IdSet.mem id_template unifiers ->
         let exp_match =
-          CmpE (`EqOp, `BoolT, exp_template, exp) $$ (exp.at, BoolT)
+          let at = over_region [ exp_template.at; exp.at ] in
+          CmpE (`EqOp, `BoolT, exp_template, exp) $$ (at, BoolT)
         in
         let prem_match = IfPr exp_match $ exp_match.at in
         [ prem_match ]
@@ -162,7 +163,8 @@ let rec populate_exp (unifiers : IdSet.t) (exp_template : exp) (exp : exp) :
         populate_exps unifiers exps_template exps
     | _ ->
         let exp_match =
-          CmpE (`EqOp, `BoolT, exp_template, exp) $$ (exp.at, BoolT)
+          let at = over_region [ exp_template.at; exp.at ] in
+          CmpE (`EqOp, `BoolT, exp_template, exp) $$ (at, BoolT)
         in
         let prem_match = IfPr exp_match $ exp_match.at in
         [ prem_match ]

--- a/p4spec/lib/pass/algo/binding/multibind.ml
+++ b/p4spec/lib/pass/algo/binding/multibind.ml
@@ -33,17 +33,17 @@ let gen_sidecondition (benv : Bind.BEnv.t) (iterctx : Iterctx.t) (id : Id.t)
   let exp =
     let exp =
       let exp_l = VarE id $$ (id.at, typ.it) in
-      let exp_r = VarE id_rename $$ (id_rename.at, typ.it) in
-      CmpE (`EqOp, `BoolT, exp_l, exp_r) $$ (id_rename.at, BoolT)
+      let exp_r = VarE id_rename $$ (id.at, typ.it) in
+      CmpE (`EqOp, `BoolT, exp_l, exp_r) $$ (id.at, BoolT)
     in
     List.fold_left
       (fun exp_l id_rename ->
         let exp_r =
           let exp_l = VarE id $$ (id.at, typ.it) in
-          let exp_r = VarE id_rename $$ (id_rename.at, typ.it) in
-          CmpE (`EqOp, `BoolT, exp_l, exp_r) $$ (id_rename.at, BoolT)
+          let exp_r = VarE id_rename $$ (id.at, typ.it) in
+          CmpE (`EqOp, `BoolT, exp_l, exp_r) $$ (id.at, BoolT)
         in
-        BinE (`AndOp, `BoolT, exp_l, exp_r) $$ (id_rename.at, BoolT))
+        BinE (`AndOp, `BoolT, exp_l, exp_r) $$ (id.at, BoolT))
       exp ids_rename
   in
   let sidecondition = IfPr exp $ id.at in

--- a/p4spec/lib/pass/algo/sidecondition/guard.ml
+++ b/p4spec/lib/pass/algo/sidecondition/guard.ml
@@ -194,46 +194,54 @@ let gen_iter_guard (iterexp : iterexp) : prem list =
       let exp_a = gen_eq_epsilon_exp iter var_a in
       let exp_b = gen_eq_epsilon_exp iter var_b in
       let exp_if =
-        Il.BinE (`EquivOp, `BoolT, exp_a, exp_b) $$ (exp_a.at, Typ.Make.bool')
+        let at = over_region [ exp_a.at; exp_b.at ] in
+        Il.BinE (`EquivOp, `BoolT, exp_a, exp_b)
+        $$ (at, Typ.Make.bool')
       in
       let _, exp_if =
         List.fold_left
           (fun (exp_prev, exp_if) var ->
             let exp = gen_eq_epsilon_exp iter var in
             let exp_bin =
+              let at = over_region [ exp_prev.at; exp.at ] in
               Il.BinE (`EquivOp, `BoolT, exp_prev, exp)
-              $$ (exp_prev.at, Typ.Make.bool')
+              $$ (at, Typ.Make.bool')
             in
             let exp_if =
+              let at = over_region [ exp_if.at; exp_bin.at ] in
               Il.BinE (`AndOp, `BoolT, exp_if, exp_bin)
-              $$ (exp_if.at, Typ.Make.bool')
+              $$ (at, Typ.Make.bool')
             in
             (exp, exp_if))
           (exp_b, exp_if) vars
       in
-      [ Il.IfPr exp_if $ no_region ]
+      [ Il.IfPr exp_if $ exp_if.at ]
   | var_a :: var_b :: vars when iter = List ->
       let exp_a = gen_len_exp iter var_a in
       let exp_b = gen_len_exp iter var_b in
       let exp_if =
-        Il.CmpE (`EqOp, `BoolT, exp_a, exp_b) $$ (exp_a.at, Typ.Make.bool')
+        let at = over_region [ exp_a.at; exp_b.at ] in
+        Il.CmpE (`EqOp, `BoolT, exp_a, exp_b)
+        $$ (at, Typ.Make.bool')
       in
       let _, exp_if =
         List.fold_left
           (fun (exp_prev, exp_if) var ->
             let exp = gen_len_exp iter var in
             let exp_cmp =
+              let at = over_region [ exp_prev.at; exp.at ] in
               Il.CmpE (`EqOp, `BoolT, exp_prev, exp)
-              $$ (exp_prev.at, Typ.Make.bool')
+              $$ (at, Typ.Make.bool')
             in
             let exp_if =
+              let at = over_region [ exp_if.at; exp_cmp.at ] in
               Il.BinE (`AndOp, `BoolT, exp_if, exp_cmp)
-              $$ (exp_if.at, Typ.Make.bool')
+              $$ (at, Typ.Make.bool')
             in
             (exp, exp_if))
           (exp_b, exp_if) vars
       in
-      [ Il.IfPr exp_if $ no_region ]
+      [ Il.IfPr exp_if $ exp_if.at ]
   | _ -> []
 
 let collector : Result.t Walk.Collect.collector =

--- a/p4spec/lib/pass/annotate/expand/expand.ml
+++ b/p4spec/lib/pass/annotate/expand/expand.ml
@@ -104,7 +104,7 @@ let replace_call_exp ~(call_e_count : call_e_count) ?(iter_locals = IdSet.empty)
       in
       let wrap_in_let body =
         LetI (exp_new, exp_orig, iterinstrs, [ body ])
-        $$ (no_region, { iid = -1 })
+        $$ (body.at, { iid = -1 })
       in
       Some (wrap_in_let, exp_new_full, ids_used)
   | None -> None

--- a/p4spec/lib/pass/annotate/linearize.ml
+++ b/p4spec/lib/pass/annotate/linearize.ml
@@ -56,4 +56,5 @@ and linearize_block (block : block) : Ll.Ast.block =
   | [ instr ] -> linearize_instr instr
   | _ ->
       let arms = List.map linearize_instr block in
-      [ Ll.Ast.TryI arms $$ (no_region, { iid = -1 }) ]
+      let at = block |> List.map Util.Source.at |> over_region in
+      [ Ll.Ast.TryI arms $$ (at, { iid = -1 }) ]

--- a/p4spec/lib/pass/elaborate/elab.ml
+++ b/p4spec/lib/pass/elaborate/elab.ml
@@ -1079,15 +1079,7 @@ and elab_exp_variant (ctx : Ctx.t) (typ_il_expect : Il.typ)
               let id, targs_il = typorigin_il.it in
               Il.VarT (id, targs_il) $ typorigin_il.at
             in
-            let exp_il =
-              let atoms = Mixfix.atoms notexp_il in
-              let at =
-                match atoms with
-                | [] -> exp_list_region (Mixfix.args notexp_il)
-                | _ -> atoms |> List.map at |> over_region
-              in
-              Il.CaseE notexp_il $$ (at, typ_il.it)
-            in
+            let exp_il = Il.CaseE notexp_il $$ (exp.at, typ_il.it) in
             let+ exp_il = cast_exp ctx typ_il_expect typ_il exp_il in
             (ctx, exps_il @ [ exp_il ])
         | Fail _ -> (ctx, exps_il))

--- a/p4spec/lib/pass/elaborate/elab.ml
+++ b/p4spec/lib/pass/elaborate/elab.ml
@@ -597,7 +597,7 @@ and infer_dot_exp (ctx : Ctx.t) (exp : exp) (atom : atom) :
     |> fun typfield_opt ->
     match typfield_opt with
     | Some (_, typ_il) -> Ok typ_il
-    | None -> fail exp.at "cannot infer type of field"
+    | None -> fail atom.at "cannot infer type of field"
   in
   let exp_il = Il.DotE (exp_il, atom) in
   Ok (ctx, exp_il, typ_il.it)

--- a/p4spec/lib/pass/structure/antiunify.ml
+++ b/p4spec/lib/pass/structure/antiunify.ml
@@ -24,7 +24,8 @@ let rec populate_exp_template (uenv : UEnv.t) (exp_template : exp) (exp : exp) :
   let populate_exp_template_unequal () =
     match (exp_template.it, exp.it) with
     | VarE id_template, _ when UEnv.unified id_template uenv ->
-        let prem = Il.LetPr (exp, exp_template) $ exp.at in
+        let at = over_region [ exp.at; exp_template.at ] in
+        let prem = Il.LetPr (exp, exp_template) $ at in
         [ prem ]
     | TupleE exps_template, TupleE exps ->
         populate_exps_templates uenv exps_template exps
@@ -40,9 +41,10 @@ let rec populate_exp_template (uenv : UEnv.t) (exp_template : exp) (exp : exp) :
     | ( IterE (exp_template, (iter_template, vars_template)),
         IterE (exp, (iter, vars)) )
       when Il.Eq.eq_iter iter_template iter ->
+        let at = over_region [ exp.at; exp_template.at ] in
         let iterprem = (iter_template, vars_template, vars) in
-        let prem = Il.LetPr (exp, exp_template) $ exp.at in
-        let prem = Il.IterPr (prem, iterprem) $ exp.at in
+        let prem = Il.LetPr (exp, exp_template) $ at in
+        let prem = Il.IterPr (prem, iterprem) $ at in
         [ prem ]
     | _ ->
         Format.asprintf "cannot populate anti-unified expressions %s and %s"

--- a/p4spec/lib/pass/structure/struct.ml
+++ b/p4spec/lib/pass/structure/struct.ml
@@ -133,7 +133,14 @@ let struct_rule_matches (frees : IdSet.t)
 
 let struct_rule_paths (rel_signature : Ol.Ast.rel_signature)
     (prems_path : prem list) (exps_output : exp list) : Ol.Ast.block =
-  let at = exps_output |> List.map Util.Source.at |> over_region in
+  let at =
+    match (exps_output, prems_path) with
+    | [], [] ->
+        let nottyp, _ = rel_signature in
+        nottyp.at
+    | [], _ -> prems_path |> List.map Util.Source.at |> over_region
+    | _ -> exps_output |> List.map Util.Source.at |> over_region
+  in
   let instr_res = Ol.Ast.ResultI (rel_signature, exps_output) $ at in
   [ struct_prems prems_path instr_res ]
 

--- a/p4spec/lib/runtime/type/equiv.ml
+++ b/p4spec/lib/runtime/type/equiv.ml
@@ -37,7 +37,7 @@ and equiv_functyp (find_typdef_opt : TId.t -> Typdef.t option) (at : region)
     (tparams_b : tparam list) (typs_params_b : typ list) (typ_b : typ) : bool =
   check
     (List.length tparams_a = List.length tparams_b)
-    no_region "type parameters do not match";
+    at "type parameters do not match";
   let tids_fresh, theta_a, theta_b =
     List.fold_left2
       (fun (tids_fresh, theta_a, theta_b) tparam_a tparam_b ->


### PR DESCRIPTION
Fixes wrong `.at` regions produced by the passes. Regions come from parsing and should follow a construct through EL → IL → AL → SL → PL. In several places a synthesized node took the wrong region.

## 1. Use-site regions in elaboration

Synthesized nodes took a *definition* region instead of the *use* site.

**CaseE** took its type-definition's region instead of the expression's.

```
def $callableId'(`EMPTY) = eps     # use site
syntax parameterList = | `EMPTY    # definition, elsewhere
```

```diff
- let at = notexp_il |> Mixfix.atoms |> List.map at |> over_region in
- Il.CaseE notexp_il $$ (at, typ_il.it)
+ Il.CaseE notexp_il $$ (exp.at, typ_il.it)
```

**Fresh/wildcard var** took the metavariable declaration's region.

```
def $write_value_from_bits'(`B _, ...) = ...   # use site (the _)
var b : bool                                   # declaration
```

```diff
- then Some (tid, typ_alias, [])
+ then Some (tid.it $ at, typ_alias, [])
```

## 2. Multi-source synthesized nodes (algo, structure)

A node built from several sources took one source's region; now it spans all of them.

**Anti-unification** builds a `template = instance` premise from two rules:

```
rule Type_alpha/left:   (TYPEDEF _ typeIR_a) ~~ typeIR_b
rule Type_alpha/right:  typeIR_a ~~ (TYPEDEF _ typeIR_b)
```

```diff
- CmpE (`EqOp, `BoolT, exp_template, exp) $$ (exp.at, BoolT)
+ let at = over_region [ exp_template.at; exp.at ] in
+ CmpE (`EqOp, `BoolT, exp_template, exp) $$ (at, BoolT)
```

**Length guard** `|a*| = |b*|` took only the first operand's region:

```diff
- Il.CmpE (`EqOp, `BoolT, exp_a, exp_b) $$ (exp_a.at, Typ.Make.bool')
+ Il.CmpE (`EqOp, `BoolT, exp_a, exp_b)
+ $$ (over_region [ exp_a.at; exp_b.at ], Typ.Make.bool')
```

**Parallel-bind** reconciliation mixed two ids' regions; now uniform:

```diff
- let exp_r = VarE id_rename $$ (id_rename.at, typ.it) in
+ let exp_r = VarE id_rename $$ (id.at, typ.it) in
```

## 3. Control-flow wrappers (structure, annotate)

These wrappers were stamped `no_region`; now they inherit the block they wrap.

**ResultI** for predicate relations, which have no output expressions:

```
relation Type_wf:
  bound |- typeIR    # all inputs, no output
```

```diff
- let at = exps_output |> List.map Util.Source.at |> over_region in
+ let at =
+   match (exps_output, prems_path) with
+   | [], [] -> let nottyp, _ = rel_signature in nottyp.at
+   | [], _ -> prems_path |> List.map Util.Source.at |> over_region
+   | _ -> exps_output |> List.map Util.Source.at |> over_region
+ in
  let instr_res = Ol.Ast.ResultI (rel_signature, exps_output) $ at in
```

**TryI** and **LetI** wrappers:

```diff
- [ Ll.Ast.TryI arms $$ (no_region, { iid = -1 }) ]
+ let at = block |> List.map Util.Source.at |> over_region in
+ [ Ll.Ast.TryI arms $$ (at, { iid = -1 }) ]
```

```diff
- LetI (exp_new, exp_orig, iterinstrs, [ body ]) $$ (no_region, { iid = -1 })
+ LetI (exp_new, exp_orig, iterinstrs, [ body ]) $$ (body.at, { iid = -1 })
```

## 4. Error-report regions

Two error sites pointed at the wrong region.

```diff
  (* report the missing field, not the base expression *)
- | None -> fail exp.at "cannot infer type of field"
+ | None -> fail atom.at "cannot infer type of field"
```

```diff
  (* sibling arity check below already uses at *)
- no_region "type parameters do not match";
+ at "type parameters do not match";
```

All changes are region-only; no behavior changes.
