### PR TITLE
Optimization for #163: Incremental hashing for compiled native OCaml types

### DIFF
--- a/p4spec/lib/backend-ocaml-il/val_native.ml
+++ b/p4spec/lib/backend-ocaml-il/val_native.ml
@@ -16,7 +16,7 @@ module Mixop = Domain.Mixop
 module Il = Lang.Il
 module Num = Lang.Xl.Num
 
-(* This library's own generated dispatch tables (spec-meta/il), not P4's. *)
+(* This library's own generated dispatch tables (spec-meta/sl), not P4's. *)
 module Spec_parts = Spec_parts_il
 open Util.Source
 
@@ -47,14 +47,17 @@ module V_native : Runtime.Valrep.VAL with type t = Obj.t = struct
        collapses the tag, so an arbitrary tag is safe. *)
     let num (x : t) : Num.t = `Int (Obj.obj x : Bigint.t)
     let bool (x : t) : bool = (Obj.obj x : bool)
-    let list (x : t) : t list = (Obj.obj x : Obj.t list)
-    let opt (x : t) : t option = (Obj.obj x : Obj.t option)
+    (* Composites are note-wrapped [(body, vnote) note_phrase]; the body is
+       field 0 ([it]) of the info block, so unwrap before projecting. *)
+    let list (x : t) : t list = (Obj.obj (Obj.field x 0) : Obj.t list)
+    let opt (x : t) : t option = (Obj.obj (Obj.field x 0) : Obj.t option)
 
-    (* A native tuple is a plain OCaml tuple block; project its fields (a nullary
-       tuple is the immediate unit). *)
+    (* A native tuple's body is a plain OCaml tuple block; project its fields (a
+       nullary tuple is the immediate unit). *)
     let tuple (x : t) : t list =
-      if Obj.is_int x then []
-      else List.init (Obj.size x) (fun i -> Obj.field x i)
+      let body = Obj.field x 0 in
+      if Obj.is_int body then []
+      else List.init (Obj.size body) (fun i -> Obj.field body i)
 
     (* Shallow one-level destructure of the native variant of spec type [typ]
        into its mixop shell (args left as native [Obj.t]). *)
@@ -83,6 +86,8 @@ module V_native : Runtime.Valrep.VAL with type t = Obj.t = struct
        variant with [n] args is [hash; arg] for n=1 and [hash; (a0..an-1)] for
        n>=2; a nullary one is the immediate hash. *)
     let args_by_arity (x : t) (n : int) : t list =
+      (* unwrap the note_phrase to the poly-variant body ([it], field 0) *)
+      let x = Obj.field x 0 in
       if n = 0 then []
       else if n = 1 then [ Obj.field x 1 ]
       else
@@ -105,6 +110,27 @@ module V_native : Runtime.Valrep.VAL with type t = Obj.t = struct
       if Mixop.eq mixop mixop_expect then Some args else None
   end
 
+  (* Note-wrapping for [Make]. A composite built at the boundary must carry a
+     note whose [vhash] matches what the compiled [mk_<t>] would compute, so
+     structural eq/hashing stays consistent across the boundary: prims hash by
+     [Hashtbl.hash] (same as the generated [hash_<prim>]), wrapped children read
+     their slot ([expr_slot_hash]), and the fold mirrors the prelude
+     [hash_list]/[hash_opt]/tuple combine. *)
+
+  (* Hash of one child, dispatched purely on representation so no spec type is
+     needed: a wrapped child (the [note_phrase] record is the only tag-0, size-3
+     block) reads its slot; anything else is bare and hashes flat by
+     [Hashtbl.hash] (matching the generated [hash_<prim>]/extern hash). *)
+  let child_hash (x : t) : int =
+    if Obj.is_block x && Obj.tag x = 0 && Obj.size x = 3 then
+      (Obj.obj x : (t, Il.vnote) note_phrase).note.vhash
+    else Hashtbl.hash x
+
+  (* Stamp [body] with a fresh note carrying [vhash] and the reified [typ]. *)
+  let wrap_note (typ : Typ.t) (vhash : int) (body : t) : t =
+    let note = { Il.vid = Value.fresh (); typ = typ.it; vhash } in
+    Obj.repr (body $$ (no_region, note))
+
   module Make = struct
     let text ?(at = no_region) (s : string) : t =
       ignore at;
@@ -122,23 +148,31 @@ module V_native : Runtime.Valrep.VAL with type t = Obj.t = struct
       ignore at;
       Obj.repr b
 
-    let opt ?(at = no_region) (_typ : Typ.t) (o : t option) : t =
+    let opt ?(at = no_region) (typ : Typ.t) (o : t option) : t =
       ignore at;
-      Obj.repr o
+      let vhash = match o with None -> 0 | Some x -> 31 + child_hash x in
+      wrap_note typ vhash (Obj.repr o)
 
-    let list ?(at = no_region) (_typ : Typ.t) (xs : t list) : t =
+    let list ?(at = no_region) (typ : Typ.t) (xs : t list) : t =
       ignore at;
-      Obj.repr xs
+      let vhash = List.fold_left (fun h x -> (h * 31) + child_hash x) 1 xs in
+      wrap_note typ vhash (Obj.repr xs)
 
-    let tuple ?(at = no_region) (_typ : Typ.t) (xs : t list) : t =
+    let tuple ?(at = no_region) (typ : Typ.t) (xs : t list) : t =
       ignore at;
-      match xs with
-      | [] -> Obj.repr ()
-      | _ ->
-          let n = List.length xs in
-          let b = Obj.new_block 0 n in
-          List.iteri (fun i v -> Obj.set_field b i v) xs;
-          b
+      let body =
+        match xs with
+        | [] -> Obj.repr ()
+        | _ ->
+            let n = List.length xs in
+            let b = Obj.new_block 0 n in
+            List.iteri (fun i v -> Obj.set_field b i v) xs;
+            b
+      in
+      let vhash =
+        List.fold_left (fun h x -> (h * 31) + child_hash x) (List.length xs) xs
+      in
+      wrap_note typ vhash body
 
     let extern ?(at = no_region) (_typ : Typ.t) (y : Yojson.Safe.t) : t =
       ignore at;

--- a/p4spec/lib/backend-ocaml-p4/val_native.ml
+++ b/p4spec/lib/backend-ocaml-p4/val_native.ml
@@ -16,7 +16,7 @@ module Mixop = Domain.Mixop
 module Il = Lang.Il
 module Num = Lang.Xl.Num
 
-(* This library's own generated dispatch tables (spec/, the P4 spec). *)
+(* This library's own generated dispatch tables (spec-meta/sl), not P4's. *)
 module Spec_parts = Spec_parts_p4
 open Util.Source
 
@@ -47,14 +47,17 @@ module V_native : Runtime.Valrep.VAL with type t = Obj.t = struct
        collapses the tag, so an arbitrary tag is safe. *)
     let num (x : t) : Num.t = `Int (Obj.obj x : Bigint.t)
     let bool (x : t) : bool = (Obj.obj x : bool)
-    let list (x : t) : t list = (Obj.obj x : Obj.t list)
-    let opt (x : t) : t option = (Obj.obj x : Obj.t option)
+    (* Composites are note-wrapped [(body, vnote) note_phrase]; the body is
+       field 0 ([it]) of the info block, so unwrap before projecting. *)
+    let list (x : t) : t list = (Obj.obj (Obj.field x 0) : Obj.t list)
+    let opt (x : t) : t option = (Obj.obj (Obj.field x 0) : Obj.t option)
 
-    (* A native tuple is a plain OCaml tuple block; project its fields (a nullary
-       tuple is the immediate unit). *)
+    (* A native tuple's body is a plain OCaml tuple block; project its fields (a
+       nullary tuple is the immediate unit). *)
     let tuple (x : t) : t list =
-      if Obj.is_int x then []
-      else List.init (Obj.size x) (fun i -> Obj.field x i)
+      let body = Obj.field x 0 in
+      if Obj.is_int body then []
+      else List.init (Obj.size body) (fun i -> Obj.field body i)
 
     (* Shallow one-level destructure of the native variant of spec type [typ]
        into its mixop shell (args left as native [Obj.t]). *)
@@ -83,6 +86,8 @@ module V_native : Runtime.Valrep.VAL with type t = Obj.t = struct
        variant with [n] args is [hash; arg] for n=1 and [hash; (a0..an-1)] for
        n>=2; a nullary one is the immediate hash. *)
     let args_by_arity (x : t) (n : int) : t list =
+      (* unwrap the note_phrase to the poly-variant body ([it], field 0) *)
+      let x = Obj.field x 0 in
       if n = 0 then []
       else if n = 1 then [ Obj.field x 1 ]
       else
@@ -105,6 +110,27 @@ module V_native : Runtime.Valrep.VAL with type t = Obj.t = struct
       if Mixop.eq mixop mixop_expect then Some args else None
   end
 
+  (* Note-wrapping for [Make]. A composite built at the boundary must carry a
+     note whose [vhash] matches what the compiled [mk_<t>] would compute, so
+     structural eq/hashing stays consistent across the boundary: prims hash by
+     [Hashtbl.hash] (same as the generated [hash_<prim>]), wrapped children read
+     their slot ([expr_slot_hash]), and the fold mirrors the prelude
+     [hash_list]/[hash_opt]/tuple combine. *)
+
+  (* Hash of one child, dispatched purely on representation so no spec type is
+     needed: a wrapped child (the [note_phrase] record is the only tag-0, size-3
+     block) reads its slot; anything else is bare and hashes flat by
+     [Hashtbl.hash] (matching the generated [hash_<prim>]/extern hash). *)
+  let child_hash (x : t) : int =
+    if Obj.is_block x && Obj.tag x = 0 && Obj.size x = 3 then
+      (Obj.obj x : (t, Il.vnote) note_phrase).note.vhash
+    else Hashtbl.hash x
+
+  (* Stamp [body] with a fresh note carrying [vhash] and the reified [typ]. *)
+  let wrap_note (typ : Typ.t) (vhash : int) (body : t) : t =
+    let note = { Il.vid = Value.fresh (); typ = typ.it; vhash } in
+    Obj.repr (body $$ (no_region, note))
+
   module Make = struct
     let text ?(at = no_region) (s : string) : t =
       ignore at;
@@ -122,23 +148,31 @@ module V_native : Runtime.Valrep.VAL with type t = Obj.t = struct
       ignore at;
       Obj.repr b
 
-    let opt ?(at = no_region) (_typ : Typ.t) (o : t option) : t =
+    let opt ?(at = no_region) (typ : Typ.t) (o : t option) : t =
       ignore at;
-      Obj.repr o
+      let vhash = match o with None -> 0 | Some x -> 31 + child_hash x in
+      wrap_note typ vhash (Obj.repr o)
 
-    let list ?(at = no_region) (_typ : Typ.t) (xs : t list) : t =
+    let list ?(at = no_region) (typ : Typ.t) (xs : t list) : t =
       ignore at;
-      Obj.repr xs
+      let vhash = List.fold_left (fun h x -> (h * 31) + child_hash x) 1 xs in
+      wrap_note typ vhash (Obj.repr xs)
 
-    let tuple ?(at = no_region) (_typ : Typ.t) (xs : t list) : t =
+    let tuple ?(at = no_region) (typ : Typ.t) (xs : t list) : t =
       ignore at;
-      match xs with
-      | [] -> Obj.repr ()
-      | _ ->
-          let n = List.length xs in
-          let b = Obj.new_block 0 n in
-          List.iteri (fun i v -> Obj.set_field b i v) xs;
-          b
+      let body =
+        match xs with
+        | [] -> Obj.repr ()
+        | _ ->
+            let n = List.length xs in
+            let b = Obj.new_block 0 n in
+            List.iteri (fun i v -> Obj.set_field b i v) xs;
+            b
+      in
+      let vhash =
+        List.fold_left (fun h x -> (h * 31) + child_hash x) (List.length xs) xs
+      in
+      wrap_note typ vhash body
 
     let extern ?(at = no_region) (_typ : Typ.t) (y : Yojson.Safe.t) : t =
       ignore at;

--- a/p4spec/lib/backend-ocaml-sl/val_native.ml
+++ b/p4spec/lib/backend-ocaml-sl/val_native.ml
@@ -47,14 +47,17 @@ module V_native : Runtime.Valrep.VAL with type t = Obj.t = struct
        collapses the tag, so an arbitrary tag is safe. *)
     let num (x : t) : Num.t = `Int (Obj.obj x : Bigint.t)
     let bool (x : t) : bool = (Obj.obj x : bool)
-    let list (x : t) : t list = (Obj.obj x : Obj.t list)
-    let opt (x : t) : t option = (Obj.obj x : Obj.t option)
+    (* Composites are note-wrapped [(body, vnote) note_phrase]; the body is
+       field 0 ([it]) of the info block, so unwrap before projecting. *)
+    let list (x : t) : t list = (Obj.obj (Obj.field x 0) : Obj.t list)
+    let opt (x : t) : t option = (Obj.obj (Obj.field x 0) : Obj.t option)
 
-    (* A native tuple is a plain OCaml tuple block; project its fields (a nullary
-       tuple is the immediate unit). *)
+    (* A native tuple's body is a plain OCaml tuple block; project its fields (a
+       nullary tuple is the immediate unit). *)
     let tuple (x : t) : t list =
-      if Obj.is_int x then []
-      else List.init (Obj.size x) (fun i -> Obj.field x i)
+      let body = Obj.field x 0 in
+      if Obj.is_int body then []
+      else List.init (Obj.size body) (fun i -> Obj.field body i)
 
     (* Shallow one-level destructure of the native variant of spec type [typ]
        into its mixop shell (args left as native [Obj.t]). *)
@@ -83,6 +86,8 @@ module V_native : Runtime.Valrep.VAL with type t = Obj.t = struct
        variant with [n] args is [hash; arg] for n=1 and [hash; (a0..an-1)] for
        n>=2; a nullary one is the immediate hash. *)
     let args_by_arity (x : t) (n : int) : t list =
+      (* unwrap the note_phrase to the poly-variant body ([it], field 0) *)
+      let x = Obj.field x 0 in
       if n = 0 then []
       else if n = 1 then [ Obj.field x 1 ]
       else
@@ -105,6 +110,27 @@ module V_native : Runtime.Valrep.VAL with type t = Obj.t = struct
       if Mixop.eq mixop mixop_expect then Some args else None
   end
 
+  (* Note-wrapping for [Make]. A composite built at the boundary must carry a
+     note whose [vhash] matches what the compiled [mk_<t>] would compute, so
+     structural eq/hashing stays consistent across the boundary: prims hash by
+     [Hashtbl.hash] (same as the generated [hash_<prim>]), wrapped children read
+     their slot ([expr_slot_hash]), and the fold mirrors the prelude
+     [hash_list]/[hash_opt]/tuple combine. *)
+
+  (* Hash of one child, dispatched purely on representation so no spec type is
+     needed: a wrapped child (the [note_phrase] record is the only tag-0, size-3
+     block) reads its slot; anything else is bare and hashes flat by
+     [Hashtbl.hash] (matching the generated [hash_<prim>]/extern hash). *)
+  let child_hash (x : t) : int =
+    if Obj.is_block x && Obj.tag x = 0 && Obj.size x = 3 then
+      (Obj.obj x : (t, Il.vnote) note_phrase).note.vhash
+    else Hashtbl.hash x
+
+  (* Stamp [body] with a fresh note carrying [vhash] and the reified [typ]. *)
+  let wrap_note (typ : Typ.t) (vhash : int) (body : t) : t =
+    let note = { Il.vid = Value.fresh (); typ = typ.it; vhash } in
+    Obj.repr (body $$ (no_region, note))
+
   module Make = struct
     let text ?(at = no_region) (s : string) : t =
       ignore at;
@@ -122,23 +148,31 @@ module V_native : Runtime.Valrep.VAL with type t = Obj.t = struct
       ignore at;
       Obj.repr b
 
-    let opt ?(at = no_region) (_typ : Typ.t) (o : t option) : t =
+    let opt ?(at = no_region) (typ : Typ.t) (o : t option) : t =
       ignore at;
-      Obj.repr o
+      let vhash = match o with None -> 0 | Some x -> 31 + child_hash x in
+      wrap_note typ vhash (Obj.repr o)
 
-    let list ?(at = no_region) (_typ : Typ.t) (xs : t list) : t =
+    let list ?(at = no_region) (typ : Typ.t) (xs : t list) : t =
       ignore at;
-      Obj.repr xs
+      let vhash = List.fold_left (fun h x -> (h * 31) + child_hash x) 1 xs in
+      wrap_note typ vhash (Obj.repr xs)
 
-    let tuple ?(at = no_region) (_typ : Typ.t) (xs : t list) : t =
+    let tuple ?(at = no_region) (typ : Typ.t) (xs : t list) : t =
       ignore at;
-      match xs with
-      | [] -> Obj.repr ()
-      | _ ->
-          let n = List.length xs in
-          let b = Obj.new_block 0 n in
-          List.iteri (fun i v -> Obj.set_field b i v) xs;
-          b
+      let body =
+        match xs with
+        | [] -> Obj.repr ()
+        | _ ->
+            let n = List.length xs in
+            let b = Obj.new_block 0 n in
+            List.iteri (fun i v -> Obj.set_field b i v) xs;
+            b
+      in
+      let vhash =
+        List.fold_left (fun h x -> (h * 31) + child_hash x) (List.length xs) xs
+      in
+      wrap_note typ vhash body
 
     let extern ?(at = no_region) (_typ : Typ.t) (y : Yojson.Safe.t) : t =
       ignore at;

--- a/p4spec/lib/pass/compile/ctx.ml
+++ b/p4spec/lib/pass/compile/ctx.ml
@@ -76,6 +76,14 @@ let find_ctor (ctx : t) (typ : Typ.t) (mixop : Mixop.t) : Ml.ctor =
         (Format.asprintf "%s is not a variant type"
            (Sl.Print.string_of_typ typ))
 
+(* Expand a typ through aliases to its underlying form, e.g. to name the
+   [mk_<t>] of the wrapped variant/record a construction really targets *)
+
+let expand_typ (ctx : t) (typ : Typ.t) : Typ.t =
+  Runtime.Type.Expand.expand_typ
+    (fun tid -> Typdefs.find_opt tid ctx.typdefs)
+    typ
+
 let find_typdef_opt (ctx : t) (id : TId.t) : Typdef.t option =
   Typdefs.find_opt id ctx.typdefs
 

--- a/p4spec/lib/pass/compile/gen/ast/exp.ml
+++ b/p4spec/lib/pass/compile/gen/ast/exp.ml
@@ -9,6 +9,11 @@ open Util.Source
 
 (* Compiling expressions: [Sl.exp] -> [Ml.expr] *)
 
+(* Note-wrapping lives in gen/wrap.ml so gen/bind.ml can share it without a
+   [Bind]->[Ast] module cycle *)
+
+let compile_mk_wrap = Wrap.compile_mk_wrap
+
 let rec compile_exp ~(tparams : string list) (ctx : Ctx.t) (exp : exp) :
     Ctx.t * Ml.expr =
   let wrap_ctx (expr_ml : Ml.expr) : Ctx.t * Ml.expr = (ctx, expr_ml) in
@@ -27,12 +32,12 @@ let rec compile_exp ~(tparams : string list) (ctx : Ctx.t) (exp : exp) :
   | DownCastE (typ, exp) -> compile_downcast_exp ~tparams ctx typ exp
   | SubE (exp, typ) -> compile_sub_exp ~tparams ctx exp typ
   | MatchE (exp, pattern) -> compile_match_exp ~tparams ctx exp pattern
-  | TupleE exps -> compile_tuple_exp ~tparams ctx exps
+  | TupleE exps -> compile_tuple_exp ~tparams ctx typ_exp exps
   | CaseE notexp -> compile_case_exp ~tparams ctx typ_exp notexp
   | StrE expfields -> compile_str_exp ~tparams ctx typ_exp expfields
-  | OptE exp_opt -> compile_opt_exp ~tparams ctx exp_opt
-  | ListE exps -> compile_list_exp ~tparams ctx exps
-  | ConsE (exp_h, exp_t) -> compile_cons_exp ~tparams ctx exp_h exp_t
+  | OptE exp_opt -> compile_opt_exp ~tparams ctx typ_exp exp_opt
+  | ListE exps -> compile_list_exp ~tparams ctx typ_exp exps
+  | ConsE (exp_h, exp_t) -> compile_cons_exp ~tparams ctx typ_exp exp_h exp_t
   | CatE (exp_l, exp_r) -> compile_cat_exp ~tparams ctx typ_exp exp_l exp_r
   | MemE (exp_e, exp_s) -> compile_mem_exp ~tparams ctx exp_e exp_s
   | LenE exp -> compile_len_exp ~tparams ctx exp
@@ -158,23 +163,30 @@ and compile_cmpop_num (cmpop : Num.cmpop) : string =
   | `GeOp -> "Bigint.( >= )"
 
 and compile_cmp_exp ~(tparams : string list) (ctx : Ctx.t) (cmpop : cmpop)
-    (optyp : optyp) (exp_l : exp) (exp_r : exp) : Ctx.t * Ml.expr =
+    (_optyp : optyp) (exp_l : exp) (exp_r : exp) : Ctx.t * Ml.expr =
   let ctx, expr_ml_l = compile_exp ~tparams ctx exp_l in
   let ctx, expr_ml_r = compile_exp ~tparams ctx exp_r in
+  (* Equality is chosen by the operand type: a wrapped/compound value needs the
+     structural [eq_<type>] since the note breaks OCaml (=); only a bare bool or
+     number compares directly *)
+  let typ_operand = exp_l.note $ exp_l.at in
   let expr_ml =
-    match (cmpop, optyp) with
-    | ((`EqOp | `NeOp) as cmpop), `BoolT ->
-        let cmpop_ml = compile_cmpop_bool cmpop in
-        Ml.BinopE (cmpop_ml, expr_ml_l, expr_ml_r)
-    | `EqOp, _ -> Ml.AppE (Ml.VarE "Bigint.equal", [ expr_ml_l; expr_ml_r ])
-    | `NeOp, _ ->
-        let expr_ml =
-          Ml.AppE (Ml.VarE "Bigint.equal", [ expr_ml_l; expr_ml_r ])
+    match cmpop with
+    | (`EqOp | `NeOp) as cmpop ->
+        let expr_eq_ml =
+          match typ_operand.it with
+          | Il.BoolT -> Ml.BinopE ("=", expr_ml_l, expr_ml_r)
+          | Il.NumT _ ->
+              Ml.AppE (Ml.VarE "Bigint.equal", [ expr_ml_l; expr_ml_r ])
+          | _ ->
+              let conv = Interface.Converter.resolve ctx tparams typ_operand in
+              Ml.AppE (conv.eq, [ expr_ml_l; expr_ml_r ])
         in
-        Ml.UnopE ("not", expr_ml)
-    | ((`LtOp | `GtOp | `LeOp | `GeOp) as cmpop), _ ->
-        let cmpop_ml = compile_cmpop_num cmpop in
-        Ml.AppE (Ml.VarE cmpop_ml, [ expr_ml_l; expr_ml_r ])
+        (match cmpop with
+        | `EqOp -> expr_eq_ml
+        | `NeOp -> Ml.UnopE ("not", expr_eq_ml))
+    | (`LtOp | `GtOp | `LeOp | `GeOp) as cmpop ->
+        Ml.AppE (Ml.VarE (compile_cmpop_num cmpop), [ expr_ml_l; expr_ml_r ])
   in
   (ctx, expr_ml)
 
@@ -204,8 +216,18 @@ and compile_downcast_exp_var ~(tparams : string list) (ctx : Ctx.t) (id : id)
     (targs : targ list) (exp : exp) : Ctx.t * Ml.expr =
   let ctors_typ = Ctx.find_ctors ctx id in
   let ctx, expr_ml = compile_exp ~tparams ctx exp in
-  let typ_target_ml =
-    Type.compile_typ ~tparams (Il.VarT (id, targs) $ no_region)
+  (* target's raw body type, to re-type [.it] while keeping the note; expand
+     through aliases so the body name matches the underlying variant *)
+  let typ_body_ml =
+    let typ_expand = Ctx.expand_typ ctx (Il.VarT (id, targs) $ no_region) in
+    match typ_expand.it with
+    | Il.VarT (id_under, targs_under) -> (
+        match targs_under with
+        | [] -> Ml.NameT (Names.body_of_id id_under)
+        | _ ->
+            Ml.AppT
+              (Names.body_of_id id_under, Type.compile_typs ~tparams targs_under))
+    | _ -> Ml.NameT (Names.body_of_id id)
   in
   if ctors_typ = [] then (ctx, expr_ml)
   else
@@ -223,7 +245,11 @@ and compile_downcast_exp_var ~(tparams : string list) (ctx : Ctx.t) (id : id)
           (ctor_ml, Type.compile_typs ~tparams typs_inst))
         ctors_typ
     in
-    let expr_scrut_ml = Ml.AnnotE (expr_ml, Ml.OpenRowT typrows_ml) in
+    (* bind the wrapped value, then re-type its body on a matching ctor *)
+    let ctx, id_val_ml = Stub.OCaml.var ctx "dc_val__" in
+    let expr_scrut_ml =
+      Ml.AnnotE (Ml.FieldE (Ml.VarE id_val_ml, "it"), Ml.OpenRowT typrows_ml)
+    in
     let pats_ml =
       List.map
         (fun (ctor_ml, typs) ->
@@ -232,18 +258,22 @@ and compile_downcast_exp_var ~(tparams : string list) (ctx : Ctx.t) (id : id)
         ctors_typ
     in
     let pat_or_ml = Ml.OrP pats_ml in
-    let ctx, id_downcast_val_ml = Stub.OCaml.var ctx "dc__" in
-    let pat_as_ml = Ml.AsP (pat_or_ml, id_downcast_val_ml) in
-    let expr_coerce_ml =
-      Ml.CoerceE (Ml.VarE id_downcast_val_ml, typ_target_ml)
+    let ctx, id_downcast_ml = Stub.OCaml.var ctx "dc__" in
+    let pat_as_ml = Ml.AsP (pat_or_ml, id_downcast_ml) in
+    let expr_ok_ml =
+      Ml.RecordUpdateE
+        ( Ml.VarE id_val_ml,
+          [ ("it", Ml.CoerceE (Ml.VarE id_downcast_ml, typ_body_ml)) ] )
     in
-    ( ctx,
+    let expr_match_ml =
       Ml.MatchE
         ( expr_scrut_ml,
           [
-            (pat_as_ml, expr_coerce_ml);
+            (pat_as_ml, expr_ok_ml);
             (Ml.WildP, Common.raise_unmatch "DownCastE: type mismatch");
-          ] ) )
+          ] )
+    in
+    (ctx, Ml.LetE (Ml.VarP id_val_ml, expr_ml, expr_match_ml))
 
 (* Tuple downcast: [(T1,..,Tn) exp]
 
@@ -274,8 +304,12 @@ and compile_downcast_exp_tuple ~(tparams : string list) (ctx : Ctx.t)
   let expr_ml =
     let pats_ml = List.map (fun id_bind_ml -> Ml.VarP id_bind_ml) ids_stub_ml in
     let pat_ml = Ml.TupleP pats_ml in
-    let expr_sub_ml = Ml.TupleE expr_elems_ml in
-    Ml.LetE (pat_ml, expr_ml, expr_sub_ml)
+    (* destructure the unwrapped body, then re-wrap the rebuilt tuple *)
+    let typ_tup = Il.TupleT typs $ no_region in
+    let expr_sub_ml =
+      compile_mk_wrap ~tparams ctx typ_tup (Ml.TupleE expr_elems_ml)
+    in
+    Ml.LetE (pat_ml, Ml.FieldE (expr_ml, "it"), expr_sub_ml)
   in
   (ctx, expr_ml)
 
@@ -297,9 +331,14 @@ and compile_downcast_exp_iter_opt ~(tparams : string list) (ctx : Ctx.t)
   let ctx, expr_elem_ml = compile_downcast_exp ~tparams ctx typ exp_stub in
   (* Promote preamble *)
   let ctx = Ctx.promote_preamble ctx ctx_outer in
-  (* Create map on option *)
+  (* Map over the unwrapped body, then re-wrap the rebuilt option *)
   let expr_lambda_ml = Ml.FunE ([ Ml.VarP id_stub_ml ], expr_elem_ml) in
-  let expr_ml = Ml.AppE (Ml.VarE "Option.map", [ expr_lambda_ml; expr_ml ]) in
+  let expr_body_ml =
+    Ml.AppE
+      (Ml.VarE "Option.map", [ expr_lambda_ml; Ml.FieldE (expr_ml, "it") ])
+  in
+  let typ_opt = Il.IterT (typ, Il.Opt) $ no_region in
+  let expr_ml = compile_mk_wrap ~tparams ctx typ_opt expr_body_ml in
   (ctx, expr_ml)
 
 (* List downcast: [(T* ) exp]
@@ -320,9 +359,13 @@ and compile_downcast_exp_iter_list ~(tparams : string list) (ctx : Ctx.t)
   let ctx, expr_elem_ml = compile_downcast_exp ~tparams ctx typ exp_stub in
   (* Promote preamble *)
   let ctx = Ctx.promote_preamble ctx ctx_outer in
-  (* Create map on list *)
+  (* Map over the unwrapped body, then re-wrap the rebuilt list *)
   let expr_lambda_ml = Ml.FunE ([ Ml.VarP id_stub_ml ], expr_elem_ml) in
-  let expr_ml = Ml.AppE (Ml.VarE "List.map", [ expr_lambda_ml; expr_ml ]) in
+  let expr_body_ml =
+    Ml.AppE (Ml.VarE "List.map", [ expr_lambda_ml; Ml.FieldE (expr_ml, "it") ])
+  in
+  let typ_list = Il.IterT (typ, Il.List) $ no_region in
+  let expr_ml = compile_mk_wrap ~tparams ctx typ_list expr_body_ml in
   (ctx, expr_ml)
 
 and compile_downcast_exp_iter ~(tparams : string list) (ctx : Ctx.t) (typ : typ)
@@ -367,7 +410,10 @@ and compile_sub_match ~(tparams : string list) (ctx : Ctx.t) (exp : exp)
       (fun (ctor_ml, typs) -> (ctor_ml, Type.compile_typs ~tparams typs))
       ctors_inter
   in
-  let expr_scrut_ml = Ml.AnnotE (expr_ml, Ml.OpenRowT typrows_ml) in
+  (* match the unwrapped variant body against the intersecting ctors *)
+  let expr_scrut_ml =
+    Ml.AnnotE (Ml.FieldE (expr_ml, "it"), Ml.OpenRowT typrows_ml)
+  in
   (* Compile match arms *)
   let ctx, arms_ml =
     List.fold_left
@@ -505,7 +551,8 @@ and compile_sub_exp_tuple ~(tparams : string list) (ctx : Ctx.t) (exp : exp)
             (fun acc e -> Ml.BinopE ("&&", acc, e))
             (Ml.BoolE true) exprs_elem_ml
         in
-        Ml.LetE (pat_ml, expr_ml, expr_sub_ml)
+        (* destructure the unwrapped tuple body *)
+        Ml.LetE (pat_ml, Ml.FieldE (expr_ml, "it"), expr_sub_ml)
   in
   (ctx, expr_ml)
 
@@ -535,7 +582,8 @@ and compile_sub_exp_opt ~(tparams : string list) (ctx : Ctx.t) (exp : exp)
     | _ ->
         let arm_none_ml = (Ml.OptP None, Ml.BoolE true) in
         let arm_some_ml = (Ml.OptP (Some (Ml.VarP id_stub_ml)), expr_cond_ml) in
-        Ml.MatchE (expr_ml, [ arm_none_ml; arm_some_ml ])
+        (* match the unwrapped option body *)
+        Ml.MatchE (Ml.FieldE (expr_ml, "it"), [ arm_none_ml; arm_some_ml ])
   in
   (ctx, expr_ml)
 
@@ -562,7 +610,10 @@ and compile_sub_exp_list ~(tparams : string list) (ctx : Ctx.t) (exp : exp)
     | Ml.BoolE true -> Ml.BoolE true
     | _ ->
         let expr_lambda_ml = Ml.FunE ([ Ml.VarP id_stub_ml ], expr_cond_ml) in
-        Ml.AppE (Ml.VarE "List.for_all", [ expr_lambda_ml; expr_ml ])
+        (* iterate the unwrapped list body *)
+        Ml.AppE
+          ( Ml.VarE "List.for_all",
+            [ expr_lambda_ml; Ml.FieldE (expr_ml, "it") ] )
   in
   (ctx, expr_ml)
 
@@ -600,21 +651,26 @@ and compile_match_exp ~(tparams : string list) (ctx : Ctx.t) (exp : exp)
         let ctor_ml = Ctx.find_ctor ctx typ_exp mixop in
         let arity = Mixfix.arity mixop in
         let pats_ml = List.init arity (fun _ -> Ml.WildP) in
+        (* match the unwrapped variant body *)
         Ml.MatchE
-          ( expr_ml,
+          ( Ml.FieldE (expr_ml, "it"),
             [
               (Ml.VariantP (`Poly (ctor_ml, pats_ml)), Ml.BoolE true);
               (Ml.WildP, Ml.BoolE false);
             ] )
-    | ListP `Cons -> Ml.BinopE ("<>", expr_ml, Ml.ListE [])
+    (* list/option shape tests run on the unwrapped body *)
+    | ListP `Cons ->
+        Ml.BinopE ("<>", Ml.FieldE (expr_ml, "it"), Ml.ListE [])
     | ListP (`Fixed n) ->
         Ml.BinopE
           ( "=",
-            Ml.AppE (Ml.VarE "List.length", [ expr_ml ]),
+            Ml.AppE (Ml.VarE "List.length", [ Ml.FieldE (expr_ml, "it") ]),
             Ml.LitE (string_of_int n) )
-    | ListP `Nil -> Ml.BinopE ("=", expr_ml, Ml.ListE [])
-    | OptP `Some -> Ml.AppE (Ml.VarE "Option.is_some", [ expr_ml ])
-    | OptP `None -> Ml.AppE (Ml.VarE "Option.is_none", [ expr_ml ])
+    | ListP `Nil -> Ml.BinopE ("=", Ml.FieldE (expr_ml, "it"), Ml.ListE [])
+    | OptP `Some ->
+        Ml.AppE (Ml.VarE "Option.is_some", [ Ml.FieldE (expr_ml, "it") ])
+    | OptP `None ->
+        Ml.AppE (Ml.VarE "Option.is_none", [ Ml.FieldE (expr_ml, "it") ])
   in
   (ctx, expr_ml)
 
@@ -622,10 +678,11 @@ and compile_match_exp ~(tparams : string list) (ctx : Ctx.t) (exp : exp)
 
    [(expr1, .., exprn)] *)
 
-and compile_tuple_exp ~(tparams : string list) (ctx : Ctx.t) (exps : exp list) :
-    Ctx.t * Ml.expr =
+and compile_tuple_exp ~(tparams : string list) (ctx : Ctx.t) (typ_exp : typ)
+    (exps : exp list) : Ctx.t * Ml.expr =
   let ctx, exprs_ml = compile_exps ~tparams ctx exps in
-  let expr_ml = Ml.TupleE exprs_ml in
+  let expr_body_ml = Ml.TupleE exprs_ml in
+  let expr_ml = compile_mk_wrap ~tparams ctx typ_exp expr_body_ml in
   (ctx, expr_ml)
 
 (* Case expression: [op(exp1, .., expn)]
@@ -637,7 +694,8 @@ and compile_case_exp ~(tparams : string list) (ctx : Ctx.t) (typ_exp : typ)
   let mixop, exps = Mixfix.split notexp in
   let ctor_ml = Ctx.find_ctor ctx typ_exp mixop in
   let ctx, exprs_ml = compile_exps ~tparams ctx exps in
-  let expr_ml = Ml.VariantE (ctor_ml, exprs_ml) in
+  let expr_body_ml = Ml.VariantE (ctor_ml, exprs_ml) in
+  let expr_ml = compile_mk_wrap ~tparams ctx typ_exp expr_body_ml in
   (ctx, expr_ml)
 
 (* Record expression: [{a1=exp1, .., an=expn}]
@@ -655,9 +713,8 @@ and compile_str_exp ~(tparams : string list) (ctx : Ctx.t) (typ_exp : typ)
         (ctx, exprfields_ml @ [ exprfield_ml ]))
       (ctx, []) expfields
   in
-  let expr_ml = Ml.RecordE exprfields_ml in
-  let typ_ml = Type.compile_typ ~tparams typ_exp in
-  let expr_ml = Ml.AnnotE (expr_ml, typ_ml) in
+  let expr_body_ml = Ml.RecordE exprfields_ml in
+  let expr_ml = compile_mk_wrap ~tparams ctx typ_exp expr_body_ml in
   (ctx, expr_ml)
 
 (* Option expression: [exp?]
@@ -665,36 +722,41 @@ and compile_str_exp ~(tparams : string list) (ctx : Ctx.t) (typ_exp : typ)
    None    ->  [None]
    Some e  ->  [Some expr] *)
 
-and compile_opt_exp ~(tparams : string list) (ctx : Ctx.t)
+and compile_opt_exp ~(tparams : string list) (ctx : Ctx.t) (typ_exp : typ)
     (exp_opt : exp option) : Ctx.t * Ml.expr =
   match exp_opt with
   | None ->
-      let expr_ml = Ml.OptE None in
+      let expr_ml = compile_mk_wrap ~tparams ctx typ_exp (Ml.OptE None) in
       (ctx, expr_ml)
   | Some exp ->
       let ctx, expr_ml = compile_exp ~tparams ctx exp in
-      let expr_ml = Ml.OptE (Some expr_ml) in
+      let expr_ml =
+        compile_mk_wrap ~tparams ctx typ_exp (Ml.OptE (Some expr_ml))
+      in
       (ctx, expr_ml)
 
 (* List expression: [[exp1, .., expn]]
 
    [[expr1; ..; exprn]] *)
 
-and compile_list_exp ~(tparams : string list) (ctx : Ctx.t) (exps : exp list) :
-    Ctx.t * Ml.expr =
+and compile_list_exp ~(tparams : string list) (ctx : Ctx.t) (typ_exp : typ)
+    (exps : exp list) : Ctx.t * Ml.expr =
   let ctx, exprs_ml = compile_exps ~tparams ctx exps in
-  let expr_ml = Ml.ListE exprs_ml in
+  let expr_body_ml = Ml.ListE exprs_ml in
+  let expr_ml = compile_mk_wrap ~tparams ctx typ_exp expr_body_ml in
   (ctx, expr_ml)
 
 (* Cons expression: [exp_h :: exp_t]
 
    [expr_h :: expr_t] *)
 
-and compile_cons_exp ~(tparams : string list) (ctx : Ctx.t) (exp_h : exp)
-    (exp_t : exp) : Ctx.t * Ml.expr =
+and compile_cons_exp ~(tparams : string list) (ctx : Ctx.t) (typ_exp : typ)
+    (exp_h : exp) (exp_t : exp) : Ctx.t * Ml.expr =
   let ctx, expr_h_ml = compile_exp ~tparams ctx exp_h in
   let ctx, expr_t_ml = compile_exp ~tparams ctx exp_t in
-  let expr_ml = Ml.ConsE (expr_h_ml, expr_t_ml) in
+  (* the tail is a wrapped list; cons onto its unwrapped body, then re-wrap *)
+  let expr_body_ml = Ml.ConsE (expr_h_ml, Ml.FieldE (expr_t_ml, "it")) in
+  let expr_ml = compile_mk_wrap ~tparams ctx typ_exp expr_body_ml in
   (ctx, expr_ml)
 
 (* Concatenation expression: [exp_l ++ exp_r]
@@ -704,10 +766,19 @@ and compile_cons_exp ~(tparams : string list) (ctx : Ctx.t) (exp_h : exp)
 
 and compile_cat_exp ~(tparams : string list) (ctx : Ctx.t) (typ_exp : typ)
     (exp_l : exp) (exp_r : exp) : Ctx.t * Ml.expr =
-  let binop_ml = match typ_exp.it with TextT -> "^" | _ -> "@" in
   let ctx, expr_l_ml = compile_exp ~tparams ctx exp_l in
   let ctx, expr_r_ml = compile_exp ~tparams ctx exp_r in
-  let expr_ml = Ml.BinopE (binop_ml, expr_l_ml, expr_r_ml) in
+  let expr_ml =
+    match typ_exp.it with
+    | TextT -> Ml.BinopE ("^", expr_l_ml, expr_r_ml)
+    | _ ->
+        (* concatenate the unwrapped list bodies, then re-wrap *)
+        let expr_body_ml =
+          Ml.BinopE
+            ("@", Ml.FieldE (expr_l_ml, "it"), Ml.FieldE (expr_r_ml, "it"))
+        in
+        compile_mk_wrap ~tparams ctx typ_exp expr_body_ml
+  in
   (ctx, expr_ml)
 
 (* Membership expression: [exp_e <- exp_s]
@@ -718,7 +789,13 @@ and compile_mem_exp ~(tparams : string list) (ctx : Ctx.t) (exp_e : exp)
     (exp_s : exp) : Ctx.t * Ml.expr =
   let ctx, expr_e_ml = compile_exp ~tparams ctx exp_e in
   let ctx, expr_s_ml = compile_exp ~tparams ctx exp_s in
-  let expr_ml = Ml.AppE (Ml.VarE "List.mem", [ expr_e_ml; expr_s_ml ]) in
+  (* structural membership: the note breaks OCaml (=) on wrapped values *)
+  let conv = Interface.Converter.resolve ctx tparams (exp_e.note $ exp_e.at) in
+  let expr_ml =
+    Ml.AppE
+      ( Ml.VarE "List.exists",
+        [ Ml.AppE (conv.eq, [ expr_e_ml ]); Ml.FieldE (expr_s_ml, "it") ] )
+  in
   (ctx, expr_ml)
 
 (* Length expression: [|exp|]
@@ -729,12 +806,15 @@ and compile_mem_exp ~(tparams : string list) (ctx : Ctx.t) (exp_e : exp)
 and compile_len_exp ~(tparams : string list) (ctx : Ctx.t) (exp : exp) :
     Ctx.t * Ml.expr =
   let ctx, expr_ml = compile_exp ~tparams ctx exp in
-  let id_len_ml =
-    match exp.note with TextT -> "String.length" | _ -> "List.length"
+  (* text length is on the bare string; list length on the unwrapped body *)
+  let id_len_ml, expr_arg_ml =
+    match exp.note with
+    | TextT -> ("String.length", expr_ml)
+    | _ -> ("List.length", Ml.FieldE (expr_ml, "it"))
   in
   let expr_ml =
     Ml.AppE
-      (Ml.VarE "Bigint.of_int", [ Ml.AppE (Ml.VarE id_len_ml, [ expr_ml ]) ])
+      (Ml.VarE "Bigint.of_int", [ Ml.AppE (Ml.VarE id_len_ml, [ expr_arg_ml ]) ])
   in
   (ctx, expr_ml)
 
@@ -746,7 +826,8 @@ and compile_dot_exp ~(tparams : string list) (ctx : Ctx.t) (exp_b : exp)
     (atom : atom) : Ctx.t * Ml.expr =
   let field_ml = Names.field atom in
   let ctx, expr_b_ml = compile_exp ~tparams ctx exp_b in
-  let expr_ml = Ml.FieldE (expr_b_ml, field_ml) in
+  (* unwrap the note before projecting the record field *)
+  let expr_ml = Ml.FieldE (Ml.FieldE (expr_b_ml, "it"), field_ml) in
   (ctx, expr_ml)
 
 (* Index expression: [exp_b[exp_i]]
@@ -763,7 +844,9 @@ and compile_idx_exp ~(tparams : string list) (ctx : Ctx.t) (exp_b : exp)
     match exp_b.note with
     | TextT ->
         Ml.AppE (Ml.VarE "String.sub", [ expr_b_ml; expr_i_ml; Ml.LitE "1" ])
-    | _ -> Ml.AppE (Ml.VarE "List.nth", [ expr_b_ml; expr_i_ml ])
+    | _ ->
+        Ml.AppE
+          (Ml.VarE "List.nth", [ Ml.FieldE (expr_b_ml, "it"); expr_i_ml ])
   in
   (ctx, expr_ml)
 
@@ -788,7 +871,8 @@ and compile_slice_exp ~(tparams : string list) (ctx : Ctx.t) (exp_b : exp)
   | _ ->
       let ctx_outer = ctx in
       let ctx, id_stub_ml = Stub.OCaml.var ctx "elem_list__" in
-      let expr_ml =
+      (* filter the unwrapped body, then re-wrap the sliced list *)
+      let expr_body_ml =
         Ml.AppE
           ( Ml.VarE "List.filteri",
             [
@@ -801,10 +885,13 @@ and compile_slice_exp ~(tparams : string list) (ctx : Ctx.t) (exp_b : exp)
                         ( "<",
                           Ml.VarE id_stub_ml,
                           Ml.BinopE ("+", expr_i_ml, expr_n_ml) ) ) );
-              expr_b_ml;
+              Ml.FieldE (expr_b_ml, "it");
             ] )
       in
       let ctx = Ctx.promote_preamble ctx ctx_outer in
+      let expr_ml =
+        compile_mk_wrap ~tparams ctx (exp_b.note $ exp_b.at) expr_body_ml
+      in
       (ctx, expr_ml)
 
 (* Update expressions *)
@@ -825,7 +912,9 @@ and compile_access_path_idx ~(tparams : string list) (ctx : Ctx.t) (path : path)
     match path.note with
     | Il.TextT ->
         Ml.AppE (Ml.VarE "String.sub", [ expr_inner_ml; expr_i_ml; Ml.LitE "1" ])
-    | _ -> Ml.AppE (Ml.VarE "List.nth", [ expr_inner_ml; expr_i_ml ])
+    | _ ->
+        Ml.AppE
+          (Ml.VarE "List.nth", [ Ml.FieldE (expr_inner_ml, "it"); expr_i_ml ])
   in
   (ctx, expr_ml)
 
@@ -846,7 +935,8 @@ and compile_access_path_slice ~(tparams : string list) (ctx : Ctx.t)
       let ctx_outer = ctx in
       let ctx, id_j_ml = Stub.OCaml.var ctx "j" in
       let ctx = Ctx.promote_preamble ctx ctx_outer in
-      let expr_ml =
+      (* filter the unwrapped body, then re-wrap the sliced list *)
+      let expr_body_ml =
         Ml.AppE
           ( Ml.VarE "List.filteri",
             [
@@ -859,8 +949,11 @@ and compile_access_path_slice ~(tparams : string list) (ctx : Ctx.t)
                         ( "<",
                           Ml.VarE id_j_ml,
                           Ml.BinopE ("+", expr_i_ml, expr_n_ml) ) ) );
-              expr_inner_ml;
+              Ml.FieldE (expr_inner_ml, "it");
             ] )
+      in
+      let expr_ml =
+        compile_mk_wrap ~tparams ctx (path.note $ path.at) expr_body_ml
       in
       (ctx, expr_ml)
 
@@ -871,7 +964,8 @@ and compile_access_path ~(tparams : string list) (ctx : Ctx.t) (path : path)
   | DotP (path, atom) ->
       let ctx, expr_ml = compile_access_path ~tparams ctx path expr_b_ml in
       let field_ml = Names.field atom in
-      let expr_ml = Ml.FieldE (expr_ml, field_ml) in
+      (* unwrap the note before projecting the record field *)
+      let expr_ml = Ml.FieldE (Ml.FieldE (expr_ml, "it"), field_ml) in
       (ctx, expr_ml)
   | IdxP (path, exp_i) ->
       compile_access_path_idx ~tparams ctx path exp_i expr_b_ml
@@ -910,13 +1004,15 @@ and compile_upd_idx_text (ctx : Ctx.t) (expr_ml : Ml.expr) (expr_i_ml : Ml.expr)
   in
   (ctx, expr_ml)
 
-and compile_upd_idx_list (ctx : Ctx.t) (expr_ml : Ml.expr) (expr_i_ml : Ml.expr)
-    (expr_n_ml : Ml.expr) : Ctx.t * Ml.expr =
+and compile_upd_idx_list ~(tparams : string list) (ctx : Ctx.t) (typ : typ)
+    (expr_ml : Ml.expr) (expr_i_ml : Ml.expr) (expr_n_ml : Ml.expr) :
+    Ctx.t * Ml.expr =
   let ctx_outer = ctx in
   let ctx, id_j_ml = Stub.OCaml.var ctx "j" in
   let ctx, id_x_ml = Stub.OCaml.var ctx "x" in
   let ctx = Ctx.promote_preamble ctx ctx_outer in
-  let expr_ml =
+  (* map over the unwrapped body, then re-wrap the updated list *)
+  let expr_body_ml =
     Ml.AppE
       ( Ml.VarE "List.mapi",
         [
@@ -926,9 +1022,10 @@ and compile_upd_idx_list (ctx : Ctx.t) (expr_ml : Ml.expr) (expr_i_ml : Ml.expr)
                 ( Ml.BinopE ("=", Ml.VarE id_j_ml, expr_i_ml),
                   expr_n_ml,
                   Some (Ml.VarE id_x_ml) ) );
-          expr_ml;
+          Ml.FieldE (expr_ml, "it");
         ] )
   in
+  let expr_ml = compile_mk_wrap ~tparams ctx typ expr_body_ml in
   (ctx, expr_ml)
 
 and compile_upd_idx ~(tparams : string list) (ctx : Ctx.t) (path : path)
@@ -940,7 +1037,9 @@ and compile_upd_idx ~(tparams : string list) (ctx : Ctx.t) (path : path)
   let ctx, expr_ml =
     match path.note with
     | Il.TextT -> compile_upd_idx_text ctx expr_ml expr_i_ml expr_n_ml
-    | _ -> compile_upd_idx_list ctx expr_ml expr_i_ml expr_n_ml
+    | _ ->
+        compile_upd_idx_list ~tparams ctx (path.note $ path.at) expr_ml expr_i_ml
+          expr_n_ml
   in
   compile_upd ~tparams ctx path expr_b_ml expr_ml
 
@@ -970,15 +1069,16 @@ and compile_upd_slice_text (ctx : Ctx.t) (expr_ml : Ml.expr)
   in
   (ctx, expr_ml)
 
-and compile_upd_slice_list (ctx : Ctx.t) (expr_ml : Ml.expr)
-    (expr_i_ml : Ml.expr) (expr_n_len_ml : Ml.expr) (expr_n_ml : Ml.expr) :
-    Ctx.t * Ml.expr =
+and compile_upd_slice_list ~(tparams : string list) (ctx : Ctx.t) (typ : typ)
+    (expr_ml : Ml.expr) (expr_i_ml : Ml.expr) (expr_n_len_ml : Ml.expr)
+    (expr_n_ml : Ml.expr) : Ctx.t * Ml.expr =
   let ctx_outer = ctx in
   let ctx, id_j_ml = Stub.OCaml.var ctx "j" in
   let ctx, id_x_ml = Stub.OCaml.var ctx "x" in
   let ctx = Ctx.promote_preamble ctx ctx_outer in
   let expr_idx_hi_ml = Ml.BinopE ("+", expr_i_ml, expr_n_len_ml) in
-  let expr_ml =
+  (* map over the unwrapped body, indexing the unwrapped replacement, re-wrap *)
+  let expr_body_ml =
     Ml.AppE
       ( Ml.VarE "List.mapi",
         [
@@ -991,12 +1091,15 @@ and compile_upd_slice_list (ctx : Ctx.t) (expr_ml : Ml.expr)
                       Ml.BinopE ("<", Ml.VarE id_j_ml, expr_idx_hi_ml) ),
                   Ml.AppE
                     ( Ml.VarE "List.nth",
-                      [ expr_n_ml; Ml.BinopE ("-", Ml.VarE id_j_ml, expr_i_ml) ]
-                    ),
+                      [
+                        Ml.FieldE (expr_n_ml, "it");
+                        Ml.BinopE ("-", Ml.VarE id_j_ml, expr_i_ml);
+                      ] ),
                   Some (Ml.VarE id_x_ml) ) );
-          expr_ml;
+          Ml.FieldE (expr_ml, "it");
         ] )
   in
+  let expr_ml = compile_mk_wrap ~tparams ctx typ expr_body_ml in
   (ctx, expr_ml)
 
 and compile_upd_slice ~(tparams : string list) (ctx : Ctx.t) (path : path)
@@ -1013,7 +1116,9 @@ and compile_upd_slice ~(tparams : string list) (ctx : Ctx.t) (path : path)
     match path.note with
     | Il.TextT ->
         compile_upd_slice_text ctx expr_ml expr_i_ml expr_n_len_ml expr_n_ml
-    | _ -> compile_upd_slice_list ctx expr_ml expr_i_ml expr_n_len_ml expr_n_ml
+    | _ ->
+        compile_upd_slice_list ~tparams ctx (path.note $ path.at) expr_ml
+          expr_i_ml expr_n_len_ml expr_n_ml
   in
   compile_upd ~tparams ctx path expr_b_ml expr_ml
 
@@ -1025,9 +1130,13 @@ and compile_upd_dot ~(tparams : string list) (ctx : Ctx.t) (path : path)
     (atom : atom) (expr_b_ml : Ml.expr) (expr_n_ml : Ml.expr) : Ctx.t * Ml.expr
     =
   let ctx, expr_ml = compile_access_path ~tparams ctx path expr_b_ml in
+  let field_ml = Names.field atom in
+  (* update the field on the unwrapped body, then re-wrap to refresh the note *)
+  let expr_body_ml =
+    Ml.RecordUpdateE (Ml.FieldE (expr_ml, "it"), [ (field_ml, expr_n_ml) ])
+  in
   let expr_ml =
-    let field_ml = Names.field atom in
-    Ml.RecordUpdateE (expr_ml, [ (field_ml, expr_n_ml) ])
+    compile_mk_wrap ~tparams ctx (path.note $ path.at) expr_body_ml
   in
   compile_upd ~tparams ctx path expr_b_ml expr_ml
 
@@ -1082,7 +1191,13 @@ and compile_arg ~(tparams : string list) (ctx : Ctx.t) (arg : arg) :
                   let expr_typ_ml =
                     Interface.Dynamic_gen.make_typ_expr ~tparams typ_tparam
                   in
-                  [ converter.marshal; converter.unmarshal; expr_typ_ml ])
+                  [
+              converter.marshal;
+              converter.unmarshal;
+              expr_typ_ml;
+              converter.hash;
+              converter.eq;
+            ])
                 callee_tparams
             in
             Ml.AppE (Ml.VarE id_ml, exprs_converter_ml)
@@ -1113,7 +1228,13 @@ and compile_call_exp ~(tparams : string list) (ctx : Ctx.t) (id : id)
             let expr_typ_ml =
               Interface.Dynamic_gen.make_typ_expr ~tparams targ
             in
-            [ converter.marshal; converter.unmarshal; expr_typ_ml ])
+            [
+              converter.marshal;
+              converter.unmarshal;
+              expr_typ_ml;
+              converter.hash;
+              converter.eq;
+            ])
           targs
       in
       (ctx, Ml.AppE (Ml.VarE id_func_ml, exprs_converter_ml @ exprs_arg_ml))
@@ -1127,8 +1248,8 @@ and compile_call_exp ~(tparams : string list) (ctx : Ctx.t) (id : id)
    multi-var   ->  [Option.fold_N_1 (fun x .. -> expr) x? y? ..]
                    (fuses [Option.map f (Option.combineN x? y? ..)]) *)
 
-and compile_iter_exp_opt ~(tparams : string list) (ctx : Ctx.t) (exp : exp)
-    (vars : var list) : Ctx.t * Ml.expr =
+and compile_iter_exp_opt ~(tparams : string list) (ctx : Ctx.t) (typ_exp : typ)
+    (exp : exp) (vars : var list) : Ctx.t * Ml.expr =
   (* Fetch iteration target variables *)
   let ids_opt_ml =
     List.map
@@ -1143,7 +1264,8 @@ and compile_iter_exp_opt ~(tparams : string list) (ctx : Ctx.t) (exp : exp)
   let ctx, expr_body_ml = compile_exp ~tparams ctx exp in
   let ctx, expr_ml =
     if n >= 2 then
-      (* Fuse [Option.map f (combineN o0 ..)] into [Option.fold_N_1 f o0 ..] *)
+      (* Fuse [Option.map f (combineN o0 ..)] into [Option.fold_N_1 f o0 ..];
+         [make_opt_fold] unwraps each guide's body *)
       Common.make_opt_fold ctx ids_opt_ml ids_stub_ml expr_body_ml n 1
     else
       (* Single guide: a plain Option.map, no combine to eliminate. *)
@@ -1153,14 +1275,17 @@ and compile_iter_exp_opt ~(tparams : string list) (ctx : Ctx.t) (exp : exp)
         | ids_ml -> Ml.TupleP (List.map (fun id_ml -> Ml.VarP id_ml) ids_ml)
       in
       let expr_lambda_ml = Ml.FunE ([ pat_ml ], expr_body_ml) in
+      (* guides are wrapped options; iterate over their bare bodies *)
       let ctx, expr_opt_ml =
         match ids_opt_ml with
-        | [ id_ml ] -> (ctx, Ml.VarE id_ml)
+        | [ id_ml ] -> (ctx, Ml.FieldE (Ml.VarE id_ml, "it"))
         | _ ->
             let ctx = Ctx.add_opt_combine ctx n in
             let id_combine_ml = "Option.combine" ^ string_of_int n in
             let exprs_arg_ml =
-              List.map (fun id_opt_ml -> Ml.VarE id_opt_ml) ids_opt_ml
+              List.map
+                (fun id_opt_ml -> Ml.FieldE (Ml.VarE id_opt_ml, "it"))
+                ids_opt_ml
             in
             (ctx, Ml.AppE (Ml.VarE id_combine_ml, exprs_arg_ml))
       in
@@ -1168,6 +1293,8 @@ and compile_iter_exp_opt ~(tparams : string list) (ctx : Ctx.t) (exp : exp)
   in
   (* Promote preamble *)
   let ctx = Ctx.promote_preamble ctx ctx_outer in
+  (* the map/fold yields a bare option; re-wrap to the iteration type *)
+  let expr_ml = compile_mk_wrap ~tparams ctx typ_exp expr_ml in
   (ctx, expr_ml)
 
 (* List iterator expression: [exp{x*}]
@@ -1176,8 +1303,8 @@ and compile_iter_exp_opt ~(tparams : string list) (ctx : Ctx.t) (exp : exp)
    multi-var   ->  [List.fold_left_N_1 (fun x .. -> expr) x* y* ..]
                    (fuses [List.map f (List.combineN x* y* ..)]) *)
 
-and compile_iter_exp_list ~(tparams : string list) (ctx : Ctx.t) (exp : exp)
-    (vars : var list) : Ctx.t * Ml.expr =
+and compile_iter_exp_list ~(tparams : string list) (ctx : Ctx.t) (typ_exp : typ)
+    (exp : exp) (vars : var list) : Ctx.t * Ml.expr =
   (* Save outer context for promotion *)
   let ctx_outer = ctx in
   (* Fetch iteration target variables *)
@@ -1193,7 +1320,8 @@ and compile_iter_exp_list ~(tparams : string list) (ctx : Ctx.t) (exp : exp)
   let ctx, expr_body_ml = compile_exp ~tparams ctx exp in
   let ctx, expr_ml =
     if n >= 2 then
-      (* Fuse [List.map f (combineN l0 ..)] into a single [fold_left_N_1 f l0 ..] *)
+      (* Fuse [List.map f (combineN l0 ..)] into a single [fold_left_N_1 f l0 ..];
+         [make_list_fold] unwraps each guide's body *)
       Common.make_list_fold ctx ids_list_ml ids_stub_ml expr_body_ml n 1
     else
       (* Single guide: a plain List.map, no combine to eliminate. *)
@@ -1203,14 +1331,17 @@ and compile_iter_exp_list ~(tparams : string list) (ctx : Ctx.t) (exp : exp)
         | ids_ml -> Ml.TupleP (List.map (fun id_ml -> Ml.VarP id_ml) ids_ml)
       in
       let expr_lambda_ml = Ml.FunE ([ pat_ml ], expr_body_ml) in
+      (* guides are wrapped lists; iterate over their bare bodies *)
       let ctx, expr_list_ml =
         match ids_list_ml with
-        | [ id_ml ] -> (ctx, Ml.VarE id_ml)
+        | [ id_ml ] -> (ctx, Ml.FieldE (Ml.VarE id_ml, "it"))
         | _ ->
             let ctx = Ctx.add_list_combine ctx n in
             let id_combine_ml = "List.combine" ^ string_of_int n in
             let exprs_arg_ml =
-              List.map (fun id_list_ml -> Ml.VarE id_list_ml) ids_list_ml
+              List.map
+                (fun id_list_ml -> Ml.FieldE (Ml.VarE id_list_ml, "it"))
+                ids_list_ml
             in
             (ctx, Ml.AppE (Ml.VarE id_combine_ml, exprs_arg_ml))
       in
@@ -1218,6 +1349,8 @@ and compile_iter_exp_list ~(tparams : string list) (ctx : Ctx.t) (exp : exp)
   in
   (* Promote preamble *)
   let ctx = Ctx.promote_preamble ctx ctx_outer in
+  (* the map/fold yields a bare list; re-wrap to the iteration type *)
+  let expr_ml = compile_mk_wrap ~tparams ctx typ_exp expr_ml in
   (ctx, expr_ml)
 
 and compile_iter_exp ~(tparams : string list) (ctx : Ctx.t) (typ_exp : typ)
@@ -1232,5 +1365,5 @@ and compile_iter_exp ~(tparams : string list) (ctx : Ctx.t) (typ_exp : typ)
   | None -> (
       let iter, vars = iterexp in
       match iter with
-      | Opt -> compile_iter_exp_opt ~tparams ctx exp vars
-      | List -> compile_iter_exp_list ~tparams ctx exp vars)
+      | Opt -> compile_iter_exp_opt ~tparams ctx typ_exp exp vars
+      | List -> compile_iter_exp_list ~tparams ctx typ_exp exp vars)

--- a/p4spec/lib/pass/compile/gen/ast/func.ml
+++ b/p4spec/lib/pass/compile/gen/ast/func.ml
@@ -91,10 +91,18 @@ let compile_tparams (tparams_ml : Ml.tparam list) : Ml.param list =
       let id_unmarshal_ml = Interface.Converter.name_unmarshal tparam_ml in
       let typ_unmarshal_ml = Ml.FuncT (Ml.NameT "Value.t", Ml.VarT tparam_ml) in
       let id_typ_ml = Interface.Naming.name_typ tparam_ml in
+      let id_hash_ml = Interface.Converter.name_hash tparam_ml in
+      let typ_hash_ml = Ml.FuncT (Ml.VarT tparam_ml, Ml.NameT "int") in
+      let id_eq_ml = Interface.Converter.name_eq tparam_ml in
+      let typ_eq_ml =
+        Ml.FuncT (Ml.VarT tparam_ml, Ml.FuncT (Ml.VarT tparam_ml, Ml.BoolT))
+      in
       [
         (id_marshal_ml, Some typ_marshal_ml);
         (id_unmarshal_ml, Some typ_unmarshal_ml);
         (id_typ_ml, Some (Ml.NameT "Typ.t"));
+        (id_hash_ml, Some typ_hash_ml);
+        (id_eq_ml, Some typ_eq_ml);
       ])
     tparams_ml
 

--- a/p4spec/lib/pass/compile/gen/ast/instr.ml
+++ b/p4spec/lib/pass/compile/gen/ast/instr.ml
@@ -24,7 +24,7 @@ let rec compile_instr ~(tparams : string list) (ctx : Ctx.t) (instr : instr) :
   | IfI (exp_cond, iterexps, block, _) ->
       compile_if_instr ~tparams ctx exp_cond iterexps block
   | HoldI (id, notexp, iterexps, holdcase) ->
-      compile_hold_instr ~tparams ctx id notexp iterexps holdcase
+      compile_hold_instr ~tparams ~at:instr.at ctx id notexp iterexps holdcase
   | CaseI (exp, cases, _) -> compile_case_instr ~tparams ctx exp cases
   | GroupI (_, _, _, block) -> compile_group_instr ~tparams ctx block
   | LetI (exp_l, exp_r, iterinstrs, block) ->
@@ -81,7 +81,8 @@ and compile_if_cond_list ~(tparams : string list) (ctx : Ctx.t) (exp_cond : exp)
       in
       let expr_guide_ml =
         match ids_guide_ml with
-        | [ id_guide_ml ] -> Ml.VarE id_guide_ml
+        (* guide is a wrapped composite; iterate over its bare body *)
+        | [ id_guide_ml ] -> Ml.FieldE (Ml.VarE id_guide_ml, "it")
         | _ -> assert false
       in
       ( ctx,
@@ -123,7 +124,8 @@ and compile_if_cond_opt ~(tparams : string list) (ctx : Ctx.t) (exp_cond : exp)
       in
       let expr_guide_ml =
         match ids_guide_ml with
-        | [ id_guide_ml ] -> Ml.VarE id_guide_ml
+        (* guide is a wrapped composite; iterate over its bare body *)
+        | [ id_guide_ml ] -> Ml.FieldE (Ml.VarE id_guide_ml, "it")
         | _ -> assert false
       in
       ( ctx,
@@ -217,7 +219,8 @@ and compile_hold_cond_list ~(tparams : string list) (ctx : Ctx.t) (id : id)
       in
       let expr_guide_ml =
         match ids_guide_ml with
-        | [ id_guide_ml ] -> Ml.VarE id_guide_ml
+        (* guide is a wrapped composite; iterate over its bare body *)
+        | [ id_guide_ml ] -> Ml.FieldE (Ml.VarE id_guide_ml, "it")
         | _ -> assert false
       in
       ( ctx,
@@ -259,7 +262,8 @@ and compile_hold_cond_opt ~(tparams : string list) (ctx : Ctx.t) (id : id)
       in
       let expr_guide_ml =
         match ids_guide_ml with
-        | [ id_guide_ml ] -> Ml.VarE id_guide_ml
+        (* guide is a wrapped composite; iterate over its bare body *)
+        | [ id_guide_ml ] -> Ml.FieldE (Ml.VarE id_guide_ml, "it")
         | _ -> assert false
       in
       ( ctx,
@@ -281,8 +285,9 @@ and compile_hold_cond_iter ~(tparams : string list) (ctx : Ctx.t) (id : id)
       | Il.List -> compile_hold_cond_list ~tparams ctx id notexp vars iterexps_t
       | Il.Opt -> compile_hold_cond_opt ~tparams ctx id notexp vars iterexps_t)
 
-and compile_hold_case ~(tparams : string list) (ctx : Ctx.t)
+and compile_hold_case ~(tparams : string list) ~(at : region) (ctx : Ctx.t)
     (holdcase : holdcase) (id_hold_ml : string) : Ctx.t * Ml.expr =
+  let region = Util.Source.string_of_region at in
   match holdcase with
   | BothH (block_hold, block_nothold) ->
       (* Both branches reachable; no Unmatch on either path *)
@@ -296,7 +301,7 @@ and compile_hold_case ~(tparams : string list) (ctx : Ctx.t)
         Ml.IfE
           ( Ml.VarE id_hold_ml,
             expr_hold_ml,
-            Some (Common.raise_unmatch "hold failed") ) )
+            Some (Common.raise_unmatch ("hold failed " ^ region)) ) )
   | NotHoldH (block_nothold, _) ->
       (* If condition holds: Unmatch -> fall through to next sibling *)
       let ctx, expr_nothold_ml = compile_block ~tparams ctx block_nothold in
@@ -304,11 +309,11 @@ and compile_hold_case ~(tparams : string list) (ctx : Ctx.t)
         Ml.IfE
           ( Ml.UnopE ("not", Ml.VarE id_hold_ml),
             expr_nothold_ml,
-            Some (Common.raise_unmatch "not-hold failed") ) )
+            Some (Common.raise_unmatch ("not-hold failed " ^ region)) ) )
 
-and compile_hold_instr ~(tparams : string list) (ctx : Ctx.t) (id : id)
-    (notexp : notexp) (iterexps : iterexp list) (holdcase : holdcase) :
-    Ctx.t * Ml.expr =
+and compile_hold_instr ~(tparams : string list) ~(at : region) (ctx : Ctx.t)
+    (id : id) (notexp : notexp) (iterexps : iterexp list)
+    (holdcase : holdcase) : Ctx.t * Ml.expr =
   let ctx_outer = ctx in
   (* Process iterexps innermost-first, matching interpreter's List.rev *)
   let iterexps_rev = List.rev iterexps in
@@ -317,7 +322,9 @@ and compile_hold_instr ~(tparams : string list) (ctx : Ctx.t) (id : id)
   in
   (* Bind hold__ so holdcase branches can reference it *)
   let ctx, id_hold_ml = Stub.OCaml.var ctx "hold__" in
-  let ctx, expr_body_ml = compile_hold_case ~tparams ctx holdcase id_hold_ml in
+  let ctx, expr_body_ml =
+    compile_hold_case ~tparams ~at ctx holdcase id_hold_ml
+  in
   let ctx = Ctx.promote_preamble ctx ctx_outer in
   (ctx, Ml.LetE (Ml.VarP id_hold_ml, expr_hold_ml, expr_body_ml))
 
@@ -415,6 +422,51 @@ and compile_let ~(tparams : string list) (ctx : Ctx.t) (exp_l : exp)
   let expr_ml = Chain.apply chain expr_result_ml in
   (ctx, expr_ml)
 
+(* Bind an iterated-let/rule's bare split columns [expr_rhs_ml] to fresh temps,
+   re-wrap each to its lifted [iter] type, bind the lifted outputs, and emit
+   [let (raw..) = rhs in let out0 = wrap raw0 in .. in cont] *)
+and compile_iter_out ~(tparams : string list) (ctx : Ctx.t) (ctx_outer : Ctx.t)
+    (vars_bind : var list) (iter : Il.iter) (expr_rhs_ml : Ml.expr)
+    (cont : Ctx.t -> Ctx.t * Ml.expr) : Ctx.t * Ml.expr =
+  let ctx, ids_raw_ml =
+    Stub.OCaml.vars ctx "iter_out__" (List.length vars_bind)
+  in
+  let pat_raw_ml =
+    match ids_raw_ml with
+    | [ id_raw_ml ] -> Ml.VarP id_raw_ml
+    | _ -> Ml.TupleP (List.map (fun id_raw_ml -> Ml.VarP id_raw_ml) ids_raw_ml)
+  in
+  let outs =
+    List.map2
+      (fun (id, typ, iters) id_raw_ml ->
+        let id_out_ml = Names.var_of_var (id, iters @ [ iter ]) in
+        let typ_out =
+          List.fold_left
+            (fun t it -> Il.IterT (t, it) $ typ.at)
+            typ (iters @ [ iter ])
+        in
+        let expr_wrap_ml =
+          Wrap.compile_mk_wrap ~tparams ctx typ_out (Ml.VarE id_raw_ml)
+        in
+        (id, iters, id_out_ml, expr_wrap_ml))
+      vars_bind ids_raw_ml
+  in
+  let ctx =
+    List.fold_left
+      (fun ctx (id, iters, id_out_ml, _) ->
+        Ctx.add_binding ctx (id, iters @ [ iter ]) id_out_ml)
+      ctx outs
+  in
+  let ctx, expr_cont_ml = cont ctx in
+  let ctx = Ctx.promote_preamble ctx ctx_outer in
+  let expr_cont_ml =
+    List.fold_right
+      (fun (_, _, id_out_ml, expr_wrap_ml) acc ->
+        Ml.LetE (Ml.VarP id_out_ml, expr_wrap_ml, acc))
+      outs expr_cont_ml
+  in
+  (ctx, Ml.LetE (pat_raw_ml, expr_rhs_ml, expr_cont_ml))
+
 and compile_let_opt ~(tparams : string list) (ctx : Ctx.t) (exp_l : exp)
     (exp_r : exp) (vars_bound : var list) (vars_bind : var list)
     (iterinstrs : iterinstr list) (cont : Ctx.t -> Ctx.t * Ml.expr) :
@@ -461,14 +513,15 @@ and compile_let_opt ~(tparams : string list) (ctx : Ctx.t) (exp_l : exp)
     else
       let ctx, expr_guide_ml =
         match ids_guide_ml with
-        | [ id_guide_ml ] -> (ctx, Ml.VarE id_guide_ml)
+        | [ id_guide_ml ] -> (ctx, Ml.FieldE (Ml.VarE id_guide_ml, "it"))
         | _ ->
             let ctx = Ctx.add_opt_combine ctx n_bound in
             ( ctx,
               Ml.AppE
                 ( Ml.VarE ("Option.combine" ^ string_of_int n_bound),
-                  List.map (fun id_guide_ml -> Ml.VarE id_guide_ml) ids_guide_ml
-                ) )
+                  List.map
+                    (fun id_guide_ml -> Ml.FieldE (Ml.VarE id_guide_ml, "it"))
+                    ids_guide_ml ) )
       in
       let pat_elem_ml =
         match ids_elem_ml with
@@ -489,32 +542,8 @@ and compile_let_opt ~(tparams : string list) (ctx : Ctx.t) (exp_l : exp)
       in
       (ctx, expr_split_ml)
   in
-  (* Name output vars with __quest suffix *)
-  let ids_out_ml =
-    List.map
-      (fun (id, _, iters) -> Names.var_of_var (id, iters @ [ Il.Opt ]))
-      vars_bind
-  in
-  (* Build output pattern *)
-  let pat_out_ml =
-    match ids_out_ml with
-    | [ id_out_ml ] -> Ml.VarP id_out_ml
-    | _ -> Ml.TupleP (List.map (fun id_out_ml -> Ml.VarP id_out_ml) ids_out_ml)
-  in
-  (* Add output bindings to ctx *)
-  let ctx =
-    List.fold_left2
-      (fun ctx (id, _, iters) id_out_ml ->
-        Ctx.add_binding ctx (id, iters @ [ Il.Opt ]) id_out_ml)
-      ctx vars_bind ids_out_ml
-  in
-  (* Compile continuation *)
-  let ctx, expr_cont_ml = cont ctx in
-  (* Promote preamble to outer ctx *)
-  let ctx = Ctx.promote_preamble ctx ctx_outer in
-  (* Build let expression *)
-  let expr_ml = Ml.LetE (pat_out_ml, expr_rhs_ml, expr_cont_ml) in
-  (ctx, expr_ml)
+  (* re-wrap the bare split columns to their lifted option types *)
+  compile_iter_out ~tparams ctx ctx_outer vars_bind Il.Opt expr_rhs_ml cont
 
 and compile_let_list ~(tparams : string list) (ctx : Ctx.t) (exp_l : exp)
     (exp_r : exp) (vars_bound : var list) (vars_bind : var list)
@@ -562,14 +591,15 @@ and compile_let_list ~(tparams : string list) (ctx : Ctx.t) (exp_l : exp)
     else
       let ctx, expr_guide_ml =
         match ids_guide_ml with
-        | [ id_guide_ml ] -> (ctx, Ml.VarE id_guide_ml)
+        | [ id_guide_ml ] -> (ctx, Ml.FieldE (Ml.VarE id_guide_ml, "it"))
         | _ ->
             let ctx = Ctx.add_list_combine ctx n_bound in
             ( ctx,
               Ml.AppE
                 ( Ml.VarE ("List.combine" ^ string_of_int n_bound),
-                  List.map (fun id_guide_ml -> Ml.VarE id_guide_ml) ids_guide_ml
-                ) )
+                  List.map
+                    (fun id_guide_ml -> Ml.FieldE (Ml.VarE id_guide_ml, "it"))
+                    ids_guide_ml ) )
       in
       let pat_elem_ml =
         match ids_elem_ml with
@@ -589,32 +619,8 @@ and compile_let_list ~(tparams : string list) (ctx : Ctx.t) (exp_l : exp)
       in
       (ctx, expr_split_ml)
   in
-  (* Name output vars with __star suffix *)
-  let ids_out_ml =
-    List.map
-      (fun (id, _, iters) -> Names.var_of_var (id, iters @ [ Il.List ]))
-      vars_bind
-  in
-  (* Build output pattern *)
-  let pat_out_ml =
-    match ids_out_ml with
-    | [ id_out_ml ] -> Ml.VarP id_out_ml
-    | _ -> Ml.TupleP (List.map (fun id_out_ml -> Ml.VarP id_out_ml) ids_out_ml)
-  in
-  (* Add output bindings to ctx *)
-  let ctx =
-    List.fold_left2
-      (fun ctx (id, _, iters) id_out_ml ->
-        Ctx.add_binding ctx (id, iters @ [ Il.List ]) id_out_ml)
-      ctx vars_bind ids_out_ml
-  in
-  (* Compile continuation *)
-  let ctx, expr_cont_ml = cont ctx in
-  (* Promote preamble to outer ctx *)
-  let ctx = Ctx.promote_preamble ctx ctx_outer in
-  (* Build let expression *)
-  let expr_ml = Ml.LetE (pat_out_ml, expr_rhs_ml, expr_cont_ml) in
-  (ctx, expr_ml)
+  (* re-wrap the bare split columns to their lifted list types *)
+  compile_iter_out ~tparams ctx ctx_outer vars_bind Il.List expr_rhs_ml cont
 
 and compile_let_iter ~(tparams : string list) (ctx : Ctx.t) (exp_l : exp)
     (exp_r : exp) (iterinstrs_rev : iterinstr list)
@@ -740,14 +746,15 @@ and compile_rule_opt ~(tparams : string list) (ctx : Ctx.t) (rel_id : id)
     else
       let ctx, expr_guide_ml =
         match ids_guide_ml with
-        | [ id_guide_ml ] -> (ctx, Ml.VarE id_guide_ml)
+        | [ id_guide_ml ] -> (ctx, Ml.FieldE (Ml.VarE id_guide_ml, "it"))
         | _ ->
             let ctx = Ctx.add_opt_combine ctx n_bound in
             ( ctx,
               Ml.AppE
                 ( Ml.VarE ("Option.combine" ^ string_of_int n_bound),
-                  List.map (fun id_guide_ml -> Ml.VarE id_guide_ml) ids_guide_ml
-                ) )
+                  List.map
+                    (fun id_guide_ml -> Ml.FieldE (Ml.VarE id_guide_ml, "it"))
+                    ids_guide_ml ) )
       in
       let pat_elem_ml =
         match ids_elem_ml with
@@ -768,30 +775,8 @@ and compile_rule_opt ~(tparams : string list) (ctx : Ctx.t) (rel_id : id)
       in
       (ctx, expr_split_ml)
   in
-  (* Name output vars with __quest suffix *)
-  let ids_out_ml =
-    List.map
-      (fun (id, _, iters) -> Names.var_of_var (id, iters @ [ Il.Opt ]))
-      vars_bind
-  in
-  (* Build output pattern *)
-  let pat_out_ml =
-    match ids_out_ml with
-    | [ id_out_ml ] -> Ml.VarP id_out_ml
-    | _ -> Ml.TupleP (List.map (fun id_out_ml -> Ml.VarP id_out_ml) ids_out_ml)
-  in
-  (* Add output bindings to ctx *)
-  let ctx =
-    List.fold_left2
-      (fun ctx (id, _, iters) id_out_ml ->
-        Ctx.add_binding ctx (id, iters @ [ Il.Opt ]) id_out_ml)
-      ctx vars_bind ids_out_ml
-  in
-  (* Compile continuation *)
-  let ctx, expr_cont_ml = cont ctx in
-  let ctx = Ctx.promote_preamble ctx ctx_outer in
-  let expr_ml = Ml.LetE (pat_out_ml, expr_rhs_ml, expr_cont_ml) in
-  (ctx, expr_ml)
+  (* re-wrap the bare split columns to their lifted option types *)
+  compile_iter_out ~tparams ctx ctx_outer vars_bind Il.Opt expr_rhs_ml cont
 
 and compile_rule_list ~(tparams : string list) (ctx : Ctx.t) (rel_id : id)
     (notexp : notexp) (inputs : Hints.Input.t) (vars_bound : var list)
@@ -839,14 +824,15 @@ and compile_rule_list ~(tparams : string list) (ctx : Ctx.t) (rel_id : id)
     else
       let ctx, expr_guide_ml =
         match ids_guide_ml with
-        | [ id_guide_ml ] -> (ctx, Ml.VarE id_guide_ml)
+        | [ id_guide_ml ] -> (ctx, Ml.FieldE (Ml.VarE id_guide_ml, "it"))
         | _ ->
             let ctx = Ctx.add_list_combine ctx n_bound in
             ( ctx,
               Ml.AppE
                 ( Ml.VarE ("List.combine" ^ string_of_int n_bound),
-                  List.map (fun id_guide_ml -> Ml.VarE id_guide_ml) ids_guide_ml
-                ) )
+                  List.map
+                    (fun id_guide_ml -> Ml.FieldE (Ml.VarE id_guide_ml, "it"))
+                    ids_guide_ml ) )
       in
       let pat_elem_ml =
         match ids_elem_ml with
@@ -866,30 +852,8 @@ and compile_rule_list ~(tparams : string list) (ctx : Ctx.t) (rel_id : id)
       in
       (ctx, expr_split_ml)
   in
-  (* Name output vars with __star suffix *)
-  let ids_out_ml =
-    List.map
-      (fun (id, _, iters) -> Names.var_of_var (id, iters @ [ Il.List ]))
-      vars_bind
-  in
-  (* Build output pattern *)
-  let pat_out_ml =
-    match ids_out_ml with
-    | [ id_out_ml ] -> Ml.VarP id_out_ml
-    | _ -> Ml.TupleP (List.map (fun id_out_ml -> Ml.VarP id_out_ml) ids_out_ml)
-  in
-  (* Add output bindings to ctx *)
-  let ctx =
-    List.fold_left2
-      (fun ctx (id, _, iters) id_out_ml ->
-        Ctx.add_binding ctx (id, iters @ [ Il.List ]) id_out_ml)
-      ctx vars_bind ids_out_ml
-  in
-  (* Compile continuation *)
-  let ctx, expr_cont_ml = cont ctx in
-  let ctx = Ctx.promote_preamble ctx ctx_outer in
-  let expr_ml = Ml.LetE (pat_out_ml, expr_rhs_ml, expr_cont_ml) in
-  (ctx, expr_ml)
+  (* re-wrap the bare split columns to their lifted list types *)
+  compile_iter_out ~tparams ctx ctx_outer vars_bind Il.List expr_rhs_ml cont
 
 and compile_rule_iter ~(tparams : string list) (ctx : Ctx.t) (rel_id : id)
     (notexp : notexp) (inputs : Hints.Input.t) (iterinstrs_rev : iterinstr list)

--- a/p4spec/lib/pass/compile/gen/bind.ml
+++ b/p4spec/lib/pass/compile/gen/bind.ml
@@ -10,7 +10,7 @@ open Util.Source
 
 let compile_blk_footer (ctx_inner : Ctx.t) (ctx_outer : Ctx.t) (chain : Chain.t)
     (bindings : Binding.t list) : Ctx.t * Ml.expr =
-  let ids_bind_ml = List.map (fun (_, id_bind_ml) -> id_bind_ml) bindings in
+  let ids_bind_ml = List.map (fun (_, id_bind_ml, _) -> id_bind_ml) bindings in
   let expr_bind_ml =
     let exprs_bind_ml =
       List.map (fun id_bind_ml -> Ml.VarE id_bind_ml) ids_bind_ml
@@ -69,7 +69,7 @@ and compile_var_binding ~(tparams : string list) (ctx : Ctx.t)
     (expr_stub_ml : Ml.expr) (id : id) (typ : typ) :
     Ctx.t * Binding.t list * Chain.t =
   let id_ml = Names.var_of_id id in
-  let binding = ((id, []), id_ml) in
+  let binding = ((id, []), id_ml, typ) in
   let is_struct_typ =
     match typ.it with
     | Il.VarT (tid, _) -> (
@@ -114,7 +114,8 @@ and compile_tuple_binding ~(tparams : string list) (ctx : Ctx.t)
   let chain_tuple =
     let pats_ml = List.map (fun id_stub_ml -> Ml.VarP id_stub_ml) ids_stub_ml in
     let pat_ml = Ml.TupleP pats_ml in
-    Chain.make_let pat_ml expr_stub_ml
+    (* destructure the unwrapped tuple body *)
+    Chain.make_let pat_ml (Ml.FieldE (expr_stub_ml, "it"))
   in
   (* Create chains for tuple elements *)
   let ctx, bindings, chain_elems =
@@ -126,7 +127,7 @@ and compile_tuple_binding ~(tparams : string list) (ctx : Ctx.t)
   let ctx, expr_bind_ml = compile_blk_footer ctx ctx_outer chain bindings in
   (* Create [let (..._a, ..., ..._z) = ... in ...] *)
   let chain =
-    let ids_bind_ml = List.map (fun (_, id_bind_ml) -> id_bind_ml) bindings in
+    let ids_bind_ml = List.map (fun (_, id_bind_ml, _) -> id_bind_ml) bindings in
     let pats_ml = List.map (fun id_bind_ml -> Ml.VarP id_bind_ml) ids_bind_ml in
     let pat_ml = Ml.TupleP pats_ml in
     Chain.make_let pat_ml expr_bind_ml
@@ -164,7 +165,8 @@ and compile_case_binding ~(tparams : string list) (ctx : Ctx.t) (typ_exp : typ)
     let ctor_ml = Ctx.find_ctor ctx typ_exp mixop in
     let pats_ml = List.map (fun id_stub_ml -> Ml.VarP id_stub_ml) ids_stub_ml in
     let pat_ml = Ml.VariantP (`Poly (ctor_ml, pats_ml)) in
-    Chain.make_match expr_stub_ml pat_ml
+    (* match the unwrapped variant body *)
+    Chain.make_match (Ml.FieldE (expr_stub_ml, "it")) pat_ml
   in
   (* Create chains for case elements *)
   let ctx, bindings, chain_elems =
@@ -176,7 +178,7 @@ and compile_case_binding ~(tparams : string list) (ctx : Ctx.t) (typ_exp : typ)
   let ctx, expr_bind_ml = compile_blk_footer ctx ctx_outer chain bindings in
   (* Create [let (..._a, ..., ..._z) = ... in ...] *)
   let chain =
-    let ids_bind_ml = List.map (fun (_, id_bind_ml) -> id_bind_ml) bindings in
+    let ids_bind_ml = List.map (fun (_, id_bind_ml, _) -> id_bind_ml) bindings in
     let pats_ml = List.map (fun id_bind_ml -> Ml.VarP id_bind_ml) ids_bind_ml in
     let pat_ml = Ml.TupleP pats_ml in
     Chain.make_let pat_ml expr_bind_ml
@@ -223,7 +225,8 @@ and compile_opt_binding ~(tparams : string list) (ctx : Ctx.t)
         (* Create [match expr with Some expr_inner -> ...] *)
         let chain_some =
           let pat_then_ml = Ml.OptP (Some (Ml.VarP id_elem_ml)) in
-          Chain.make_match expr_stub_ml pat_then_ml
+          (* match the unwrapped option body *)
+          Chain.make_match (Ml.FieldE (expr_stub_ml, "it")) pat_then_ml
         in
         (* Create chain for option element *)
         let ctx, bindings, chain_then =
@@ -240,7 +243,8 @@ and compile_opt_binding ~(tparams : string list) (ctx : Ctx.t)
         (* Create [match expr with None -> ...] *)
         let chain_none =
           let pat_then_ml = Ml.OptP None in
-          Chain.make_match expr_stub_ml pat_then_ml
+          (* match the unwrapped option body *)
+          Chain.make_match (Ml.FieldE (expr_stub_ml, "it")) pat_then_ml
         in
         (* Finish nested block with bindings *)
         let ctx, expr_bind_ml =
@@ -250,7 +254,7 @@ and compile_opt_binding ~(tparams : string list) (ctx : Ctx.t)
   in
   (* Create [let (..._a, ..., ..._z) = ... in ...] *)
   let chain =
-    let ids_bind_ml = List.map (fun (_, id_bind_ml) -> id_bind_ml) bindings in
+    let ids_bind_ml = List.map (fun (_, id_bind_ml, _) -> id_bind_ml) bindings in
     let pats_ml = List.map (fun id_bind_ml -> Ml.VarP id_bind_ml) ids_bind_ml in
     let pat_ml = Ml.TupleP pats_ml in
     Chain.make_let pat_ml expr_bind_ml
@@ -285,7 +289,8 @@ and compile_list_binding ~(tparams : string list) (ctx : Ctx.t)
   let chain_list =
     let pats_ml = List.map (fun id_stub_ml -> Ml.VarP id_stub_ml) ids_stub_ml in
     let pat_ml = Ml.ListP pats_ml in
-    Chain.make_let pat_ml expr_stub_ml
+    (* destructure the unwrapped list body *)
+    Chain.make_let pat_ml (Ml.FieldE (expr_stub_ml, "it"))
   in
   (* Create chains for list elements *)
   let ctx, bindings, chain_elems =
@@ -297,7 +302,7 @@ and compile_list_binding ~(tparams : string list) (ctx : Ctx.t)
   let ctx, expr_bind_ml = compile_blk_footer ctx ctx_outer chain bindings in
   (* Create [let (..._a, ..., ..._z) = ... in ...] *)
   let chain =
-    let ids_bind_ml = List.map (fun (_, id_bind_ml) -> id_bind_ml) bindings in
+    let ids_bind_ml = List.map (fun (_, id_bind_ml, _) -> id_bind_ml) bindings in
     let pats_ml = List.map (fun id_bind_ml -> Ml.VarP id_bind_ml) ids_bind_ml in
     let pat_ml = Ml.TupleP pats_ml in
     Chain.make_let pat_ml expr_bind_ml
@@ -326,11 +331,16 @@ and compile_cons_binding ~(tparams : string list) (ctx : Ctx.t)
   let ctx, id_h_stub_ml = Stub.OCaml.var ctx "h__" in
   let ctx, id_t_stub_ml = Stub.OCaml.var ctx "t__" in
   let expr_h_stub_ml = Ml.VarE id_h_stub_ml in
-  let expr_t_stub_ml = Ml.VarE id_t_stub_ml in
+  (* the tail is a fresh sub-list, so re-wrap it to the cons list type *)
+  let expr_t_stub_ml =
+    Wrap.compile_mk_wrap ~tparams ctx (exp_t.note $ exp_t.at)
+      (Ml.VarE id_t_stub_ml)
+  in
   (* Create [match expr with expr_h :: expr_t -> ...] *)
   let chain_cons =
     let pat_then_ml = Ml.ConsP (Ml.VarP id_h_stub_ml, Ml.VarP id_t_stub_ml) in
-    Chain.make_match expr_stub_ml pat_then_ml
+    (* match the unwrapped list body *)
+    Chain.make_match (Ml.FieldE (expr_stub_ml, "it")) pat_then_ml
   in
   (* Create chains for head and tail *)
   let ctx, bindings, chain_elems =
@@ -344,7 +354,7 @@ and compile_cons_binding ~(tparams : string list) (ctx : Ctx.t)
   let ctx, expr_bind_ml = compile_blk_footer ctx ctx_outer chain bindings in
   (* Create [let (..._ah, ..., ..._at, ...) = ... in ...] *)
   let chain =
-    let ids_bind_ml = List.map (fun (_, id_bind_ml) -> id_bind_ml) bindings in
+    let ids_bind_ml = List.map (fun (_, id_bind_ml, _) -> id_bind_ml) bindings in
     let pats_ml = List.map (fun id_bind_ml -> Ml.VarP id_bind_ml) ids_bind_ml in
     let pat_ml = Ml.TupleP pats_ml in
     Chain.make_let pat_ml expr_bind_ml
@@ -374,8 +384,10 @@ and compile_iter_opt_binding ~(tparams : string list) (ctx : Ctx.t)
   (* Create stub expression for option element *)
   let ctx, id_stub_iter_ml = Stub.OCaml.var ctx "elem_opt__" in
   let expr_stub_iter_ml = Ml.VarE id_stub_iter_ml in
-  (* Create [Option.map (fun expr_stub_inner -> ...) expr] *)
-  let chain_map = Chain.make_option_map expr_stub_ml id_stub_iter_ml in
+  (* Create [Option.map (fun expr_stub_inner -> ...) expr.it] *)
+  let chain_map =
+    Chain.make_option_map (Ml.FieldE (expr_stub_ml, "it")) id_stub_iter_ml
+  in
   (* Create chains for option element *)
   let ctx, bindings, chain_elem =
     compile_binding ~tparams ctx expr_stub_iter_ml exp
@@ -400,23 +412,28 @@ and compile_iter_opt_binding ~(tparams : string list) (ctx : Ctx.t)
         let id_split_ml = "Option.split" ^ string_of_int arity in
         (ctx, Ml.AppE (Ml.VarE id_split_ml, [ expr_bind_ml ]))
   in
-  (* Create [let (..._ah, ..., ..._at, ...) = ... in ...] *)
-  let chain =
-    let ids_bind_ml =
-      List.map
-        (fun ((id, iters), _) -> Names.var_of_var (id, iters @ [ Il.Opt ]))
-        bindings
-    in
-    let pats_ml = List.map (fun id_bind_ml -> Ml.VarP id_bind_ml) ids_bind_ml in
-    let pat_ml = Ml.TupleP pats_ml in
-    Chain.make_let pat_ml expr_split_ml
+  (* Bind the raw split columns, then re-wrap each to its lifted option type *)
+  let ctx, ids_raw_ml = Stub.OCaml.vars ctx "opt_col__" (List.length bindings) in
+  let chain_split =
+    let pats_ml = List.map (fun id_raw_ml -> Ml.VarP id_raw_ml) ids_raw_ml in
+    Chain.make_let (Ml.TupleP pats_ml) expr_split_ml
   in
+  let chains_wrap =
+    List.map2
+      (fun ((id, iters), _, typ) id_raw_ml ->
+        let id_lift_ml = Names.var_of_var (id, iters @ [ Il.Opt ]) in
+        let typ_opt = Il.IterT (typ, Il.Opt) $ typ.at in
+        Chain.make_let (Ml.VarP id_lift_ml)
+          (Wrap.compile_mk_wrap ~tparams ctx typ_opt (Ml.VarE id_raw_ml)))
+      bindings ids_raw_ml
+  in
+  let chain = Chain.connect (chain_split :: chains_wrap) in
   (* Lift bindings *)
   let bindings_lift =
     List.map
-      (fun ((id, iters), _) ->
+      (fun ((id, iters), _, typ) ->
         let id_ml = Names.var_of_var (id, iters @ [ Il.Opt ]) in
-        ((id, iters @ [ Il.Opt ]), id_ml))
+        ((id, iters @ [ Il.Opt ]), id_ml, Il.IterT (typ, Il.Opt) $ typ.at))
       bindings
   in
   (ctx, bindings_lift, chain)
@@ -442,8 +459,10 @@ and compile_iter_list_binding ~(tparams : string list) (ctx : Ctx.t)
   (* Create stub expression for list element *)
   let ctx, id_stub_iter_ml = Stub.OCaml.var ctx "elem_list__" in
   let expr_stub_iter_ml = Ml.VarE id_stub_iter_ml in
-  (* Create [List.map (fun expr_stub_inner -> ...) expr] *)
-  let chain_map = Chain.make_list_map expr_stub_ml id_stub_iter_ml in
+  (* Create [List.map (fun expr_stub_inner -> ...) expr.it] *)
+  let chain_map =
+    Chain.make_list_map (Ml.FieldE (expr_stub_ml, "it")) id_stub_iter_ml
+  in
   (* Create chains for list element *)
   let ctx, bindings, chain_elem =
     compile_binding ~tparams ctx expr_stub_iter_ml exp
@@ -468,23 +487,28 @@ and compile_iter_list_binding ~(tparams : string list) (ctx : Ctx.t)
         let id_split_ml = "List.split" ^ string_of_int arity in
         (ctx, Ml.AppE (Ml.VarE id_split_ml, [ expr_bind_ml ]))
   in
-  (* Create [let (..._a, ..., ..._z) = ... in ...] *)
-  let chain =
-    let ids_bind_ml =
-      List.map
-        (fun ((id, iters), _) -> Names.var_of_var (id, iters @ [ Il.List ]))
-        bindings
-    in
-    let pats_ml = List.map (fun id_bind_ml -> Ml.VarP id_bind_ml) ids_bind_ml in
-    let pat_ml = Ml.TupleP pats_ml in
-    Chain.make_let pat_ml expr_split_ml
+  (* Bind the raw split columns, then re-wrap each to its lifted list type *)
+  let ctx, ids_raw_ml = Stub.OCaml.vars ctx "list_col__" (List.length bindings) in
+  let chain_split =
+    let pats_ml = List.map (fun id_raw_ml -> Ml.VarP id_raw_ml) ids_raw_ml in
+    Chain.make_let (Ml.TupleP pats_ml) expr_split_ml
   in
+  let chains_wrap =
+    List.map2
+      (fun ((id, iters), _, typ) id_raw_ml ->
+        let id_lift_ml = Names.var_of_var (id, iters @ [ Il.List ]) in
+        let typ_list = Il.IterT (typ, Il.List) $ typ.at in
+        Chain.make_let (Ml.VarP id_lift_ml)
+          (Wrap.compile_mk_wrap ~tparams ctx typ_list (Ml.VarE id_raw_ml)))
+      bindings ids_raw_ml
+  in
+  let chain = Chain.connect (chain_split :: chains_wrap) in
   (* Lift bindings *)
   let bindings_lift =
     List.map
-      (fun ((id, iters), _) ->
+      (fun ((id, iters), _, typ) ->
         let id_ml = Names.var_of_var (id, iters @ [ Il.List ]) in
-        ((id, iters @ [ Il.List ]), id_ml))
+        ((id, iters @ [ Il.List ]), id_ml, Il.IterT (typ, Il.List) $ typ.at))
       bindings
   in
   (ctx, bindings_lift, chain)
@@ -497,7 +521,7 @@ and compile_iter_binding ~(tparams : string list) (ctx : Ctx.t) (typ_exp : typ)
   with
   | Some var ->
       let id_ml = Names.var_of_var var in
-      let binding = (var, id_ml) in
+      let binding = (var, id_ml, typ_exp) in
       let chain = Chain.make_let (Ml.VarP id_ml) expr_stub_ml in
       (ctx, [ binding ], chain)
   | None -> (
@@ -511,6 +535,7 @@ and compile_iter_binding ~(tparams : string list) (ctx : Ctx.t) (typ_exp : typ)
 let compile ~(tparams : string list) (ctx : Ctx.t) (expr_stub_ml : Ml.expr)
     (exp : exp) : Ctx.t * Chain.t =
   let ctx, bindings, chain = compile_binding ~tparams ctx expr_stub_ml exp in
-  let vars, ids_ml = List.split bindings in
+  let vars = List.map (fun (var, _, _) -> var) bindings in
+  let ids_ml = List.map (fun (_, id_ml, _) -> id_ml) bindings in
   let ctx = Ctx.add_bindings ctx vars ids_ml in
   (ctx, chain)

--- a/p4spec/lib/pass/compile/gen/common.ml
+++ b/p4spec/lib/pass/compile/gen/common.ml
@@ -46,7 +46,11 @@ let make_opt_fold (ctx : Ctx.t) (ids_in_ml : Ml.id list)
   let expr_lambda_ml = Ml.FunE (pats_elem_ml, expr_inner_ml) in
   let id_fold_ml = Printf.sprintf "Option.fold_%d_%d" n_in n_out in
   let exprs_arg_ml =
-    expr_lambda_ml :: List.map (fun id_in_ml -> Ml.VarE id_in_ml) ids_in_ml
+    (* iteration guides are wrapped composites; fold over their bare bodies *)
+    expr_lambda_ml
+    :: List.map
+         (fun id_in_ml -> Ml.FieldE (Ml.VarE id_in_ml, "it"))
+         ids_in_ml
   in
   let expr_ml = Ml.AppE (Ml.VarE id_fold_ml, exprs_arg_ml) in
   (ctx, expr_ml)
@@ -64,7 +68,11 @@ let make_opt_forall (ctx : Ctx.t) (ids_in_ml : Ml.id list)
   let expr_lambda_ml = Ml.FunE (pats_elem_ml, expr_body_ml) in
   let id_forall_ml = Printf.sprintf "Option.for_all_%d" n_in in
   let exprs_arg_ml =
-    expr_lambda_ml :: List.map (fun id_in_ml -> Ml.VarE id_in_ml) ids_in_ml
+    (* iteration guides are wrapped composites; fold over their bare bodies *)
+    expr_lambda_ml
+    :: List.map
+         (fun id_in_ml -> Ml.FieldE (Ml.VarE id_in_ml, "it"))
+         ids_in_ml
   in
   (ctx, Ml.AppE (Ml.VarE id_forall_ml, exprs_arg_ml))
 
@@ -81,7 +89,11 @@ let make_list_fold (ctx : Ctx.t) (ids_in_ml : Ml.id list)
   let expr_lambda_ml = Ml.FunE (pats_elem_ml, expr_inner_ml) in
   let id_fold_ml = Printf.sprintf "List.fold_left_%d_%d" n_in n_out in
   let exprs_arg_ml =
-    expr_lambda_ml :: List.map (fun id_in_ml -> Ml.VarE id_in_ml) ids_in_ml
+    (* iteration guides are wrapped composites; fold over their bare bodies *)
+    expr_lambda_ml
+    :: List.map
+         (fun id_in_ml -> Ml.FieldE (Ml.VarE id_in_ml, "it"))
+         ids_in_ml
   in
   let expr_ml = Ml.AppE (Ml.VarE id_fold_ml, exprs_arg_ml) in
   (ctx, expr_ml)
@@ -98,6 +110,10 @@ let make_list_forall (ctx : Ctx.t) (ids_in_ml : Ml.id list)
   let expr_lambda_ml = Ml.FunE (pats_elem_ml, expr_body_ml) in
   let id_forall_ml = Printf.sprintf "List.for_all_%d" n_in in
   let exprs_arg_ml =
-    expr_lambda_ml :: List.map (fun id_in_ml -> Ml.VarE id_in_ml) ids_in_ml
+    (* iteration guides are wrapped composites; fold over their bare bodies *)
+    expr_lambda_ml
+    :: List.map
+         (fun id_in_ml -> Ml.FieldE (Ml.VarE id_in_ml, "it"))
+         ids_in_ml
   in
   (ctx, Ml.AppE (Ml.VarE id_forall_ml, exprs_arg_ml))

--- a/p4spec/lib/pass/compile/gen/dispatch.ml
+++ b/p4spec/lib/pass/compile/gen/dispatch.ml
@@ -53,6 +53,14 @@ let compile_dispatcher (name : string)
       with Unmatch msg_ -> Run.Fail (no_region, ..)
          | NoConverter tyname__ -> Run.Fail (no_region, ..)] *)
 
+(* Project field [i] of the registry's 4-tuple [(marshal, unmarshal, hash, eq)] *)
+
+let proj_of_4 (i : int) (expr_ml : Ml.expr) : Ml.expr =
+  let pats_ml =
+    List.init 4 (fun j -> if j = i then Ml.VarP "z__" else Ml.WildP)
+  in
+  Ml.LetE (Ml.TupleP pats_ml, expr_ml, Ml.VarE "z__")
+
 let compile_converter_binding (tparams_ml : string list) :
     (string * Ml.expr) list =
   tparams_ml
@@ -69,31 +77,40 @@ let compile_converter_binding (tparams_ml : string list) :
                ] )
          in
          let binding_converter_ml = (id_entry_ml, expr_lookup_ml) in
-         (* [let marshal__x, unmarshal__x = ..] *)
-         let id_marshal_ml = Interface.Converter.name_marshal tparam_ml in
-         let expr_marshal_ml =
-           let typ_marshal_ml =
-             Ml.FuncT (Ml.VarT tparam_ml, Ml.NameT "Value.t")
-           in
-           Ml.AnnotE
-             ( Ml.AppE
-                 ( Ml.LitE "Obj.obj",
-                   [ Ml.AppE (Ml.LitE "fst", [ Ml.VarE id_entry_ml ]) ] ),
-               typ_marshal_ml )
+         let binding_of (id_ml : string) (proj : int) (typ_ml : Ml.typ) :
+             string * Ml.expr =
+           ( id_ml,
+             Ml.AnnotE
+               ( Ml.AppE
+                   (Ml.LitE "Obj.obj", [ proj_of_4 proj (Ml.VarE id_entry_ml) ]),
+                 typ_ml ) )
          in
-         let binding_marshal_ml = (id_marshal_ml, expr_marshal_ml) in
-         let id_unmarshal_ml = Interface.Converter.name_unmarshal tparam_ml in
-         let expr_unmarshal_ml =
-           let typ_unmarshal_ml =
-             Ml.FuncT (Ml.NameT "Value.t", Ml.VarT tparam_ml)
-           in
-           Ml.AnnotE
-             ( Ml.AppE
-                 ( Ml.LitE "Obj.obj",
-                   [ Ml.AppE (Ml.LitE "snd", [ Ml.VarE id_entry_ml ]) ] ),
-               typ_unmarshal_ml )
+         (* [marshal__x]/[unmarshal__x]/[hash__x]/[eq__x] off the 4-tuple *)
+         let binding_marshal_ml =
+           binding_of
+             (Interface.Converter.name_marshal tparam_ml)
+             0
+             (Ml.FuncT (Ml.VarT tparam_ml, Ml.NameT "Value.t"))
          in
-         let binding_unmarshal_ml = (id_unmarshal_ml, expr_unmarshal_ml) in
+         let binding_unmarshal_ml =
+           binding_of
+             (Interface.Converter.name_unmarshal tparam_ml)
+             1
+             (Ml.FuncT (Ml.NameT "Value.t", Ml.VarT tparam_ml))
+         in
+         let binding_hash_ml =
+           binding_of
+             (Interface.Converter.name_hash tparam_ml)
+             2
+             (Ml.FuncT (Ml.VarT tparam_ml, Ml.NameT "int"))
+         in
+         let binding_eq_ml =
+           binding_of
+             (Interface.Converter.name_eq tparam_ml)
+             3
+             (Ml.FuncT
+                (Ml.VarT tparam_ml, Ml.FuncT (Ml.VarT tparam_ml, Ml.BoolT)))
+         in
          (* [let typ__x = List.nth typs__ i] *)
          let id_typ_ml = Interface.Naming.name_typ tparam_ml in
          let expr_typ_ml =
@@ -106,6 +123,8 @@ let compile_converter_binding (tparams_ml : string list) :
            binding_converter_ml;
            binding_marshal_ml;
            binding_unmarshal_ml;
+           binding_hash_ml;
+           binding_eq_ml;
            binding_targs_ml;
          ])
   |> List.concat
@@ -123,6 +142,8 @@ let compile_func_arm_body (ctx : Ctx.t) (name : string) (tparams : string list)
           Ml.VarE (Interface.Converter.name_marshal tparam);
           Ml.VarE (Interface.Converter.name_unmarshal tparam);
           Ml.VarE (Interface.Naming.name_typ tparam);
+          Ml.VarE (Interface.Converter.name_hash tparam);
+          Ml.VarE (Interface.Converter.name_eq tparam);
         ])
       tparams_ml
   in

--- a/p4spec/lib/pass/compile/gen/interface/converter.ml
+++ b/p4spec/lib/pass/compile/gen/interface/converter.ml
@@ -29,14 +29,81 @@ open Util.Source
    (the "list" layer is handled the same way it would be for [List<int>];
    the "X" layer just plugs in the closure already in scope, [marshal__x]) *)
 
-(* A boundary-call converter *)
+(* A boundary-call converter: [marshal]/[unmarshal] cross the [Value.t] edge,
+   [hash]/[eq] give a value's structural hash/equality without leaving native
+   form (a wrapped node's [hash] is an O(1) slot read) *)
 
-type t = { marshal : Ml.expr; unmarshal : Ml.expr }
+type t = {
+  marshal : Ml.expr;
+  unmarshal : Ml.expr;
+  hash : Ml.expr;
+  eq : Ml.expr;
+}
 
 (* Naming *)
 
 let name_marshal (tvar : string) = "marshal__" ^ tvar
 let name_unmarshal (tvar : string) = "unmarshal__" ^ tvar
+let name_hash (tvar : string) = "hash__" ^ tvar
+let name_eq (tvar : string) = "eq__" ^ tvar
+
+(* A wrapped node's hash is its stored slot; its structural eq is the poly
+   [eq_<base>] applied to the element eqs *)
+
+(* [.Il.vhash] is qualified because this closure's [x__] is unannotated, so the
+   field cannot be disambiguated by type *)
+
+let expr_slot_hash : Ml.expr =
+  Ml.FunE
+    ([ Ml.VarP "x__" ], Ml.FieldE (Ml.FieldE (Ml.VarE "x__", "note"), "Il.vhash"))
+
+(* Wrap a raw composite body [expr_body_ml] into a note-carrying value, stamping
+   a fresh vid, the reified typ, and the incremental vhash [expr_hash_ml] (which
+   folds over [body__]) *)
+
+let wrap_note (tparams : string list) (typ : Sl.typ) (expr_body_ml : Ml.expr)
+    (expr_hash_ml : Ml.expr) : Ml.expr =
+  Ml.LetE
+    ( Ml.VarP "body__",
+      expr_body_ml,
+      Ml.BinopE
+        ( "$$",
+          Ml.VarE "body__",
+          Ml.TupleE
+            [
+              Ml.LitE "no_region";
+              Ml.RecordE
+                [
+                  ("Il.vid", Ml.AppE (Ml.LitE "Value.fresh", []));
+                  ( "typ",
+                    Ml.LetE
+                      ( Ml.VarP "typ__w",
+                        Dynamic_gen.make_typ_expr ~tparams typ,
+                        Ml.FieldE (Ml.VarE "typ__w", "it") ) );
+                  ("vhash", expr_hash_ml);
+                ];
+            ] ) )
+
+(* == / vid / vhash short-circuit, then the structural comparison [expr_cmp_ml]
+   over the two bodies [l__.it]/[r__.it] *)
+
+let eq_composite_ladder (expr_cmp_ml : Ml.expr) : Ml.expr =
+  let note_of id_ml field_ml =
+    Ml.FieldE (Ml.FieldE (Ml.VarE id_ml, "note"), field_ml)
+  in
+  Ml.FunE
+    ( [ Ml.VarP "l__"; Ml.VarP "r__" ],
+      Ml.BinopE
+        ( "||",
+          Ml.BinopE ("==", Ml.VarE "l__", Ml.VarE "r__"),
+          Ml.BinopE
+            ( "||",
+              Ml.BinopE ("=", note_of "l__" "Il.vid", note_of "r__" "Il.vid"),
+              Ml.BinopE
+                ( "&&",
+                  Ml.BinopE
+                    ("=", note_of "l__" "Il.vhash", note_of "r__" "Il.vhash"),
+                  expr_cmp_ml ) ) ) )
 
 (* Application *)
 
@@ -79,31 +146,38 @@ let rec resolve ?(visiting : string list = []) (ctx : Ctx.t)
   | Il.VarT (id, []) when List.mem id.it tparams -> resolve_var_typ_tparam id
   | Il.VarT (id, targs) when Type.is_generic tparams typ ->
       resolve_var_typ ~visiting ctx tparams typ id targs
-  | Il.TupleT typs when Type.is_generic tparams typ ->
-      resolve_tuple_typ ~visiting ctx tparams typ typs
-  | Il.IterT (t, Il.Opt) when Type.is_generic tparams t ->
-      resolve_opt_typ ~visiting ctx tparams typ t
-  | Il.IterT (t, Il.List) when Type.is_generic tparams t ->
-      resolve_list_typ ~visiting ctx tparams typ t
-  | _ when Type.is_generic tparams typ -> resolve_unsupported typ
+  | Il.VarT (id, targs) ->
+      resolve_var_typ_ground ~visiting ctx tparams typ id targs
+  (* composites resolve to closures over the element converters even when
+     ground, so a composite (e.g. [infer?]) never needs a mono function that
+     the marshal-driven [Collect] may not have produced *)
+  | Il.TupleT typs -> resolve_tuple_typ ~visiting ctx tparams typ typs
+  | Il.IterT (t, Il.Opt) -> resolve_opt_typ ~visiting ctx tparams typ t
+  | Il.IterT (t, Il.List) -> resolve_list_typ ~visiting ctx tparams typ t
   | _ -> resolve_ground typ
 
 (* Ground type *)
 
 and resolve_ground (typ : Sl.typ) : t =
   let name = Naming.name typ in
-  let expr_marshal_ml = Ml.VarE ("marshal_" ^ name) in
-  let expr_unmarshal_ml = Ml.VarE ("unmarshal_" ^ name) in
-  { marshal = expr_marshal_ml; unmarshal = expr_unmarshal_ml }
+  {
+    marshal = Ml.VarE ("marshal_" ^ name);
+    unmarshal = Ml.VarE ("unmarshal_" ^ name);
+    hash = Ml.VarE ("hash_" ^ name);
+    eq = Ml.VarE ("eq_" ^ name);
+  }
 
 (* Bare type parameter
 
    - the converter is just the caller-supplied dictionary entry *)
 
 and resolve_var_typ_tparam (id : Sl.id) : t =
-  let expr_marshal_ml = Ml.VarE (name_marshal (Names.tvar id)) in
-  let expr_unmarshal_ml = Ml.VarE (name_unmarshal (Names.tvar id)) in
-  { marshal = expr_marshal_ml; unmarshal = expr_unmarshal_ml }
+  {
+    marshal = Ml.VarE (name_marshal (Names.tvar id));
+    unmarshal = Ml.VarE (name_unmarshal (Names.tvar id));
+    hash = Ml.VarE (name_hash (Names.tvar id));
+    eq = Ml.VarE (name_eq (Names.tvar id));
+  }
 
 (* Variable type *)
 
@@ -118,43 +192,119 @@ and resolve_var_typ ~(visiting : string list) (ctx : Ctx.t)
          id.it)
   else resolve_typdef ~visiting:(id.it :: visiting) ctx tparams typ id targs
 
+(* Ground variable type: mono marshal/unmarshal, but hash is the poly base's
+   slot read and eq the poly base applied to the arg eqs, so a parametric
+   instantiation never needs a mono hash/eq that may not have been collected *)
+
+and resolve_var_typ_ground ~(visiting : string list) (ctx : Ctx.t)
+    (tparams : string list) (typ : Sl.typ) (id : Sl.id) (targs : Sl.targ list) :
+    t =
+  match Ctx.find_typdef ctx id with
+  | Typdef.Defined (tparams_def, deftyp) -> (
+      let theta = Domain.Lib.TIdMap.of_lists tparams_def targs in
+      match deftyp.it with
+      | Il.PlainT typ_alias ->
+          resolve ~visiting ctx tparams (Typ.Subst.subst_typ theta typ_alias)
+      | Il.StructT _ | Il.VariantT _ ->
+          let name = Naming.name typ in
+          {
+            marshal = Ml.VarE ("marshal_" ^ name);
+            unmarshal = Ml.VarE ("unmarshal_" ^ name);
+            hash = Ml.VarE ("hash_" ^ Names.var_of_id id);
+            eq = resolve_wrapped_eq ~visiting ctx tparams typ;
+          })
+  | _ -> resolve_ground typ
+
 (* Tuple type *)
 
 and resolve_tuple_typ ~(visiting : string list) (ctx : Ctx.t)
     (tparams : string list) (typ : Sl.typ) (typs : Sl.typ list) : t =
   let convs = List.map (resolve ~visiting ctx tparams) typs in
+  let n = List.length typs in
   let vars_m = List.mapi (fun i _ -> "x" ^ string_of_int i) typs in
   let marshal_calls_ml =
     List.map2
       (fun conv var -> apply_converter "resolved_" conv.marshal (Ml.VarE var))
       convs vars_m
   in
-  let n = List.length typs in
   let vars_u = List.init n (fun i -> "v" ^ string_of_int i) in
   let unmarshal_calls_ml =
     List.map2
       (fun conv var -> apply_converter "resolved_" conv.unmarshal (Ml.VarE var))
       convs vars_u
   in
+  (* the body is the native tuple; marshal reads it from [x__.it] *)
   let expr_marshal_ml =
     let pat_vars_ml = Ml.TupleP (List.map (fun var -> Ml.VarP var) vars_m) in
-    let expr_typ_ml = Dynamic_gen.make_typ_expr ~tparams typ in
     let expr_tuple_ml =
       Ml.AppE
-        (Ml.LitE "Value.Make.tuple", [ expr_typ_ml; Ml.ListE marshal_calls_ml ])
+        ( Ml.LitE "Value.Make.tuple",
+          [ Dynamic_gen.make_typ_expr ~tparams typ; Ml.ListE marshal_calls_ml ] )
     in
-    let expr_let_ml = Ml.LetE (pat_vars_ml, Ml.VarE "x__", expr_tuple_ml) in
-    Ml.FunE ([ Ml.VarP "x__" ], expr_let_ml)
+    Ml.FunE
+      ( [ Ml.VarP "x__" ],
+        Ml.LetE (pat_vars_ml, Ml.FieldE (Ml.VarE "x__", "it"), expr_tuple_ml) )
+  in
+  (* the tuple hash folds [conv.hash] over the freshly-built body components *)
+  let vars_h = List.mapi (fun i _ -> "h" ^ string_of_int i) typs in
+  let expr_hash_body_ml =
+    let exprs_hash_ml =
+      List.map2 (fun conv var -> Ml.AppE (conv.hash, [ Ml.VarE var ])) convs vars_h
+    in
+    let expr_combine_ml =
+      List.fold_left
+        (fun acc_ml expr_ml ->
+          Ml.BinopE ("+", Ml.BinopE ("*", acc_ml, Ml.LitE "31"), expr_ml))
+        (Ml.LitE (string_of_int n))
+        exprs_hash_ml
+    in
+    Ml.LetE
+      ( Ml.TupleP (List.map (fun var -> Ml.VarP var) vars_h),
+        Ml.VarE "body__",
+        expr_combine_ml )
   in
   let expr_unmarshal_ml =
     let expr_get_ml = Ml.AppE (Ml.LitE "Value.Get.tuple", [ Ml.VarE "v__" ]) in
     let pat_vars_ml = Ml.ListP (List.map (fun var -> Ml.VarP var) vars_u) in
     let arm_ok_ml = (pat_vars_ml, Ml.TupleE unmarshal_calls_ml) in
     let arm_wild_ml = (Ml.WildP, Common.raise_unmatch "resolve: tuple") in
-    let expr_match_ml = Ml.MatchE (expr_get_ml, [ arm_ok_ml; arm_wild_ml ]) in
-    Ml.FunE ([ Ml.VarP "v__" ], expr_match_ml)
+    let expr_body_ml = Ml.MatchE (expr_get_ml, [ arm_ok_ml; arm_wild_ml ]) in
+    Ml.FunE
+      ( [ Ml.VarP "v__" ],
+        wrap_note tparams typ expr_body_ml expr_hash_body_ml )
   in
-  { marshal = expr_marshal_ml; unmarshal = expr_unmarshal_ml }
+  let expr_eq_ml =
+    let vars_l = List.mapi (fun i _ -> "l" ^ string_of_int i) typs in
+    let vars_r = List.mapi (fun i _ -> "r" ^ string_of_int i) typs in
+    let pat_l_ml = Ml.TupleP (List.map (fun var -> Ml.VarP var) vars_l) in
+    let pat_r_ml = Ml.TupleP (List.map (fun var -> Ml.VarP var) vars_r) in
+    let exprs_eq_ml =
+      List.map2
+        (fun conv (var_l, var_r) ->
+          Ml.AppE (conv.eq, [ Ml.VarE var_l; Ml.VarE var_r ]))
+        convs
+        (List.combine vars_l vars_r)
+    in
+    let expr_and_ml =
+      match exprs_eq_ml with
+      | [] -> Ml.BoolE true
+      | expr_ml :: exprs_ml ->
+          List.fold_left
+            (fun acc_ml expr_ml -> Ml.BinopE ("&&", acc_ml, expr_ml))
+            expr_ml exprs_ml
+    in
+    eq_composite_ladder
+      (Ml.LetE
+         ( pat_l_ml,
+           Ml.FieldE (Ml.VarE "l__", "it"),
+           Ml.LetE (pat_r_ml, Ml.FieldE (Ml.VarE "r__", "it"), expr_and_ml) ))
+  in
+  {
+    marshal = expr_marshal_ml;
+    unmarshal = expr_unmarshal_ml;
+    hash = expr_slot_hash;
+    eq = expr_eq_ml;
+  }
 
 (* Option type *)
 
@@ -162,23 +312,45 @@ and resolve_opt_typ ~(visiting : string list) (ctx : Ctx.t)
     (tparams : string list) (typ : Sl.typ) (t : Sl.typ) : t =
   let conv = resolve ~visiting ctx tparams t in
   let expr_marshal_ml =
-    let expr_map_ml =
-      Ml.AppE (Ml.LitE "Option.map", [ conv.marshal; Ml.VarE "x__" ])
-    in
-    let expr_typ_ml = Dynamic_gen.make_typ_expr ~tparams typ in
-    let expr_opt_ml =
-      Ml.AppE (Ml.LitE "Value.Make.opt", [ expr_typ_ml; expr_map_ml ])
-    in
-    Ml.FunE ([ Ml.VarP "x__" ], expr_opt_ml)
+    Ml.FunE
+      ( [ Ml.VarP "x__" ],
+        Ml.AppE
+          ( Ml.LitE "Value.Make.opt",
+            [
+              Dynamic_gen.make_typ_expr ~tparams typ;
+              Ml.AppE
+                ( Ml.LitE "Option.map",
+                  [ conv.marshal; Ml.FieldE (Ml.VarE "x__", "it") ] );
+            ] ) )
   in
   let expr_unmarshal_ml =
-    let expr_get_ml = Ml.AppE (Ml.LitE "Value.Get.opt", [ Ml.VarE "v__" ]) in
-    let expr_map_ml =
-      Ml.AppE (Ml.LitE "Option.map", [ conv.unmarshal; expr_get_ml ])
-    in
-    Ml.FunE ([ Ml.VarP "v__" ], expr_map_ml)
+    Ml.FunE
+      ( [ Ml.VarP "v__" ],
+        wrap_note tparams typ
+          (Ml.AppE
+             ( Ml.LitE "Option.map",
+               [
+                 conv.unmarshal;
+                 Ml.AppE (Ml.LitE "Value.Get.opt", [ Ml.VarE "v__" ]);
+               ] ))
+          (Ml.AppE (Ml.LitE "hash_opt", [ conv.hash; Ml.VarE "body__" ])) )
   in
-  { marshal = expr_marshal_ml; unmarshal = expr_unmarshal_ml }
+  let expr_eq_ml =
+    eq_composite_ladder
+      (Ml.AppE
+         ( Ml.LitE "Option.equal",
+           [
+             conv.eq;
+             Ml.FieldE (Ml.VarE "l__", "it");
+             Ml.FieldE (Ml.VarE "r__", "it");
+           ] ))
+  in
+  {
+    marshal = expr_marshal_ml;
+    unmarshal = expr_unmarshal_ml;
+    hash = expr_slot_hash;
+    eq = expr_eq_ml;
+  }
 
 (* List type *)
 
@@ -186,23 +358,45 @@ and resolve_list_typ ~(visiting : string list) (ctx : Ctx.t)
     (tparams : string list) (typ : Sl.typ) (t : Sl.typ) : t =
   let conv = resolve ~visiting ctx tparams t in
   let expr_marshal_ml =
-    let expr_map_ml =
-      Ml.AppE (Ml.LitE "List.map", [ conv.marshal; Ml.VarE "x__" ])
-    in
-    let expr_typ_ml = Dynamic_gen.make_typ_expr ~tparams typ in
-    let expr_list_ml =
-      Ml.AppE (Ml.LitE "Value.Make.list", [ expr_typ_ml; expr_map_ml ])
-    in
-    Ml.FunE ([ Ml.VarP "x__" ], expr_list_ml)
+    Ml.FunE
+      ( [ Ml.VarP "x__" ],
+        Ml.AppE
+          ( Ml.LitE "Value.Make.list",
+            [
+              Dynamic_gen.make_typ_expr ~tparams typ;
+              Ml.AppE
+                ( Ml.LitE "List.map",
+                  [ conv.marshal; Ml.FieldE (Ml.VarE "x__", "it") ] );
+            ] ) )
   in
   let expr_unmarshal_ml =
-    let expr_get_ml = Ml.AppE (Ml.LitE "Value.Get.list", [ Ml.VarE "v__" ]) in
-    let expr_map_ml =
-      Ml.AppE (Ml.LitE "List.map", [ conv.unmarshal; expr_get_ml ])
-    in
-    Ml.FunE ([ Ml.VarP "v__" ], expr_map_ml)
+    Ml.FunE
+      ( [ Ml.VarP "v__" ],
+        wrap_note tparams typ
+          (Ml.AppE
+             ( Ml.LitE "List.map",
+               [
+                 conv.unmarshal;
+                 Ml.AppE (Ml.LitE "Value.Get.list", [ Ml.VarE "v__" ]);
+               ] ))
+          (Ml.AppE (Ml.LitE "hash_list", [ conv.hash; Ml.VarE "body__" ])) )
   in
-  { marshal = expr_marshal_ml; unmarshal = expr_unmarshal_ml }
+  let expr_eq_ml =
+    eq_composite_ladder
+      (Ml.AppE
+         ( Ml.LitE "List.equal",
+           [
+             conv.eq;
+             Ml.FieldE (Ml.VarE "l__", "it");
+             Ml.FieldE (Ml.VarE "r__", "it");
+           ] ))
+  in
+  {
+    marshal = expr_marshal_ml;
+    unmarshal = expr_unmarshal_ml;
+    hash = expr_slot_hash;
+    eq = expr_eq_ml;
+  }
 
 (* Error *)
 
@@ -248,6 +442,39 @@ and resolve_typdef ~(visiting : string list) (ctx : Ctx.t)
       failwith
         (Printf.sprintf "resolve: %s: not a plain/struct/variant typedef" id.it)
 
+(* Wrap a raw body through the poly [mk_<base>] with a typ/hash dictionary per
+   type argument, resolved in the ambient generic context *)
+
+and mk_wrap ~(visiting : string list) (ctx : Ctx.t) (tparams : string list)
+    (typ : Sl.typ) (expr_body_ml : Ml.expr) : Ml.expr =
+  match typ.it with
+  | Il.VarT (id, targs) ->
+      let exprs_dict_ml =
+        List.concat_map
+          (fun targ ->
+            [
+              Dynamic_gen.make_typ_expr ~tparams targ;
+              (resolve ~visiting ctx tparams targ).hash;
+            ])
+          targs
+      in
+      Ml.AppE (Ml.VarE ("mk_" ^ Names.var_of_id id), exprs_dict_ml @ [ expr_body_ml ])
+  | _ -> expr_body_ml
+
+(* A wrapped typedef's eq is the poly [eq_<base>] applied to its element eqs *)
+
+and resolve_wrapped_eq ~(visiting : string list) (ctx : Ctx.t)
+    (tparams : string list) (typ : Sl.typ) : Ml.expr =
+  match typ.it with
+  | Il.VarT (id, targs) -> (
+      let exprs_eq_targ_ml =
+        List.map (fun targ -> (resolve ~visiting ctx tparams targ).eq) targs
+      in
+      match exprs_eq_targ_ml with
+      | [] -> Ml.VarE ("eq_" ^ Names.var_of_id id)
+      | _ -> Ml.AppE (Ml.VarE ("eq_" ^ Names.var_of_id id), exprs_eq_targ_ml))
+  | _ -> Ml.LitE "(=)"
+
 and resolve_struct_typdef ~(visiting : string list) (ctx : Ctx.t)
     (tparams : string list) (typ : Sl.typ) (typfields : Sl.typfield list) : t =
   let field_convs =
@@ -262,7 +489,9 @@ and resolve_struct_typdef ~(visiting : string list) (ctx : Ctx.t)
         (fun (atom, conv) ->
           let atom_str = Names.Ctor.atom atom in
           let expr_atom_ml = compile_field_atom atom_str in
-          let expr_field_ml = Ml.FieldE (x_ann, Names.field atom) in
+          let expr_field_ml =
+            Ml.FieldE (Ml.FieldE (x_ann, "it"), Names.field atom)
+          in
           let expr_conv_ml =
             apply_converter "resolved_" conv.marshal expr_field_ml
           in
@@ -293,12 +522,17 @@ and resolve_struct_typdef ~(visiting : string list) (ctx : Ctx.t)
     let pat_fields_ml = Ml.VarP "fields__" in
     let expr_str_ml = Ml.AppE (Ml.LitE "Value.Get.str", [ Ml.VarE "v__" ]) in
     let expr_record_ml =
-      Ml.AnnotE (Ml.RecordE field_bindings_ml, Type.compile_typ ~tparams typ)
+      mk_wrap ~visiting ctx tparams typ (Ml.RecordE field_bindings_ml)
     in
     let expr_let_ml = Ml.LetE (pat_fields_ml, expr_str_ml, expr_record_ml) in
     Ml.FunE ([ Ml.VarP "v__" ], expr_let_ml)
   in
-  { marshal = expr_marshal_ml; unmarshal = expr_unmarshal_ml }
+  {
+    marshal = expr_marshal_ml;
+    unmarshal = expr_unmarshal_ml;
+    hash = expr_slot_hash;
+    eq = resolve_wrapped_eq ~visiting ctx tparams typ;
+  }
 
 and resolve_variant_typdef ~(visiting : string list) (ctx : Ctx.t)
     (tparams : string list) (typ : Sl.typ)
@@ -335,7 +569,7 @@ and resolve_variant_typdef ~(visiting : string list) (ctx : Ctx.t)
           (pat_ml, expr_case_ml))
         per_ctor
     in
-    let expr_match_ml = Ml.MatchE (Ml.VarE "x__", arms_ml) in
+    let expr_match_ml = Ml.MatchE (Ml.FieldE (Ml.VarE "x__", "it"), arms_ml) in
     Ml.FunE ([ Ml.VarP "x__" ], expr_match_ml)
   in
   let expr_unmarshal_ml =
@@ -367,9 +601,14 @@ and resolve_variant_typdef ~(visiting : string list) (ctx : Ctx.t)
     let arm_case_ml = (pat_case_ml, expr_match_ctor_ml) in
     let arm_wild_ml = (Ml.WildP, Common.raise_unmatch ("unmarshal_" ^ name)) in
     let expr_match_ml = Ml.MatchE (expr_it_ml, [ arm_case_ml; arm_wild_ml ]) in
-    Ml.FunE ([ Ml.VarP "v__" ], expr_match_ml)
+    Ml.FunE ([ Ml.VarP "v__" ], mk_wrap ~visiting ctx tparams typ expr_match_ml)
   in
-  { marshal = expr_marshal_ml; unmarshal = expr_unmarshal_ml }
+  {
+    marshal = expr_marshal_ml;
+    unmarshal = expr_unmarshal_ml;
+    hash = expr_slot_hash;
+    eq = resolve_wrapped_eq ~visiting ctx tparams typ;
+  }
 
 (* Table for finding converters *)
 
@@ -384,8 +623,18 @@ let compile_converter_table (typs : Sl.typ list) : Ml.toplevel =
         let expr_unmarshal_ml =
           Ml.AppE (Ml.LitE "Obj.repr", [ Ml.VarE ("unmarshal_" ^ name) ])
         in
+        let expr_hash_ml =
+          Ml.AppE (Ml.LitE "Obj.repr", [ Ml.VarE ("hash_" ^ name) ])
+        in
+        let expr_eq_ml =
+          Ml.AppE (Ml.LitE "Obj.repr", [ Ml.VarE ("eq_" ^ name) ])
+        in
         Ml.TupleE
-          [ Ml.StrE name; Ml.TupleE [ expr_marshal_ml; expr_unmarshal_ml ] ])
+          [
+            Ml.StrE name;
+            Ml.TupleE
+              [ expr_marshal_ml; expr_unmarshal_ml; expr_hash_ml; expr_eq_ml ];
+          ])
       typs
   in
   let expr_seq_ml = Ml.AppE (Ml.LitE "List.to_seq", [ Ml.ListE entries_ml ]) in

--- a/p4spec/lib/pass/compile/gen/interface/interface.ml
+++ b/p4spec/lib/pass/compile/gen/interface/interface.ml
@@ -5,6 +5,7 @@ module Dynamic_gen = Dynamic_gen
 module Constpool = Constpool
 module Marshal = Marshal
 module Unmarshal = Unmarshal
+module Note = Note
 module Converter = Converter
 module Typed = Typed
 module Trampoline = Trampoline
@@ -31,15 +32,28 @@ let compile (ctx : Ctx.t) (typs : Sl.typ list) (typs_groups : Sl.typ list list)
         match funcdefs with [] -> None | _ -> Some (Ml.LetRec funcdefs))
       unmarshal_groups
   in
+  (* one mutually-recursive block: a mono family resolves a [set] field to the
+     poly [eq_set], and a poly family resolves a ground field to a mono one *)
+  let funcdefs_note_ml =
+    List.concat_map (List.concat_map (Note.compile ctx)) typs_groups
+    @ Note.compile_poly_all ctx
+  in
+  let toplevel_notes_ml =
+    match funcdefs_note_ml with [] -> [] | _ -> [ Ml.LetRec funcdefs_note_ml ]
+  in
   let pool, funcdefs_typed = Typed.compile ctx pool typs in
   let funcdefs_marshal_dispatch = Typed.compile_marshal_dispatch typs in
+  (* [hash_typed] first: [make_case]'s element hash dictionaries call it *)
+  let funcdef_hash_dispatch = Typed.compile_hash_dispatch typs in
   let toplevel_typed_ml =
-    (funcdefs_typed @ funcdefs_marshal_dispatch)
+    (funcdef_hash_dispatch :: funcdefs_typed) @ funcdefs_marshal_dispatch
     |> List.map (fun funcdef_ml -> Ml.LetRec [ funcdef_ml ])
   in
   let toplevel_consts_ml =
     List.rev_map (fun (var, expr_ml) -> Ml.Let (var, expr_ml)) pool.consts
   in
   let toplevel_converter_table_ml = Converter.compile_converter_table typs in
-  toplevel_consts_ml @ toplevel_marshals_ml @ toplevel_unmarshals_ml
-  @ toplevel_typed_ml @ [ toplevel_converter_table_ml ]
+  (* notes first: [unmarshal]/[typed] construct via [mk_<t>], and marshal reads
+     only [.it], so nothing notes depend on comes earlier *)
+  toplevel_consts_ml @ toplevel_notes_ml @ toplevel_marshals_ml
+  @ toplevel_unmarshals_ml @ toplevel_typed_ml @ [ toplevel_converter_table_ml ]

--- a/p4spec/lib/pass/compile/gen/interface/marshal.ml
+++ b/p4spec/lib/pass/compile/gen/interface/marshal.ml
@@ -32,7 +32,7 @@ let compile_struct_typ (typ_ref : string) (typfields : Sl.typfield list) :
         let atom_str = Names.Ctor.atom atom in
         let field_id = Names.field atom in
         let expr_atom_ml = compile_field_atom atom_str in
-        let expr_field_ml = Ml.FieldE (Ml.VarE "x", field_id) in
+        let expr_field_ml = Ml.FieldE (Ml.FieldE (Ml.VarE "x", "it"), field_id) in
         let expr_marshal_ml =
           Ml.AppE (Ml.VarE ("marshal_" ^ Naming.name typ), [ expr_field_ml ])
         in
@@ -79,7 +79,8 @@ let compile_variant_typ (pool : Constpool.t) (typ_ref : string)
         (pool, (pat_ml, expr_case_ml)))
       pool ctors
   in
-  (pool, Ml.MatchE (Ml.VarE "x", arms_ml))
+  (* match the unwrapped variant body *)
+  (pool, Ml.MatchE (Ml.FieldE (Ml.VarE "x", "it"), arms_ml))
 
 let compile_var_typ (ctx : Ctx.t) (pool : Constpool.t) (typ_ref : string)
     (id : Sl.id) (targs : Sl.targ list) : Constpool.t * Ml.expr =
@@ -132,7 +133,7 @@ let compile_tuple_typ (typ_ref : string) (typs : Sl.typ list) : Ml.expr =
       ( Ml.LitE "Value.Make.tuple",
         [ Ml.VarE typ_ref; Ml.ListE marshal_calls_ml ] )
   in
-  Ml.LetE (pat_vars_ml, Ml.VarE "x", expr_tuple_ml)
+  Ml.LetE (pat_vars_ml, Ml.FieldE (Ml.VarE "x", "it"), expr_tuple_ml)
 
 (* Iterations *)
 
@@ -140,7 +141,10 @@ let compile_iter_opt_typ (typ_ref : string) (typ : Sl.typ) : Ml.expr =
   let expr_map_ml =
     Ml.AppE
       ( Ml.LitE "Option.map",
-        [ Ml.VarE ("marshal_" ^ Naming.name typ); Ml.VarE "x" ] )
+        [
+          Ml.VarE ("marshal_" ^ Naming.name typ);
+          Ml.FieldE (Ml.VarE "x", "it");
+        ] )
   in
   Ml.AppE (Ml.LitE "Value.Make.opt", [ Ml.VarE typ_ref; expr_map_ml ])
 
@@ -148,7 +152,10 @@ let compile_iter_list_typ (typ_ref : string) (typ : Sl.typ) : Ml.expr =
   let expr_map_ml =
     Ml.AppE
       ( Ml.LitE "List.map",
-        [ Ml.VarE ("marshal_" ^ Naming.name typ); Ml.VarE "x" ] )
+        [
+          Ml.VarE ("marshal_" ^ Naming.name typ);
+          Ml.FieldE (Ml.VarE "x", "it");
+        ] )
   in
   Ml.AppE (Ml.LitE "Value.Make.list", [ Ml.VarE typ_ref; expr_map_ml ])
 

--- a/p4spec/lib/pass/compile/gen/interface/note.ml
+++ b/p4spec/lib/pass/compile/gen/interface/note.ml
@@ -1,0 +1,420 @@
+open Lang
+module Typ = Runtime.Type
+module Typdef = Typ.Typdef
+open Util.Source
+
+(* Generates the note-wrapping companions of each type:
+     [hash_<name>]  reads a wrapped node's stored slot (structural otherwise)
+     [mk_<name>]    wraps a raw body, computing the incremental vhash once
+     [eq_<name>]    cheap note checks short-circuit before the deep compare
+   A ground instantiation gets a monomorphic family; a parametric definition
+   gets a polymorphic one taking a [typ]/[hash] dictionary per type parameter
+   for [mk] and an [eq] dictionary for [eq], so construction inside a generic
+   function has a [mk] to call. Children route through [Converter.resolve],
+   which plugs a mono function for a ground child and the caller's dictionary
+   for a bare type parameter *)
+
+(* e.note.<field> *)
+
+let note_field (expr_ml : Ml.expr) (field_ml : Ml.field) : Ml.expr =
+  Ml.FieldE (Ml.FieldE (expr_ml, "note"), field_ml)
+
+(* seed*31 + h0 ..*31 + hn *)
+
+let hash_combine (seed : int) (exprs_hash_ml : Ml.expr list) : Ml.expr =
+  List.fold_left
+    (fun expr_acc_ml expr_ml ->
+      Ml.BinopE ("+", Ml.BinopE ("*", expr_acc_ml, Ml.LitE "31"), expr_ml))
+    (Ml.LitE (string_of_int seed))
+    exprs_hash_ml
+
+let and_all (exprs_ml : Ml.expr list) : Ml.expr =
+  match exprs_ml with
+  | [] -> Ml.BoolE true
+  | expr_ml :: exprs_ml ->
+      List.fold_left
+        (fun expr_acc_ml expr_ml -> Ml.BinopE ("&&", expr_acc_ml, expr_ml))
+        expr_ml exprs_ml
+
+(* Child hash/eq: a mono function for a ground child, a dictionary for a bare
+   type parameter, an inline closure for a composite *)
+
+let hash_child (ctx : Ctx.t) (tparams : string list) (typ : Sl.typ)
+    (expr_ml : Ml.expr) : Ml.expr =
+  Ml.AppE ((Converter.resolve ctx tparams typ).hash, [ expr_ml ])
+
+let eq_child (ctx : Ctx.t) (tparams : string list) (typ : Sl.typ)
+    (expr_l_ml : Ml.expr) (expr_r_ml : Ml.expr) : Ml.expr =
+  Ml.AppE ((Converter.resolve ctx tparams typ).eq, [ expr_l_ml; expr_r_ml ])
+
+(* Body folds over the raw [x] body (mk) and comparisons over [l]/[r] (eq) *)
+
+let hash_struct_body (ctx : Ctx.t) (tparams : string list)
+    (typfields : Sl.typfield list) : Ml.expr =
+  hash_combine (List.length typfields)
+    (List.map
+       (fun (atom, typ) ->
+         hash_child ctx tparams typ (Ml.FieldE (Ml.VarE "x", Names.field atom)))
+       typfields)
+
+(* Seed the case hash by a type-independent ctor id ([Hashtbl.hash] of the ctor
+   name), never its positional index: an included/coerced value keeps its hash
+   across variant subtyping, so the vhash eq short-circuit stays sound *)
+
+let hash_variant_body (ctx : Ctx.t) (tparams : string list)
+    (ctors : (Domain.Mixop.t * Ml.ctor * Sl.typ list) list) : Ml.expr =
+  let arms_ml =
+    List.map
+      (fun (_, ctor_ml, payload_typs) ->
+        let ids_ml =
+          List.mapi (fun i _ -> "p_" ^ string_of_int i) payload_typs
+        in
+        let pat_ml =
+          Ml.VariantP
+            (`Poly (ctor_ml, List.map (fun id_ml -> Ml.VarP id_ml) ids_ml))
+        in
+        let exprs_hash_ml =
+          List.map2
+            (fun typ id_ml -> hash_child ctx tparams typ (Ml.VarE id_ml))
+            payload_typs ids_ml
+        in
+        (pat_ml, hash_combine (Hashtbl.hash ctor_ml) exprs_hash_ml))
+      ctors
+  in
+  Ml.MatchE (Ml.VarE "x", arms_ml)
+
+let eq_struct_body (ctx : Ctx.t) (tparams : string list)
+    (typfields : Sl.typfield list) : Ml.expr =
+  and_all
+    (List.map
+       (fun (atom, typ) ->
+         let field_ml = Names.field atom in
+         eq_child ctx tparams typ
+           (Ml.FieldE (Ml.VarE "l", field_ml))
+           (Ml.FieldE (Ml.VarE "r", field_ml)))
+       typfields)
+
+let eq_variant_body (ctx : Ctx.t) (tparams : string list)
+    (ctors : (Domain.Mixop.t * Ml.ctor * Sl.typ list) list) : Ml.expr =
+  let arms_ml =
+    List.map
+      (fun (_, ctor_ml, payload_typs) ->
+        let ids_l_ml =
+          List.mapi (fun i _ -> "l_" ^ string_of_int i) payload_typs
+        in
+        let ids_r_ml =
+          List.mapi (fun i _ -> "r_" ^ string_of_int i) payload_typs
+        in
+        let pat_ml =
+          Ml.TupleP
+            [
+              Ml.VariantP
+                (`Poly (ctor_ml, List.map (fun id_ml -> Ml.VarP id_ml) ids_l_ml));
+              Ml.VariantP
+                (`Poly (ctor_ml, List.map (fun id_ml -> Ml.VarP id_ml) ids_r_ml));
+            ]
+        in
+        let expr_cmp_ml =
+          and_all
+            (List.map2
+               (fun typ (id_l_ml, id_r_ml) ->
+                 eq_child ctx tparams typ (Ml.VarE id_l_ml) (Ml.VarE id_r_ml))
+               payload_typs
+               (List.combine ids_l_ml ids_r_ml))
+        in
+        (pat_ml, expr_cmp_ml))
+      ctors
+  in
+  Ml.MatchE
+    ( Ml.TupleE [ Ml.VarE "l"; Ml.VarE "r" ],
+      arms_ml @ [ (Ml.WildP, Ml.BoolE false) ] )
+
+(* Physical, vid, then vhash checks short-circuit before the deep [.it] compare *)
+
+let eq_short_circuit (expr_cmp_ml : Ml.expr) : Ml.expr =
+  Ml.BinopE
+    ( "||",
+      Ml.BinopE ("==", Ml.VarE "l", Ml.VarE "r"),
+      Ml.BinopE
+        ( "||",
+          Ml.BinopE
+            ("=", note_field (Ml.VarE "l") "vid", note_field (Ml.VarE "r") "vid"),
+          Ml.BinopE
+            ( "&&",
+              Ml.BinopE
+                ( "=",
+                  note_field (Ml.VarE "l") "vhash",
+                  note_field (Ml.VarE "r") "vhash" ),
+              Ml.LetE
+                ( Ml.VarP "l",
+                  Ml.FieldE (Ml.VarE "l", "it"),
+                  Ml.LetE
+                    (Ml.VarP "r", Ml.FieldE (Ml.VarE "r", "it"), expr_cmp_ml) )
+            ) ) )
+
+(* [('x, ..) name], or [name] with no args *)
+
+let typ_app_ml (name : Ml.id) (typs_arg_ml : Ml.typ list) : Ml.typ =
+  match typs_arg_ml with [] -> Ml.NameT name | _ -> Ml.AppT (name, typs_arg_ml)
+
+(* [mk]'s [typ__x : Typ.t] / [hash__x : 'x -> int] dictionary parameters *)
+
+let params_mk_dict (tparams_ml : Ml.tparam list) : Ml.param list =
+  List.concat_map
+    (fun tparam_ml ->
+      [
+        (Naming.name_typ tparam_ml, Some (Ml.NameT "Typ.t"));
+        ( Converter.name_hash tparam_ml,
+          Some (Ml.FuncT (Ml.VarT tparam_ml, Ml.NameT "int")) );
+      ])
+    tparams_ml
+
+(* [eq]'s [eq__x : 'x -> 'x -> bool] dictionary parameters *)
+
+let params_eq_dict (tparams_ml : Ml.tparam list) : Ml.param list =
+  List.map
+    (fun tparam_ml ->
+      ( Converter.name_eq tparam_ml,
+        Some (Ml.FuncT (Ml.VarT tparam_ml, Ml.FuncT (Ml.VarT tparam_ml, Ml.BoolT)))
+      ))
+    tparams_ml
+
+type wrapped_body =
+  | BodyStruct of Sl.typfield list
+  | BodyVariant of (Domain.Mixop.t * Ml.ctor * Sl.typ list) list
+  | BodyList of Sl.typ
+  | BodyOpt of Sl.typ
+  | BodyTuple of Sl.typ list
+
+(* mk fold / eq compare over a raw tuple body *)
+
+let hash_tuple_body (ctx : Ctx.t) (tparams : string list) (typs : Sl.typ list) :
+    Ml.expr =
+  let ids_ml = List.mapi (fun i _ -> "x" ^ string_of_int i) typs in
+  Ml.LetE
+    ( Ml.TupleP (List.map (fun id_ml -> Ml.VarP id_ml) ids_ml),
+      Ml.VarE "x",
+      hash_combine (List.length typs)
+        (List.map2
+           (fun typ id_ml -> hash_child ctx tparams typ (Ml.VarE id_ml))
+           typs ids_ml) )
+
+let eq_tuple_body (ctx : Ctx.t) (tparams : string list) (typs : Sl.typ list) :
+    Ml.expr =
+  let ids_l_ml = List.mapi (fun i _ -> "l" ^ string_of_int i) typs in
+  let ids_r_ml = List.mapi (fun i _ -> "r" ^ string_of_int i) typs in
+  Ml.LetE
+    ( Ml.TupleP (List.map (fun id_ml -> Ml.VarP id_ml) ids_l_ml),
+      Ml.VarE "l",
+      Ml.LetE
+        ( Ml.TupleP (List.map (fun id_ml -> Ml.VarP id_ml) ids_r_ml),
+          Ml.VarE "r",
+          and_all
+            (List.map2
+               (fun typ (id_l_ml, id_r_ml) ->
+                 eq_child ctx tparams typ (Ml.VarE id_l_ml) (Ml.VarE id_r_ml))
+               typs
+               (List.combine ids_l_ml ids_r_ml)) ) )
+
+(* [hash_<name>]/[eq_<name>]/[mk_<name>] for a wrapped (struct/variant) type *)
+
+let compile_wrapped_family (ctx : Ctx.t) ~(tparams : string list)
+    ~(tparams_ml : Ml.tparam list) ~(name : Ml.id) ~(typ_wrapped_ml : Ml.typ)
+    ~(typ_body_ml : Ml.typ) ~(typ_reify : Sl.typ) ~(body : wrapped_body) :
+    Ml.funcdef list =
+  let expr_hash_body_ml, expr_eq_body_ml =
+    match body with
+    | BodyStruct typfields ->
+        (hash_struct_body ctx tparams typfields, eq_struct_body ctx tparams typfields)
+    | BodyVariant ctors ->
+        (hash_variant_body ctx tparams ctors, eq_variant_body ctx tparams ctors)
+    | BodyList elem ->
+        let conv = Converter.resolve ctx tparams elem in
+        ( Ml.AppE (Ml.LitE "hash_list", [ conv.hash; Ml.VarE "x" ]),
+          Ml.AppE (Ml.LitE "List.equal", [ conv.eq; Ml.VarE "l"; Ml.VarE "r" ]) )
+    | BodyOpt elem ->
+        let conv = Converter.resolve ctx tparams elem in
+        ( Ml.AppE (Ml.LitE "hash_opt", [ conv.hash; Ml.VarE "x" ]),
+          Ml.AppE
+            (Ml.LitE "Option.equal", [ conv.eq; Ml.VarE "l"; Ml.VarE "r" ]) )
+    | BodyTuple typs ->
+        (hash_tuple_body ctx tparams typs, eq_tuple_body ctx tparams typs)
+  in
+  let funcdef_hash_ml =
+    ( "hash_" ^ name,
+      tparams_ml,
+      [ ("x", Some typ_wrapped_ml) ],
+      Some (Ml.NameT "int"),
+      note_field (Ml.VarE "x") "vhash" )
+  in
+  let funcdef_eq_ml =
+    ( "eq_" ^ name,
+      tparams_ml,
+      params_eq_dict tparams_ml
+      @ [ ("l", Some typ_wrapped_ml); ("r", Some typ_wrapped_ml) ],
+      Some Ml.BoolT,
+      eq_short_circuit expr_eq_body_ml )
+  in
+  let funcdef_mk_ml =
+    let expr_note_ml =
+      Ml.RecordE
+        [
+          ("Il.vid", Ml.AppE (Ml.LitE "Value.fresh", []));
+          ( "typ",
+            Ml.LetE
+              ( Ml.VarP "typ_",
+                Dynamic_gen.make_typ_expr ~tparams typ_reify,
+                Ml.FieldE (Ml.VarE "typ_", "it") ) );
+          ("vhash", expr_hash_body_ml);
+        ]
+    in
+    let expr_body_ml =
+      Ml.BinopE
+        ("$$", Ml.VarE "x", Ml.TupleE [ Ml.LitE "no_region"; expr_note_ml ])
+    in
+    ( "mk_" ^ name,
+      tparams_ml,
+      params_mk_dict tparams_ml @ [ ("x", Some typ_body_ml) ],
+      Some typ_wrapped_ml,
+      expr_body_ml )
+  in
+  [ funcdef_hash_ml; funcdef_eq_ml; funcdef_mk_ml ]
+
+(* Structural (non-wrapped) types: only [hash_<name>]/[eq_<name>], no [mk] *)
+
+let compile_hash_eq (name : Ml.id) (typ_ml : Ml.typ) (expr_hash_ml : Ml.expr)
+    (expr_eq_ml : Ml.expr) : Ml.funcdef list =
+  [
+    ( "hash_" ^ name,
+      [],
+      [ ("x", Some typ_ml) ],
+      Some (Ml.NameT "int"),
+      expr_hash_ml );
+    ( "eq_" ^ name,
+      [],
+      [ ("l", Some typ_ml); ("r", Some typ_ml) ],
+      Some Ml.BoolT,
+      expr_eq_ml );
+  ]
+
+let compile_prim (name : Ml.id) (typ_ml : Ml.typ) : Ml.funcdef list =
+  compile_hash_eq name typ_ml
+    (Ml.AppE (Ml.LitE "Hashtbl.hash", [ Ml.VarE "x" ]))
+    (Ml.BinopE ("=", Ml.VarE "l", Ml.VarE "r"))
+
+let compile_delegate (ctx : Ctx.t) (name : Ml.id) (typ_ml : Ml.typ)
+    (typ_under : Sl.typ) : Ml.funcdef list =
+  let conv = Converter.resolve ctx [] typ_under in
+  compile_hash_eq name typ_ml
+    (Ml.AppE (conv.hash, [ Ml.VarE "x" ]))
+    (Ml.AppE (conv.eq, [ Ml.VarE "l"; Ml.VarE "r" ]))
+
+let _compile_iter_unused (ctx : Ctx.t) (name : Ml.id) (typ_ml : Ml.typ)
+    (typ_inner : Sl.typ) (iter : Sl.iter) : Ml.funcdef list =
+  let conv = Converter.resolve ctx [] typ_inner in
+  let id_hash_ml, id_eq_ml =
+    match iter with
+    | Il.List -> ("hash_list", "List.equal")
+    | Il.Opt -> ("hash_opt", "Option.equal")
+  in
+  compile_hash_eq name typ_ml
+    (Ml.AppE (Ml.LitE id_hash_ml, [ conv.hash; Ml.VarE "x" ]))
+    (Ml.AppE (Ml.LitE id_eq_ml, [ conv.eq; Ml.VarE "l"; Ml.VarE "r" ]))
+
+let compile_func (name : Ml.id) (typ_ml : Ml.typ) : Ml.funcdef list =
+  compile_hash_eq name typ_ml (Ml.LitE "0")
+    (Ml.BinopE ("==", Ml.VarE "l", Ml.VarE "r"))
+
+(* Monomorphic family for a ground collected type *)
+
+let compile (ctx : Ctx.t) (typ : Sl.typ) : Ml.funcdef list =
+  let name = Naming.name typ in
+  let typ_ml = Type.compile_typ ~tparams:[] typ in
+  match typ.it with
+  | Il.BoolT | Il.NumT _ | Il.TextT -> compile_prim name typ_ml
+  | Il.TupleT typs ->
+      let typ_body_ml = Ml.TupleT (List.map (Type.compile_typ ~tparams:[]) typs) in
+      compile_wrapped_family ctx ~tparams:[] ~tparams_ml:[] ~name
+        ~typ_wrapped_ml:typ_ml ~typ_body_ml ~typ_reify:typ ~body:(BodyTuple typs)
+  | Il.IterT (typ_inner, Il.List) ->
+      let typ_body_ml =
+        Ml.AppT ("list", [ Type.compile_typ ~tparams:[] typ_inner ])
+      in
+      compile_wrapped_family ctx ~tparams:[] ~tparams_ml:[] ~name
+        ~typ_wrapped_ml:typ_ml ~typ_body_ml ~typ_reify:typ
+        ~body:(BodyList typ_inner)
+  | Il.IterT (typ_inner, Il.Opt) ->
+      let typ_body_ml =
+        Ml.AppT ("option", [ Type.compile_typ ~tparams:[] typ_inner ])
+      in
+      compile_wrapped_family ctx ~tparams:[] ~tparams_ml:[] ~name
+        ~typ_wrapped_ml:typ_ml ~typ_body_ml ~typ_reify:typ
+        ~body:(BodyOpt typ_inner)
+  | Il.FuncT _ -> compile_func name typ_ml
+  | Il.VarT (id, targs) -> (
+      match Ctx.find_typdef ctx id with
+      | Typdef.Defined (tparams_def, deftyp) -> (
+          let theta = Domain.Lib.TIdMap.of_lists tparams_def targs in
+          let typ_body_ml =
+            typ_app_ml (Names.body_of_id id)
+              (List.map (Type.compile_typ ~tparams:[]) targs)
+          in
+          match deftyp.it with
+          | Il.PlainT typ_alias ->
+              compile_delegate ctx name typ_ml (Typ.Subst.subst_typ theta typ_alias)
+          | Il.StructT typfields ->
+              let typfields =
+                List.map
+                  (fun (atom, typ) -> (atom, Typ.Subst.subst_typ theta typ))
+                  typfields
+              in
+              compile_wrapped_family ctx ~tparams:[] ~tparams_ml:[] ~name
+                ~typ_wrapped_ml:typ_ml ~typ_body_ml ~typ_reify:typ
+                ~body:(BodyStruct typfields)
+          | Il.VariantT _ ->
+              let ctors =
+                Ctx.find_ctors_full ctx id
+                |> List.map (fun (mixop, ctor_ml, typs) ->
+                       (mixop, ctor_ml, Typ.Subst.subst_typs theta typs))
+              in
+              compile_wrapped_family ctx ~tparams:[] ~tparams_ml:[] ~name
+                ~typ_wrapped_ml:typ_ml ~typ_body_ml ~typ_reify:typ
+                ~body:(BodyVariant ctors))
+      | Typdef.Extern -> compile_prim name typ_ml
+      | Typdef.Param | Typdef.Defining _ -> [])
+
+(* Polymorphic family for a parametric struct/variant definition *)
+
+let compile_poly (ctx : Ctx.t) (id : Sl.id) (tparams_def : Sl.tparam list)
+    (deftyp : Sl.deftyp) : Ml.funcdef list =
+  let tparams = List.map it tparams_def in
+  let tparams_ml = List.map Names.tvar tparams_def in
+  let name = Names.var_of_id id in
+  let typs_arg_ml = List.map (fun tparam_ml -> Ml.VarT tparam_ml) tparams_ml in
+  let typ_wrapped_ml = typ_app_ml name typs_arg_ml in
+  let typ_body_ml = typ_app_ml (Names.body_of_id id) typs_arg_ml in
+  let typ_reify =
+    Il.VarT (id, List.map (fun tparam -> Il.VarT (tparam, []) $ no_region) tparams_def)
+    $ no_region
+  in
+  match deftyp.it with
+  | Il.StructT typfields ->
+      compile_wrapped_family ctx ~tparams ~tparams_ml ~name ~typ_wrapped_ml
+        ~typ_body_ml ~typ_reify ~body:(BodyStruct typfields)
+  | Il.VariantT _ ->
+      let ctors = Ctx.find_ctors_full ctx id in
+      compile_wrapped_family ctx ~tparams ~tparams_ml ~name ~typ_wrapped_ml
+        ~typ_body_ml ~typ_reify ~body:(BodyVariant ctors)
+  | Il.PlainT _ -> []
+
+let compile_poly_all (ctx : Ctx.t) : Ml.funcdef list =
+  Ctx.fold_typdefs
+    (fun id typdef funcdefs_ml ->
+      match typdef with
+      | Typdef.Defined (tparams_def, deftyp) when tparams_def <> [] -> (
+          match deftyp.it with
+          | Il.StructT _ | Il.VariantT _ ->
+              funcdefs_ml @ compile_poly ctx id tparams_def deftyp
+          | _ -> funcdefs_ml)
+      | _ -> funcdefs_ml)
+    ctx []

--- a/p4spec/lib/pass/compile/gen/interface/typed.ml
+++ b/p4spec/lib/pass/compile/gen/interface/typed.ml
@@ -81,16 +81,47 @@ let parametric_scrut_typ (head : string) : Ml.typ =
   | "res" -> Ml.AppT ("res", [ Ml.NameT "Obj.t" ])
   | _ -> Ml.AppT ("set", [ Ml.NameT "Obj.t" ])
 
+(* An element's hash dictionary via the [hash_typed] runtime dispatch, sound for
+   a wrapped (slot read) or primitive element unlike a blind slot read *)
+
+let elem_hash_dict (expr_elem_typ_ml : Ml.expr) : Ml.expr =
+  Ml.FunE
+    ( [ Ml.VarP "v__" ],
+      Ml.AppE (Ml.LitE "hash_typed", [ expr_elem_typ_ml; Ml.VarE "v__" ]) )
+
+(* [mk_<base>] and its per-element [typ] dictionaries for a parametric head;
+   [map] is [set] of pairs, so it wraps through [mk_set] over a pair element *)
+
+let parametric_mk (head : string) : string * Ml.expr list =
+  match head with
+  | "pair" ->
+      ("pair", [ Ml.LitE "(List.nth targs__ 0)"; Ml.LitE "(List.nth targs__ 1)" ])
+  | "res" -> ("res", [ Ml.LitE "(List.nth targs__ 0)" ])
+  | "map" ->
+      ("set", [ Ml.LitE "(Typ.Make.var (\"pair\" $ no_region) targs__)" ])
+  | _ -> ("set", [ Ml.LitE "(List.nth targs__ 0)" ])
+
 let make_parametric_arms (ctx : Ctx.t) : Ml.arm list =
   List.map
     (fun head ->
+      let base, exprs_elem_typ_ml = parametric_mk head in
+      let exprs_dict_ml =
+        List.concat_map
+          (fun expr_typ_ml -> [ expr_typ_ml; elem_hash_dict expr_typ_ml ])
+          exprs_elem_typ_ml
+      in
       let inner_arms =
         List.map
           (fun (mixop, ctor_ml, payload_typs) ->
             let canon = Mixop.string_of_mixop mixop in
             let args = List.mapi (fun i _ -> obj_obj_nth i) payload_typs in
+            let expr_wrapped_ml =
+              Ml.AppE
+                ( Ml.VarE ("mk_" ^ base),
+                  exprs_dict_ml @ [ Ml.VariantE (ctor_ml, args) ] )
+            in
             ( Ml.LitP (Printf.sprintf "%S" canon),
-              Ml.AppE (Ml.LitE "Obj.repr", [ Ml.VariantE (ctor_ml, args) ]) ))
+              Ml.AppE (Ml.LitE "Obj.repr", [ expr_wrapped_ml ]) ))
           (parametric_ctors ctx head)
       in
       let wild =
@@ -105,7 +136,10 @@ let make_parametric_arms (ctx : Ctx.t) : Ml.arm list =
               ] ) )
       in
       ( Ml.LitP (Printf.sprintf "%S" head),
-        Ml.MatchE (Ml.VarE "mixop", inner_arms @ [ wild ]) ))
+        Ml.LetE
+          ( Ml.VarP "targs__",
+            Ml.LitE "(match typ.it with Il.VarT (_, ts__) -> ts__ | _ -> [])",
+            Ml.MatchE (Ml.VarE "mixop", inner_arms @ [ wild ]) ) ))
     (parametric_heads_present ctx)
 
 let case_parametric_arms (ctx : Ctx.t) (pool : Constpool.t) :
@@ -135,9 +169,12 @@ let case_parametric_arms (ctx : Ctx.t) (pool : Constpool.t) :
           pool (parametric_ctors ctx head)
       in
       let scrut =
-        Ml.AnnotE
-          ( Ml.AppE (Ml.LitE "Obj.obj", [ Ml.VarE "x" ]),
-            parametric_scrut_typ head )
+        (* unwrap the note before matching the variant body *)
+        Ml.FieldE
+          ( Ml.AnnotE
+              ( Ml.AppE (Ml.LitE "Obj.obj", [ Ml.VarE "x" ]),
+                parametric_scrut_typ head ),
+            "it" )
       in
       (pool, (Ml.LitP (Printf.sprintf "%S" head), Ml.MatchE (scrut, inner_arms))))
     pool
@@ -161,7 +198,12 @@ let compile_make_case (ctx : Ctx.t) (variants : (Sl.id * Sl.typ) list) :
               in
               ( Ml.LitP (Printf.sprintf "%S" canon),
                 Ml.AppE
-                  (Ml.LitE "Obj.repr", [ Ml.VariantE (ctor_ml, arg_exprs) ]) ))
+                  ( Ml.LitE "Obj.repr",
+                    [
+                      Ml.AppE
+                        ( Ml.VarE ("mk_" ^ Names.var_of_id id),
+                          [ Ml.VariantE (ctor_ml, arg_exprs) ] );
+                    ] ) ))
             ctors
         in
         let inner_wild =
@@ -185,7 +227,7 @@ let compile_make_case (ctx : Ctx.t) (variants : (Sl.id * Sl.typ) list) :
         ( Ml.LitE "failwith",
           [
             Ml.BinopE
-              ("^", Ml.StrE "make_case_typed: unknown typ ", Ml.VarE "typ");
+              ("^", Ml.StrE "make_case_typed: unknown typ ", Ml.VarE "typname__");
           ] ) )
   in
   ( "make_case_typed",
@@ -196,15 +238,16 @@ let compile_make_case (ctx : Ctx.t) (variants : (Sl.id * Sl.typ) list) :
       ("typ", Some (Ml.NameT "Il.typ"));
     ],
     Some (Ml.NameT "Obj.t"),
+    (* keep [typ] (the Il.typ) unshadowed so parametric arms read its targs *)
     Ml.LetE
-      ( Ml.VarP "typ",
+      ( Ml.VarP "typname__",
         typename_of_expr,
         Ml.LetE
           ( Ml.VarP "mixop",
             Ml.AppE (Ml.LitE "Mixop.string_of_mixop", [ Ml.VarE "mixop" ]),
             Ml.MatchE
-              (Ml.VarE "typ", outer_arms @ make_parametric_arms ctx @ [ outer_wild ])
-          ) ) )
+              ( Ml.VarE "typname__",
+                outer_arms @ make_parametric_arms ctx @ [ outer_wild ] ) ) ) )
 
 let compile_case_of (ctx : Ctx.t) (pool : Constpool.t)
     (variants : (Sl.id * Sl.typ) list) : Constpool.t * Ml.funcdef =
@@ -236,9 +279,12 @@ let compile_case_of (ctx : Ctx.t) (pool : Constpool.t)
             pool ctors
         in
         let scrut =
-          Ml.AnnotE
-            ( Ml.AppE (Ml.LitE "Obj.obj", [ Ml.VarE "x" ]),
-              Type.compile_typ ~tparams:[] typ )
+          (* unwrap the note before matching the variant body *)
+          Ml.FieldE
+            ( Ml.AnnotE
+                ( Ml.AppE (Ml.LitE "Obj.obj", [ Ml.VarE "x" ]),
+                  Type.compile_typ ~tparams:[] typ ),
+              "it" )
         in
         (pool, (Ml.LitP (Printf.sprintf "%S" id.it), Ml.MatchE (scrut, inner_arms))))
       pool variants
@@ -330,3 +376,50 @@ let compile_marshal_dispatch (typs : Sl.typ list) : Ml.funcdef list =
       Some (Ml.NameT "Obj.t"),
       Ml.MatchE (scrut, unmarshal_arms @ [ wild "unmarshal_typed" ]) );
   ]
+
+(* [hash_typed]: runtime [Typ.t]-dispatched hash, for the boundary [make_case]'s
+   element hash dictionaries. A named type routes to its [hash_<name>] (a slot
+   read for a wrapped type); a primitive hashes directly. *)
+let compile_hash_dispatch (typs : Sl.typ list) : Ml.funcdef =
+  let keys =
+    List.filter_map
+      (fun (t : Sl.typ) ->
+        match t.it with
+        | Il.VarT (id, _) -> Some (id.it, Naming.name t)
+        | _ -> None)
+      typs
+    |> List.sort_uniq compare
+  in
+  let scrut = Ml.FieldE (Ml.VarE "typ", "it") in
+  let arms_var =
+    List.map
+      (fun (key, iname) ->
+        ( Ml.LitP (Printf.sprintf "Il.VarT ({ it = %S; _ }, _)" key),
+          Ml.AppE
+            (Ml.VarE ("hash_" ^ iname), [ Ml.AppE (Ml.LitE "Obj.obj", [ Ml.VarE "x" ]) ]) ))
+      keys
+  in
+  let arm_prim = Ml.AppE (Ml.LitE "Hashtbl.hash", [ Ml.VarE "x" ]) in
+  let arms_prim =
+    [
+      (Ml.LitP "Il.BoolT", arm_prim);
+      (Ml.LitP "Il.NumT _", arm_prim);
+      (Ml.LitP "Il.TextT", arm_prim);
+    ]
+  in
+  let wild =
+    ( Ml.WildP,
+      Ml.AppE
+        ( Ml.LitE "failwith",
+          [
+            Ml.BinopE
+              ( "^",
+                Ml.StrE "hash_typed: unknown type ",
+                Ml.AppE (Ml.LitE "Typ.to_string", [ Ml.VarE "typ" ]) );
+          ] ) )
+  in
+  ( "hash_typed",
+    [],
+    [ ("typ", Some (Ml.NameT "Typ.t")); ("x", Some (Ml.NameT "Obj.t")) ],
+    Some (Ml.NameT "int"),
+    Ml.MatchE (scrut, arms_var @ arms_prim @ [ wild ]) )

--- a/p4spec/lib/pass/compile/gen/interface/unmarshal.ml
+++ b/p4spec/lib/pass/compile/gen/interface/unmarshal.ml
@@ -110,7 +110,8 @@ let compile_var_typ (ctx : Ctx.t) (id : Sl.id) (targs : Sl.targ list)
                 (atom, typ))
               typfields
           in
-          compile_struct_typ typfields
+          (* wrap the unmarshaled body through the smart constructor *)
+          Ml.AppE (Ml.VarE ("mk_" ^ name), [ compile_struct_typ typfields ])
       | Il.VariantT _ ->
           let ctors = Ctx.find_ctors_full ctx id in
           let ctors =
@@ -120,7 +121,7 @@ let compile_var_typ (ctx : Ctx.t) (id : Sl.id) (targs : Sl.targ list)
                 (mixop, ctor_ml, typs))
               ctors
           in
-          compile_variant_typ name ctors)
+          Ml.AppE (Ml.VarE ("mk_" ^ name), [ compile_variant_typ name ctors ]))
   | Typdef.Extern -> Ml.AppE (Ml.LitE "Value.Get.extern", [ Ml.VarE "v" ])
 
 (* Tuples *)
@@ -176,8 +177,11 @@ let compile_body_typ (ctx : Ctx.t) (typ : Sl.typ) : Ml.expr =
   | Il.NumT _ -> compile_num_typ
   | Il.TextT -> compile_text_typ
   | Il.VarT (id, targs) -> compile_var_typ ctx id targs name
-  | Il.TupleT typs -> compile_tuple_typ name typs
-  | Il.IterT (typ_inner, iter) -> compile_iter_typ typ_inner iter
+  (* composites are wrapped: build the raw body, then wrap via the smart ctor *)
+  | Il.TupleT typs ->
+      Ml.AppE (Ml.VarE ("mk_" ^ name), [ compile_tuple_typ name typs ])
+  | Il.IterT (typ_inner, iter) ->
+      Ml.AppE (Ml.VarE ("mk_" ^ name), [ compile_iter_typ typ_inner iter ])
   | Il.FuncT _ -> Common.raise_unmatch "unmarshal_func"
 
 let compile (ctx : Ctx.t) (typ : Sl.typ) : Ml.funcdef =

--- a/p4spec/lib/pass/compile/gen/names.ml
+++ b/p4spec/lib/pass/compile/gen/names.ml
@@ -65,6 +65,11 @@ let tvar (id : Id.t) = id.it |> sanitize |> String.lowercase_ascii
 
 let var_of_id (id : Id.t) = id.it |> sanitize
 
+(* Raw body type of a note-wrapped named type: [foo] wraps [foo'], mirroring
+   [value]/[value']; the prime cannot collide with any [var_of_id] output *)
+
+let body_of_id (id : Id.t) = var_of_id id ^ "'"
+
 let var_of_var (var_ : Var.t) =
   let id, iters = var_ in
   var_of_id

--- a/p4spec/lib/pass/compile/gen/type.ml
+++ b/p4spec/lib/pass/compile/gen/type.ml
@@ -56,23 +56,24 @@ and compile_var_typ ~(tparams : string list) (id : Sl.id) (targs : Sl.targ list)
       let targs_ml = compile_typs ~tparams targs in
       Ml.AppT (id_ml, targs_ml)
 
+(* [(body, vnote) note_phrase]: a composite carries a note like a named type *)
+
+and wrap_body_typ (typ_body_ml : Ml.typ) : Ml.typ =
+  Ml.AppT ("note_phrase", [ typ_body_ml; Ml.NameT "Il.vnote" ])
+
 (* Tuple types *)
 
 and compile_tuple_typ ~(tparams : string list) (typs : Sl.typ list) : Ml.typ =
-  let typs_ml = compile_typs ~tparams typs in
-  Ml.TupleT typs_ml
+  wrap_body_typ (Ml.TupleT (compile_typs ~tparams typs))
 
 (* Iter types *)
 
 and compile_iter_typ ~(tparams : string list) (typ : Sl.typ) (iter : Sl.iter) :
     Ml.typ =
+  let typ_ml = compile_typ ~tparams typ in
   match iter with
-  | Il.Opt ->
-      let typ_ml = compile_typ ~tparams typ in
-      Ml.AppT ("option", [ typ_ml ])
-  | Il.List ->
-      let typ_ml = compile_typ ~tparams typ in
-      Ml.AppT ("list", [ typ_ml ])
+  | Il.Opt -> wrap_body_typ (Ml.AppT ("option", [ typ_ml ]))
+  | Il.List -> wrap_body_typ (Ml.AppT ("list", [ typ_ml ]))
 
 (* Func types *)
 
@@ -176,31 +177,47 @@ and compile_variant_deftyp ~(tparams : string list) (ctx : Ctx.t) (id : Sl.id)
 
 (* Defs *)
 
-let compile_def (ctx : Ctx.t) (def : Sl.def) : Ctx.t * Ml.typdef option =
+(* Wrap a variant/record named type as [foo = (foo_body, vnote) note_phrase],
+   emitting the raw body type first; aliases and externs stay unwrapped *)
+
+let wrap_typdefs (tparams_ml : Ml.tparam list) (id : Sl.id)
+    (deftyp_ml : Ml.deftyp) : Ml.typdef list =
+  let id_ml = Names.var_of_id id in
+  match deftyp_ml with
+  | Ml.AliasTD _ -> [ (tparams_ml, id_ml, deftyp_ml) ]
+  | Ml.RecordTD _ | Ml.VariantTD _ ->
+      let body_id_ml = Names.body_of_id id in
+      let typ_body_ml =
+        match tparams_ml with
+        | [] -> Ml.NameT body_id_ml
+        | _ -> Ml.AppT (body_id_ml, List.map (fun t -> Ml.VarT t) tparams_ml)
+      in
+      let wrapper_ml =
+        Ml.AliasTD
+          (Ml.AppT ("note_phrase", [ typ_body_ml; Ml.NameT "Il.vnote" ]))
+      in
+      [ (tparams_ml, body_id_ml, deftyp_ml); (tparams_ml, id_ml, wrapper_ml) ]
+
+let compile_def (ctx : Ctx.t) (def : Sl.def) : Ctx.t * Ml.typdef list =
   match def.it with
   | Sl.TypD (id, tparams, deftyp, _) ->
       let tparams_ml = List.map Names.var_of_id tparams in
-      let id_ml = Names.var_of_id id in
       let ctx, deftyp_ml =
         let tparams = List.map it tparams in
         compile_deftyp ~tparams ctx id deftyp
       in
-      let typdef_ml_opt = Some (tparams_ml, id_ml, deftyp_ml) in
-      (ctx, typdef_ml_opt)
+      (ctx, wrap_typdefs tparams_ml id deftyp_ml)
   | Sl.ExternTypD (id, _) ->
       let id_ml = Names.var_of_id id in
       let deftyp_ml = Ml.AliasTD (Ml.NameT "Yojson.Safe.t") in
-      let typdef_ml_opt = Some ([], id_ml, deftyp_ml) in
-      (ctx, typdef_ml_opt)
-  | _ -> (ctx, None)
+      (ctx, [ ([], id_ml, deftyp_ml) ])
+  | _ -> (ctx, [])
 
 let compile_defs (ctx : Ctx.t) (defs : Sl.def list) : Ctx.t * Ml.typdef list =
   List.fold_left
     (fun (ctx, defs_ml) def ->
-      let ctx, def_ml_opt = compile_def ctx def in
-      match def_ml_opt with
-      | None -> (ctx, defs_ml)
-      | Some def_ml -> (ctx, defs_ml @ [ def_ml ]))
+      let ctx, typdefs_ml = compile_def ctx def in
+      (ctx, defs_ml @ typdefs_ml))
     (ctx, []) defs
 
 (* Spec *)

--- a/p4spec/lib/pass/compile/gen/wrap.ml
+++ b/p4spec/lib/pass/compile/gen/wrap.ml
@@ -1,0 +1,70 @@
+open Lang
+open Sl
+
+(* Note-wrapping shared by expression construction (gen/ast/exp.ml) and cons-tail
+   re-wrapping (gen/bind.ml); kept gen-level so [Bind] need not depend on [Ast] *)
+
+(* Hash of a generic composite's [body__], mirroring the converter's per-shape
+   fold: [hash_list]/[hash_opt] over the element hash, tuple folds seed*31+.. *)
+
+let compile_wrap_hash ~(tparams : string list) (ctx : Ctx.t) (typ : typ) :
+    Ml.expr =
+  match typ.it with
+  | Il.IterT (typ_elem, Il.List) ->
+      let conv = Interface.Converter.resolve ctx tparams typ_elem in
+      Ml.AppE (Ml.VarE "hash_list", [ conv.hash; Ml.VarE "body__" ])
+  | Il.IterT (typ_elem, Il.Opt) ->
+      let conv = Interface.Converter.resolve ctx tparams typ_elem in
+      Ml.AppE (Ml.VarE "hash_opt", [ conv.hash; Ml.VarE "body__" ])
+  | Il.TupleT typs ->
+      let convs = List.map (Interface.Converter.resolve ctx tparams) typs in
+      let vars_h = List.mapi (fun i _ -> "h" ^ string_of_int i) typs in
+      let exprs_hash_ml =
+        List.map2
+          (fun (conv : Interface.Converter.t) var ->
+            Ml.AppE (conv.hash, [ Ml.VarE var ]))
+          convs vars_h
+      in
+      let expr_combine_ml =
+        List.fold_left
+          (fun acc_ml expr_ml ->
+            Ml.BinopE ("+", Ml.BinopE ("*", acc_ml, Ml.LitE "31"), expr_ml))
+          (Ml.LitE (string_of_int (List.length typs)))
+          exprs_hash_ml
+      in
+      Ml.LetE
+        ( Ml.TupleP (List.map (fun var -> Ml.VarP var) vars_h),
+          Ml.VarE "body__",
+          expr_combine_ml )
+  | _ -> assert false
+
+(* Wrap a raw body through the target type's smart constructor: a parametric
+   named type calls the polymorphic [mk_<base>] with a [typ]/[hash] dictionary
+   per argument, a generic composite (no mono [mk]) wraps via [Converter.wrap_note]
+   with a folded hash, a ground type calls its monomorphic [mk_<name>] *)
+
+let compile_mk_wrap ~(tparams : string list) (ctx : Ctx.t) (typ_exp : typ)
+    (expr_body_ml : Ml.expr) : Ml.expr =
+  let typ_expand = Ctx.expand_typ ctx typ_exp in
+  match typ_expand.it with
+  | Il.VarT (id, (_ :: _ as targs)) ->
+      (* parametric: the polymorphic [mk_<base>] with a typ/hash dictionary per
+         argument, resolved to a mono function for a ground arg *)
+      let id_mk_ml = "mk_" ^ Names.var_of_id id in
+      let exprs_dict_ml =
+        List.concat_map
+          (fun targ ->
+            let expr_typ_ml = Interface.Dynamic_gen.make_typ_expr ~tparams targ in
+            let conv = Interface.Converter.resolve ctx tparams targ in
+            [ expr_typ_ml; conv.hash ])
+          targs
+      in
+      Ml.AppE (Ml.VarE id_mk_ml, exprs_dict_ml @ [ expr_body_ml ])
+  | Il.TupleT _ | Il.IterT _ ->
+      (* composites have no reliable mono [mk] (nested/generic ones are never
+         collected), so stamp a note directly via the element converters *)
+      let expr_hash_ml = compile_wrap_hash ~tparams ctx typ_expand in
+      Interface.Converter.wrap_note tparams typ_expand expr_body_ml expr_hash_ml
+  | _ ->
+      let id_mk_ml = "mk_" ^ Interface.Naming.name typ_expand in
+      Ml.AppE (Ml.VarE id_mk_ml, [ expr_body_ml ])

--- a/p4spec/lib/pass/compile/ml/print.ml
+++ b/p4spec/lib/pass/compile/ml/print.ml
@@ -122,8 +122,10 @@ let print_binop (op : binop) = op
 (* Expressions *)
 
 let is_compound_expr = function
+  (* [AppE (_, [])] renders [f ()], still an application, so it needs parens in
+     a function or field position *)
   | MatchE _ | IfE _ | TryE _ | LetE _ | FunE _ | SeqE _ | AnnotE _ | CoerceE _
-  | AppE (_, _ :: _) ->
+  | AppE _ ->
       true
   | _ -> false
 
@@ -201,7 +203,13 @@ let rec print_expr ~level expr =
              fields)
       ^ " }"
   | FieldE (expr_rec, field) ->
-      print_expr ~level expr_rec ^ "." ^ print_field field
+      (* a compound record position (application, match) needs parens or the
+         projection binds to its last sub-token *)
+      let str_rec =
+        if is_compound_expr expr_rec then "(" ^ print_expr ~level expr_rec ^ ")"
+        else print_expr ~level expr_rec
+      in
+      str_rec ^ "." ^ print_field field
   | AppE (expr_fn, []) -> print_expr ~level expr_fn ^ " ()"
   | AppE (expr_fn, exprs_arg) ->
       let print_arg expr =
@@ -212,8 +220,13 @@ let rec print_expr ~level expr =
           ^ "\n" ^ Util.Print.indent level ^ ")"
         else "(" ^ print_expr ~level expr ^ ")"
       in
-      print_expr ~level expr_fn ^ " "
-      ^ String.concat " " (List.map print_arg exprs_arg)
+      (* a compound function position (lambda, let, match) needs parens or the
+         arguments bind inside its body *)
+      let str_fn =
+        if is_compound_expr expr_fn then "(" ^ print_expr ~level expr_fn ^ ")"
+        else print_expr ~level expr_fn
+      in
+      str_fn ^ " " ^ String.concat " " (List.map print_arg exprs_arg)
   | IfE (expr_cond, expr_then, expr_else_opt) ->
       let str_else =
         match expr_else_opt with
@@ -230,7 +243,9 @@ let rec print_expr ~level expr =
         let body_str = print_expr ~level:(level + 2) expr in
         let body_wrapped =
           match expr with
-          | MatchE _ | TryE _ ->
+          (* [LetE] ending in a bare match would otherwise swallow the following
+             arms into that inner match *)
+          | MatchE _ | TryE _ | LetE _ ->
               "\n"
               ^ indent (level + 2)
               ^ "begin\n"

--- a/p4spec/lib/pass/compile/runtime/binding.ml
+++ b/p4spec/lib/pass/compile/runtime/binding.ml
@@ -1,3 +1,6 @@
+open Lang
 open Runtime.Dynamic_Sl
 
-type t = Var.t * Ml.id
+(* [typ] is the SpecTec type of the bound variable, needed to re-wrap composite
+   values whose OCaml representation carries a note *)
+type t = Var.t * Ml.id * Sl.typ

--- a/p4spec/lib/pass/compile/template/converter.ml
+++ b/p4spec/lib/pass/compile/template/converter.ml
@@ -64,7 +64,7 @@ let rec interface_name_ (typ : Typ.t) : string =
 
 exception NoConverter of string
 
-let find_converter_dynamic (typ : Typ.t) : Obj.t * Obj.t =
+let find_converter_dynamic (typ : Typ.t) : Obj.t * Obj.t * Obj.t * Obj.t =
   let name = interface_name_ typ in
   match Hashtbl.find_opt interface_registry_ name with
   | Some entry -> entry

--- a/p4spec/lib/pass/compile/template/prelude.ml
+++ b/p4spec/lib/pass/compile/template/prelude.ml
@@ -16,6 +16,10 @@ open Util.Source
 
 exception Unmatch of string
 
+(* Incremental-hash folds for structural children of note-wrapped values *)
+let hash_list f xs = List.fold_left (fun h x -> (h * 31) + f x) 1 xs
+let hash_opt f = function None -> 0 | Some x -> 31 + f x
+
 |}
 
 (* Option prelude *)

--- a/p4spec/lib/runtime/value/value.ml
+++ b/p4spec/lib/runtime/value/value.ml
@@ -18,6 +18,11 @@ type t = value [@@deriving yojson]
 
 let to_string t = string_of_value t
 
+(* Fresh vid, shared with compiled note-wrapped values so vids stay globally
+   unique across both representations *)
+
+let fresh () = Fresh_.fresh ()
+
 (* Comparison *)
 
 let rec compare (value_l : t) (value_r : t) =


### PR DESCRIPTION
## What

Every composite compiled OCaml type is now `(body, Il.vnote) note_phrase`, the same shape named types already use. Tuples, lists, options, and their nested/generic forms carry a note holding a fresh `vid`, the reified type, and an incremental `vhash`. This gives composites an O(1) structural hash (a slot read) and a `== / vid / vhash` short-circuit equality, closing the gap that forced the ML tower into deep structural comparison for tuples/lists/options.

## Codegen (`gen/ast/{exp,bind,instr}.ml`)

- Construction wraps through a shared smart constructor; destructuring reads `.it`.
- `Binding.t` now carries the SpecTec type, so iteration-list/option bindings, iteration expressions, and instruction iterated-lets/rules re-wrap the bare lists/options their `splitN`/`fold` produce:

```ocaml
type t = Var.t * Ml.id * Sl.typ
```

- `gen/wrap.ml` (new) holds `compile_mk_wrap` / `compile_wrap_hash`, shared by `exp` and `bind` without a `Bind -> Ast` module cycle. A composite with no monomorphic `mk` (nested or generic) wraps inline via `Converter.wrap_note` instead:

```ocaml
| Il.TupleT _ | Il.IterT _ ->
    Interface.Converter.wrap_note tparams typ_expand expr_body_ml
      (compile_wrap_hash ~tparams ctx typ_expand)
```

## Boundary (`backend-ocaml-{sl,p4,il}/val_native.ml`)

`Get` unwraps the note body (field 0); `Make` stamps a note. `child_hash` dispatches on representation — the `note_phrase` record is the only tag-0, size-3 block — so the boundary needs no spec type:

```ocaml
let child_hash (x : t) : int =
  if Obj.is_block x && Obj.tag x = 0 && Obj.size x = 3 then
    (Obj.obj x : (t, Il.vnote) note_phrase).note.vhash
  else Hashtbl.hash x
```

## Fixes surfaced by the ebpf packet sim

- `val_native.child_hash` no longer slot-reads a bare prim-alias (`bit<9>`, externs), which segfaulted on values that carry no note.
- `gen/interface/note.ml` seeds a variant case hash by `Hashtbl.hash ctor_ml` (the ctor name), not its positional index. With an index seed the same ctor (`` `DEFAULT ``) hashed differently in `simple_keyset_expression` vs `keyset_expression`, so the `vhash` eq short-circuit wrongly rejected two equal `` `DEFAULT `` values across a variant-inclusion coercion — which broke `default`/`_` select keysets (compared via `eq`). A type-independent seed keeps a value's `vhash` stable across variant subtyping, restoring soundness.

## Result

ebpf packet sim (ML/compiled mode): **2/17 → 15/17**. `Program_ok` and `Program_init` both pass in ML. The remaining two (`ebpf_checksum_extern`, `ebpf_conntrack_extern`) fail in `EBPF_filter` on the checksum/conntrack extern paths, unrelated to note-wrapping.

## Verify

```
make build && make gen-ocaml && make build-compiled
make gen-ocaml-il && make gen-ocaml-sl && make build-boot-comp
cd p4spec && opam exec -- dune build @sim-ebpf-p4c-ml --profile=release
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)