### PR TITLE
Reimplementation of #163: Bypassing the Value.t abstraction in builtin/extern calls from the compiled OCaml

### DIFF
--- a/p4spec/lib/backend-boot/build.ml
+++ b/p4spec/lib/backend-boot/build.ml
@@ -13,6 +13,25 @@ let interp_ml_of_interface (interface : Config.interface) : (module INTERP_ML) =
   | Config.IL_interface -> (module Backend_ocaml_il.Interp_ml : INTERP_ML)
   | Config.SL_interface -> (module Backend_ocaml_sl.Interp_ml : INTERP_ML)
 
+(* The [Spectec.Make_null]/[Make_parametric] value representation: under
+   [ML_mode] the compiled interface's own native [V], matching what compiled
+   code reads/writes at the [Run.EXTERN] boundary; [Valrep.V_value] (the
+   interpreted representation) otherwise. *)
+
+let valrep_of_mode_interface (mode : Run.mode) (interface : Config.interface) :
+    (module Runtime.Valrep.VAL) =
+  match mode with
+  | Run.ML_mode -> (
+      match interface with
+      | Config.P4_interface ->
+          (module Backend_ocaml_p4.Val_native.V_native : Runtime.Valrep.VAL)
+      | Config.IL_interface ->
+          (module Backend_ocaml_il.Val_native.V_native : Runtime.Valrep.VAL)
+      | Config.SL_interface ->
+          (module Backend_ocaml_sl.Val_native.V_native : Runtime.Valrep.VAL))
+  | Run.IL_mode | Run.SL_mode | Run.Empty_mode ->
+      (module Runtime.Valrep.V_value : Runtime.Valrep.VAL)
+
 (* A [spec] value for [paths_spec]/[level], given an execution mode. [ML_mode]
    needs no parse/elaborate — the compiled code is already linked in. *)
 
@@ -35,24 +54,22 @@ let build_target ?(cache = true) ?(det = false) ?(guard = false)
     match level.interface with
     | P4_interface -> (module P4.Make () : Run.RUNNER)
     | IL_interface ->
-        let module Interface_SpecTec =
-          Interface.SpecTec_IL.Make (Runtime.Valrep.V_value)
-        in
+        let (module V) = valrep_of_mode_interface mode IL_interface in
+        let module Interface_SpecTec = Interface.SpecTec_IL.Make (V) in
         let (module Interp_ml) = interp_ml_of_interface IL_interface in
         (module Runner.Make.Make_rec
                   (Interface_SpecTec)
-                  (Spectec.Make_null (Interface_SpecTec))
+                  (Spectec.Make_null (V) (Interface_SpecTec))
                   (Interp_il.Interp.Make)
                   (Interp_sl.Interp.Make)
                   (Interp_ml.Make) : Run.RUNNER)
     | SL_interface ->
-        let module Interface_SpecTec =
-          Interface.SpecTec_SL.Make (Runtime.Valrep.V_value)
-        in
+        let (module V) = valrep_of_mode_interface mode SL_interface in
+        let module Interface_SpecTec = Interface.SpecTec_SL.Make (V) in
         let (module Interp_ml) = interp_ml_of_interface SL_interface in
         (module Runner.Make.Make_rec
                   (Interface_SpecTec)
-                  (Spectec.Make_null (Interface_SpecTec))
+                  (Spectec.Make_null (V) (Interface_SpecTec))
                   (Interp_il.Interp.Make)
                   (Interp_sl.Interp.Make)
                   (Interp_ml.Make) : Run.RUNNER)
@@ -68,22 +85,23 @@ let build_target ?(cache = true) ?(det = false) ?(guard = false)
 let build_level ?(cache = true) ?(det = false) ?(guard = false)
     (module Runner_above : Run.RUNNER) (mode : Run.mode) (level : Config.level)
     =
+  let (module V) = valrep_of_mode_interface mode level.interface in
   let (module Interface_SpecTec) =
     match level.interface with
     | P4_interface ->
         error_no_region "P4 interface not supported outside of target level"
     | IL_interface ->
-        (module Interface.SpecTec_IL.Make (Runtime.Valrep.V_value)
-        : Spectec.INTERFACE_SPECTEC)
+        (module Interface.SpecTec_IL.Make (V) : Spectec.INTERFACE_SPECTEC
+          with type vt = V.t)
     | SL_interface ->
-        (module Interface.SpecTec_SL.Make (Runtime.Valrep.V_value)
-        : Spectec.INTERFACE_SPECTEC)
+        (module Interface.SpecTec_SL.Make (V) : Spectec.INTERFACE_SPECTEC
+          with type vt = V.t)
   in
   let (module Interp_ml) = interp_ml_of_interface level.interface in
   let (module Runner) =
     (module Runner.Make.Make_nonrec
               (Interface_SpecTec)
-              (Spectec.Make_parametric (Runner_above) (Interface_SpecTec))
+              (Spectec.Make_parametric (V) (Runner_above) (Interface_SpecTec))
               (Interp_il.Interp.Make)
               (Interp_sl.Interp.Make)
               (Interp_ml.Make) : Run.RUNNER)
@@ -127,22 +145,23 @@ let build_tower ?(cache = true) ?(det = false) ?(guard = false)
 
 let build_null ?(cache = true) ?(det = false) ?(guard = false) (mode : Run.mode)
     (interface : Config.interface) (paths_spec : string list) =
+  let (module V) = valrep_of_mode_interface mode interface in
   let (module Interface_SpecTec) =
     match interface with
     | P4_interface ->
         error_no_region "P4 interface not supported outside of target level"
     | IL_interface ->
-        (module Interface.SpecTec_IL.Make (Runtime.Valrep.V_value)
-        : Spectec.INTERFACE_SPECTEC)
+        (module Interface.SpecTec_IL.Make (V) : Spectec.INTERFACE_SPECTEC
+          with type vt = V.t)
     | SL_interface ->
-        (module Interface.SpecTec_SL.Make (Runtime.Valrep.V_value)
-        : Spectec.INTERFACE_SPECTEC)
+        (module Interface.SpecTec_SL.Make (V) : Spectec.INTERFACE_SPECTEC
+          with type vt = V.t)
   in
   let (module Interp_ml) = interp_ml_of_interface interface in
   let (module Runner) =
     (module Runner.Make.Make_rec
               (Interface_SpecTec)
-              (Spectec.Make_null (Interface_SpecTec))
+              (Spectec.Make_null (V) (Interface_SpecTec))
               (Interp_il.Interp.Make)
               (Interp_sl.Interp.Make)
               (Interp_ml.Make) : Run.RUNNER)

--- a/p4spec/lib/backend-boot/build.ml
+++ b/p4spec/lib/backend-boot/build.ml
@@ -35,7 +35,9 @@ let build_target ?(cache = true) ?(det = false) ?(guard = false)
     match level.interface with
     | P4_interface -> (module P4.Make () : Run.RUNNER)
     | IL_interface ->
-        let module Interface_SpecTec = Interface.SpecTec_IL in
+        let module Interface_SpecTec =
+          Interface.SpecTec_IL.Make (Runtime.Valrep.V_value)
+        in
         let (module Interp_ml) = interp_ml_of_interface IL_interface in
         (module Runner.Make.Make_rec
                   (Interface_SpecTec)
@@ -44,7 +46,9 @@ let build_target ?(cache = true) ?(det = false) ?(guard = false)
                   (Interp_sl.Interp.Make)
                   (Interp_ml.Make) : Run.RUNNER)
     | SL_interface ->
-        let module Interface_SpecTec = Interface.SpecTec_SL in
+        let module Interface_SpecTec =
+          Interface.SpecTec_SL.Make (Runtime.Valrep.V_value)
+        in
         let (module Interp_ml) = interp_ml_of_interface SL_interface in
         (module Runner.Make.Make_rec
                   (Interface_SpecTec)
@@ -68,8 +72,12 @@ let build_level ?(cache = true) ?(det = false) ?(guard = false)
     match level.interface with
     | P4_interface ->
         error_no_region "P4 interface not supported outside of target level"
-    | IL_interface -> (module Interface.SpecTec_IL : Spectec.INTERFACE_SPECTEC)
-    | SL_interface -> (module Interface.SpecTec_SL : Spectec.INTERFACE_SPECTEC)
+    | IL_interface ->
+        (module Interface.SpecTec_IL.Make (Runtime.Valrep.V_value)
+        : Spectec.INTERFACE_SPECTEC)
+    | SL_interface ->
+        (module Interface.SpecTec_SL.Make (Runtime.Valrep.V_value)
+        : Spectec.INTERFACE_SPECTEC)
   in
   let (module Interp_ml) = interp_ml_of_interface level.interface in
   let (module Runner) =
@@ -123,8 +131,12 @@ let build_null ?(cache = true) ?(det = false) ?(guard = false) (mode : Run.mode)
     match interface with
     | P4_interface ->
         error_no_region "P4 interface not supported outside of target level"
-    | IL_interface -> (module Interface.SpecTec_IL : Spectec.INTERFACE_SPECTEC)
-    | SL_interface -> (module Interface.SpecTec_SL : Spectec.INTERFACE_SPECTEC)
+    | IL_interface ->
+        (module Interface.SpecTec_IL.Make (Runtime.Valrep.V_value)
+        : Spectec.INTERFACE_SPECTEC)
+    | SL_interface ->
+        (module Interface.SpecTec_SL.Make (Runtime.Valrep.V_value)
+        : Spectec.INTERFACE_SPECTEC)
   in
   let (module Interp_ml) = interp_ml_of_interface interface in
   let (module Runner) =

--- a/p4spec/lib/backend-boot/build.ml
+++ b/p4spec/lib/backend-boot/build.ml
@@ -42,19 +42,19 @@ let spec_of_paths (mode : Run.mode) (paths_spec : string list) : Run.spec =
   | ML_mode -> ML
   | Empty_mode -> assert false
 
-let spec_of_level (mode : Run.mode) (level : Config.level) : Run.spec =
-  spec_of_paths mode [ level.layer.specdir ]
+let spec_of_level (level : Config.level) : Run.spec =
+  spec_of_paths level.mode [ level.layer.specdir ]
 
 (* Building a tower *)
 
 let build_target ?(cache = true) ?(det = false) ?(guard = false)
-    (mode : Run.mode) (level : Config.level) =
+    (level : Config.level) =
   (* Create the target runner *)
   let (module Runner_target) =
     match level.interface with
     | P4_interface -> (module P4.Make () : Run.RUNNER)
     | IL_interface ->
-        let (module V) = valrep_of_mode_interface mode IL_interface in
+        let (module V) = valrep_of_mode_interface level.mode IL_interface in
         let module Interface_SpecTec = Interface.SpecTec_IL.Make (V) in
         let (module Interp_ml) = interp_ml_of_interface IL_interface in
         (module Runner.Make.Make_rec
@@ -64,7 +64,7 @@ let build_target ?(cache = true) ?(det = false) ?(guard = false)
                   (Interp_sl.Interp.Make)
                   (Interp_ml.Make) : Run.RUNNER)
     | SL_interface ->
-        let (module V) = valrep_of_mode_interface mode SL_interface in
+        let (module V) = valrep_of_mode_interface level.mode SL_interface in
         let module Interface_SpecTec = Interface.SpecTec_SL.Make (V) in
         let (module Interp_ml) = interp_ml_of_interface SL_interface in
         (module Runner.Make.Make_rec
@@ -74,7 +74,7 @@ let build_target ?(cache = true) ?(det = false) ?(guard = false)
                   (Interp_sl.Interp.Make)
                   (Interp_ml.Make) : Run.RUNNER)
   in
-  Runner_target.init ~cache ~det ~guard (spec_of_level mode level);
+  Runner_target.init ~cache ~det ~guard (spec_of_level level);
   (module Runner_target : Run.RUNNER)
 
 (* Build a non-target level (intermediate or boot) above [Runner_above],
@@ -83,9 +83,8 @@ let build_target ?(cache = true) ?(det = false) ?(guard = false)
    spec (for [Inst.Hook.init_spec]), intermediate levels' callers discard it. *)
 
 let build_level ?(cache = true) ?(det = false) ?(guard = false)
-    (module Runner_above : Run.RUNNER) (mode : Run.mode) (level : Config.level)
-    =
-  let (module V) = valrep_of_mode_interface mode level.interface in
+    (module Runner_above : Run.RUNNER) (level : Config.level) =
+  let (module V) = valrep_of_mode_interface level.mode level.interface in
   let (module Interface_SpecTec) =
     match level.interface with
     | P4_interface ->
@@ -106,16 +105,14 @@ let build_level ?(cache = true) ?(det = false) ?(guard = false)
               (Interp_sl.Interp.Make)
               (Interp_ml.Make) : Run.RUNNER)
   in
-  let spec = spec_of_level mode level in
+  let spec = spec_of_level level in
   Runner.init ~cache ~det ~guard spec;
   (spec, (module Runner : Run.RUNNER))
 
 let build_tower ?(cache = true) ?(det = false) ?(guard = false)
     (tower : Config.tower) =
   (* Build the target runner *)
-  let runner_target =
-    build_target ~cache ~det ~guard tower.mode tower.level_target
-  in
+  let runner_target = build_target ~cache ~det ~guard tower.level_target in
   (* Reverse the levels, so that we build levels from the target to boot *)
   let levels = tower.level_boot :: tower.levels_interm |> List.rev in
   let spec_boot = ref None in
@@ -126,9 +123,7 @@ let build_tower ?(cache = true) ?(det = false) ?(guard = false)
     |> List.fold_left
          (fun ((module Runner_above : Run.RUNNER), runners) (last, level) ->
            let spec, (module Runner) =
-             build_level ~cache ~det ~guard
-               (module Runner_above)
-               tower.mode level
+             build_level ~cache ~det ~guard (module Runner_above) level
            in
            if last then (
              spec_boot := Some spec;

--- a/p4spec/lib/backend-boot/config.ml
+++ b/p4spec/lib/backend-boot/config.ml
@@ -9,12 +9,14 @@ type interface = P4_interface | IL_interface | SL_interface
 type layer = { specdir : string; rel : string }
 type target = { includes : string list; path : string }
 
-(* Tower is an alternation of a layer and an interface *)
+(* Tower is an alternation of a layer, an interface, and an execution mode.
+   Each level picks its own [mode] independently — e.g. the boot level can
+   run fully-compiled [ML_mode] while an intermediate or the target runs
+   interpreted, or vice versa. *)
 
-type level = { layer : layer; interface : interface }
+type level = { layer : layer; interface : interface; mode : Run.mode }
 
 type tower = {
-  mode : Run.mode;
   level_boot : level;
   levels_interm : level list;
   level_target : level;
@@ -23,24 +25,19 @@ type tower = {
 
 (* Load a tower from a JSON file.
    JSON schema:
-     { "mode": "il"|"sl"|"ml",
-       "levels": [ { "specdir": "...", "rel": "...", "interface": "p4"|"il"|"sl" }, ... ] }
+     { "levels":
+         [ { "specdir": "...", "rel": "...", "interface": "p4"|"il"|"sl",
+             "mode": "il"|"sl"|"ml" }, ... ] }
    First level = boot, last = target, middle = intermediates.
-   `target` is supplied separately (from CLI -p/-i flags).
-   "ml" is used by spectec-boot-comp's fully-compiled towers: [Build.build_tower]
-   applies [mode] uniformly to every level (target, intermediates, boot), not
-   just the boot level, so "ml" drives the whole tower through compiled code. *)
+   `target` is supplied separately (from CLI -p/-i flags). Each level's
+   "mode" is independent: "ml" only works for a level whose "interface" has
+   a compiled backend actually generated (spec-meta/il, spec-meta/sl, or
+   spec — see the gen-ocaml* Makefile targets); "il"/"sl" run that level's
+   interface interpreted regardless of what the levels above/below it do. *)
 
 let tower_of_file path target =
   let json = Yojson.Basic.from_file path in
   let open Yojson.Basic.Util in
-  let mode =
-    match json |> member "mode" |> to_string with
-    | "il" -> Run.IL_mode
-    | "sl" -> Run.SL_mode
-    | "ml" -> Run.ML_mode
-    | s -> failwith (Format.sprintf "tower: unknown mode %S" s)
-  in
   let level_of_json json =
     let interface =
       match json |> member "interface" |> to_string with
@@ -49,6 +46,13 @@ let tower_of_file path target =
       | "sl" -> SL_interface
       | s -> failwith (Format.sprintf "tower: unknown interface %S" s)
     in
+    let mode =
+      match json |> member "mode" |> to_string with
+      | "il" -> Run.IL_mode
+      | "sl" -> Run.SL_mode
+      | "ml" -> Run.ML_mode
+      | s -> failwith (Format.sprintf "tower: unknown mode %S" s)
+    in
     {
       layer =
         {
@@ -56,6 +60,7 @@ let tower_of_file path target =
           rel = json |> member "rel" |> to_string;
         };
       interface;
+      mode;
     }
   in
   let levels = json |> member "levels" |> to_list |> List.map level_of_json in
@@ -67,4 +72,4 @@ let tower_of_file path target =
         levels |> List.tl |> List.rev |> List.tl |> List.rev
       in
       let level_target = levels |> List.rev |> List.hd in
-      { mode; level_boot; levels_interm; level_target; target }
+      { level_boot; levels_interm; level_target; target }

--- a/p4spec/lib/backend-boot/spectec.ml
+++ b/p4spec/lib/backend-boot/spectec.ml
@@ -11,7 +11,11 @@ open Util.Source
 
 let typ_funccache = Typ.Make.var ("funccache" $ no_region) []
 let typ_relcache = Typ.Make.var ("relcache" $ no_region) []
-let typ_valres = Typ.Make.var ("res" $ no_region) []
+
+(* Declared aliases [valres = res<val>] / [valsres = res<val*>], keyed by their
+   alias name so [make_case_typed] resolves the OK ctor and payload shape. *)
+let typ_valres = Typ.Make.var ("valres" $ no_region) []
+let typ_valsres = Typ.Make.var ("valsres" $ no_region) []
 
 (* A wrapper for SpecTec interfaces, providing apis for caching boot/unboots *)
 
@@ -315,7 +319,7 @@ module Make_parametric
     in
     let vt_output = Interface_SpecTec.boot_values values_output in
     let value_values_output_res =
-      V.Make.("OK val*" <| [ vt_output ] <<| typ_valres) |> V.to_value
+      V.Make.("OK val*" <| [ vt_output ] <<| typ_valsres) |> V.to_value
     in
     Interface_SpecTec.pop_cache ();
     [ value_values_output_res ]

--- a/p4spec/lib/backend-boot/spectec.ml
+++ b/p4spec/lib/backend-boot/spectec.ml
@@ -5,6 +5,14 @@ module Run = Runtime.Dynamic_Runner.Signature
 open Error
 open Util.Source
 
+(* [Il.typ] witnesses for the cache-shell types, used with the generic
+   [V.Make.( <<| )] (which needs a real [Il.typ], unlike [Value.Make]'s own
+   [( <<| )] overload that takes the type name as a string). *)
+
+let typ_funccache = Typ.Make.var ("funccache" $ no_region) []
+let typ_relcache = Typ.Make.var ("relcache" $ no_region) []
+let typ_valres = Typ.Make.var ("res" $ no_region) []
+
 (* A wrapper for SpecTec interfaces, providing apis for caching boot/unboots *)
 
 module type INTERFACE_SPECTEC = sig
@@ -21,19 +29,38 @@ module type INTERFACE_SPECTEC = sig
   val cache_disable_reset : cache -> unit
   val cache_clear : cache -> unit
 
-  (* Boot / unboots *)
+  (* Boot / unboots. [vt] is the concrete representation ([V.t]) the module
+     implementing this interface was built over; [boot_*]/[unboot_*] operate on
+     it directly. A [Make_null]/[Make_parametric] built with some [V] must be
+     paired with an [Interface_SpecTec] whose [vt = V.t] (enforced at the
+     functor signature) — a mismatch is a type error, not a silent
+     representation-confusion bug at runtime. *)
 
-  val boot_value : Value.t -> Value.t
-  val boot_values : Value.t list -> Value.t
-  val unboot_id : Value.t -> string phrase
-  val unboot_typs : Value.t -> Typ.t list
-  val unboot_values : Value.t -> Value.t list
+  type vt
+
+  val boot_value : Value.t -> vt
+  val boot_values : Value.t list -> vt
+  val unboot_id : vt -> string phrase
+  val unboot_typs : vt -> Typ.t list
+  val unboot_values : vt -> Value.t list
+
+  (* [call_builtin], fixed at [Valrep.V_value] regardless of the module's own
+     [vt], for values already real [Value.t] (e.g. from [unboot_values]) that
+     [call_builtin] would recast to [vt] with no actual conversion *)
+
+  val call_builtin_value :
+    (Value.t -> unit) ->
+    Domain.Lib.Id.t ->
+    Typ.t list ->
+    Value.t list ->
+    Value.t
 end
 
 (* The null layer *)
 
 module Make_null
-    (Interface_SpecTec : INTERFACE_SPECTEC)
+    (V : Runtime.Valrep.VAL)
+    (Interface_SpecTec : INTERFACE_SPECTEC with type vt = V.t)
     (Interp_IL : Run.INTERP_IL)
     (Interp_SL : Run.INTERP_SL)
     (Interp_ML : Run.INTERP_ML) : Run.EXTERN = struct
@@ -65,15 +92,15 @@ module Make_null
       | _ ->
           error_no_region "unexpected number of arguments to call_builtin_func"
     in
-    let id = value_id |> Interface_SpecTec.unboot_id in
-    let typs = value_typs |> Interface_SpecTec.unboot_typs in
-    let values = value_values |> Interface_SpecTec.unboot_values in
+    let id = value_id |> V.of_value |> Interface_SpecTec.unboot_id in
+    let typs = value_typs |> V.of_value |> Interface_SpecTec.unboot_typs in
+    let values = value_values |> V.of_value |> Interface_SpecTec.unboot_values in
     let value_output = !call_func id.it typs values in
-    let value_value_output = Interface_SpecTec.boot_value value_output in
-    let value_value_output_res =
-      Value.Make.("OK val" <| [ value_value_output ] <<| "valres")
+    let vt_output = Interface_SpecTec.boot_value value_output in
+    let value_output_res =
+      V.Make.("OK val" <| [ vt_output ] <<| typ_valres) |> V.to_value
     in
-    [ value_value_output_res ]
+    [ value_output_res ]
 
   (* Cache management *)
 
@@ -83,7 +110,7 @@ module Make_null
       | [ value_id; value_values_input ] -> (value_id, value_values_input)
       | _ -> error_no_region "unexpected number of arguments to cache_find_func"
     in
-    Value.Make.("NONE" <| [] <<| "funccache")
+    V.Make.("NONE" <| [] <<| typ_funccache) |> V.to_value
 
   let cache_add_func_maybe (values_input : Value.t list) : Value.t =
     let _value_seff, _value_id, _value_values_input, _value_valres =
@@ -94,7 +121,7 @@ module Make_null
           error_no_region
             "unexpected number of arguments to cache_add_func_maybe"
     in
-    Value.Make.bool true
+    V.Make.bool true |> V.to_value
 
   let cache_find_rel (values_input : Value.t list) : Value.t =
     let _value_id, _value_values_input =
@@ -102,13 +129,14 @@ module Make_null
       | [ value_id; value_values_input ] -> (value_id, value_values_input)
       | _ -> error_no_region "unexpected number of arguments to cache_find_rel"
     in
-    Value.Make.("NONE" <| [] <<| "relcache")
+    V.Make.("NONE" <| [] <<| typ_relcache) |> V.to_value
 
   let cache_checkpoint (values_input : Value.t list) : Value.t =
     (match values_input with
     | [] -> ()
     | _ -> error_no_region "unexpected number of arguments to cache_checkpoint");
-    Value.Make.extern (Typ.Make.var ("cachepoint" $ no_region) []) (`Int 42)
+    V.Make.extern (Typ.Make.var ("cachepoint" $ no_region) []) (`Int 42)
+    |> V.to_value
 
   let cache_add_rel_maybe (values_input : Value.t list) : Value.t =
     let _value_seff, _value_id, _value_values_input, _value_valsres =
@@ -119,7 +147,7 @@ module Make_null
           error_no_region
             "unexpected number of arguments to cache_add_rel_maybe"
     in
-    Value.Make.bool true
+    V.Make.bool true |> V.to_value
 
   let cache_seff (values_input : Value.t list) : Value.t =
     let _value_cachepoint_before, _value_cachepoint_after =
@@ -128,7 +156,7 @@ module Make_null
           (value_cachepoint_before, value_cachepoint_after)
       | _ -> error_no_region "unexpected number of arguments to cache_seff"
     in
-    Value.Make.bool false
+    V.Make.bool false |> V.to_value
 
   (* Externs *)
 
@@ -179,8 +207,9 @@ end
 (* The intermediate layer *)
 
 module Make_parametric
+    (V : Runtime.Valrep.VAL)
     (Runner : Run.RUNNER)
-    (Interface_SpecTec : INTERFACE_SPECTEC)
+    (Interface_SpecTec : INTERFACE_SPECTEC with type vt = V.t)
     () : Run.EXTERN = struct
   (* Mode initialization *)
 
@@ -232,20 +261,20 @@ module Make_parametric
           error_no_region "unexpected number of arguments to call_builtin_func"
     in
     Interface_SpecTec.push_cache cache.interface;
-    let id = value_id |> Interface_SpecTec.unboot_id in
-    let typs = value_typs |> Interface_SpecTec.unboot_typs in
-    let values = value_values |> Interface_SpecTec.unboot_values in
+    let id = value_id |> V.of_value |> Interface_SpecTec.unboot_id in
+    let typs = value_typs |> V.of_value |> Interface_SpecTec.unboot_typs in
+    let values = value_values |> V.of_value |> Interface_SpecTec.unboot_values in
     let value_output =
       match Runner.Interp.eval_func id.it typs values with
       | Pass value_output -> value_output
       | Fail (at, msg) -> error at msg
     in
-    let value_value_output = Interface_SpecTec.boot_value value_output in
-    let value_value_output_res =
-      Value.Make.("OK val" <| [ value_value_output ] <<| "valres")
+    let vt_output = Interface_SpecTec.boot_value value_output in
+    let value_output_res =
+      V.Make.("OK val" <| [ vt_output ] <<| typ_valres) |> V.to_value
     in
     Interface_SpecTec.pop_cache ();
-    [ value_value_output_res ]
+    [ value_output_res ]
 
   let call_extern_func (values_input : Value.t list) : Value.t list =
     let value_id, value_typs, value_values =
@@ -255,20 +284,20 @@ module Make_parametric
       | _ -> error_no_region "unexpected number of arguments to call_extern_rel"
     in
     Interface_SpecTec.push_cache cache.interface;
-    let id = value_id |> Interface_SpecTec.unboot_id in
-    let typs = value_typs |> Interface_SpecTec.unboot_typs in
-    let values = value_values |> Interface_SpecTec.unboot_values in
+    let id = value_id |> V.of_value |> Interface_SpecTec.unboot_id in
+    let typs = value_typs |> V.of_value |> Interface_SpecTec.unboot_typs in
+    let values = value_values |> V.of_value |> Interface_SpecTec.unboot_values in
     let value_output =
       match Runner.Interp.eval_func id.it typs values with
       | Pass value_output -> value_output
       | Fail (at, msg) -> error at msg
     in
-    let value_value_output = Interface_SpecTec.boot_value value_output in
-    let value_value_output_res =
-      Value.Make.("OK val" <| [ value_value_output ] <<| "valsres")
+    let vt_output = Interface_SpecTec.boot_value value_output in
+    let value_output_res =
+      V.Make.("OK val" <| [ vt_output ] <<| typ_valres) |> V.to_value
     in
     Interface_SpecTec.pop_cache ();
-    [ value_value_output_res ]
+    [ value_output_res ]
 
   let call_extern_rel (values_input : Value.t list) : Value.t list =
     let value_id, value_values =
@@ -277,24 +306,43 @@ module Make_parametric
       | _ -> error_no_region "unexpected number of arguments to call_extern_rel"
     in
     Interface_SpecTec.push_cache cache.interface;
-    let id = value_id |> Interface_SpecTec.unboot_id in
-    let values = value_values |> Interface_SpecTec.unboot_values in
+    let id = value_id |> V.of_value |> Interface_SpecTec.unboot_id in
+    let values = value_values |> V.of_value |> Interface_SpecTec.unboot_values in
     let values_output =
       match Runner.Interp.eval_rel id.it values with
       | Pass values_output -> values_output
       | Fail (at, msg) -> error at msg
     in
-    let value_values_output = Interface_SpecTec.boot_values values_output in
+    let vt_output = Interface_SpecTec.boot_values values_output in
     let value_values_output_res =
-      Value.Make.("OK val*" <| [ value_values_output ] <<| "valsres")
+      V.Make.("OK val*" <| [ vt_output ] <<| typ_valres) |> V.to_value
     in
     Interface_SpecTec.pop_cache ();
     [ value_values_output_res ]
 
-  (* Meta-cache management *)
+  (* Meta-cache management.
+
+     Wrapper shells ([funccache]/[relcache]/[bool]/[extern cachepoint]) are
+     built through [V.Make]/[V.to_value] so [ML_mode] gets a genuinely
+     native-shaped result instead of an interpreted [Value.t] that compiled
+     code then misreads (see [Make_null] above).
+
+     The [value_valres]/[value_valsres] payload *extraction* below is a
+     different, still-open problem: [valres]/[valsres] are the parametric type
+     [res<X>] at [val]/[val*], and [V_native]'s generated [case_of_typed] has
+     no entry for parametric heads outside [set;pair;map]. Under [V_native] the
+     [V.Get.( |>>? )] below therefore raises; since this cache is a pure
+     optimization (a miss just recomputes, never a wrong answer), the failure
+     is caught and treated as "nothing to cache" rather than propagated. *)
+
+  let typ_valres_ext = Typ.Make.var ("valres" $ no_region) []
+  let typ_valsres_ext = Typ.Make.var ("valsres" $ no_region) []
+  let mixop_ok_val = Value.Mixops.of_string "OK val"
+  let mixop_ok_vals = Value.Mixops.of_string "OK val*"
 
   let cache_find_func (values_input : Value.t list) : Value.t =
-    if not cache.meta.enabled then Value.Make.("NONE" <| [] <<| "funccache")
+    if not cache.meta.enabled then
+      V.Make.("NONE" <| [] <<| typ_funccache) |> V.to_value
     else
       let value_id, value_values_input =
         match values_input with
@@ -302,17 +350,19 @@ module Make_parametric
         | _ ->
             error_no_region "unexpected number of arguments to cache_find_func"
       in
-      let id = value_id |> Interface_SpecTec.unboot_id in
+      let id = value_id |> V.of_value |> Interface_SpecTec.unboot_id in
       let cache_result =
         CCache.find cache.meta.func (id.it, [ value_values_input ])
       in
-      match cache_result with
+      (match cache_result with
       | Some value_value_output ->
-          Value.Make.("OK val" <| [ value_value_output ] <<| "funccache")
-      | None -> Value.Make.("NONE" <| [] <<| "funccache")
+          V.Make.(
+            "OK val" <| [ value_value_output |> V.of_value ] <<| typ_funccache)
+      | None -> V.Make.("NONE" <| [] <<| typ_funccache))
+      |> V.to_value
 
   let cache_add_func_maybe (values_input : Value.t list) : Value.t =
-    if not cache.meta.enabled then Value.Make.bool true
+    if not cache.meta.enabled then V.Make.bool true |> V.to_value
     else
       let value_seff, value_id, value_values_input, value_valres =
         match values_input with
@@ -322,19 +372,24 @@ module Make_parametric
             error_no_region
               "unexpected number of arguments to cache_add_func_maybe"
       in
-      let seff = value_seff |> Value.Get.bool in
+      let seff = value_seff |> V.of_value |> V.Get.bool in
       (if not seff then
-         match Value.Get.(value_valres |>>? "OK val") with
-         | Some [ value_value_output ] ->
-             let id = value_id |> Interface_SpecTec.unboot_id in
-             CCache.add cache.meta.func
-               (id.it, [ value_values_input ])
-               value_value_output
-         | _ -> ());
-      Value.Make.bool true
+         try
+           match
+             V.Get.((value_valres |> V.of_value) |>>? (mixop_ok_val, typ_valres_ext))
+           with
+           | Some [ value_value_output ] ->
+               let id = value_id |> V.of_value |> Interface_SpecTec.unboot_id in
+               CCache.add cache.meta.func
+                 (id.it, [ value_values_input ])
+                 (value_value_output |> V.to_value)
+           | _ -> ()
+         with Failure _ -> ());
+      V.Make.bool true |> V.to_value
 
   let cache_find_rel (values_input : Value.t list) : Value.t =
-    if not cache.meta.enabled then Value.Make.("NONE" <| [] <<| "relcache")
+    if not cache.meta.enabled then
+      V.Make.("NONE" <| [] <<| typ_relcache) |> V.to_value
     else
       let value_id, value_values_input =
         match values_input with
@@ -342,17 +397,19 @@ module Make_parametric
         | _ ->
             error_no_region "unexpected number of arguments to cache_find_rel"
       in
-      let id = value_id |> Interface_SpecTec.unboot_id in
+      let id = value_id |> V.of_value |> Interface_SpecTec.unboot_id in
       let cache_result =
         CCache.find cache.meta.rel (id.it, [ value_values_input ])
       in
-      match cache_result with
+      (match cache_result with
       | Some value_values_output ->
-          Value.Make.("OK val*" <| [ value_values_output ] <<| "relcache")
-      | None -> Value.Make.("NONE" <| [] <<| "relcache")
+          V.Make.(
+            "OK val*" <| [ value_values_output |> V.of_value ] <<| typ_relcache)
+      | None -> V.Make.("NONE" <| [] <<| typ_relcache))
+      |> V.to_value
 
   let cache_add_rel_maybe (values_input : Value.t list) : Value.t =
-    if not cache.meta.enabled then Value.Make.bool true
+    if not cache.meta.enabled then V.Make.bool true |> V.to_value
     else
       let value_seff, value_id, value_values_input, value_valsres =
         match values_input with
@@ -362,25 +419,29 @@ module Make_parametric
             error_no_region
               "unexpected number of arguments to cache_add_rel_maybe"
       in
-      let seff = value_seff |> Value.Get.bool in
+      let seff = value_seff |> V.of_value |> V.Get.bool in
       (if not seff then
-         match Value.Get.(value_valsres |>>? "OK val*") with
-         | Some [ value_values_output ] ->
-             let id = value_id |> Interface_SpecTec.unboot_id in
-             CCache.add cache.meta.rel
-               (id.it, [ value_values_input ])
-               value_values_output
-         | _ -> ());
-      Value.Make.bool true
+         try
+           match
+             V.Get.(
+               (value_valsres |> V.of_value) |>>? (mixop_ok_vals, typ_valsres_ext))
+           with
+           | Some [ value_values_output ] ->
+               let id = value_id |> V.of_value |> Interface_SpecTec.unboot_id in
+               CCache.add cache.meta.rel
+                 (id.it, [ value_values_input ])
+                 (value_values_output |> V.to_value)
+           | _ -> ()
+         with Failure _ -> ());
+      V.Make.bool true |> V.to_value
 
   let cache_checkpoint (values_input : Value.t list) : Value.t =
     (match values_input with
     | [] -> ()
     | _ -> error_no_region "unexpected number of arguments to cache_checkpoint");
     let checkpoint = Runner.Interface.checkpoint () in
-    Value.Make.extern
-      (Typ.Make.var ("cachepoint" $ no_region) [])
-      (`Int checkpoint)
+    V.Make.extern (Typ.Make.var ("cachepoint" $ no_region) []) (`Int checkpoint)
+    |> V.to_value
 
   let cache_seff (values_input : Value.t list) : Value.t =
     let value_cachepoint_before, value_cachepoint_after =
@@ -390,17 +451,17 @@ module Make_parametric
       | _ -> error_no_region "unexpected number of arguments to cache_seff"
     in
     let cachepoint_before =
-      value_cachepoint_before |> Value.Get.extern |> function
+      value_cachepoint_before |> V.of_value |> V.Get.extern |> function
       | `Int i -> i
       | _ -> error_no_region "unexpected type for cachepoint_before"
     in
     let cachepoint_after =
-      value_cachepoint_after |> Value.Get.extern |> function
+      value_cachepoint_after |> V.of_value |> V.Get.extern |> function
       | `Int i -> i
       | _ -> error_no_region "unexpected type for cachepoint_after"
     in
     let seff = Runner.Interface.seff cachepoint_before cachepoint_after in
-    Value.Make.bool seff
+    V.Make.bool seff |> V.to_value
 
   (* Extern handlers *)
 

--- a/p4spec/lib/backend-boot/spectec.ml
+++ b/p4spec/lib/backend-boot/spectec.ml
@@ -12,6 +12,11 @@ open Util.Source
 let typ_funccache = Typ.Make.var ("funccache" $ no_region) []
 let typ_relcache = Typ.Make.var ("relcache" $ no_region) []
 
+(* [val*] witness for marshaling the meta-cache keys/values: [V.marshal] on it
+   routes through [marshal_typed]'s structural [IterT] arm. *)
+let typ_val = Typ.Make.var ("val" $ no_region) []
+let typ_val_star = Typ.Make.list typ_val
+
 (* Declared aliases [valres = res<val>] / [valsres = res<val*>], keyed by their
    alias name so [make_case_typed] resolves the OK ctor and payload shape. *)
 let typ_valres = Typ.Make.var ("valres" $ no_region) []
@@ -215,10 +220,6 @@ module Make_parametric
     (Runner : Run.RUNNER)
     (Interface_SpecTec : INTERFACE_SPECTEC with type vt = V.t)
     () : Run.EXTERN = struct
-  (* Mode initialization *)
-
-  let init_mode _ = ()
-
   (* Caches
    * a meta-cache for storing results of meta-relation and meta-meta-function calls
    * an interface cache for storing results of booting and unbooting values, types, and mixops *)
@@ -253,6 +254,15 @@ module Make_parametric
       CCache.reset cache.meta.rel;
       Interface_SpecTec.cache_disable_reset cache.interface
   end
+
+  (* Mode initialization. Called once per level, right after that level's own
+     [-no-cache] state is set, so this runs last and wins. Under [ML_mode] the
+     meta-cache key/value marshal walks the full native argument tree into a
+     fresh [Value.t] to hash it on every call - costlier than recomputing. IL/SL
+     pay nothing for the marshal (identity under [V_value]), so they keep it. *)
+
+  let init_mode (mode : Run.mode) : unit =
+    match mode with Run.ML_mode -> Cache.cache_off () | _ -> ()
 
   (* Threading extern calls to the runner *)
 
@@ -331,13 +341,13 @@ module Make_parametric
      native-shaped result instead of an interpreted [Value.t] that compiled
      code then misreads (see [Make_null] above).
 
-     The [value_valres]/[value_valsres] payload *extraction* below is a
-     different, still-open problem: [valres]/[valsres] are the parametric type
-     [res<X>] at [val]/[val*], and [V_native]'s generated [case_of_typed] has
-     no entry for parametric heads outside [set;pair;map]. Under [V_native] the
-     [V.Get.( |>>? )] below therefore raises; since this cache is a pure
-     optimization (a miss just recomputes, never a wrong answer), the failure
-     is caught and treated as "nothing to cache" rather than propagated. *)
+     [CCache] always stores genuine [Value.t] (shared, mode-agnostic, hashed
+     structurally), but the [val*] key/value here crossed the [EXTERN] wire,
+     which under [ML_mode]/[V_native] is [Obj.magic], not a real conversion. So
+     each is put through [V.marshal]/[V.unmarshal] on [typ_val_star] - identity
+     under [V_value], a real native-to-[Value.t] decode under [V_native] - before
+     it touches the [Hashtbl]. [|>>?] returns [Some]/[None] for OK-vs-FAIL, so a
+     genuine structural mismatch surfaces rather than being silently dropped. *)
 
   let typ_valres_ext = Typ.Make.var ("valres" $ no_region) []
   let typ_valsres_ext = Typ.Make.var ("valsres" $ no_region) []
@@ -355,13 +365,18 @@ module Make_parametric
             error_no_region "unexpected number of arguments to cache_find_func"
       in
       let id = value_id |> V.of_value |> Interface_SpecTec.unboot_id in
+      let value_values_input =
+        value_values_input |> V.of_value |> V.marshal typ_val_star
+      in
       let cache_result =
         CCache.find cache.meta.func (id.it, [ value_values_input ])
       in
       (match cache_result with
       | Some value_value_output ->
           V.Make.(
-            "OK val" <| [ value_value_output |> V.of_value ] <<| typ_funccache)
+            "OK val"
+            <| [ value_value_output |> V.unmarshal typ_val ]
+            <<| typ_funccache)
       | None -> V.Make.("NONE" <| [] <<| typ_funccache))
       |> V.to_value
 
@@ -378,17 +393,18 @@ module Make_parametric
       in
       let seff = value_seff |> V.of_value |> V.Get.bool in
       (if not seff then
-         try
-           match
-             V.Get.((value_valres |> V.of_value) |>>? (mixop_ok_val, typ_valres_ext))
-           with
-           | Some [ value_value_output ] ->
-               let id = value_id |> V.of_value |> Interface_SpecTec.unboot_id in
-               CCache.add cache.meta.func
-                 (id.it, [ value_values_input ])
-                 (value_value_output |> V.to_value)
-           | _ -> ()
-         with Failure _ -> ());
+         match
+           V.Get.((value_valres |> V.of_value) |>>? (mixop_ok_val, typ_valres_ext))
+         with
+         | Some [ value_value_output ] ->
+             let id = value_id |> V.of_value |> Interface_SpecTec.unboot_id in
+             let value_values_input =
+               value_values_input |> V.of_value |> V.marshal typ_val_star
+             in
+             CCache.add cache.meta.func
+               (id.it, [ value_values_input ])
+               (value_value_output |> V.marshal typ_val)
+         | _ -> ());
       V.Make.bool true |> V.to_value
 
   let cache_find_rel (values_input : Value.t list) : Value.t =
@@ -402,13 +418,18 @@ module Make_parametric
             error_no_region "unexpected number of arguments to cache_find_rel"
       in
       let id = value_id |> V.of_value |> Interface_SpecTec.unboot_id in
+      let value_values_input =
+        value_values_input |> V.of_value |> V.marshal typ_val_star
+      in
       let cache_result =
         CCache.find cache.meta.rel (id.it, [ value_values_input ])
       in
       (match cache_result with
       | Some value_values_output ->
           V.Make.(
-            "OK val*" <| [ value_values_output |> V.of_value ] <<| typ_relcache)
+            "OK val*"
+            <| [ value_values_output |> V.unmarshal typ_val_star ]
+            <<| typ_relcache)
       | None -> V.Make.("NONE" <| [] <<| typ_relcache))
       |> V.to_value
 
@@ -425,18 +446,19 @@ module Make_parametric
       in
       let seff = value_seff |> V.of_value |> V.Get.bool in
       (if not seff then
-         try
-           match
-             V.Get.(
-               (value_valsres |> V.of_value) |>>? (mixop_ok_vals, typ_valsres_ext))
-           with
-           | Some [ value_values_output ] ->
-               let id = value_id |> V.of_value |> Interface_SpecTec.unboot_id in
-               CCache.add cache.meta.rel
-                 (id.it, [ value_values_input ])
-                 (value_values_output |> V.to_value)
-           | _ -> ()
-         with Failure _ -> ());
+         match
+           V.Get.(
+             (value_valsres |> V.of_value) |>>? (mixop_ok_vals, typ_valsres_ext))
+         with
+         | Some [ value_values_output ] ->
+             let id = value_id |> V.of_value |> Interface_SpecTec.unboot_id in
+             let value_values_input =
+               value_values_input |> V.of_value |> V.marshal typ_val_star
+             in
+             CCache.add cache.meta.rel
+               (id.it, [ value_values_input ])
+               (value_values_output |> V.marshal typ_val_star)
+         | _ -> ());
       V.Make.bool true |> V.to_value
 
   let cache_checkpoint (values_input : Value.t list) : Value.t =

--- a/p4spec/lib/backend-ocaml-il/compiled_stub/dispatch.ml
+++ b/p4spec/lib/backend-ocaml-il/compiled_stub/dispatch.ml
@@ -29,3 +29,20 @@ let eval_program (_relname : string) (_includes : string list) (_path : string)
 
 let unmarshal_program (_value : Value.t) : Value.t =
   failwith "ML interpreter: run `make gen-ocaml-il` to generate it"
+
+(* Typed bridges re-exported by the real Dispatch from the generated parts.
+   Stubbed here so the [spec_parts_il] surface stays stable when the stub is in
+   place (`make build`), letting [Val_native] bind them. *)
+
+let marshal_typed (_typ : Typ.t) (_x : Obj.t) : Value.t =
+  failwith "ML interpreter: run `make gen-ocaml-il` to generate it"
+
+let unmarshal_typed (_typ : Typ.t) (_v : Value.t) : Obj.t =
+  failwith "ML interpreter: run `make gen-ocaml-il` to generate it"
+
+let case_of_typed (_x : Obj.t) (_typ : Lang.Il.typ) : Obj.t Domain.Mixfix.t =
+  failwith "ML interpreter: run `make gen-ocaml-il` to generate it"
+
+let make_case_typed (_mixop : Lang.Il.mixop) (_args : Obj.t list)
+    (_typ : Lang.Il.typ) : Obj.t =
+  failwith "ML interpreter: run `make gen-ocaml-il` to generate it"

--- a/p4spec/lib/backend-ocaml-il/val_native.ml
+++ b/p4spec/lib/backend-ocaml-il/val_native.ml
@@ -1,0 +1,158 @@
+(* Native value representation at the compiled-spec <-> extern boundary.
+
+   [t = Obj.t] holding the compiled spec's native OCaml values. A boundary
+   crossing is an O(1) box/unbox ([Obj.repr]/[Obj.obj]) instead of the deep
+   conversion the [V_value] path pays.
+
+   Soundness rests on the invariant the generated code already relies on: a
+   given relation/function argument slot has one spec type, so the boxed [Obj.t]
+   carries exactly the OCaml type a projection expects. A wrong cast fails fast
+   and is caught by the sim suite.
+
+   Mirrors the -il/-sl siblings; only the [Spec_parts_*] binding differs (here
+   spec-meta/il's own generated dispatch). *)
+
+module Value = Runtime.Value
+module Typ = Runtime.Type.Typ
+module Mixfix = Domain.Mixfix
+module Mixop = Domain.Mixop
+module Il = Lang.Il
+module Num = Lang.Xl.Num
+
+(* This library's own generated dispatch tables (spec-meta/il). *)
+module Spec_parts = Spec_parts_il
+open Util.Source
+
+module V_native : Runtime.Valrep.VAL with type t = Obj.t = struct
+  type t = Obj.t
+
+  (* Pass straight back to compiled code, never decoded: identity cast. *)
+  let to_value (x : t) : Value.t = Obj.obj x
+  let of_value (v : Value.t) : t = Obj.repr v
+
+  (* Compiled native values carry no per-node region; matches every
+     [V_native.Make.*] constructor already discarding [~at]. *)
+  let at (_ : t) : region = no_region
+
+  (* Convert to/from a real [Value.t] when the value is stored in a serialized
+     field. Dispatch a per-type [marshal_<typ>]/[unmarshal_<typ>] by the
+     caller-supplied spec type. *)
+  let marshal (typ : Typ.t) (x : t) : Value.t =
+    Spec_parts.Dispatch.marshal_typed typ x
+
+  let unmarshal (typ : Typ.t) (v : Value.t) : t =
+    Spec_parts.Dispatch.unmarshal_typed typ v
+
+  module Get = struct
+    let text (x : t) : string = (Obj.obj x : string)
+
+    (* Native nums drop the Nat/Int tag (both are [Bigint.t]); every caller
+       collapses the tag, so an arbitrary tag is safe. *)
+    let num (x : t) : Num.t = `Int (Obj.obj x : Bigint.t)
+    let bool (x : t) : bool = (Obj.obj x : bool)
+    let list (x : t) : t list = (Obj.obj x : Obj.t list)
+    let opt (x : t) : t option = (Obj.obj x : Obj.t option)
+
+    (* A native tuple is a plain OCaml tuple block; project its fields (a nullary
+       tuple is the immediate unit). *)
+    let tuple (x : t) : t list =
+      if Obj.is_int x then []
+      else List.init (Obj.size x) (fun i -> Obj.field x i)
+
+    (* Shallow one-level destructure of the native variant of spec type [typ]
+       into its mixop shell (args left as native [Obj.t]). *)
+    let case (x : t) (typ : Il.typ) : t Mixfix.t =
+      Spec_parts.Dispatch.case_of_typed x typ
+
+    let extern (x : t) : Yojson.Safe.t = (Obj.obj x : Yojson.Safe.t)
+
+    (* Extractors over [t list] — representation-agnostic, mirror [Value.Get]. *)
+    let nth (n : int) (xs : t list) : t = List.nth xs n
+
+    let one : t list -> t = function
+      | [ x ] -> x
+      | _ -> failwith "V_native.Get.one: expected exactly one value"
+
+    let two : t list -> t * t = function
+      | [ a; b ] -> (a, b)
+      | _ -> failwith "V_native.Get.two: expected exactly two values"
+
+    let three : t list -> t * t * t = function
+      | [ a; b; c ] -> (a, b, c)
+      | _ -> failwith "V_native.Get.three: expected exactly three values"
+
+    (* Project a native variant's args by arity, trusting the value is the
+       expected constructor (well-typedness, same trust as [Obj.obj]). A poly
+       variant with [n] args is [hash; arg] for n=1 and [hash; (a0..an-1)] for
+       n>=2; a nullary one is the immediate hash. *)
+    let args_by_arity (x : t) (n : int) : t list =
+      if n = 0 then []
+      else if n = 1 then [ Obj.field x 1 ]
+      else
+        let payload = Obj.field x 1 in
+        List.init n (fun i -> Obj.field payload i)
+
+    let ( |>> ) (x : t) (s_mixop : string) : t list =
+      args_by_arity x (Mixop.arity (Value.Mixops.of_string s_mixop))
+
+    (* Shape [x] (spec type [typ]) into its mixop shell and test whether it is
+       the expected constructor. [typ] must be the value's actual (possibly
+       union) type, not a leaf single-ctor type: [case_of_typed] emits a
+       wildcard fallthrough so a wrong runtime ctor fails fast, not silently.
+       Shallow, so returned args stay native [Obj.t]. *)
+    let ( |>>? ) (x : t) ((mixop_expect, typ) : Il.mixop * Il.typ) :
+        t list option =
+      let mixop, args =
+        Mixfix.split (Spec_parts.Dispatch.case_of_typed x typ)
+      in
+      if Mixop.eq mixop mixop_expect then Some args else None
+  end
+
+  module Make = struct
+    let text ?(at = no_region) (s : string) : t =
+      ignore at;
+      Obj.repr s
+
+    let int ?(at = no_region) (i : Bigint.t) : t =
+      ignore at;
+      Obj.repr i
+
+    let nat ?(at = no_region) (n : Bigint.t) : t =
+      ignore at;
+      Obj.repr n
+
+    let bool ?(at = no_region) (b : bool) : t =
+      ignore at;
+      Obj.repr b
+
+    let opt ?(at = no_region) (_typ : Typ.t) (o : t option) : t =
+      ignore at;
+      Obj.repr o
+
+    let list ?(at = no_region) (_typ : Typ.t) (xs : t list) : t =
+      ignore at;
+      Obj.repr xs
+
+    let tuple ?(at = no_region) (_typ : Typ.t) (xs : t list) : t =
+      ignore at;
+      match xs with
+      | [] -> Obj.repr ()
+      | _ ->
+          let n = List.length xs in
+          let b = Obj.new_block 0 n in
+          List.iteri (fun i v -> Obj.set_field b i v) xs;
+          b
+
+    let extern ?(at = no_region) (_typ : Typ.t) (y : Yojson.Safe.t) : t =
+      ignore at;
+      Obj.repr y
+
+    let ( <| ) (s_mixop : string) (args : t list) : Il.mixop * t list =
+      (Value.Mixops.of_string s_mixop, args)
+
+    let ( <<| ) ?(at = no_region) ((mixop, args) : Il.mixop * t list)
+        (typ : Il.typ) : t =
+      ignore at;
+      Spec_parts.Dispatch.make_case_typed mixop args typ
+  end
+end

--- a/p4spec/lib/backend-ocaml-sl/compiled_stub/dispatch.ml
+++ b/p4spec/lib/backend-ocaml-sl/compiled_stub/dispatch.ml
@@ -29,3 +29,20 @@ let eval_program (_relname : string) (_includes : string list) (_path : string)
 
 let unmarshal_program (_value : Value.t) : Value.t =
   failwith "ML interpreter: run `make gen-ocaml-sl` to generate it"
+
+(* Typed bridges re-exported by the real Dispatch from the generated parts.
+   Stubbed here so the [spec_parts_sl] surface stays stable when the stub is in
+   place (`make build`), letting [Val_native] bind them. *)
+
+let marshal_typed (_typ : Typ.t) (_x : Obj.t) : Value.t =
+  failwith "ML interpreter: run `make gen-ocaml-sl` to generate it"
+
+let unmarshal_typed (_typ : Typ.t) (_v : Value.t) : Obj.t =
+  failwith "ML interpreter: run `make gen-ocaml-sl` to generate it"
+
+let case_of_typed (_x : Obj.t) (_typ : Lang.Il.typ) : Obj.t Domain.Mixfix.t =
+  failwith "ML interpreter: run `make gen-ocaml-sl` to generate it"
+
+let make_case_typed (_mixop : Lang.Il.mixop) (_args : Obj.t list)
+    (_typ : Lang.Il.typ) : Obj.t =
+  failwith "ML interpreter: run `make gen-ocaml-sl` to generate it"

--- a/p4spec/lib/backend-ocaml-sl/val_native.ml
+++ b/p4spec/lib/backend-ocaml-sl/val_native.ml
@@ -1,0 +1,158 @@
+(* Native value representation at the compiled-spec <-> extern boundary.
+
+   [t = Obj.t] holding the compiled spec's native OCaml values. A boundary
+   crossing is an O(1) box/unbox ([Obj.repr]/[Obj.obj]) instead of the deep
+   conversion the [V_value] path pays.
+
+   Soundness rests on the invariant the generated code already relies on: a
+   given relation/function argument slot has one spec type, so the boxed [Obj.t]
+   carries exactly the OCaml type a projection expects. A wrong cast fails fast
+   and is caught by the sim suite.
+
+   Mirrors the -il/-sl siblings; only the [Spec_parts_*] binding differs (here
+   spec-meta/sl's own generated dispatch). *)
+
+module Value = Runtime.Value
+module Typ = Runtime.Type.Typ
+module Mixfix = Domain.Mixfix
+module Mixop = Domain.Mixop
+module Il = Lang.Il
+module Num = Lang.Xl.Num
+
+(* This library's own generated dispatch tables (spec-meta/sl). *)
+module Spec_parts = Spec_parts_sl
+open Util.Source
+
+module V_native : Runtime.Valrep.VAL with type t = Obj.t = struct
+  type t = Obj.t
+
+  (* Pass straight back to compiled code, never decoded: identity cast. *)
+  let to_value (x : t) : Value.t = Obj.obj x
+  let of_value (v : Value.t) : t = Obj.repr v
+
+  (* Compiled native values carry no per-node region; matches every
+     [V_native.Make.*] constructor already discarding [~at]. *)
+  let at (_ : t) : region = no_region
+
+  (* Convert to/from a real [Value.t] when the value is stored in a serialized
+     field. Dispatch a per-type [marshal_<typ>]/[unmarshal_<typ>] by the
+     caller-supplied spec type. *)
+  let marshal (typ : Typ.t) (x : t) : Value.t =
+    Spec_parts.Dispatch.marshal_typed typ x
+
+  let unmarshal (typ : Typ.t) (v : Value.t) : t =
+    Spec_parts.Dispatch.unmarshal_typed typ v
+
+  module Get = struct
+    let text (x : t) : string = (Obj.obj x : string)
+
+    (* Native nums drop the Nat/Int tag (both are [Bigint.t]); every caller
+       collapses the tag, so an arbitrary tag is safe. *)
+    let num (x : t) : Num.t = `Int (Obj.obj x : Bigint.t)
+    let bool (x : t) : bool = (Obj.obj x : bool)
+    let list (x : t) : t list = (Obj.obj x : Obj.t list)
+    let opt (x : t) : t option = (Obj.obj x : Obj.t option)
+
+    (* A native tuple is a plain OCaml tuple block; project its fields (a nullary
+       tuple is the immediate unit). *)
+    let tuple (x : t) : t list =
+      if Obj.is_int x then []
+      else List.init (Obj.size x) (fun i -> Obj.field x i)
+
+    (* Shallow one-level destructure of the native variant of spec type [typ]
+       into its mixop shell (args left as native [Obj.t]). *)
+    let case (x : t) (typ : Il.typ) : t Mixfix.t =
+      Spec_parts.Dispatch.case_of_typed x typ
+
+    let extern (x : t) : Yojson.Safe.t = (Obj.obj x : Yojson.Safe.t)
+
+    (* Extractors over [t list] — representation-agnostic, mirror [Value.Get]. *)
+    let nth (n : int) (xs : t list) : t = List.nth xs n
+
+    let one : t list -> t = function
+      | [ x ] -> x
+      | _ -> failwith "V_native.Get.one: expected exactly one value"
+
+    let two : t list -> t * t = function
+      | [ a; b ] -> (a, b)
+      | _ -> failwith "V_native.Get.two: expected exactly two values"
+
+    let three : t list -> t * t * t = function
+      | [ a; b; c ] -> (a, b, c)
+      | _ -> failwith "V_native.Get.three: expected exactly three values"
+
+    (* Project a native variant's args by arity, trusting the value is the
+       expected constructor (well-typedness, same trust as [Obj.obj]). A poly
+       variant with [n] args is [hash; arg] for n=1 and [hash; (a0..an-1)] for
+       n>=2; a nullary one is the immediate hash. *)
+    let args_by_arity (x : t) (n : int) : t list =
+      if n = 0 then []
+      else if n = 1 then [ Obj.field x 1 ]
+      else
+        let payload = Obj.field x 1 in
+        List.init n (fun i -> Obj.field payload i)
+
+    let ( |>> ) (x : t) (s_mixop : string) : t list =
+      args_by_arity x (Mixop.arity (Value.Mixops.of_string s_mixop))
+
+    (* Shape [x] (spec type [typ]) into its mixop shell and test whether it is
+       the expected constructor. [typ] must be the value's actual (possibly
+       union) type, not a leaf single-ctor type: [case_of_typed] emits a
+       wildcard fallthrough so a wrong runtime ctor fails fast, not silently.
+       Shallow, so returned args stay native [Obj.t]. *)
+    let ( |>>? ) (x : t) ((mixop_expect, typ) : Il.mixop * Il.typ) :
+        t list option =
+      let mixop, args =
+        Mixfix.split (Spec_parts.Dispatch.case_of_typed x typ)
+      in
+      if Mixop.eq mixop mixop_expect then Some args else None
+  end
+
+  module Make = struct
+    let text ?(at = no_region) (s : string) : t =
+      ignore at;
+      Obj.repr s
+
+    let int ?(at = no_region) (i : Bigint.t) : t =
+      ignore at;
+      Obj.repr i
+
+    let nat ?(at = no_region) (n : Bigint.t) : t =
+      ignore at;
+      Obj.repr n
+
+    let bool ?(at = no_region) (b : bool) : t =
+      ignore at;
+      Obj.repr b
+
+    let opt ?(at = no_region) (_typ : Typ.t) (o : t option) : t =
+      ignore at;
+      Obj.repr o
+
+    let list ?(at = no_region) (_typ : Typ.t) (xs : t list) : t =
+      ignore at;
+      Obj.repr xs
+
+    let tuple ?(at = no_region) (_typ : Typ.t) (xs : t list) : t =
+      ignore at;
+      match xs with
+      | [] -> Obj.repr ()
+      | _ ->
+          let n = List.length xs in
+          let b = Obj.new_block 0 n in
+          List.iteri (fun i v -> Obj.set_field b i v) xs;
+          b
+
+    let extern ?(at = no_region) (_typ : Typ.t) (y : Yojson.Safe.t) : t =
+      ignore at;
+      Obj.repr y
+
+    let ( <| ) (s_mixop : string) (args : t list) : Il.mixop * t list =
+      (Value.Mixops.of_string s_mixop, args)
+
+    let ( <<| ) ?(at = no_region) ((mixop, args) : Il.mixop * t list)
+        (typ : Il.typ) : t =
+      ignore at;
+      Spec_parts.Dispatch.make_case_typed mixop args typ
+  end
+end

--- a/p4spec/lib/interface/interface.ml
+++ b/p4spec/lib/interface/interface.ml
@@ -100,10 +100,10 @@ end
 (* SpecTec IL *)
 
 module SpecTec_IL = struct
-  include Spectec.Common.Boot
-  include Spectec.Common.Unboot
-  include Spectec.Ili.Boot
-  include Spectec.Ili.Unboot
+  (* [Ili.*.Make (V)] already includes [Common.*.Make (V)]. Instantiated at
+     [V_value]; a later task turns this module into a proper [Make (V)]. *)
+  include Spectec.Ili.Boot.Make (Runtime.Valrep.V_value)
+  include Spectec.Ili.Unboot.Make (Runtime.Valrep.V_value)
   include Spectec.Caches
 
   (* Program parsing *)
@@ -156,10 +156,10 @@ end
 (* SpecTec SL *)
 
 module SpecTec_SL = struct
-  include Spectec.Common.Boot
-  include Spectec.Common.Unboot
-  include Spectec.Sli.Boot
-  include Spectec.Sli.Unboot
+  (* [Sli.*.Make (V)] already includes [Common.*.Make (V)]. Instantiated at
+     [V_value]; a later task turns this module into a proper [Make (V)]. *)
+  include Spectec.Sli.Boot.Make (Runtime.Valrep.V_value)
+  include Spectec.Sli.Unboot.Make (Runtime.Valrep.V_value)
   include Spectec.Caches
 
   (* Program parsing *)

--- a/p4spec/lib/interface/interface.ml
+++ b/p4spec/lib/interface/interface.ml
@@ -100,13 +100,18 @@ end
 (* SpecTec IL *)
 
 module SpecTec_IL = struct
-  (* [Ili.*.Make (V)] already includes [Common.*.Make (V)]. Instantiated at
-     [V_value]; a later task turns this module into a proper [Make (V)]. *)
-  include Spectec.Ili.Boot.Make (Runtime.Valrep.V_value)
-  include Spectec.Ili.Unboot.Make (Runtime.Valrep.V_value)
-  include Spectec.Caches
+  (* Boot-time-only entry points used by backend-boot/patch.ml: they
+     process the spec itself (elaboration/patch input), never a runtime
+     value under whatever mode the meta-interpreter ends up running, so
+     they stay fixed to [Valrep.V_value] regardless of [Make]'s [V] *)
 
-  (* Program parsing *)
+  module Boot_value = Spectec.Ili.Boot.Make (Valrep.V_value)
+  module Unboot_value = Spectec.Ili.Unboot.Make (Valrep.V_value)
+
+  let boot_spec = Boot_value.boot_spec
+  let unboot_script = Unboot_value.unboot_script
+
+  (* Program parsing doesn't depend on the runtime value rep either *)
 
   let parse_program (_includes : string list) (paths : string list) :
       Run.parse_result =
@@ -125,44 +130,94 @@ module SpecTec_IL = struct
     | ParseError (at, msg) -> Run.Fail (`Syntax (at, msg))
     | ElabError (at, msg) -> Run.Fail (`Syntax (at, msg))
 
-  (* Program unparsing *)
+  (* The mode-dependent boundary: which [V] the meta-interpreter uses for
+     runtime values is fixed at construction, so there is no runtime
+     [!cur_mode] branch with a bespoke [Obj.magic] in every function *)
 
-  let unparse_program (value_script : Value.t) : string =
-    value_script |> unboot_script |> Il.Print.string_of_spec
+  module Make (V : Runtime.Valrep.VAL) = struct
+    include Spectec.Caches
 
-  (* Builtins *)
+    let boot_spec = boot_spec
+    let unboot_script = unboot_script
+    let parse_program = parse_program
+    let parse_string = parse_string
 
-  module Builtins (V : Valrep.SAFE) : Run.BUILTINS with type vt = V.t = struct
+    module Boot = Spectec.Ili.Boot.Make (V)
+    module Unboot = Spectec.Ili.Unboot.Make (V)
+
     type vt = V.t
 
-    module F = Builtin.Call.Make_funcs (V)
-    include F.Make (F.No_ext) ()
+    (* [unparse_program] crosses [Value.t] -> [V] through [V.of_value] since
+       [Run.INTERFACE] fixes its argument at [Value.t] *)
+
+    let unparse_program (value_script : Value.t) : string =
+      Il.Print.string_of_spec (Unboot.unboot_script (V.of_value value_script))
+
+    let boot_value (value : Value.t) : vt = Boot.boot_value (value : Il.value)
+
+    let boot_values (values : Value.t list) : vt =
+      Boot.boot_values (values : Il.value list)
+
+    let unboot_id (value : vt) : Il.id = Unboot.unboot_id value
+    let unboot_typs (value : vt) : Typ.t list = Unboot.unboot_typs value
+    let unboot_values (value : vt) : Value.t list = Unboot.unboot_values value
+
+    (* Builtins *)
+
+    module Builtins (V : Valrep.SAFE) : Run.BUILTINS with type vt = V.t = struct
+      type vt = V.t
+
+      module F = Builtin.Call.Make_funcs (V)
+      include F.Make (F.No_ext) ()
+    end
+
+    module Builtin_SpecTec = Builtins (V)
+
+    let call_builtin (add : Value.t -> unit) (id : Domain.Lib.Id.t)
+        (typs : Typ.t list) (values : Value.t list) : Value.t =
+      Builtin_SpecTec.invoke
+        (fun v -> add (V.to_value v))
+        id typs
+        (List.map V.of_value values)
+      |> V.to_value
+
+    (* Fixed at [Valrep.V_value] regardless of this functor's own [V], for
+       callers whose [values] are already real [Value.t] from
+       [unboot_values]; [call_builtin] above would [V.of_value]-recast them
+       with no actual conversion *)
+
+    module Builtin_SpecTec_value = Builtins (Valrep.V_value)
+
+    let call_builtin_value (add : Value.t -> unit) (id : Domain.Lib.Id.t)
+        (typs : Typ.t list) (values : Value.t list) : Value.t =
+      Builtin_SpecTec_value.invoke add id typs values
+
+    (* State management *)
+
+    let checkpoint = Builtin_SpecTec.checkpoint
+    let seff = Builtin_SpecTec.seff
+
+    (* Initialization: [V] already fixes the mode *)
+
+    let init (_ : Run.spec) : unit = ()
   end
-
-  module Builtin_SpecTec = Builtins (Valrep.V_value)
-
-  let call_builtin = Builtin_SpecTec.invoke
-
-  (* State management *)
-
-  let checkpoint = Builtin_SpecTec.checkpoint
-  let seff = Builtin_SpecTec.seff
-
-  (* Initialization *)
-
-  let init (_spec : Run.spec) : unit = ()
 end
 
 (* SpecTec SL *)
 
 module SpecTec_SL = struct
-  (* [Sli.*.Make (V)] already includes [Common.*.Make (V)]. Instantiated at
-     [V_value]; a later task turns this module into a proper [Make (V)]. *)
-  include Spectec.Sli.Boot.Make (Runtime.Valrep.V_value)
-  include Spectec.Sli.Unboot.Make (Runtime.Valrep.V_value)
-  include Spectec.Caches
+  (* Boot-time-only entry points used by backend-boot/patch.ml: they
+     process the spec itself (elaboration/patch input), never a runtime
+     value under whatever mode the meta-interpreter ends up running, so
+     they stay fixed to [Valrep.V_value] regardless of [Make]'s [V] *)
 
-  (* Program parsing *)
+  module Boot_value = Spectec.Sli.Boot.Make (Valrep.V_value)
+  module Unboot_value = Spectec.Sli.Unboot.Make (Valrep.V_value)
+
+  let boot_spec = Boot_value.boot_spec
+  let unboot_script = Unboot_value.unboot_script
+
+  (* Program parsing doesn't depend on the runtime value rep either *)
 
   let parse_program (_includes : string list) (paths : string list) :
       Run.parse_result =
@@ -181,30 +236,75 @@ module SpecTec_SL = struct
     | ParseError (at, msg) -> Run.Fail (`Syntax (at, msg))
     | ElabError (at, msg) -> Run.Fail (`Syntax (at, msg))
 
-  (* Program unparsing *)
+  (* The mode-dependent boundary: which [V] the meta-interpreter uses for
+     runtime values is fixed at construction, so there is no runtime
+     [!cur_mode] branch with a bespoke [Obj.magic] in every function *)
 
-  let unparse_program (value_script : Value.t) : string =
-    value_script |> unboot_script |> Sl.Print.string_of_spec
+  module Make (V : Runtime.Valrep.VAL) = struct
+    include Spectec.Caches
 
-  (* Builtins *)
+    let boot_spec = boot_spec
+    let unboot_script = unboot_script
+    let parse_program = parse_program
+    let parse_string = parse_string
 
-  module Builtins (V : Valrep.SAFE) : Run.BUILTINS with type vt = V.t = struct
+    module Boot = Spectec.Sli.Boot.Make (V)
+    module Unboot = Spectec.Sli.Unboot.Make (V)
+
     type vt = V.t
 
-    module F = Builtin.Call.Make_funcs (V)
-    include F.Make (F.No_ext) ()
+    (* [unparse_program] crosses [Value.t] -> [V] through [V.of_value] since
+       [Run.INTERFACE] fixes its argument at [Value.t] *)
+
+    let unparse_program (value_script : Value.t) : string =
+      Sl.Print.string_of_spec (Unboot.unboot_script (V.of_value value_script))
+
+    let boot_value (value : Value.t) : vt = Boot.boot_value (value : Il.value)
+
+    let boot_values (values : Value.t list) : vt =
+      Boot.boot_values (values : Il.value list)
+
+    let unboot_id (value : vt) : Il.id = Unboot.unboot_id value
+    let unboot_typs (value : vt) : Typ.t list = Unboot.unboot_typs value
+    let unboot_values (value : vt) : Value.t list = Unboot.unboot_values value
+
+    (* Builtins *)
+
+    module Builtins (V : Valrep.SAFE) : Run.BUILTINS with type vt = V.t = struct
+      type vt = V.t
+
+      module F = Builtin.Call.Make_funcs (V)
+      include F.Make (F.No_ext) ()
+    end
+
+    module Builtin_SpecTec = Builtins (V)
+
+    let call_builtin (add : Value.t -> unit) (id : Domain.Lib.Id.t)
+        (typs : Typ.t list) (values : Value.t list) : Value.t =
+      Builtin_SpecTec.invoke
+        (fun v -> add (V.to_value v))
+        id typs
+        (List.map V.of_value values)
+      |> V.to_value
+
+    (* Fixed at [Valrep.V_value] regardless of this functor's own [V], for
+       callers whose [values] are already real [Value.t] from
+       [unboot_values]; [call_builtin] above would [V.of_value]-recast them
+       with no actual conversion *)
+
+    module Builtin_SpecTec_value = Builtins (Valrep.V_value)
+
+    let call_builtin_value (add : Value.t -> unit) (id : Domain.Lib.Id.t)
+        (typs : Typ.t list) (values : Value.t list) : Value.t =
+      Builtin_SpecTec_value.invoke add id typs values
+
+    (* State management *)
+
+    let checkpoint = Builtin_SpecTec.checkpoint
+    let seff = Builtin_SpecTec.seff
+
+    (* Initialization: [V] already fixes the mode *)
+
+    let init (_ : Run.spec) : unit = ()
   end
-
-  module Builtin_SpecTec = Builtins (Valrep.V_value)
-
-  let call_builtin = Builtin_SpecTec.invoke
-
-  (* State management *)
-
-  let checkpoint = Builtin_SpecTec.checkpoint
-  let seff = Builtin_SpecTec.seff
-
-  (* Initialization *)
-
-  let init (_spec : Run.spec) : unit = ()
 end

--- a/p4spec/lib/interface/spectec/common/boot.ml
+++ b/p4spec/lib/interface/spectec/common/boot.ml
@@ -5,607 +5,564 @@ module Il = Lang.Il
 open Lang.Xl
 open Mixops
 open Typs
-module Value = Runtime.Value
-module VCache = Runtime.Dynamic.Caches.ValueCache
-module MCache = Domain.Caches.MixopCache
-open Caches
 open Util.Source
 
-(* Identifiers *)
-
-let boot_id (id : Il.id) : Value.t =
-  let value_id = Value.Make.text ~at:id.at id.it in
-  Value.Make.(value_id #@@ "id")
-
-(* Atoms *)
-
-let boot_atom (atom : Il.atom) : Value.t =
-  let value_atom =
-    atom.it |> Atom.string_of_atom |> Value.Make.text ~at:atom.at
-  in
-  Value.Make.(value_atom #@@ "atom")
-
-(* Mixfix operators *)
-
-let boot_mixop (mixop : Il.mixop) : Value.t =
-  let cached = !find_boot_mixop_cache mixop in
-  match cached with
-  | Some value -> value
-  | None ->
-      let atoms_matrix = Mixop.atoms_matrix mixop in
-      let values_atoms =
-        List.map
-          (fun atoms ->
-            let values_atoms = List.map boot_atom atoms in
-            let typ_atoms =
-              Runtime.Type.Typ.Make.var ("atom" $ no_region) []
-              |> Runtime.Type.Typ.Make.list
-            in
-            Value.Make.list typ_atoms values_atoms)
-          atoms_matrix
-      in
-      let value_atoms_matrix =
-        let typ_atoms_matrix =
-          Runtime.Type.Typ.Make.var ("atom" $ no_region) []
-          |> Runtime.Type.Typ.Make.list
-        in
-        Value.Make.list typ_atoms_matrix values_atoms
-      in
-      let value = Value.Make.(value_atoms_matrix #@@ "mixop") in
-      !add_boot_mixop_cache mixop value;
-      value
-
-(* Iterators *)
-
-let boot_iter (iter : Il.iter) : Value.t =
-  match iter with
-  | Opt -> Value.Make.(mop_quest <|! [] <<|! typ_iter)
-  | List -> Value.Make.(mop_star <|! [] <<|! typ_iter)
-
-let boot_iters (iters : Il.iter list) : Value.t =
-  let values_iters = List.map boot_iter iters in
-  Value.Make.list (Runtime.Type.Typ.Make.list typ_iter) values_iters
-
-(* Variables *)
-
-let rec boot_var (var : Il.var) : Value.t =
-  let id, typ, iters = var in
-  let value_id = boot_id id in
-  let value_typ = boot_typ typ in
-  let value_iters = boot_iters iters in
-  Value.Make.(mop_vari <|! [ value_id; value_typ; value_iters ] <<|! typ_vari)
-
-and boot_vars (vars : Il.var list) : Value.t =
-  let values_vars = List.map boot_var vars in
-  Value.Make.list (Runtime.Type.Typ.Make.list typ_vari) values_vars
-
-(* Types *)
-
-and boot_typ (typ : Il.typ) : Value.t =
-  let at = typ.at in
-  match typ.it with
-  | BoolT -> boot_bool_typ at
-  | NumT numtyp -> boot_num_typ at numtyp
-  | TextT -> boot_text_typ at
-  | VarT (id, targs) -> boot_var_typ at id targs
-  | TupleT typs -> boot_tuple_typ at typs
-  | IterT (typ, iter) -> boot_iter_typ at typ iter
-  | FuncT (_, _, _) -> boot_func_typ at
-
-and boot_typs (typs : Il.typ list) : Value.t =
-  let values_typs = List.map boot_typ typs in
-  Value.Make.list (Runtime.Type.Typ.Make.list typ_typ) values_typs
-
-and boot_bool_typ (at : region) : Value.t =
-  Value.Make.(mop_bool_typ <|! [] <<|! typ_optyp <<<| at)
-
-and boot_num_typ (at : region) (numtyp : Num.typ) : Value.t =
-  match numtyp with
-  | `NatT -> Value.Make.(mop_num_typ_nat <|! [] <<|! typ_numtyp <<<| at)
-  | `IntT -> Value.Make.(mop_num_typ_int <|! [] <<|! typ_numtyp <<<| at)
-
-and boot_text_typ (at : region) : Value.t =
-  Value.Make.(mop_text_typ <|! [] <<|! typ_optyp <<<| at)
-
-and boot_var_typ (at : region) (id : Il.id) (targs : Il.targ list) : Value.t =
-  let value_id = boot_id id in
-  let value_targs = boot_targs targs in
-  Value.Make.(mop_var_typ <|! [ value_id; value_targs ] <<|! typ_typ <<<| at)
-
-and boot_tuple_typ (at : region) (typs : Il.typ list) : Value.t =
-  let value_typs = boot_typs typs in
-  Value.Make.(mop_tuple_typ <|! [ value_typs ] <<|! typ_typ <<<| at)
-
-and boot_iter_typ (at : region) (typ : Il.typ) (iter : Il.iter) : Value.t =
-  let value_typ = boot_typ typ in
-  let value_iter = boot_iter iter in
-  Value.Make.(mop_iter_typ <|! [ value_typ; value_iter ] <<|! typ_typ <<<| at)
-
-and boot_func_typ (at : region) : Value.t =
-  Value.Make.(mop_func_typ <|! [] <<|! typ_typ <<<| at)
-
-(* Defined types *)
-
-and boot_deftyp (deftyp : Il.deftyp) : Value.t =
-  let at = deftyp.at in
-  match deftyp.it with
-  | PlainT typ -> boot_plain_deftyp at typ
-  | StructT typfields -> boot_struct_deftyp at typfields
-  | VariantT typcases -> boot_variant_deftyp at typcases
-
-and boot_plain_deftyp (at : region) (typ : Il.typ) : Value.t =
-  let value_typ = boot_typ typ in
-  Value.Make.(mop_plain_deftyp <|! [ value_typ ] <<|! typ_deftyp <<<| at)
-
-and boot_typfield (typfield : Il.typfield) : Value.t =
-  let atom, typ = typfield in
-  let value_atom = boot_atom atom in
-  let value_typ = boot_typ typ in
-  Value.Make.(mop_typfield <|! [ value_atom; value_typ ] <<|! typ_typfield)
-
-and boot_typfields (typfields : Il.typfield list) : Value.t =
-  let values_typfields = List.map boot_typfield typfields in
-  Value.Make.list (Runtime.Type.Typ.Make.list typ_typfield) values_typfields
-
-and boot_struct_deftyp (at : region) (typfields : Il.typfield list) : Value.t =
-  let value_typfields = boot_typfields typfields in
-  Value.Make.(mop_struct_deftyp <|! [ value_typfields ] <<|! typ_deftyp <<<| at)
-
-and boot_typcase (typcase : Il.typcase) : Value.t =
-  let nottyp, _, _ = typcase in
-  let mixop, typs = Mixfix.split nottyp.it in
-  let value_mixop = boot_mixop mixop in
-  let value_typs = boot_typs typs in
-  Value.Make.(
-    mop_typcase <|! [ value_mixop; value_typs ] <<|! typ_typcase <<<| nottyp.at)
-
-and boot_typcases (typcases : Il.typcase list) : Value.t =
-  let values_typcases = List.map boot_typcase typcases in
-  Value.Make.list (Runtime.Type.Typ.Make.list typ_typcase) values_typcases
-
-and boot_variant_deftyp (at : region) (typcases : Il.typcase list) : Value.t =
-  let value_typcases = boot_typcases typcases in
-  Value.Make.(mop_variant_deftyp <|! [ value_typcases ] <<|! typ_deftyp <<<| at)
-
-(* Values *)
-
-and boot_value (value : Il.value) : Value.t =
-  let cached =
-    let cached = !find_boot_value_pingpong_cache value in
-    match cached with
-    | Some value -> Some value
-    | None -> !find_boot_value_cache value
-  in
-  match cached with
-  | Some value_value -> value_value
-  | None ->
-      let at = value.at in
-      let value_value =
-        match value.it with
-        | BoolV b -> boot_bool_value at b
-        | NumV num -> boot_num_value at num
-        | TextV t -> boot_text_value at t
-        | StructV valuefields -> boot_struct_value at valuefields
-        | CaseV valuecase -> boot_case_value at valuecase
-        | TupleV values -> boot_tuple_value at values
-        | OptV value_opt -> boot_opt_value at value_opt
-        | ListV values -> boot_list_value at values
-        | FuncV id -> boot_func_value at id
-        | ExternV json -> boot_extern_value at json
-      in
-      !add_boot_value_cache value value_value;
-      !add_unboot_value_pingpong_cache value_value value;
-      value_value
-
-and boot_value_opt (value_opt : Il.value option) : Value.t =
-  Value.Make.opt
-    (Runtime.Type.Typ.Make.opt typ_val)
-    (Option.map boot_value value_opt)
-
-and boot_values (values : Il.value list) : Value.t =
-  let values_values = List.map boot_value values in
-  Value.Make.list (Runtime.Type.Typ.Make.list typ_val) values_values
-
-and boot_bool_value (at : region) (b : bool) : Value.t =
-  Value.Make.(mop_bool_value <|! [ bool b ] <<|! typ_val <<<| at)
-
-and boot_num_value (at : region) (num : Il.num) : Value.t =
-  match num with
-  | `Nat n -> Value.Make.(mop_num_value_nat <|! [ nat n ] <<|! typ_num <<<| at)
-  | `Int i -> Value.Make.(mop_num_value_int <|! [ int i ] <<|! typ_num <<<| at)
-
-and boot_text_value (at : region) (t : string) : Value.t =
-  Value.Make.(mop_text_value <|! [ text t ] <<|! typ_val <<<| at)
-
-and boot_valuefield (vf : Il.valuefield) : Value.t =
-  let atom, value = vf in
-  let value_atom = boot_atom atom in
-  let value_value = boot_value value in
-  Value.Make.(mop_valuefield <|! [ value_atom; value_value ] <<|! typ_valfield)
-
-and boot_valuefields (valuefields : Il.valuefield list) : Value.t =
-  let values_valuefields = List.map boot_valuefield valuefields in
-  Value.Make.list (Runtime.Type.Typ.Make.list typ_valfield) values_valuefields
-
-and boot_struct_value (at : region) (valuefields : Il.valuefield list) : Value.t
-    =
-  let value_valuefields = boot_valuefields valuefields in
-  Value.Make.(mop_struct_value <|! [ value_valuefields ] <<|! typ_val <<<| at)
-
-and boot_valuecase (valuecase : Il.valuecase) : Value.t =
-  let mixop, values = Mixfix.split valuecase in
-  let value_mixop = boot_mixop mixop in
-  let value_values = boot_values values in
-  Value.Make.(mop_valuecase <|! [ value_mixop; value_values ] <<|! typ_valcase)
-
-and boot_case_value (at : region) (vc : Il.valuecase) : Value.t =
-  let value_valuecase = boot_valuecase vc in
-  Value.Make.(mop_case_value <|! [ value_valuecase ] <<|! typ_val <<<| at)
-
-and boot_tuple_value (at : region) (values : Il.value list) : Value.t =
-  let value_values = boot_values values in
-  Value.Make.(mop_tuple_value <|! [ value_values ] <<|! typ_val <<<| at)
-
-and boot_opt_value (at : region) (value_opt : Il.value option) : Value.t =
-  let value_value_opt = boot_value_opt value_opt in
-  Value.Make.(mop_opt_value <|! [ value_value_opt ] <<|! typ_val <<<| at)
-
-and boot_list_value (at : region) (values : Il.value list) : Value.t =
-  let value_values = boot_values values in
-  Value.Make.(mop_list_value <|! [ value_values ] <<|! typ_val <<<| at)
-
-and boot_func_value (at : region) (id : Il.id) : Value.t =
-  let value_id = boot_id id in
-  Value.Make.(mop_func_value <|! [ value_id ] <<|! typ_val <<<| at)
-
-and boot_extern_value (at : region) (json : Yojson.Safe.t) : Value.t =
-  let typ_json = Runtime.Type.Typ.Make.var ("json" $ no_region) [] in
-  let value_json = Value.Make.extern typ_json json in
-  Value.Make.(mop_extern_value <|! [ value_json ] <<|! typ_val <<<| at)
-
-(* Operators *)
-
-and boot_unop (unop : Il.unop) : Value.t =
-  match unop with
-  | #Bool.unop as unop -> boot_unop_bool unop
-  | #Num.unop as unop -> boot_unop_num unop
-
-and boot_unop_bool (unop : Bool.unop) : Value.t =
-  match unop with `NotOp -> Value.Make.(mop_not_unop <|! [] <<|! typ_boolunop)
-
-and boot_unop_num (unop : Num.unop) : Value.t =
-  match unop with
-  | `PlusOp -> Value.Make.(mop_plus_unop <|! [] <<|! typ_numunop)
-  | `MinusOp -> Value.Make.(mop_minus_unop <|! [] <<|! typ_numunop)
-
-and boot_binop (binop : Il.binop) : Value.t =
-  match binop with
-  | #Bool.binop as binop -> boot_binop_bool binop
-  | #Num.binop as binop -> boot_binop_num binop
-
-and boot_binop_bool (binop : Bool.binop) : Value.t =
-  match binop with
-  | `AndOp -> Value.Make.(mop_and_binop <|! [] <<|! typ_boolbinop)
-  | `OrOp -> Value.Make.(mop_or_binop <|! [] <<|! typ_boolbinop)
-  | `ImplOp -> Value.Make.(mop_impl_binop <|! [] <<|! typ_boolbinop)
-  | `EquivOp -> Value.Make.(mop_equiv_binop <|! [] <<|! typ_boolbinop)
-
-and boot_binop_num (binop : Num.binop) : Value.t =
-  match binop with
-  | `AddOp -> Value.Make.(mop_add_binop <|! [] <<|! typ_numbinop)
-  | `SubOp -> Value.Make.(mop_sub_binop <|! [] <<|! typ_numbinop)
-  | `MulOp -> Value.Make.(mop_mul_binop <|! [] <<|! typ_numbinop)
-  | `DivOp -> Value.Make.(mop_div_binop <|! [] <<|! typ_numbinop)
-  | `ModOp -> Value.Make.(mop_mod_binop <|! [] <<|! typ_numbinop)
-  | `PowOp -> Value.Make.(mop_pow_binop <|! [] <<|! typ_numbinop)
-
-and boot_cmpop (cmpop : Il.cmpop) : Value.t =
-  match cmpop with
-  | #Bool.cmpop as cmpop -> boot_cmpop_bool cmpop
-  | #Num.cmpop as cmpop -> boot_cmpop_num cmpop
-
-and boot_cmpop_bool (cmpop : Bool.cmpop) : Value.t =
-  match cmpop with
-  | `EqOp -> Value.Make.(mop_eq_cmpop <|! [] <<|! typ_polycmpop)
-  | `NeOp -> Value.Make.(mop_ne_cmpop <|! [] <<|! typ_polycmpop)
-
-and boot_cmpop_num (cmpop : Num.cmpop) : Value.t =
-  match cmpop with
-  | `LtOp -> Value.Make.(mop_lt_cmpop <|! [] <<|! typ_numcmpop)
-  | `LeOp -> Value.Make.(mop_le_cmpop <|! [] <<|! typ_numcmpop)
-  | `GtOp -> Value.Make.(mop_gt_cmpop <|! [] <<|! typ_numcmpop)
-  | `GeOp -> Value.Make.(mop_ge_cmpop <|! [] <<|! typ_numcmpop)
-
-(* Type arguments *)
-
-and boot_targ (targ : Il.targ) : Value.t =
-  let value_targ = boot_typ targ in
-  Value.Make.(value_targ #@@ "targ")
-
-and boot_targs (targs : Il.targ list) : Value.t =
-  let values_targs = List.map boot_targ targs in
-  Value.Make.list
-    (Runtime.Type.Typ.Make.list
-       (Runtime.Type.Typ.Make.var ("targ" $ no_region) []))
-    values_targs
-
-(* Type parameters *)
-
-and boot_tparam (tparam : Il.tparam) : Value.t = boot_id tparam
-
-and boot_tparams (tparams : Il.tparam list) : Value.t =
-  let values_tparams = List.map boot_tparam tparams in
-  Value.Make.list
-    (Runtime.Type.Typ.Make.list
-       (Runtime.Type.Typ.Make.var ("tparam" $ no_region) []))
-    values_tparams
-
-(* Arguments *)
-
-and boot_arg (arg : Il.arg) : Value.t =
-  let at = arg.at in
-  match arg.it with
-  | ExpA e ->
-      let value_exp = boot_exp e in
-      Value.Make.(mop_exp_arg <|! [ value_exp ] <<|! typ_arg <<<| at)
-  | DefA id ->
-      let value_id = boot_id id in
-      Value.Make.(mop_def_arg <|! [ value_id ] <<|! typ_arg <<<| at)
-
-and boot_args (args : Il.arg list) : Value.t =
-  let values_args = List.map boot_arg args in
-  Value.Make.list (Runtime.Type.Typ.Make.list typ_arg) values_args
-
-(* Expressions *)
-
-and boot_exp (exp : Il.exp) : Value.t =
-  let at = exp.at in
-  match exp.it with
-  | BoolE b -> boot_bool_exp at b
-  | NumE num -> boot_num_exp at num
-  | TextE t -> boot_text_exp at t
-  | VarE id -> boot_var_exp at id
-  | UnE (unop, _, e) -> boot_un_exp at unop e
-  | BinE (binop, _, el, er) -> boot_bin_exp at binop el er
-  | CmpE (cmpop, _, el, er) -> boot_cmp_exp at cmpop el er
-  | UpCastE (typ, e) -> boot_upcast_exp at typ e
-  | DownCastE (typ, e) -> boot_downcast_exp at typ e
-  | SubE (e, typ) -> boot_sub_exp at e typ
-  | MatchE (e, pattern) -> boot_match_exp at e pattern
-  | TupleE exps -> boot_tuple_exp at exps
-  | CaseE notexp -> boot_case_exp at notexp
-  | StrE expfields -> boot_struct_exp at expfields
-  | OptE exp_opt -> boot_opt_exp at exp_opt
-  | ListE exps -> boot_list_exp at exps
-  | ConsE (eh, et) -> boot_cons_exp at eh et
-  | CatE (el, er) -> boot_cat_exp at el er
-  | MemE (ee, es) -> boot_mem_exp at ee es
-  | LenE e -> boot_len_exp at e
-  | DotE (e, atom) -> boot_dot_exp at e atom
-  | IdxE (eb, ei) -> boot_idx_exp at eb ei
-  | SliceE (eb, ei, en) -> boot_slice_exp at eb ei en
-  | UpdE (eb, path, en) -> boot_upd_exp at eb path en
-  | CallE (id, targs, args) -> boot_call_exp at id targs args
-  | IterE (e, ie) -> boot_iter_exp at e ie
-
-and boot_bool_exp (at : region) (b : bool) : Value.t =
-  Value.Make.(mop_bool_exp <|! [ bool b ] <<|! typ_exp <<<| at)
-
-and boot_num_exp (at : region) (num : Il.num) : Value.t =
-  let value_num = boot_num_value at num in
-  Value.Make.(value_num #@@ "exp")
-
-and boot_text_exp (at : region) (t : string) : Value.t =
-  Value.Make.(mop_text_exp <|! [ text t ] <<|! typ_exp <<<| at)
-
-and boot_var_exp (at : region) (id : Il.id) : Value.t =
-  let value_id = boot_id id in
-  Value.Make.(mop_var_exp <|! [ value_id ] <<|! typ_exp <<<| at)
-
-and boot_un_exp (at : region) (unop : Il.unop) (exp : Il.exp) : Value.t =
-  let value_unop = boot_unop unop in
-  let value_exp = boot_exp exp in
-  Value.Make.(mop_un_exp <|! [ value_unop; value_exp ] <<|! typ_exp <<<| at)
-
-and boot_bin_exp (at : region) (binop : Il.binop) (exp_l : Il.exp)
-    (exp_r : Il.exp) : Value.t =
-  let value_binop = boot_binop binop in
-  let value_exp_l = boot_exp exp_l in
-  let value_exp_r = boot_exp exp_r in
-  Value.Make.(
-    mop_bin_exp
-    <|! [ value_binop; value_exp_l; value_exp_r ]
-    <<|! typ_exp <<<| at)
-
-and boot_cmp_exp (at : region) (cmpop : Il.cmpop) (exp_l : Il.exp)
-    (exp_r : Il.exp) : Value.t =
-  let value_cmpop = boot_cmpop cmpop in
-  let value_exp_l = boot_exp exp_l in
-  let value_exp_r = boot_exp exp_r in
-  Value.Make.(
-    mop_cmp_exp
-    <|! [ value_cmpop; value_exp_l; value_exp_r ]
-    <<|! typ_exp <<<| at)
-
-and boot_upcast_exp (at : region) (typ : Il.typ) (exp : Il.exp) : Value.t =
-  let value_typ = boot_typ typ in
-  let value_exp = boot_exp exp in
-  Value.Make.(mop_upcast_exp <|! [ value_typ; value_exp ] <<|! typ_exp <<<| at)
-
-and boot_downcast_exp (at : region) (typ : Il.typ) (exp : Il.exp) : Value.t =
-  let value_typ = boot_typ typ in
-  let value_exp = boot_exp exp in
-  Value.Make.(
-    mop_downcast_exp <|! [ value_typ; value_exp ] <<|! typ_exp <<<| at)
-
-and boot_sub_exp (at : region) (exp : Il.exp) (typ : Il.typ) : Value.t =
-  let value_exp = boot_exp exp in
-  let value_typ = boot_typ typ in
-  Value.Make.(mop_sub_exp <|! [ value_exp; value_typ ] <<|! typ_exp <<<| at)
-
-and boot_match_exp (at : region) (exp : Il.exp) (pattern : Il.pattern) : Value.t
-    =
-  let value_exp = boot_exp exp in
-  let value_pattern = boot_pattern pattern in
-  Value.Make.(
-    mop_match_exp <|! [ value_exp; value_pattern ] <<|! typ_exp <<<| at)
-
-and boot_tuple_exp (at : region) (exps : Il.exp list) : Value.t =
-  let value_exps = boot_exps exps in
-  Value.Make.(mop_tuple_exp <|! [ value_exps ] <<|! typ_exp <<<| at)
-
-and boot_expcase (notexp : Il.notexp) : Value.t =
-  let mixop, exps = Mixfix.split notexp in
-  let value_mixop = boot_mixop mixop in
-  let value_exps = boot_exps exps in
-  Value.Make.(mop_expcase <|! [ value_mixop; value_exps ] <<|! typ_expcase)
-
-and boot_case_exp (at : region) (notexp : Il.notexp) : Value.t =
-  let value_expcase = boot_expcase notexp in
-  Value.Make.(mop_case_exp <|! [ value_expcase ] <<|! typ_exp <<<| at)
-
-and boot_expfield ((atom, exp) : Il.atom * Il.exp) : Value.t =
-  let value_atom = boot_atom atom in
-  let value_exp = boot_exp exp in
-  Value.Make.(mop_expfield <|! [ value_atom; value_exp ] <<|! typ_expfield)
-
-and boot_expfields (expfields : (Il.atom * Il.exp) list) : Value.t =
-  let values_expfields = List.map boot_expfield expfields in
-  Value.Make.list (Runtime.Type.Typ.Make.list typ_expfield) values_expfields
-
-and boot_struct_exp (at : region) (expfields : (Il.atom * Il.exp) list) :
-    Value.t =
-  let value_expfields = boot_expfields expfields in
-  Value.Make.(mop_struct_exp <|! [ value_expfields ] <<|! typ_exp <<<| at)
-
-and boot_opt_exp (at : region) (exp_opt : Il.exp option) : Value.t =
-  let value_exp_opt = boot_exp_opt exp_opt in
-  Value.Make.(mop_opt_exp <|! [ value_exp_opt ] <<|! typ_exp <<<| at)
-
-and boot_list_exp (at : region) (exps : Il.exp list) : Value.t =
-  let value_exps = boot_exps exps in
-  Value.Make.(mop_list_exp <|! [ value_exps ] <<|! typ_exp <<<| at)
-
-and boot_cons_exp (at : region) (exp_h : Il.exp) (exp_t : Il.exp) : Value.t =
-  let value_exp_h = boot_exp exp_h in
-  let value_exp_t = boot_exp exp_t in
-  Value.Make.(
-    mop_cons_exp <|! [ value_exp_h; value_exp_t ] <<|! typ_exp <<<| at)
-
-and boot_cat_exp (at : region) (exp_l : Il.exp) (exp_r : Il.exp) : Value.t =
-  let value_exp_l = boot_exp exp_l in
-  let value_exp_r = boot_exp exp_r in
-  Value.Make.(mop_cat_exp <|! [ value_exp_l; value_exp_r ] <<|! typ_exp <<<| at)
-
-and boot_mem_exp (at : region) (exp_e : Il.exp) (exp_s : Il.exp) : Value.t =
-  let value_exp_e = boot_exp exp_e in
-  let value_exp_s = boot_exp exp_s in
-  Value.Make.(mop_mem_exp <|! [ value_exp_e; value_exp_s ] <<|! typ_exp <<<| at)
-
-and boot_len_exp (at : region) (exp : Il.exp) : Value.t =
-  let value_exp = boot_exp exp in
-  Value.Make.(mop_len_exp <|! [ value_exp ] <<|! typ_exp <<<| at)
-
-and boot_dot_exp (at : region) (exp : Il.exp) (atom : Il.atom) : Value.t =
-  let value_exp = boot_exp exp in
-  let value_atom = boot_atom atom in
-  Value.Make.(mop_dot_exp <|! [ value_exp; value_atom ] <<|! typ_exp <<<| at)
-
-and boot_idx_exp (at : region) (exp_b : Il.exp) (exp_i : Il.exp) : Value.t =
-  let value_exp_b = boot_exp exp_b in
-  let value_exp_i = boot_exp exp_i in
-  Value.Make.(mop_idx_exp <|! [ value_exp_b; value_exp_i ] <<|! typ_exp <<<| at)
-
-and boot_slice_exp (at : region) (exp_b : Il.exp) (exp_i : Il.exp)
-    (exp_n : Il.exp) : Value.t =
-  let value_exp_b = boot_exp exp_b in
-  let value_exp_i = boot_exp exp_i in
-  let value_exp_n = boot_exp exp_n in
-  Value.Make.(
-    mop_slice_exp
-    <|! [ value_exp_b; value_exp_i; value_exp_n ]
-    <<|! typ_exp <<<| at)
-
-and boot_upd_exp (at : region) (exp_b : Il.exp) (path : Il.path)
-    (exp_n : Il.exp) : Value.t =
-  let value_exp_b = boot_exp exp_b in
-  let value_path = boot_path path in
-  let value_exp_n = boot_exp exp_n in
-  Value.Make.(
-    mop_upd_exp
-    <|! [ value_exp_b; value_path; value_exp_n ]
-    <<|! typ_exp <<<| at)
-
-and boot_call_exp (at : region) (id : Il.id) (targs : Il.targ list)
-    (args : Il.arg list) : Value.t =
-  let value_id = boot_id id in
-  let value_targs = boot_targs targs in
-  let value_args = boot_args args in
-  Value.Make.(
-    mop_call_exp <|! [ value_id; value_targs; value_args ] <<|! typ_exp <<<| at)
-
-and boot_iter_exp (at : region) (exp : Il.exp) (iterexp : Il.iterexp) : Value.t
-    =
-  let value_exp = boot_exp exp in
-  let value_iterexp = boot_iterexp iterexp in
-  Value.Make.(
-    mop_iter_exp <|! [ value_exp; value_iterexp ] <<|! typ_exp <<<| at)
-
-and boot_exps (exps : Il.exp list) : Value.t =
-  let values_exps = List.map boot_exp exps in
-  Value.Make.list (Runtime.Type.Typ.Make.list typ_exp) values_exps
-
-and boot_exp_opt (exp_opt : Il.exp option) : Value.t =
-  Value.Make.opt
-    (Runtime.Type.Typ.Make.opt typ_exp)
-    (Option.map boot_exp exp_opt)
-
-(* Paths *)
-
-and boot_path (path : Il.path) : Value.t =
-  let at = path.at in
-  match path.it with
-  | RootP -> Value.Make.(mop_root_path <|! [] <<|! typ_path <<<| at)
-  | IdxP (path, exp) ->
-      let value_path = boot_path path in
-      let value_exp = boot_exp exp in
-      Value.Make.(
-        mop_idx_path <|! [ value_path; value_exp ] <<|! typ_path <<<| at)
-  | SliceP (path, exp_i, exp_n) ->
-      let value_path = boot_path path in
-      let value_exp_i = boot_exp exp_i in
-      let value_exp_n = boot_exp exp_n in
-      Value.Make.(
-        mop_slice_path
-        <|! [ value_path; value_exp_i; value_exp_n ]
-        <<|! typ_path <<<| at)
-  | DotP (path, atom) ->
-      let value_path = boot_path path in
-      let value_atom = boot_atom atom in
-      Value.Make.(
-        mop_dot_path <|! [ value_path; value_atom ] <<|! typ_path <<<| at)
-
-(* Patterns *)
-
-and boot_pattern (pattern : Il.pattern) : Value.t =
-  match pattern with
-  | CaseP mixop ->
-      let value_mixop = boot_mixop mixop in
-      Value.Make.(mop_case_pattern <|! [ value_mixop ] <<|! typ_pattern)
-  | ListP `Cons ->
-      Value.Make.(mop_list_cons_pattern <|! [] <<|! typ_listpattern)
-  | ListP (`Fixed n) ->
-      Value.Make.(
+module Make (V : Runtime.Valrep.SAFE) = struct
+  (* [#@@]'s note-retag has no [SAFE] equivalent and is dropped here: this
+     module's own dispatch never reads [note.typ]. *)
+  let ( <|! ) (mixop : Mixop.t) (args : V.t list) : Mixop.t * V.t list =
+    (mixop, args)
+
+  let ( <<|! ) (pair : Mixop.t * V.t list) (typ : Il.typ) : V.t =
+    V.Make.( <<| ) pair typ
+
+  let case_at (at : region) (pair : Mixop.t * V.t list) (typ : Il.typ) : V.t =
+    V.Make.( <<| ) ~at pair typ
+
+  (* Identifiers *)
+
+  let boot_id (id : Il.id) : V.t = V.Make.text ~at:id.at id.it
+
+  (* Atoms *)
+
+  let boot_atom (atom : Il.atom) : V.t =
+    atom.it |> Atom.string_of_atom |> V.Make.text ~at:atom.at
+
+  (* Mixfix operators *)
+
+  let boot_mixop (mixop : Il.mixop) : V.t =
+    let atoms_matrix = Mixop.atoms_matrix mixop in
+    let values_atoms =
+      List.map
+        (fun atoms ->
+          let values_atoms = List.map boot_atom atoms in
+          let typ_atoms =
+            Runtime.Type.Typ.Make.var ("atom" $ no_region) []
+            |> Runtime.Type.Typ.Make.list
+          in
+          V.Make.list typ_atoms values_atoms)
+        atoms_matrix
+    in
+    let typ_atoms_matrix =
+      Runtime.Type.Typ.Make.var ("atom" $ no_region) []
+      |> Runtime.Type.Typ.Make.list
+    in
+    V.Make.list typ_atoms_matrix values_atoms
+
+  (* Iterators *)
+
+  let boot_iter (iter : Il.iter) : V.t =
+    match iter with
+    | Opt -> mop_quest <|! [] <<|! typ_iter
+    | List -> mop_star <|! [] <<|! typ_iter
+
+  let boot_iters (iters : Il.iter list) : V.t =
+    let values_iters = List.map boot_iter iters in
+    V.Make.list (Runtime.Type.Typ.Make.list typ_iter) values_iters
+
+  (* Variables *)
+
+  let rec boot_var (var : Il.var) : V.t =
+    let id, typ, iters = var in
+    let value_id = boot_id id in
+    let value_typ = boot_typ typ in
+    let value_iters = boot_iters iters in
+    mop_vari <|! [ value_id; value_typ; value_iters ] <<|! typ_vari
+
+  and boot_vars (vars : Il.var list) : V.t =
+    let values_vars = List.map boot_var vars in
+    V.Make.list (Runtime.Type.Typ.Make.list typ_vari) values_vars
+
+  (* Types *)
+
+  and boot_typ (typ : Il.typ) : V.t =
+    let at = typ.at in
+    match typ.it with
+    | BoolT -> boot_bool_typ at
+    | NumT numtyp -> boot_num_typ at numtyp
+    | TextT -> boot_text_typ at
+    | VarT (id, targs) -> boot_var_typ at id targs
+    | TupleT typs -> boot_tuple_typ at typs
+    | IterT (typ, iter) -> boot_iter_typ at typ iter
+    | FuncT (_, _, _) -> boot_func_typ at
+
+  and boot_typs (typs : Il.typ list) : V.t =
+    let values_typs = List.map boot_typ typs in
+    V.Make.list (Runtime.Type.Typ.Make.list typ_typ) values_typs
+
+  and boot_bool_typ (at : region) : V.t =
+    case_at at (mop_bool_typ <|! []) typ_optyp
+
+  and boot_num_typ (at : region) (numtyp : Num.typ) : V.t =
+    match numtyp with
+    | `NatT -> case_at at (mop_num_typ_nat <|! []) typ_numtyp
+    | `IntT -> case_at at (mop_num_typ_int <|! []) typ_numtyp
+
+  and boot_text_typ (at : region) : V.t =
+    case_at at (mop_text_typ <|! []) typ_optyp
+
+  and boot_var_typ (at : region) (id : Il.id) (targs : Il.targ list) : V.t =
+    let value_id = boot_id id in
+    let value_targs = boot_targs targs in
+    case_at at (mop_var_typ <|! [ value_id; value_targs ]) typ_typ
+
+  and boot_tuple_typ (at : region) (typs : Il.typ list) : V.t =
+    let value_typs = boot_typs typs in
+    case_at at (mop_tuple_typ <|! [ value_typs ]) typ_typ
+
+  and boot_iter_typ (at : region) (typ : Il.typ) (iter : Il.iter) : V.t =
+    let value_typ = boot_typ typ in
+    let value_iter = boot_iter iter in
+    case_at at (mop_iter_typ <|! [ value_typ; value_iter ]) typ_typ
+
+  and boot_func_typ (at : region) : V.t =
+    case_at at (mop_func_typ <|! []) typ_typ
+
+  (* Defined types *)
+
+  and boot_deftyp (deftyp : Il.deftyp) : V.t =
+    let at = deftyp.at in
+    match deftyp.it with
+    | PlainT typ -> boot_plain_deftyp at typ
+    | StructT typfields -> boot_struct_deftyp at typfields
+    | VariantT typcases -> boot_variant_deftyp at typcases
+
+  and boot_plain_deftyp (at : region) (typ : Il.typ) : V.t =
+    let value_typ = boot_typ typ in
+    case_at at (mop_plain_deftyp <|! [ value_typ ]) typ_deftyp
+
+  and boot_typfield (typfield : Il.typfield) : V.t =
+    let atom, typ = typfield in
+    let value_atom = boot_atom atom in
+    let value_typ = boot_typ typ in
+    mop_typfield <|! [ value_atom; value_typ ] <<|! typ_typfield
+
+  and boot_typfields (typfields : Il.typfield list) : V.t =
+    let values_typfields = List.map boot_typfield typfields in
+    V.Make.list (Runtime.Type.Typ.Make.list typ_typfield) values_typfields
+
+  and boot_struct_deftyp (at : region) (typfields : Il.typfield list) : V.t =
+    let value_typfields = boot_typfields typfields in
+    case_at at (mop_struct_deftyp <|! [ value_typfields ]) typ_deftyp
+
+  and boot_typcase (typcase : Il.typcase) : V.t =
+    let nottyp, _, _ = typcase in
+    let mixop, typs = Mixfix.split nottyp.it in
+    let value_mixop = boot_mixop mixop in
+    let value_typs = boot_typs typs in
+    case_at nottyp.at (mop_typcase <|! [ value_mixop; value_typs ]) typ_typcase
+
+  and boot_typcases (typcases : Il.typcase list) : V.t =
+    let values_typcases = List.map boot_typcase typcases in
+    V.Make.list (Runtime.Type.Typ.Make.list typ_typcase) values_typcases
+
+  and boot_variant_deftyp (at : region) (typcases : Il.typcase list) : V.t =
+    let value_typcases = boot_typcases typcases in
+    case_at at (mop_variant_deftyp <|! [ value_typcases ]) typ_deftyp
+
+  (* Values *)
+
+  and boot_value (value : Il.value) : V.t =
+    let at = value.at in
+    match value.it with
+    | BoolV b -> boot_bool_value at b
+    | NumV num -> boot_num_value at num
+    | TextV t -> boot_text_value at t
+    | StructV valuefields -> boot_struct_value at valuefields
+    | CaseV valuecase -> boot_case_value at valuecase
+    | TupleV values -> boot_tuple_value at values
+    | OptV value_opt -> boot_opt_value at value_opt
+    | ListV values -> boot_list_value at values
+    | FuncV id -> boot_func_value at id
+    | ExternV json -> boot_extern_value at json
+
+  and boot_value_opt (value_opt : Il.value option) : V.t =
+    V.Make.opt
+      (Runtime.Type.Typ.Make.opt typ_val)
+      (Option.map boot_value value_opt)
+
+  and boot_values (values : Il.value list) : V.t =
+    let values_values = List.map boot_value values in
+    V.Make.list (Runtime.Type.Typ.Make.list typ_val) values_values
+
+  and boot_bool_value (at : region) (b : bool) : V.t =
+    case_at at (mop_bool_value <|! [ V.Make.bool b ]) typ_val
+
+  and boot_num_value (at : region) (num : Il.num) : V.t =
+    match num with
+    | `Nat n -> case_at at (mop_num_value_nat <|! [ V.Make.nat n ]) typ_num
+    | `Int i -> case_at at (mop_num_value_int <|! [ V.Make.int i ]) typ_num
+
+  and boot_text_value (at : region) (t : string) : V.t =
+    case_at at (mop_text_value <|! [ V.Make.text t ]) typ_val
+
+  and boot_valuefield (vf : Il.valuefield) : V.t =
+    let atom, value = vf in
+    let value_atom = boot_atom atom in
+    let value_value = boot_value value in
+    mop_valuefield <|! [ value_atom; value_value ] <<|! typ_valfield
+
+  and boot_valuefields (valuefields : Il.valuefield list) : V.t =
+    let values_valuefields = List.map boot_valuefield valuefields in
+    V.Make.list (Runtime.Type.Typ.Make.list typ_valfield) values_valuefields
+
+  and boot_struct_value (at : region) (valuefields : Il.valuefield list) : V.t =
+    let value_valuefields = boot_valuefields valuefields in
+    case_at at (mop_struct_value <|! [ value_valuefields ]) typ_val
+
+  and boot_valuecase (valuecase : Il.valuecase) : V.t =
+    let mixop, values = Mixfix.split valuecase in
+    let value_mixop = boot_mixop mixop in
+    let value_values = boot_values values in
+    mop_valuecase <|! [ value_mixop; value_values ] <<|! typ_valcase
+
+  and boot_case_value (at : region) (vc : Il.valuecase) : V.t =
+    let value_valuecase = boot_valuecase vc in
+    case_at at (mop_case_value <|! [ value_valuecase ]) typ_val
+
+  and boot_tuple_value (at : region) (values : Il.value list) : V.t =
+    let value_values = boot_values values in
+    case_at at (mop_tuple_value <|! [ value_values ]) typ_val
+
+  and boot_opt_value (at : region) (value_opt : Il.value option) : V.t =
+    let value_value_opt = boot_value_opt value_opt in
+    case_at at (mop_opt_value <|! [ value_value_opt ]) typ_val
+
+  and boot_list_value (at : region) (values : Il.value list) : V.t =
+    let value_values = boot_values values in
+    case_at at (mop_list_value <|! [ value_values ]) typ_val
+
+  and boot_func_value (at : region) (id : Il.id) : V.t =
+    let value_id = boot_id id in
+    case_at at (mop_func_value <|! [ value_id ]) typ_val
+
+  and boot_extern_value (at : region) (json : Yojson.Safe.t) : V.t =
+    let typ_json = Runtime.Type.Typ.Make.var ("json" $ no_region) [] in
+    let value_json = V.Make.extern typ_json json in
+    case_at at (mop_extern_value <|! [ value_json ]) typ_val
+
+  (* Operators *)
+
+  and boot_unop (unop : Il.unop) : V.t =
+    match unop with
+    | #Bool.unop as unop -> boot_unop_bool unop
+    | #Num.unop as unop -> boot_unop_num unop
+
+  and boot_unop_bool (unop : Bool.unop) : V.t =
+    match unop with `NotOp -> mop_not_unop <|! [] <<|! typ_boolunop
+
+  and boot_unop_num (unop : Num.unop) : V.t =
+    match unop with
+    | `PlusOp -> mop_plus_unop <|! [] <<|! typ_numunop
+    | `MinusOp -> mop_minus_unop <|! [] <<|! typ_numunop
+
+  and boot_binop (binop : Il.binop) : V.t =
+    match binop with
+    | #Bool.binop as binop -> boot_binop_bool binop
+    | #Num.binop as binop -> boot_binop_num binop
+
+  and boot_binop_bool (binop : Bool.binop) : V.t =
+    match binop with
+    | `AndOp -> mop_and_binop <|! [] <<|! typ_boolbinop
+    | `OrOp -> mop_or_binop <|! [] <<|! typ_boolbinop
+    | `ImplOp -> mop_impl_binop <|! [] <<|! typ_boolbinop
+    | `EquivOp -> mop_equiv_binop <|! [] <<|! typ_boolbinop
+
+  and boot_binop_num (binop : Num.binop) : V.t =
+    match binop with
+    | `AddOp -> mop_add_binop <|! [] <<|! typ_numbinop
+    | `SubOp -> mop_sub_binop <|! [] <<|! typ_numbinop
+    | `MulOp -> mop_mul_binop <|! [] <<|! typ_numbinop
+    | `DivOp -> mop_div_binop <|! [] <<|! typ_numbinop
+    | `ModOp -> mop_mod_binop <|! [] <<|! typ_numbinop
+    | `PowOp -> mop_pow_binop <|! [] <<|! typ_numbinop
+
+  and boot_cmpop (cmpop : Il.cmpop) : V.t =
+    match cmpop with
+    | #Bool.cmpop as cmpop -> boot_cmpop_bool cmpop
+    | #Num.cmpop as cmpop -> boot_cmpop_num cmpop
+
+  and boot_cmpop_bool (cmpop : Bool.cmpop) : V.t =
+    match cmpop with
+    | `EqOp -> mop_eq_cmpop <|! [] <<|! typ_polycmpop
+    | `NeOp -> mop_ne_cmpop <|! [] <<|! typ_polycmpop
+
+  and boot_cmpop_num (cmpop : Num.cmpop) : V.t =
+    match cmpop with
+    | `LtOp -> mop_lt_cmpop <|! [] <<|! typ_numcmpop
+    | `LeOp -> mop_le_cmpop <|! [] <<|! typ_numcmpop
+    | `GtOp -> mop_gt_cmpop <|! [] <<|! typ_numcmpop
+    | `GeOp -> mop_ge_cmpop <|! [] <<|! typ_numcmpop
+
+  (* Type arguments *)
+
+  and boot_targ (targ : Il.targ) : V.t = boot_typ targ
+
+  and boot_targs (targs : Il.targ list) : V.t =
+    let values_targs = List.map boot_targ targs in
+    V.Make.list
+      (Runtime.Type.Typ.Make.list
+         (Runtime.Type.Typ.Make.var ("targ" $ no_region) []))
+      values_targs
+
+  (* Type parameters *)
+
+  and boot_tparam (tparam : Il.tparam) : V.t = boot_id tparam
+
+  and boot_tparams (tparams : Il.tparam list) : V.t =
+    let values_tparams = List.map boot_tparam tparams in
+    V.Make.list
+      (Runtime.Type.Typ.Make.list
+         (Runtime.Type.Typ.Make.var ("tparam" $ no_region) []))
+      values_tparams
+
+  (* Arguments *)
+
+  and boot_arg (arg : Il.arg) : V.t =
+    let at = arg.at in
+    match arg.it with
+    | ExpA e ->
+        let value_exp = boot_exp e in
+        case_at at (mop_exp_arg <|! [ value_exp ]) typ_arg
+    | DefA id ->
+        let value_id = boot_id id in
+        case_at at (mop_def_arg <|! [ value_id ]) typ_arg
+
+  and boot_args (args : Il.arg list) : V.t =
+    let values_args = List.map boot_arg args in
+    V.Make.list (Runtime.Type.Typ.Make.list typ_arg) values_args
+
+  (* Expressions *)
+
+  and boot_exp (exp : Il.exp) : V.t =
+    let at = exp.at in
+    match exp.it with
+    | BoolE b -> boot_bool_exp at b
+    | NumE num -> boot_num_exp at num
+    | TextE t -> boot_text_exp at t
+    | VarE id -> boot_var_exp at id
+    | UnE (unop, _, e) -> boot_un_exp at unop e
+    | BinE (binop, _, el, er) -> boot_bin_exp at binop el er
+    | CmpE (cmpop, _, el, er) -> boot_cmp_exp at cmpop el er
+    | UpCastE (typ, e) -> boot_upcast_exp at typ e
+    | DownCastE (typ, e) -> boot_downcast_exp at typ e
+    | SubE (e, typ) -> boot_sub_exp at e typ
+    | MatchE (e, pattern) -> boot_match_exp at e pattern
+    | TupleE exps -> boot_tuple_exp at exps
+    | CaseE notexp -> boot_case_exp at notexp
+    | StrE expfields -> boot_struct_exp at expfields
+    | OptE exp_opt -> boot_opt_exp at exp_opt
+    | ListE exps -> boot_list_exp at exps
+    | ConsE (eh, et) -> boot_cons_exp at eh et
+    | CatE (el, er) -> boot_cat_exp at el er
+    | MemE (ee, es) -> boot_mem_exp at ee es
+    | LenE e -> boot_len_exp at e
+    | DotE (e, atom) -> boot_dot_exp at e atom
+    | IdxE (eb, ei) -> boot_idx_exp at eb ei
+    | SliceE (eb, ei, en) -> boot_slice_exp at eb ei en
+    | UpdE (eb, path, en) -> boot_upd_exp at eb path en
+    | CallE (id, targs, args) -> boot_call_exp at id targs args
+    | IterE (e, ie) -> boot_iter_exp at e ie
+
+  and boot_bool_exp (at : region) (b : bool) : V.t =
+    case_at at (mop_bool_exp <|! [ V.Make.bool b ]) typ_exp
+
+  and boot_num_exp (at : region) (num : Il.num) : V.t = boot_num_value at num
+
+  and boot_text_exp (at : region) (t : string) : V.t =
+    case_at at (mop_text_exp <|! [ V.Make.text t ]) typ_exp
+
+  and boot_var_exp (at : region) (id : Il.id) : V.t =
+    let value_id = boot_id id in
+    case_at at (mop_var_exp <|! [ value_id ]) typ_exp
+
+  and boot_un_exp (at : region) (unop : Il.unop) (exp : Il.exp) : V.t =
+    let value_unop = boot_unop unop in
+    let value_exp = boot_exp exp in
+    case_at at (mop_un_exp <|! [ value_unop; value_exp ]) typ_exp
+
+  and boot_bin_exp (at : region) (binop : Il.binop) (exp_l : Il.exp)
+      (exp_r : Il.exp) : V.t =
+    let value_binop = boot_binop binop in
+    let value_exp_l = boot_exp exp_l in
+    let value_exp_r = boot_exp exp_r in
+    case_at at
+      (mop_bin_exp <|! [ value_binop; value_exp_l; value_exp_r ])
+      typ_exp
+
+  and boot_cmp_exp (at : region) (cmpop : Il.cmpop) (exp_l : Il.exp)
+      (exp_r : Il.exp) : V.t =
+    let value_cmpop = boot_cmpop cmpop in
+    let value_exp_l = boot_exp exp_l in
+    let value_exp_r = boot_exp exp_r in
+    case_at at
+      (mop_cmp_exp <|! [ value_cmpop; value_exp_l; value_exp_r ])
+      typ_exp
+
+  and boot_upcast_exp (at : region) (typ : Il.typ) (exp : Il.exp) : V.t =
+    let value_typ = boot_typ typ in
+    let value_exp = boot_exp exp in
+    case_at at (mop_upcast_exp <|! [ value_typ; value_exp ]) typ_exp
+
+  and boot_downcast_exp (at : region) (typ : Il.typ) (exp : Il.exp) : V.t =
+    let value_typ = boot_typ typ in
+    let value_exp = boot_exp exp in
+    case_at at (mop_downcast_exp <|! [ value_typ; value_exp ]) typ_exp
+
+  and boot_sub_exp (at : region) (exp : Il.exp) (typ : Il.typ) : V.t =
+    let value_exp = boot_exp exp in
+    let value_typ = boot_typ typ in
+    case_at at (mop_sub_exp <|! [ value_exp; value_typ ]) typ_exp
+
+  and boot_match_exp (at : region) (exp : Il.exp) (pattern : Il.pattern) : V.t =
+    let value_exp = boot_exp exp in
+    let value_pattern = boot_pattern pattern in
+    case_at at (mop_match_exp <|! [ value_exp; value_pattern ]) typ_exp
+
+  and boot_tuple_exp (at : region) (exps : Il.exp list) : V.t =
+    let value_exps = boot_exps exps in
+    case_at at (mop_tuple_exp <|! [ value_exps ]) typ_exp
+
+  and boot_expcase (notexp : Il.notexp) : V.t =
+    let mixop, exps = Mixfix.split notexp in
+    let value_mixop = boot_mixop mixop in
+    let value_exps = boot_exps exps in
+    mop_expcase <|! [ value_mixop; value_exps ] <<|! typ_expcase
+
+  and boot_case_exp (at : region) (notexp : Il.notexp) : V.t =
+    let value_expcase = boot_expcase notexp in
+    case_at at (mop_case_exp <|! [ value_expcase ]) typ_exp
+
+  and boot_expfield ((atom, exp) : Il.atom * Il.exp) : V.t =
+    let value_atom = boot_atom atom in
+    let value_exp = boot_exp exp in
+    mop_expfield <|! [ value_atom; value_exp ] <<|! typ_expfield
+
+  and boot_expfields (expfields : (Il.atom * Il.exp) list) : V.t =
+    let values_expfields = List.map boot_expfield expfields in
+    V.Make.list (Runtime.Type.Typ.Make.list typ_expfield) values_expfields
+
+  and boot_struct_exp (at : region) (expfields : (Il.atom * Il.exp) list) : V.t
+      =
+    let value_expfields = boot_expfields expfields in
+    case_at at (mop_struct_exp <|! [ value_expfields ]) typ_exp
+
+  and boot_opt_exp (at : region) (exp_opt : Il.exp option) : V.t =
+    let value_exp_opt = boot_exp_opt exp_opt in
+    case_at at (mop_opt_exp <|! [ value_exp_opt ]) typ_exp
+
+  and boot_list_exp (at : region) (exps : Il.exp list) : V.t =
+    let value_exps = boot_exps exps in
+    case_at at (mop_list_exp <|! [ value_exps ]) typ_exp
+
+  and boot_cons_exp (at : region) (exp_h : Il.exp) (exp_t : Il.exp) : V.t =
+    let value_exp_h = boot_exp exp_h in
+    let value_exp_t = boot_exp exp_t in
+    case_at at (mop_cons_exp <|! [ value_exp_h; value_exp_t ]) typ_exp
+
+  and boot_cat_exp (at : region) (exp_l : Il.exp) (exp_r : Il.exp) : V.t =
+    let value_exp_l = boot_exp exp_l in
+    let value_exp_r = boot_exp exp_r in
+    case_at at (mop_cat_exp <|! [ value_exp_l; value_exp_r ]) typ_exp
+
+  and boot_mem_exp (at : region) (exp_e : Il.exp) (exp_s : Il.exp) : V.t =
+    let value_exp_e = boot_exp exp_e in
+    let value_exp_s = boot_exp exp_s in
+    case_at at (mop_mem_exp <|! [ value_exp_e; value_exp_s ]) typ_exp
+
+  and boot_len_exp (at : region) (exp : Il.exp) : V.t =
+    let value_exp = boot_exp exp in
+    case_at at (mop_len_exp <|! [ value_exp ]) typ_exp
+
+  and boot_dot_exp (at : region) (exp : Il.exp) (atom : Il.atom) : V.t =
+    let value_exp = boot_exp exp in
+    let value_atom = boot_atom atom in
+    case_at at (mop_dot_exp <|! [ value_exp; value_atom ]) typ_exp
+
+  and boot_idx_exp (at : region) (exp_b : Il.exp) (exp_i : Il.exp) : V.t =
+    let value_exp_b = boot_exp exp_b in
+    let value_exp_i = boot_exp exp_i in
+    case_at at (mop_idx_exp <|! [ value_exp_b; value_exp_i ]) typ_exp
+
+  and boot_slice_exp (at : region) (exp_b : Il.exp) (exp_i : Il.exp)
+      (exp_n : Il.exp) : V.t =
+    let value_exp_b = boot_exp exp_b in
+    let value_exp_i = boot_exp exp_i in
+    let value_exp_n = boot_exp exp_n in
+    case_at at
+      (mop_slice_exp <|! [ value_exp_b; value_exp_i; value_exp_n ])
+      typ_exp
+
+  and boot_upd_exp (at : region) (exp_b : Il.exp) (path : Il.path)
+      (exp_n : Il.exp) : V.t =
+    let value_exp_b = boot_exp exp_b in
+    let value_path = boot_path path in
+    let value_exp_n = boot_exp exp_n in
+    case_at at
+      (mop_upd_exp <|! [ value_exp_b; value_path; value_exp_n ])
+      typ_exp
+
+  and boot_call_exp (at : region) (id : Il.id) (targs : Il.targ list)
+      (args : Il.arg list) : V.t =
+    let value_id = boot_id id in
+    let value_targs = boot_targs targs in
+    let value_args = boot_args args in
+    case_at at (mop_call_exp <|! [ value_id; value_targs; value_args ]) typ_exp
+
+  and boot_iter_exp (at : region) (exp : Il.exp) (iterexp : Il.iterexp) : V.t =
+    let value_exp = boot_exp exp in
+    let value_iterexp = boot_iterexp iterexp in
+    case_at at (mop_iter_exp <|! [ value_exp; value_iterexp ]) typ_exp
+
+  and boot_exps (exps : Il.exp list) : V.t =
+    let values_exps = List.map boot_exp exps in
+    V.Make.list (Runtime.Type.Typ.Make.list typ_exp) values_exps
+
+  and boot_exp_opt (exp_opt : Il.exp option) : V.t =
+    V.Make.opt (Runtime.Type.Typ.Make.opt typ_exp) (Option.map boot_exp exp_opt)
+
+  (* Paths *)
+
+  and boot_path (path : Il.path) : V.t =
+    let at = path.at in
+    match path.it with
+    | RootP -> case_at at (mop_root_path <|! []) typ_path
+    | IdxP (path, exp) ->
+        let value_path = boot_path path in
+        let value_exp = boot_exp exp in
+        case_at at (mop_idx_path <|! [ value_path; value_exp ]) typ_path
+    | SliceP (path, exp_i, exp_n) ->
+        let value_path = boot_path path in
+        let value_exp_i = boot_exp exp_i in
+        let value_exp_n = boot_exp exp_n in
+        case_at at
+          (mop_slice_path <|! [ value_path; value_exp_i; value_exp_n ])
+          typ_path
+    | DotP (path, atom) ->
+        let value_path = boot_path path in
+        let value_atom = boot_atom atom in
+        case_at at (mop_dot_path <|! [ value_path; value_atom ]) typ_path
+
+  (* Patterns *)
+
+  and boot_pattern (pattern : Il.pattern) : V.t =
+    match pattern with
+    | CaseP mixop ->
+        let value_mixop = boot_mixop mixop in
+        mop_case_pattern <|! [ value_mixop ] <<|! typ_pattern
+    | ListP `Cons -> mop_list_cons_pattern <|! [] <<|! typ_listpattern
+    | ListP (`Fixed n) ->
         mop_list_fixed_pattern
-        <|! [ nat (Bigint.of_int n) ]
-        <<|! typ_listpattern)
-  | ListP `Nil -> Value.Make.(mop_list_nil_pattern <|! [] <<|! typ_listpattern)
-  | OptP `Some -> Value.Make.(mop_opt_some_pattern <|! [] <<|! typ_optpattern)
-  | OptP `None -> Value.Make.(mop_opt_none_pattern <|! [] <<|! typ_optpattern)
+        <|! [ V.Make.nat (Bigint.of_int n) ]
+        <<|! typ_listpattern
+    | ListP `Nil -> mop_list_nil_pattern <|! [] <<|! typ_listpattern
+    | OptP `Some -> mop_opt_some_pattern <|! [] <<|! typ_optpattern
+    | OptP `None -> mop_opt_none_pattern <|! [] <<|! typ_optpattern
 
-(* Iter expressions *)
+  (* Iter expressions *)
 
-and boot_iterexp ((iter, vars) : Il.iterexp) : Value.t =
-  let value_iter = boot_iter iter in
-  let value_vars = boot_vars vars in
-  Value.Make.(mop_iterexp <|! [ value_iter; value_vars ] <<|! typ_iterexp)
+  and boot_iterexp ((iter, vars) : Il.iterexp) : V.t =
+    let value_iter = boot_iter iter in
+    let value_vars = boot_vars vars in
+    mop_iterexp <|! [ value_iter; value_vars ] <<|! typ_iterexp
+end

--- a/p4spec/lib/interface/spectec/common/il_typs.ml
+++ b/p4spec/lib/interface/spectec/common/il_typs.ml
@@ -1,0 +1,28 @@
+module Il = Lang.Il
+open Util.Source
+
+(* Il.typ mirrors of Typs constants (same underlying type, different alias path) *)
+
+let var (name : string) : Il.typ = Il.VarT (name $ no_region, []) $ no_region
+let typ_val = var "val"
+let typ_typ = var "typ"
+let typ_deftyp = var "deftyp"
+let typ_unop = var "unop"
+let typ_binop = var "binop"
+let typ_cmpop = var "cmpop"
+let typ_arg = var "arg"
+let typ_exp = var "exp"
+let typ_path = var "path"
+let typ_pattern = var "pattern"
+
+(* Constants used by common/unboot.ml's dispatch-table call sites. *)
+
+let typ_iter = var "iter"
+let typ_vari = var "vari"
+let typ_typfield = var "typfield"
+let typ_typcase = var "typcase"
+let typ_valfield = var "valfield"
+let typ_valcase = var "valcase"
+let typ_expcase = var "expcase"
+let typ_expfield = var "expfield"
+let typ_iterexp = var "iterexp"

--- a/p4spec/lib/interface/spectec/common/unboot.ml
+++ b/p4spec/lib/interface/spectec/common/unboot.ml
@@ -3,865 +3,852 @@ module Mixfix = Domain.Mixfix
 module Il = Lang.Il
 module Typ = Runtime.Type.Typ
 module Value = Runtime.Value
-module VCache = Runtime.Dynamic.Caches.ValueCache
 open Mixops
 open Stub
-open Caches
 open Util.Error
 open Util.Source
 
-(* Errors *)
+module Make (V : Runtime.Valrep.SAFE) = struct
+  module Dispatch = Runtime.Valrep.Dispatch.Make (V)
 
-let error = error_unparse
+  (* Errors *)
 
-(* Forward references for match dispatch tables,
-   populated after all sub-match functions are defined *)
+  let error = error_unparse
 
-let unboot_value_mtchtbl : Il.value Value.Get.mtchtbl ref =
-  ref (Value.Get.MtchTbl.create 0)
+  (* Forward references for match dispatch tables,
+     populated after all sub-match functions are defined *)
 
-let unboot_typ_mtchtbl : Il.typ Value.Get.mtchtbl ref =
-  ref (Value.Get.MtchTbl.create 0)
+  let unboot_value_mtchtbl : Il.value Dispatch.mtchtbl ref =
+    ref (Dispatch.MtchTbl.create 0)
 
-let unboot_deftyp_mtchtbl : Il.deftyp Value.Get.mtchtbl ref =
-  ref (Value.Get.MtchTbl.create 0)
+  let unboot_typ_mtchtbl : Il.typ Dispatch.mtchtbl ref =
+    ref (Dispatch.MtchTbl.create 0)
 
-let unboot_unop_mtchtbl : Il.unop Value.Get.mtchtbl ref =
-  ref (Value.Get.MtchTbl.create 0)
+  let unboot_deftyp_mtchtbl : Il.deftyp Dispatch.mtchtbl ref =
+    ref (Dispatch.MtchTbl.create 0)
 
-let unboot_binop_mtchtbl : Il.binop Value.Get.mtchtbl ref =
-  ref (Value.Get.MtchTbl.create 0)
+  let unboot_unop_mtchtbl : Il.unop Dispatch.mtchtbl ref =
+    ref (Dispatch.MtchTbl.create 0)
 
-let unboot_cmpop_mtchtbl : Il.cmpop Value.Get.mtchtbl ref =
-  ref (Value.Get.MtchTbl.create 0)
+  let unboot_binop_mtchtbl : Il.binop Dispatch.mtchtbl ref =
+    ref (Dispatch.MtchTbl.create 0)
 
-let unboot_arg_mtchtbl : Il.arg Value.Get.mtchtbl ref =
-  ref (Value.Get.MtchTbl.create 0)
+  let unboot_cmpop_mtchtbl : Il.cmpop Dispatch.mtchtbl ref =
+    ref (Dispatch.MtchTbl.create 0)
 
-let unboot_exp_mtchtbl : Il.exp Value.Get.mtchtbl ref =
-  ref (Value.Get.MtchTbl.create 0)
+  let unboot_arg_mtchtbl : Il.arg Dispatch.mtchtbl ref =
+    ref (Dispatch.MtchTbl.create 0)
 
-let unboot_path_mtchtbl : Il.path Value.Get.mtchtbl ref =
-  ref (Value.Get.MtchTbl.create 0)
+  let unboot_exp_mtchtbl : Il.exp Dispatch.mtchtbl ref =
+    ref (Dispatch.MtchTbl.create 0)
 
-let unboot_pattern_mtchtbl : Il.pattern Value.Get.mtchtbl ref =
-  ref (Value.Get.MtchTbl.create 0)
+  let unboot_path_mtchtbl : Il.path Dispatch.mtchtbl ref =
+    ref (Dispatch.MtchTbl.create 0)
 
-(* Identifiers *)
+  let unboot_pattern_mtchtbl : Il.pattern Dispatch.mtchtbl ref =
+    ref (Dispatch.MtchTbl.create 0)
 
-let unboot_id (value_id : Value.t) : Il.id =
-  let id = Value.Get.text value_id in
-  id $ value_id.at
+  (* Identifiers *)
 
-(* Atoms *)
+  let unboot_id (value_id : V.t) : Il.id =
+    let id = V.Get.text value_id in
+    id $ V.at value_id
 
-let unboot_atom (value_atom : Value.t) : Il.atom =
-  let atom = value_atom |> Value.Get.text |> Atom.atom_of_string in
-  atom $ value_atom.at
+  (* Atoms *)
 
-(* Mixops *)
+  let unboot_atom (value_atom : V.t) : Il.atom =
+    let atom = value_atom |> V.Get.text |> Atom.atom_of_string in
+    atom $ V.at value_atom
 
-let unboot_mixop (value_mixop : Value.t) : Il.mixop =
-  let cached = !find_unboot_mixop_cache value_mixop in
-  match cached with
-  | Some mixop -> mixop
-  | None ->
-      let atoms_matrix =
-        value_mixop |> Value.Get.list
-        |> List.map (fun value_atoms ->
-               value_atoms |> Value.Get.list |> List.map unboot_atom
-               |> List.map it)
-      in
-      let mixop = Value.Mixops.of_atoms_matrix atoms_matrix in
-      !add_unboot_mixop_cache value_mixop mixop;
-      mixop
+  (* Mixops *)
 
-(* Iterators *)
+  let unboot_mixop (value_mixop : V.t) : Il.mixop =
+    let atoms_matrix =
+      value_mixop |> V.Get.list
+      |> List.map (fun value_atoms ->
+             value_atoms |> V.Get.list |> List.map unboot_atom |> List.map it)
+    in
+    Value.Mixops.of_atoms_matrix atoms_matrix
 
-let unboot_iter_tbl =
-  Value.Get.build_mtchtbl
-    [ (mop_quest, fun _ _ -> Il.Opt); (mop_star, fun _ _ -> Il.List) ]
+  (* Iterators *)
 
-let unboot_iter (value_iter : Value.t) : Il.iter =
-  Value.Get.mtch_dispatch value_iter unboot_iter_tbl (fun _ _ ->
-      error "@unboot_iter")
+  let unboot_iter_tbl =
+    Dispatch.build_mtchtbl
+      [ (mop_quest, fun _ _ -> Il.Opt); (mop_star, fun _ _ -> Il.List) ]
 
-let unboot_iters (value_iters : Value.t) : Il.iter list =
-  value_iters |> Value.Get.list |> List.map unboot_iter
+  let unboot_iter (value_iter : V.t) : Il.iter =
+    Dispatch.dispatch value_iter Il_typs.typ_iter unboot_iter_tbl (fun _ _ ->
+        error "@unboot_iter")
 
-(* Variables *)
+  let unboot_iters (value_iters : V.t) : Il.iter list =
+    value_iters |> V.Get.list |> List.map unboot_iter
 
-let rec unboot_vari (value_vari : Value.t) : Il.var =
-  let values = Value.Get.(value_vari |>>! mop_vari) in
-  let id = Value.Get.nth 0 values |> unboot_id in
-  let typ = Value.Get.nth 1 values |> unboot_typ in
-  let iters = Value.Get.nth 2 values |> unboot_iters in
-  (id, typ, iters)
+  (* Variables *)
 
-and unboot_varis (value_varis : Value.t) : Il.var list =
-  value_varis |> Value.Get.list |> List.map unboot_vari
+  let rec unboot_vari (value_vari : V.t) : Il.var =
+    let values = Dispatch.case_exact value_vari mop_vari Il_typs.typ_vari in
+    let id = V.Get.nth 0 values |> unboot_id in
+    let typ = V.Get.nth 1 values |> unboot_typ in
+    let iters = V.Get.nth 2 values |> unboot_iters in
+    (id, typ, iters)
 
-(* Types *)
+  and unboot_varis (value_varis : V.t) : Il.var list =
+    value_varis |> V.Get.list |> List.map unboot_vari
 
-and unboot_typ (value_typ : Value.t) : Il.typ =
-  let cached = !find_unboot_typ_cache value_typ in
-  match cached with
-  | Some typ -> typ
-  | None ->
-      let typ =
-        Value.Get.mtch_dispatch value_typ !unboot_typ_mtchtbl (fun _ _ ->
-            error "@unboot_typ")
-      in
-      !add_unboot_typ_cache value_typ typ;
-      typ
-
-and unboot_typs (value_typs : Value.t) : Il.typ list =
-  value_typs |> Value.Get.list |> List.map unboot_typ
-
-and unboot_bool_typ (at : region) (_ : Value.t list) : Il.typ = Il.BoolT $ at
-
-and unboot_num_typ_nat (at : region) (_ : Value.t list) : Il.typ =
-  Il.NumT `NatT $ at
-
-and unboot_num_typ_int (at : region) (_ : Value.t list) : Il.typ =
-  Il.NumT `IntT $ at
-
-and unboot_text_typ (at : region) (_ : Value.t list) : Il.typ = Il.TextT $ at
-
-and unboot_var_typ (at : region) (values : Value.t list) : Il.typ =
-  match values with
-  | [ value_id; value_targs ] ->
-      let id = unboot_id value_id in
-      let targs = unboot_targs value_targs in
-      Il.VarT (id, targs) $ at
-  | _ -> error "@unboot_var_typ"
-
-and unboot_tuple_typ (at : region) (values : Value.t list) : Il.typ =
-  match values with
-  | [ value_typs ] ->
-      let typs = unboot_typs value_typs in
-      Il.TupleT typs $ at
-  | _ -> error "@unboot_tuple_typ"
-
-and unboot_iter_typ (at : region) (values : Value.t list) : Il.typ =
-  match values with
-  | [ value_typ; value_iter ] ->
-      let typ = unboot_typ value_typ in
-      let iter = unboot_iter value_iter in
-      Il.IterT (typ, iter) $ at
-  | _ -> error "@unboot_iter_typ"
-
-and unboot_func_typ (at : region) (_ : Value.t list) : Il.typ =
-  let tparams, typs, typ = stub_func_typ_params () in
-  Il.FuncT (tparams, typs, typ) $ at
-
-(* Type arguments and parameters *)
-
-and unboot_targ (value_targ : Value.t) : Il.targ = unboot_typ value_targ
-
-and unboot_targs (value_targs : Value.t) : Il.targ list =
-  value_targs |> Value.Get.list |> List.map unboot_targ
-
-and unboot_tparam (value_tparam : Value.t) : Il.tparam = unboot_id value_tparam
-
-and unboot_tparams (value_tparams : Value.t) : Il.tparam list =
-  value_tparams |> Value.Get.list |> List.map unboot_tparam
-
-(* Defined types *)
-
-and unboot_deftyp (value_deftyp : Value.t) : Il.deftyp =
-  Value.Get.mtch_dispatch value_deftyp !unboot_deftyp_mtchtbl (fun _ _ ->
-      error "@unboot_deftyp")
-
-and unboot_plain_deftyp (at : region) (values : Value.t list) : Il.deftyp =
-  match values with
-  | [ value_typ ] ->
-      let typ = unboot_typ value_typ in
-      Il.PlainT typ $ at
-  | _ -> error "@unboot_plain_deftyp"
-
-and unboot_typfield (value_typfield : Value.t) : Il.typfield =
-  let values = Value.Get.(value_typfield |>>! mop_typfield) in
-  let atom = Value.Get.nth 0 values |> unboot_atom in
-  let typ = Value.Get.nth 1 values |> unboot_typ in
-  (atom, typ)
-
-and unboot_typfields (value_typfields : Value.t) : Il.typfield list =
-  value_typfields |> Value.Get.list |> List.map unboot_typfield
-
-and unboot_struct_deftyp (at : region) (values : Value.t list) : Il.deftyp =
-  match values with
-  | [ value_typfields ] ->
-      let typfields = unboot_typfields value_typfields in
-      Il.StructT typfields $ at
-  | _ -> error "@unboot_struct_deftyp"
-
-and unboot_typcase (value_typcase : Value.t) : Il.typcase =
-  let values = Value.Get.(value_typcase |>>! mop_typcase) in
-  let mixop = Value.Get.nth 0 values |> unboot_mixop in
-  let typs = Value.Get.nth 1 values |> unboot_typs in
-  let nottyp = Mixfix.fill mixop typs $ value_typcase.at in
-  (nottyp, stub_typorigin (), [])
-
-and unboot_typcases (value_typcases : Value.t) : Il.typcase list =
-  value_typcases |> Value.Get.list |> List.map unboot_typcase
-
-and unboot_variant_deftyp (at : region) (values : Value.t list) : Il.deftyp =
-  match values with
-  | [ value_typcases ] ->
-      let typcases = unboot_typcases value_typcases in
-      Il.VariantT typcases $ at
-  | _ -> error "@unboot_variant_deftyp"
-
-(* Values *)
-
-and unboot_value (value_value : Value.t) : Il.value =
-  let cached =
-    let cached = !find_unboot_value_pingpong_cache value_value in
-    match cached with
-    | Some value -> Some value
-    | None -> !find_unboot_value_cache value_value
-  in
-  match cached with
-  | Some value -> value
-  | None ->
-      let value =
-        Value.Get.mtch_dispatch value_value !unboot_value_mtchtbl (fun _ _ ->
-            error "@unboot_value")
-      in
-      !add_unboot_value_cache value_value value;
-      !add_boot_value_pingpong_cache value value_value;
-      value
-
-and unboot_values (value_values : Value.t) : Il.value list =
-  value_values |> Value.Get.list |> List.map unboot_value
-
-and unboot_bool_value (at : region) (values : Value.t list) : Il.value =
-  match values with
-  | [ value_bool ] ->
-      let b = Value.Get.bool value_bool in
-      Value.Make.bool ~at b
-  | _ -> error "@unboot_bool_value"
-
-and unboot_num_value_nat (at : region) (values : Value.t list) : Il.value =
-  match values with
-  | [ value_nat ] ->
-      let n = Value.Get.num value_nat in
-      Value.Make.num ~at n
-  | _ -> error "@unboot_num_value_nat"
-
-and unboot_num_value_int (at : region) (values : Value.t list) : Il.value =
-  match values with
-  | [ value_int ] ->
-      let n = Value.Get.num value_int in
-      Value.Make.num ~at n
-  | _ -> error "@unboot_num_value_int"
-
-and unboot_text_value (at : region) (values : Value.t list) : Il.value =
-  match values with
-  | [ value_text ] ->
-      let s = Value.Get.text value_text in
-      Value.Make.text ~at s
-  | _ -> error "@unboot_text_value"
-
-and unboot_valuefield (value_valuefield : Value.t) : Il.valuefield =
-  let values = Value.Get.(value_valuefield |>>! mop_valuefield) in
-  let atom = Value.Get.nth 0 values |> unboot_atom in
-  let v = Value.Get.nth 1 values |> unboot_value in
-  (atom, v)
-
-and unboot_valuefields (value_valuefields : Value.t) : Il.valuefield list =
-  value_valuefields |> Value.Get.list |> List.map unboot_valuefield
-
-and unboot_struct_value (at : region) (values : Value.t list) : Il.value =
-  match values with
-  | [ value_valuefields ] ->
-      let valuefields = unboot_valuefields value_valuefields in
-      let typ = Typ.Make.var ("val" $ no_region) [] in
-      Value.Make.str ~at typ valuefields
-  | _ -> error "@unboot_struct_value"
-
-and unboot_valuecase (value_valuecase : Value.t) : Il.valuecase =
-  let values = Value.Get.(value_valuecase |>>! mop_valuecase) in
-  let mixop = Value.Get.nth 0 values |> unboot_mixop in
-  let values = Value.Get.nth 1 values |> unboot_values in
-  let valuecase = Mixfix.fill mixop values in
-  valuecase
-
-and unboot_variant_value (at : region) (values : Value.t list) : Il.value =
-  match values with
-  | [ value_valcase ] ->
-      let valuecase = unboot_valuecase value_valcase in
-      let typ = Typ.Make.var ("val" $ no_region) [] in
-      Value.Make.case ~at typ valuecase
-  | _ -> error "@unboot_variant_value"
-
-and unboot_tuple_value (at : region) (values : Value.t list) : Il.value =
-  match values with
-  | [ value_vals ] ->
-      let vals = unboot_values value_vals in
-      let typ = Typ.Make.var ("val" $ no_region) [] in
-      Value.Make.tuple ~at typ vals
-  | _ -> error "@unboot_tuple_value"
-
-and unboot_value_opt (value_value_opt : Value.t) : Il.value option =
-  value_value_opt |> Value.Get.opt |> Option.map unboot_value
-
-and unboot_opt_value (at : region) (values : Value.t list) : Il.value =
-  match values with
-  | [ value_value_opt ] ->
-      let value_opt = unboot_value_opt value_value_opt in
-      let typ = Typ.Make.var ("val" $ no_region) [] |> Typ.Make.opt in
-      Value.Make.opt ~at typ value_opt
-  | _ -> error "@unboot_opt_value"
-
-and unboot_list_value (at : region) (values : Value.t list) : Il.value =
-  match values with
-  | [ value_vals ] ->
-      let vals = unboot_values value_vals in
-      let typ = Typ.Make.var ("val" $ no_region) [] |> Typ.Make.list in
-      Value.Make.list ~at typ vals
-  | _ -> error "@unboot_list_value"
-
-and unboot_func_value (at : region) (values : Value.t list) : Il.value =
-  match values with
-  | [ value_id ] ->
-      let id = unboot_id value_id in
-      let tparams, typs, typ = stub_func_typ_params () in
-      Value.Make.func ~at id tparams typs typ
-  | _ -> error "@unboot_func_value"
-
-and unboot_extern_value (at : region) (values : Value.t list) : Il.value =
-  match values with
-  | [ value_json ] ->
-      let json = Value.Get.extern value_json in
-      let typ = Typ.Make.var ("json" $ no_region) [] in
-      Value.Make.extern ~at typ json
-  | _ -> error "@unboot_extern_value"
-
-(* Operators *)
-
-and unboot_unop (value_unop : Value.t) : Il.unop =
-  Value.Get.mtch_dispatch value_unop !unboot_unop_mtchtbl (fun _ _ ->
-      error "@unboot_unop")
-
-and unboot_not_unop (_ : region) (_ : Value.t list) : Il.unop = `NotOp
-and unboot_plus_unop (_ : region) (_ : Value.t list) : Il.unop = `PlusOp
-and unboot_minus_unop (_ : region) (_ : Value.t list) : Il.unop = `MinusOp
-
-and unboot_binop (value_binop : Value.t) : Il.binop =
-  Value.Get.mtch_dispatch value_binop !unboot_binop_mtchtbl (fun _ _ ->
-      error "@unboot_binop")
-
-and unboot_and_binop (_ : region) (_ : Value.t list) : Il.binop = `AndOp
-and unboot_or_binop (_ : region) (_ : Value.t list) : Il.binop = `OrOp
-and unboot_impl_binop (_ : region) (_ : Value.t list) : Il.binop = `ImplOp
-and unboot_equiv_binop (_ : region) (_ : Value.t list) : Il.binop = `EquivOp
-and unboot_add_binop (_ : region) (_ : Value.t list) : Il.binop = `AddOp
-and unboot_sub_binop (_ : region) (_ : Value.t list) : Il.binop = `SubOp
-and unboot_mul_binop (_ : region) (_ : Value.t list) : Il.binop = `MulOp
-and unboot_div_binop (_ : region) (_ : Value.t list) : Il.binop = `DivOp
-and unboot_mod_binop (_ : region) (_ : Value.t list) : Il.binop = `ModOp
-and unboot_pow_binop (_ : region) (_ : Value.t list) : Il.binop = `PowOp
-
-and unboot_cmpop (value_cmpop : Value.t) : Il.cmpop =
-  Value.Get.mtch_dispatch value_cmpop !unboot_cmpop_mtchtbl (fun _ _ ->
-      error "@unboot_cmpop")
-
-and unboot_eq_cmpop (_ : region) (_ : Value.t list) : Il.cmpop = `EqOp
-and unboot_ne_cmpop (_ : region) (_ : Value.t list) : Il.cmpop = `NeOp
-and unboot_lt_cmpop (_ : region) (_ : Value.t list) : Il.cmpop = `LtOp
-and unboot_le_cmpop (_ : region) (_ : Value.t list) : Il.cmpop = `LeOp
-and unboot_gt_cmpop (_ : region) (_ : Value.t list) : Il.cmpop = `GtOp
-and unboot_ge_cmpop (_ : region) (_ : Value.t list) : Il.cmpop = `GeOp
-
-(* Arguments *)
-
-and unboot_arg (value_arg : Value.t) : Il.arg =
-  Value.Get.mtch_dispatch value_arg !unboot_arg_mtchtbl (fun _ _ ->
-      error "@unboot_arg")
-
-and unboot_exp_arg (at : region) (values : Value.t list) : Il.arg =
-  match values with
-  | [ value_exp ] ->
-      let exp = unboot_exp value_exp in
-      Il.ExpA exp $ at
-  | _ -> error "@unboot_arg/EXP"
-
-and unboot_def_arg (at : region) (values : Value.t list) : Il.arg =
-  match values with
-  | [ value_id ] ->
-      let id = unboot_id value_id in
-      Il.DefA id $ at
-  | _ -> error "@unboot_arg/FUN"
-
-and unboot_args (value_args : Value.t) : Il.arg list =
-  value_args |> Value.Get.list |> List.map unboot_arg
-
-(* Expressions *)
-
-and unboot_exp (value_exp : Value.t) : Il.exp =
-  Value.Get.mtch_dispatch value_exp !unboot_exp_mtchtbl (fun _ _ ->
-      error "@unboot_exp")
-
-and unboot_exps (value_exps : Value.t) : Il.exp list =
-  value_exps |> Value.Get.list |> List.map unboot_exp
-
-and unboot_exp_opt (value_exp_opt : Value.t) : Il.exp option =
-  value_exp_opt |> Value.Get.opt |> Option.map unboot_exp
-
-and unboot_expfield (value_expfield : Value.t) : Il.atom * Il.exp =
-  let values = Value.Get.(value_expfield |>>! mop_expfield) in
-  let atom = Value.Get.nth 0 values |> unboot_atom in
-  let exp = Value.Get.nth 1 values |> unboot_exp in
-  (atom, exp)
-
-and unboot_expfields (value_expfields : Value.t) : (Il.atom * Il.exp) list =
-  value_expfields |> Value.Get.list |> List.map unboot_expfield
-
-and unboot_bool_exp (at : region) (values : Value.t list) : Il.exp =
-  match values with
-  | [ value_bool ] ->
-      let b = Value.Get.bool value_bool in
-      Il.BoolE b $$ (at, stub_exp_note)
-  | _ -> error "@unboot_bool_exp"
-
-and unboot_num_exp_nat (at : region) (values : Value.t list) : Il.exp =
-  match values with
-  | [ value_nat ] ->
-      let n = Value.Get.num value_nat in
-      Il.NumE n $$ (at, stub_exp_note)
-  | _ -> error "@unboot_num_exp_nat"
-
-and unboot_num_exp_int (at : region) (values : Value.t list) : Il.exp =
-  match values with
-  | [ value_int ] ->
-      let n = Value.Get.num value_int in
-      Il.NumE n $$ (at, stub_exp_note)
-  | _ -> error "@unboot_num_exp_int"
-
-and unboot_text_exp (at : region) (values : Value.t list) : Il.exp =
-  match values with
-  | [ value_text ] ->
-      let s = Value.Get.text value_text in
-      Il.TextE s $$ (at, stub_exp_note)
-  | _ -> error "@unboot_text_exp"
-
-and unboot_var_exp (at : region) (values : Value.t list) : Il.exp =
-  match values with
-  | [ value_id ] ->
-      let id = unboot_id value_id in
-      Il.VarE id $$ (at, stub_exp_note)
-  | _ -> error "@unboot_var_exp"
-
-and unboot_un_exp (at : region) (values : Value.t list) : Il.exp =
-  let optyp_of_unop : Il.unop -> Il.optyp = function
-    | `NotOp -> (`BoolT : Il.optyp)
-    | `PlusOp | `MinusOp -> `NatT
-  in
-  match values with
-  | [ value_unop; value_exp ] ->
-      let unop = unboot_unop value_unop in
-      let exp = unboot_exp value_exp in
-      let optyp = optyp_of_unop unop in
-      Il.UnE (unop, optyp, exp) $$ (at, stub_exp_note)
-  | _ -> error "@unboot_un_exp"
-
-and unboot_bin_exp (at : region) (values : Value.t list) : Il.exp =
-  let optyp_of_binop : Il.binop -> Il.optyp = function
-    | `AndOp | `OrOp | `ImplOp | `EquivOp -> (`BoolT : Il.optyp)
-    | _ -> `NatT
-  in
-  match values with
-  | [ value_binop; value_exp_l; value_exp_r ] ->
-      let binop = unboot_binop value_binop in
-      let exp_l = unboot_exp value_exp_l in
-      let exp_r = unboot_exp value_exp_r in
-      let optyp = optyp_of_binop binop in
-      Il.BinE (binop, optyp, exp_l, exp_r) $$ (at, stub_exp_note)
-  | _ -> error "@unboot_bin_exp"
-
-and unboot_cmp_exp (at : region) (values : Value.t list) : Il.exp =
-  let optyp_of_cmpop : Il.cmpop -> Il.optyp = function
-    | `EqOp | `NeOp -> (`BoolT : Il.optyp)
-    | _ -> `NatT
-  in
-  match values with
-  | [ value_cmpop; value_exp_l; value_exp_r ] ->
-      let cmpop = unboot_cmpop value_cmpop in
-      let exp_l = unboot_exp value_exp_l in
-      let exp_r = unboot_exp value_exp_r in
-      let optyp = optyp_of_cmpop cmpop in
-      Il.CmpE (cmpop, optyp, exp_l, exp_r) $$ (at, stub_exp_note)
-  | _ -> error "@unboot_cmp_exp"
-
-and unboot_upcast_exp (at : region) (values : Value.t list) : Il.exp =
-  match values with
-  | [ value_typ; value_exp ] ->
-      let typ = unboot_typ value_typ in
-      let exp = unboot_exp value_exp in
-      Il.UpCastE (typ, exp) $$ (at, stub_exp_note)
-  | _ -> error "@unboot_upcast_exp"
-
-and unboot_downcast_exp (at : region) (values : Value.t list) : Il.exp =
-  match values with
-  | [ value_typ; value_exp ] ->
-      let typ = unboot_typ value_typ in
-      let exp = unboot_exp value_exp in
-      Il.DownCastE (typ, exp) $$ (at, stub_exp_note)
-  | _ -> error "@unboot_downcast_exp"
-
-and unboot_sub_exp (at : region) (values : Value.t list) : Il.exp =
-  match values with
-  | [ value_exp; value_typ ] ->
-      let exp = unboot_exp value_exp in
-      let typ = unboot_typ value_typ in
-      Il.SubE (exp, typ) $$ (at, stub_exp_note)
-  | _ -> error "@unboot_sub_exp"
-
-and unboot_match_exp (at : region) (values : Value.t list) : Il.exp =
-  match values with
-  | [ value_exp; value_pattern ] ->
-      let exp = unboot_exp value_exp in
-      let pattern = unboot_pattern value_pattern in
-      Il.MatchE (exp, pattern) $$ (at, stub_exp_note)
-  | _ -> error "@unboot_match_exp"
-
-and unboot_tuple_exp (at : region) (values : Value.t list) : Il.exp =
-  match values with
-  | [ value_exps ] ->
-      let exps = unboot_exps value_exps in
-      Il.TupleE exps $$ (at, stub_exp_note)
-  | _ -> error "@unboot_tuple_exp"
-
-and unboot_expcase (value_expcase : Value.t) : Il.mixop * Il.exp list =
-  let values = Value.Get.(value_expcase |>>! mop_expcase) in
-  let mixop = Value.Get.nth 0 values |> unboot_mixop in
-  let exps = Value.Get.nth 1 values |> unboot_exps in
-  (mixop, exps)
-
-and unboot_case_exp (at : region) (values : Value.t list) : Il.exp =
-  match values with
-  | [ value_expcase ] ->
-      let mixop, exps = unboot_expcase value_expcase in
-      let notexp = Mixfix.fill mixop exps in
-      Il.CaseE notexp $$ (at, stub_exp_note)
-  | _ -> error "@unboot_case_exp"
-
-and unboot_str_exp (at : region) (values : Value.t list) : Il.exp =
-  match values with
-  | [ value_expfields ] ->
-      let expfields = unboot_expfields value_expfields in
-      Il.StrE expfields $$ (at, stub_exp_note)
-  | _ -> error "@unboot_str_exp"
-
-and unboot_opt_exp (at : region) (values : Value.t list) : Il.exp =
-  match values with
-  | [ value_exp_opt ] ->
-      let exp_opt = unboot_exp_opt value_exp_opt in
-      Il.OptE exp_opt $$ (at, stub_exp_note)
-  | _ -> error "@unboot_opt_exp"
-
-and unboot_list_exp (at : region) (values : Value.t list) : Il.exp =
-  match values with
-  | [ value_exps ] ->
-      let exps = unboot_exps value_exps in
-      Il.ListE exps $$ (at, stub_exp_note)
-  | _ -> error "@unboot_list_exp"
-
-and unboot_cons_exp (at : region) (values : Value.t list) : Il.exp =
-  match values with
-  | [ value_exp_h; value_exp_t ] ->
-      let exp_h = unboot_exp value_exp_h in
-      let exp_t = unboot_exp value_exp_t in
-      Il.ConsE (exp_h, exp_t) $$ (at, stub_exp_note)
-  | _ -> error "@unboot_cons_exp"
-
-and unboot_cat_exp (at : region) (values : Value.t list) : Il.exp =
-  match values with
-  | [ value_exp_l; value_exp_r ] ->
-      let exp_l = unboot_exp value_exp_l in
-      let exp_r = unboot_exp value_exp_r in
-      Il.CatE (exp_l, exp_r) $$ (at, stub_exp_note)
-  | _ -> error "@unboot_cat_exp"
-
-and unboot_mem_exp (at : region) (values : Value.t list) : Il.exp =
-  match values with
-  | [ value_exp_e; value_exp_s ] ->
-      let exp_e = unboot_exp value_exp_e in
-      let exp_s = unboot_exp value_exp_s in
-      Il.MemE (exp_e, exp_s) $$ (at, stub_exp_note)
-  | _ -> error "@unboot_mem_exp"
-
-and unboot_len_exp (at : region) (values : Value.t list) : Il.exp =
-  match values with
-  | [ value_exp ] ->
-      let exp = unboot_exp value_exp in
-      Il.LenE exp $$ (at, stub_exp_note)
-  | _ -> error "@unboot_len_exp"
-
-and unboot_dot_exp (at : region) (values : Value.t list) : Il.exp =
-  match values with
-  | [ value_exp; value_atom ] ->
-      let exp = unboot_exp value_exp in
-      let atom = unboot_atom value_atom in
-      Il.DotE (exp, atom) $$ (at, stub_exp_note)
-  | _ -> error "@unboot_dot_exp"
-
-and unboot_idx_exp (at : region) (values : Value.t list) : Il.exp =
-  match values with
-  | [ value_exp_b; value_exp_i ] ->
-      let exp_b = unboot_exp value_exp_b in
-      let exp_i = unboot_exp value_exp_i in
-      Il.IdxE (exp_b, exp_i) $$ (at, stub_exp_note)
-  | _ -> error "@unboot_idx_exp"
-
-and unboot_slice_exp (at : region) (values : Value.t list) : Il.exp =
-  match values with
-  | [ value_exp_b; value_exp_i; value_exp_n ] ->
-      let exp_b = unboot_exp value_exp_b in
-      let exp_i = unboot_exp value_exp_i in
-      let exp_n = unboot_exp value_exp_n in
-      Il.SliceE (exp_b, exp_i, exp_n) $$ (at, stub_exp_note)
-  | _ -> error "@unboot_slice_exp"
-
-and unboot_upd_exp (at : region) (values : Value.t list) : Il.exp =
-  match values with
-  | [ value_exp_b; value_path; value_exp_n ] ->
-      let exp_b = unboot_exp value_exp_b in
-      let path = unboot_path value_path in
-      let exp_n = unboot_exp value_exp_n in
-      Il.UpdE (exp_b, path, exp_n) $$ (at, stub_exp_note)
-  | _ -> error "@unboot_upd_exp"
-
-and unboot_call_exp (at : region) (values : Value.t list) : Il.exp =
-  match values with
-  | [ value_id; value_targs; value_args ] ->
-      let id = unboot_id value_id in
-      let targs = unboot_targs value_targs in
-      let args = unboot_args value_args in
-      Il.CallE (id, targs, args) $$ (at, stub_exp_note)
-  | _ -> error "@unboot_call_exp"
-
-and unboot_iter_exp (at : region) (values : Value.t list) : Il.exp =
-  match values with
-  | [ value_exp; value_iterexp ] ->
-      let exp = unboot_exp value_exp in
-      let iterexp = unboot_iterexp value_iterexp in
-      Il.IterE (exp, iterexp) $$ (at, stub_exp_note)
-  | _ -> error "@unboot_iter_exp"
-
-(* Paths *)
-
-and unboot_path (value_path : Value.t) : Il.path =
-  Value.Get.mtch_dispatch value_path !unboot_path_mtchtbl (fun _ _ ->
-      error "@unboot_path")
-
-and unboot_root_path (at : region) (_ : Value.t list) : Il.path =
-  Il.RootP $$ (at, stub_exp_note)
-
-and unboot_idx_path (at : region) (values : Value.t list) : Il.path =
-  match values with
-  | [ value_path; value_exp ] ->
-      let path = unboot_path value_path in
-      let exp = unboot_exp value_exp in
-      Il.IdxP (path, exp) $$ (at, stub_exp_note)
-  | _ -> error "@unboot_path/IDX"
-
-and unboot_slice_path (at : region) (values : Value.t list) : Il.path =
-  match values with
-  | [ value_path; value_exp_i; value_exp_n ] ->
-      let path = unboot_path value_path in
-      let exp_i = unboot_exp value_exp_i in
-      let exp_n = unboot_exp value_exp_n in
-      Il.SliceP (path, exp_i, exp_n) $$ (at, stub_exp_note)
-  | _ -> error "@unboot_path/SLICE"
-
-and unboot_dot_path (at : region) (values : Value.t list) : Il.path =
-  match values with
-  | [ value_path; value_atom ] ->
-      let path = unboot_path value_path in
-      let atom = unboot_atom value_atom in
-      Il.DotP (path, atom) $$ (at, stub_exp_note)
-  | _ -> error "@unboot_path/DOT"
-
-(* Patterns *)
-
-and unboot_pattern (value_pattern : Value.t) : Il.pattern =
-  Value.Get.mtch_dispatch value_pattern !unboot_pattern_mtchtbl (fun _ _ ->
-      error "@unboot_pattern")
-
-and unboot_inj_pattern (_ : region) (values : Value.t list) : Il.pattern =
-  match values with
-  | [ value_mixop ] ->
-      let mixop = unboot_mixop value_mixop in
-      Il.CaseP mixop
-  | _ -> error "@unboot_pattern/INJ"
-
-and unboot_cons_pattern (_ : region) (_ : Value.t list) : Il.pattern =
-  Il.ListP `Cons
-
-and unboot_fixed_pattern (_ : region) (values : Value.t list) : Il.pattern =
-  match values with
-  | [ value_nat ] ->
-      let n =
-        match Value.Get.num value_nat with
-        | `Nat n -> n
-        | `Int _ -> error "@unboot_pattern/FIXED"
-      in
-      let n_int =
-        match Bigint.to_int n with
-        | Some i -> i
-        | None -> error "@unboot_pattern/FIXED"
-      in
-      Il.ListP (`Fixed n_int)
-  | _ -> error "@unboot_pattern/FIXED"
-
-and unboot_nil_pattern (_ : region) (_ : Value.t list) : Il.pattern =
-  Il.ListP `Nil
-
-and unboot_some_pattern (_ : region) (_ : Value.t list) : Il.pattern =
-  Il.OptP `Some
-
-and unboot_none_pattern (_ : region) (_ : Value.t list) : Il.pattern =
-  Il.OptP `None
-
-(* Iter expressions *)
-
-and unboot_iterexp (value_iterexp : Value.t) : Il.iterexp =
-  let values = Value.Get.(value_iterexp |>>! mop_iterexp) in
-  let iter = Value.Get.nth 0 values |> unboot_iter in
-  let varis = Value.Get.nth 1 values |> unboot_varis in
-  (iter, varis)
-
-and unboot_iterexps (value_iterexps : Value.t) : Il.iterexp list =
-  value_iterexps |> Value.Get.list |> List.map unboot_iterexp
-
-(* Initialize dispatch tables after all handler functions are defined *)
-
-let () =
-  (* Values *)
-  unboot_value_mtchtbl :=
-    Value.Get.build_mtchtbl
-      [
-        (mop_bool_value, unboot_bool_value);
-        (mop_num_value_nat, unboot_num_value_nat);
-        (mop_num_value_int, unboot_num_value_int);
-        (mop_text_value, unboot_text_value);
-        (mop_struct_value, unboot_struct_value);
-        (mop_case_value, unboot_variant_value);
-        (mop_tuple_value, unboot_tuple_value);
-        (mop_opt_value, unboot_opt_value);
-        (mop_list_value, unboot_list_value);
-        (mop_func_value, unboot_func_value);
-        (mop_extern_value, unboot_extern_value);
-      ];
   (* Types *)
-  unboot_typ_mtchtbl :=
-    Value.Get.build_mtchtbl
-      [
-        (mop_bool_typ, unboot_bool_typ);
-        (mop_num_typ_nat, unboot_num_typ_nat);
-        (mop_num_typ_int, unboot_num_typ_int);
-        (mop_text_typ, unboot_text_typ);
-        (mop_var_typ, unboot_var_typ);
-        (mop_tuple_typ, unboot_tuple_typ);
-        (mop_iter_typ, unboot_iter_typ);
-        (mop_func_typ, unboot_func_typ);
-      ];
+
+  and unboot_typ (value_typ : V.t) : Il.typ =
+    Dispatch.dispatch value_typ Il_typs.typ_typ !unboot_typ_mtchtbl (fun _ _ ->
+        error "@unboot_typ")
+
+  and unboot_typs (value_typs : V.t) : Il.typ list =
+    value_typs |> V.Get.list |> List.map unboot_typ
+
+  and unboot_bool_typ (at : region) (_ : V.t list) : Il.typ = Il.BoolT $ at
+
+  and unboot_num_typ_nat (at : region) (_ : V.t list) : Il.typ =
+    Il.NumT `NatT $ at
+
+  and unboot_num_typ_int (at : region) (_ : V.t list) : Il.typ =
+    Il.NumT `IntT $ at
+
+  and unboot_text_typ (at : region) (_ : V.t list) : Il.typ = Il.TextT $ at
+
+  and unboot_var_typ (at : region) (values : V.t list) : Il.typ =
+    match values with
+    | [ value_id; value_targs ] ->
+        let id = unboot_id value_id in
+        let targs = unboot_targs value_targs in
+        Il.VarT (id, targs) $ at
+    | _ -> error "@unboot_var_typ"
+
+  and unboot_tuple_typ (at : region) (values : V.t list) : Il.typ =
+    match values with
+    | [ value_typs ] ->
+        let typs = unboot_typs value_typs in
+        Il.TupleT typs $ at
+    | _ -> error "@unboot_tuple_typ"
+
+  and unboot_iter_typ (at : region) (values : V.t list) : Il.typ =
+    match values with
+    | [ value_typ; value_iter ] ->
+        let typ = unboot_typ value_typ in
+        let iter = unboot_iter value_iter in
+        Il.IterT (typ, iter) $ at
+    | _ -> error "@unboot_iter_typ"
+
+  and unboot_func_typ (at : region) (_ : V.t list) : Il.typ =
+    let tparams, typs, typ = stub_func_typ_params () in
+    Il.FuncT (tparams, typs, typ) $ at
+
+  (* Type arguments and parameters *)
+
+  and unboot_targ (value_targ : V.t) : Il.targ = unboot_typ value_targ
+
+  and unboot_targs (value_targs : V.t) : Il.targ list =
+    value_targs |> V.Get.list |> List.map unboot_targ
+
+  and unboot_tparam (value_tparam : V.t) : Il.tparam = unboot_id value_tparam
+
+  and unboot_tparams (value_tparams : V.t) : Il.tparam list =
+    value_tparams |> V.Get.list |> List.map unboot_tparam
+
   (* Defined types *)
-  unboot_deftyp_mtchtbl :=
-    Value.Get.build_mtchtbl
-      [
-        (mop_plain_deftyp, unboot_plain_deftyp);
-        (mop_struct_deftyp, unboot_struct_deftyp);
-        (mop_variant_deftyp, unboot_variant_deftyp);
-      ];
+
+  and unboot_deftyp (value_deftyp : V.t) : Il.deftyp =
+    Dispatch.dispatch value_deftyp Il_typs.typ_deftyp !unboot_deftyp_mtchtbl
+      (fun _ _ -> error "@unboot_deftyp")
+
+  and unboot_plain_deftyp (at : region) (values : V.t list) : Il.deftyp =
+    match values with
+    | [ value_typ ] ->
+        let typ = unboot_typ value_typ in
+        Il.PlainT typ $ at
+    | _ -> error "@unboot_plain_deftyp"
+
+  and unboot_typfield (value_typfield : V.t) : Il.typfield =
+    let values =
+      Dispatch.case_exact value_typfield mop_typfield Il_typs.typ_typfield
+    in
+    let atom = V.Get.nth 0 values |> unboot_atom in
+    let typ = V.Get.nth 1 values |> unboot_typ in
+    (atom, typ)
+
+  and unboot_typfields (value_typfields : V.t) : Il.typfield list =
+    value_typfields |> V.Get.list |> List.map unboot_typfield
+
+  and unboot_struct_deftyp (at : region) (values : V.t list) : Il.deftyp =
+    match values with
+    | [ value_typfields ] ->
+        let typfields = unboot_typfields value_typfields in
+        Il.StructT typfields $ at
+    | _ -> error "@unboot_struct_deftyp"
+
+  and unboot_typcase (value_typcase : V.t) : Il.typcase =
+    let values =
+      Dispatch.case_exact value_typcase mop_typcase Il_typs.typ_typcase
+    in
+    let mixop = V.Get.nth 0 values |> unboot_mixop in
+    let typs = V.Get.nth 1 values |> unboot_typs in
+    let nottyp = Mixfix.fill mixop typs $ V.at value_typcase in
+    (nottyp, stub_typorigin (), [])
+
+  and unboot_typcases (value_typcases : V.t) : Il.typcase list =
+    value_typcases |> V.Get.list |> List.map unboot_typcase
+
+  and unboot_variant_deftyp (at : region) (values : V.t list) : Il.deftyp =
+    match values with
+    | [ value_typcases ] ->
+        let typcases = unboot_typcases value_typcases in
+        Il.VariantT typcases $ at
+    | _ -> error "@unboot_variant_deftyp"
+
+  (* Values *)
+
+  and unboot_value (value_value : V.t) : Il.value =
+    Dispatch.dispatch value_value Il_typs.typ_val !unboot_value_mtchtbl
+      (fun _ _ -> error "@unboot_value")
+
+  and unboot_values (value_values : V.t) : Il.value list =
+    value_values |> V.Get.list |> List.map unboot_value
+
+  and unboot_bool_value (at : region) (values : V.t list) : Il.value =
+    match values with
+    | [ value_bool ] ->
+        let b = V.Get.bool value_bool in
+        Value.Make.bool ~at b
+    | _ -> error "@unboot_bool_value"
+
+  and unboot_num_value_nat (at : region) (values : V.t list) : Il.value =
+    match values with
+    | [ value_nat ] ->
+        let n = V.Get.num value_nat in
+        Value.Make.num ~at n
+    | _ -> error "@unboot_num_value_nat"
+
+  and unboot_num_value_int (at : region) (values : V.t list) : Il.value =
+    match values with
+    | [ value_int ] ->
+        let n = V.Get.num value_int in
+        Value.Make.num ~at n
+    | _ -> error "@unboot_num_value_int"
+
+  and unboot_text_value (at : region) (values : V.t list) : Il.value =
+    match values with
+    | [ value_text ] ->
+        let s = V.Get.text value_text in
+        Value.Make.text ~at s
+    | _ -> error "@unboot_text_value"
+
+  and unboot_valuefield (value_valuefield : V.t) : Il.valuefield =
+    let values =
+      Dispatch.case_exact value_valuefield mop_valuefield Il_typs.typ_valfield
+    in
+    let atom = V.Get.nth 0 values |> unboot_atom in
+    let v = V.Get.nth 1 values |> unboot_value in
+    (atom, v)
+
+  and unboot_valuefields (value_valuefields : V.t) : Il.valuefield list =
+    value_valuefields |> V.Get.list |> List.map unboot_valuefield
+
+  and unboot_struct_value (at : region) (values : V.t list) : Il.value =
+    match values with
+    | [ value_valuefields ] ->
+        let valuefields = unboot_valuefields value_valuefields in
+        let typ = Typ.Make.var ("val" $ no_region) [] in
+        Value.Make.str ~at typ valuefields
+    | _ -> error "@unboot_struct_value"
+
+  and unboot_valuecase (value_valuecase : V.t) : Il.valuecase =
+    let values =
+      Dispatch.case_exact value_valuecase mop_valuecase Il_typs.typ_valcase
+    in
+    let mixop = V.Get.nth 0 values |> unboot_mixop in
+    let values = V.Get.nth 1 values |> unboot_values in
+    let valuecase = Mixfix.fill mixop values in
+    valuecase
+
+  and unboot_variant_value (at : region) (values : V.t list) : Il.value =
+    match values with
+    | [ value_valcase ] ->
+        let valuecase = unboot_valuecase value_valcase in
+        let typ = Typ.Make.var ("val" $ no_region) [] in
+        Value.Make.case ~at typ valuecase
+    | _ -> error "@unboot_variant_value"
+
+  and unboot_tuple_value (at : region) (values : V.t list) : Il.value =
+    match values with
+    | [ value_vals ] ->
+        let vals = unboot_values value_vals in
+        let typ = Typ.Make.var ("val" $ no_region) [] in
+        Value.Make.tuple ~at typ vals
+    | _ -> error "@unboot_tuple_value"
+
+  and unboot_value_opt (value_value_opt : V.t) : Il.value option =
+    value_value_opt |> V.Get.opt |> Option.map unboot_value
+
+  and unboot_opt_value (at : region) (values : V.t list) : Il.value =
+    match values with
+    | [ value_value_opt ] ->
+        let value_opt = unboot_value_opt value_value_opt in
+        let typ = Typ.Make.var ("val" $ no_region) [] |> Typ.Make.opt in
+        Value.Make.opt ~at typ value_opt
+    | _ -> error "@unboot_opt_value"
+
+  and unboot_list_value (at : region) (values : V.t list) : Il.value =
+    match values with
+    | [ value_vals ] ->
+        let vals = unboot_values value_vals in
+        let typ = Typ.Make.var ("val" $ no_region) [] |> Typ.Make.list in
+        Value.Make.list ~at typ vals
+    | _ -> error "@unboot_list_value"
+
+  and unboot_func_value (at : region) (values : V.t list) : Il.value =
+    match values with
+    | [ value_id ] ->
+        let id = unboot_id value_id in
+        let tparams, typs, typ = stub_func_typ_params () in
+        Value.Make.func ~at id tparams typs typ
+    | _ -> error "@unboot_func_value"
+
+  and unboot_extern_value (at : region) (values : V.t list) : Il.value =
+    match values with
+    | [ value_json ] ->
+        let json = V.Get.extern value_json in
+        let typ = Typ.Make.var ("json" $ no_region) [] in
+        Value.Make.extern ~at typ json
+    | _ -> error "@unboot_extern_value"
+
   (* Operators *)
-  unboot_unop_mtchtbl :=
-    Value.Get.build_mtchtbl
-      [
-        (mop_not_unop, unboot_not_unop);
-        (mop_plus_unop, unboot_plus_unop);
-        (mop_minus_unop, unboot_minus_unop);
-      ];
-  unboot_binop_mtchtbl :=
-    Value.Get.build_mtchtbl
-      [
-        (mop_and_binop, unboot_and_binop);
-        (mop_or_binop, unboot_or_binop);
-        (mop_impl_binop, unboot_impl_binop);
-        (mop_equiv_binop, unboot_equiv_binop);
-        (mop_add_binop, unboot_add_binop);
-        (mop_sub_binop, unboot_sub_binop);
-        (mop_mul_binop, unboot_mul_binop);
-        (mop_div_binop, unboot_div_binop);
-        (mop_mod_binop, unboot_mod_binop);
-        (mop_pow_binop, unboot_pow_binop);
-      ];
-  unboot_cmpop_mtchtbl :=
-    Value.Get.build_mtchtbl
-      [
-        (mop_eq_cmpop, unboot_eq_cmpop);
-        (mop_ne_cmpop, unboot_ne_cmpop);
-        (mop_lt_cmpop, unboot_lt_cmpop);
-        (mop_le_cmpop, unboot_le_cmpop);
-        (mop_gt_cmpop, unboot_gt_cmpop);
-        (mop_ge_cmpop, unboot_ge_cmpop);
-      ];
+
+  and unboot_unop (value_unop : V.t) : Il.unop =
+    Dispatch.dispatch value_unop Il_typs.typ_unop !unboot_unop_mtchtbl
+      (fun _ _ -> error "@unboot_unop")
+
+  and unboot_not_unop (_ : region) (_ : V.t list) : Il.unop = `NotOp
+  and unboot_plus_unop (_ : region) (_ : V.t list) : Il.unop = `PlusOp
+  and unboot_minus_unop (_ : region) (_ : V.t list) : Il.unop = `MinusOp
+
+  and unboot_binop (value_binop : V.t) : Il.binop =
+    Dispatch.dispatch value_binop Il_typs.typ_binop !unboot_binop_mtchtbl
+      (fun _ _ -> error "@unboot_binop")
+
+  and unboot_and_binop (_ : region) (_ : V.t list) : Il.binop = `AndOp
+  and unboot_or_binop (_ : region) (_ : V.t list) : Il.binop = `OrOp
+  and unboot_impl_binop (_ : region) (_ : V.t list) : Il.binop = `ImplOp
+  and unboot_equiv_binop (_ : region) (_ : V.t list) : Il.binop = `EquivOp
+  and unboot_add_binop (_ : region) (_ : V.t list) : Il.binop = `AddOp
+  and unboot_sub_binop (_ : region) (_ : V.t list) : Il.binop = `SubOp
+  and unboot_mul_binop (_ : region) (_ : V.t list) : Il.binop = `MulOp
+  and unboot_div_binop (_ : region) (_ : V.t list) : Il.binop = `DivOp
+  and unboot_mod_binop (_ : region) (_ : V.t list) : Il.binop = `ModOp
+  and unboot_pow_binop (_ : region) (_ : V.t list) : Il.binop = `PowOp
+
+  and unboot_cmpop (value_cmpop : V.t) : Il.cmpop =
+    Dispatch.dispatch value_cmpop Il_typs.typ_cmpop !unboot_cmpop_mtchtbl
+      (fun _ _ -> error "@unboot_cmpop")
+
+  and unboot_eq_cmpop (_ : region) (_ : V.t list) : Il.cmpop = `EqOp
+  and unboot_ne_cmpop (_ : region) (_ : V.t list) : Il.cmpop = `NeOp
+  and unboot_lt_cmpop (_ : region) (_ : V.t list) : Il.cmpop = `LtOp
+  and unboot_le_cmpop (_ : region) (_ : V.t list) : Il.cmpop = `LeOp
+  and unboot_gt_cmpop (_ : region) (_ : V.t list) : Il.cmpop = `GtOp
+  and unboot_ge_cmpop (_ : region) (_ : V.t list) : Il.cmpop = `GeOp
+
   (* Arguments *)
-  unboot_arg_mtchtbl :=
-    Value.Get.build_mtchtbl
-      [ (mop_exp_arg, unboot_exp_arg); (mop_def_arg, unboot_def_arg) ];
+
+  and unboot_arg (value_arg : V.t) : Il.arg =
+    Dispatch.dispatch value_arg Il_typs.typ_arg !unboot_arg_mtchtbl (fun _ _ ->
+        error "@unboot_arg")
+
+  and unboot_exp_arg (at : region) (values : V.t list) : Il.arg =
+    match values with
+    | [ value_exp ] ->
+        let exp = unboot_exp value_exp in
+        Il.ExpA exp $ at
+    | _ -> error "@unboot_arg/EXP"
+
+  and unboot_def_arg (at : region) (values : V.t list) : Il.arg =
+    match values with
+    | [ value_id ] ->
+        let id = unboot_id value_id in
+        Il.DefA id $ at
+    | _ -> error "@unboot_arg/FUN"
+
+  and unboot_args (value_args : V.t) : Il.arg list =
+    value_args |> V.Get.list |> List.map unboot_arg
+
   (* Expressions *)
-  unboot_exp_mtchtbl :=
-    Value.Get.build_mtchtbl
-      [
-        (mop_bool_exp, unboot_bool_exp);
-        (mop_num_exp_nat, unboot_num_exp_nat);
-        (mop_num_exp_int, unboot_num_exp_int);
-        (mop_text_exp, unboot_text_exp);
-        (mop_var_exp, unboot_var_exp);
-        (mop_un_exp, unboot_un_exp);
-        (mop_bin_exp, unboot_bin_exp);
-        (mop_cmp_exp, unboot_cmp_exp);
-        (mop_upcast_exp, unboot_upcast_exp);
-        (mop_downcast_exp, unboot_downcast_exp);
-        (mop_sub_exp, unboot_sub_exp);
-        (mop_match_exp, unboot_match_exp);
-        (mop_tuple_exp, unboot_tuple_exp);
-        (mop_case_exp, unboot_case_exp);
-        (mop_struct_exp, unboot_str_exp);
-        (mop_opt_exp, unboot_opt_exp);
-        (mop_list_exp, unboot_list_exp);
-        (mop_cons_exp, unboot_cons_exp);
-        (mop_cat_exp, unboot_cat_exp);
-        (mop_mem_exp, unboot_mem_exp);
-        (mop_len_exp, unboot_len_exp);
-        (mop_dot_exp, unboot_dot_exp);
-        (mop_idx_exp, unboot_idx_exp);
-        (mop_slice_exp, unboot_slice_exp);
-        (mop_upd_exp, unboot_upd_exp);
-        (mop_call_exp, unboot_call_exp);
-        (mop_iter_exp, unboot_iter_exp);
-      ];
+
+  and unboot_exp (value_exp : V.t) : Il.exp =
+    Dispatch.dispatch value_exp Il_typs.typ_exp !unboot_exp_mtchtbl (fun _ _ ->
+        error "@unboot_exp")
+
+  and unboot_exps (value_exps : V.t) : Il.exp list =
+    value_exps |> V.Get.list |> List.map unboot_exp
+
+  and unboot_exp_opt (value_exp_opt : V.t) : Il.exp option =
+    value_exp_opt |> V.Get.opt |> Option.map unboot_exp
+
+  and unboot_expfield (value_expfield : V.t) : Il.atom * Il.exp =
+    let values =
+      Dispatch.case_exact value_expfield mop_expfield Il_typs.typ_expfield
+    in
+    let atom = V.Get.nth 0 values |> unboot_atom in
+    let exp = V.Get.nth 1 values |> unboot_exp in
+    (atom, exp)
+
+  and unboot_expfields (value_expfields : V.t) : (Il.atom * Il.exp) list =
+    value_expfields |> V.Get.list |> List.map unboot_expfield
+
+  and unboot_bool_exp (at : region) (values : V.t list) : Il.exp =
+    match values with
+    | [ value_bool ] ->
+        let b = V.Get.bool value_bool in
+        Il.BoolE b $$ (at, stub_exp_note)
+    | _ -> error "@unboot_bool_exp"
+
+  and unboot_num_exp_nat (at : region) (values : V.t list) : Il.exp =
+    match values with
+    | [ value_nat ] ->
+        let n = V.Get.num value_nat in
+        Il.NumE n $$ (at, stub_exp_note)
+    | _ -> error "@unboot_num_exp_nat"
+
+  and unboot_num_exp_int (at : region) (values : V.t list) : Il.exp =
+    match values with
+    | [ value_int ] ->
+        let n = V.Get.num value_int in
+        Il.NumE n $$ (at, stub_exp_note)
+    | _ -> error "@unboot_num_exp_int"
+
+  and unboot_text_exp (at : region) (values : V.t list) : Il.exp =
+    match values with
+    | [ value_text ] ->
+        let s = V.Get.text value_text in
+        Il.TextE s $$ (at, stub_exp_note)
+    | _ -> error "@unboot_text_exp"
+
+  and unboot_var_exp (at : region) (values : V.t list) : Il.exp =
+    match values with
+    | [ value_id ] ->
+        let id = unboot_id value_id in
+        Il.VarE id $$ (at, stub_exp_note)
+    | _ -> error "@unboot_var_exp"
+
+  and unboot_un_exp (at : region) (values : V.t list) : Il.exp =
+    let optyp_of_unop : Il.unop -> Il.optyp = function
+      | `NotOp -> (`BoolT : Il.optyp)
+      | `PlusOp | `MinusOp -> `NatT
+    in
+    match values with
+    | [ value_unop; value_exp ] ->
+        let unop = unboot_unop value_unop in
+        let exp = unboot_exp value_exp in
+        let optyp = optyp_of_unop unop in
+        Il.UnE (unop, optyp, exp) $$ (at, stub_exp_note)
+    | _ -> error "@unboot_un_exp"
+
+  and unboot_bin_exp (at : region) (values : V.t list) : Il.exp =
+    let optyp_of_binop : Il.binop -> Il.optyp = function
+      | `AndOp | `OrOp | `ImplOp | `EquivOp -> (`BoolT : Il.optyp)
+      | _ -> `NatT
+    in
+    match values with
+    | [ value_binop; value_exp_l; value_exp_r ] ->
+        let binop = unboot_binop value_binop in
+        let exp_l = unboot_exp value_exp_l in
+        let exp_r = unboot_exp value_exp_r in
+        let optyp = optyp_of_binop binop in
+        Il.BinE (binop, optyp, exp_l, exp_r) $$ (at, stub_exp_note)
+    | _ -> error "@unboot_bin_exp"
+
+  and unboot_cmp_exp (at : region) (values : V.t list) : Il.exp =
+    let optyp_of_cmpop : Il.cmpop -> Il.optyp = function
+      | `EqOp | `NeOp -> (`BoolT : Il.optyp)
+      | _ -> `NatT
+    in
+    match values with
+    | [ value_cmpop; value_exp_l; value_exp_r ] ->
+        let cmpop = unboot_cmpop value_cmpop in
+        let exp_l = unboot_exp value_exp_l in
+        let exp_r = unboot_exp value_exp_r in
+        let optyp = optyp_of_cmpop cmpop in
+        Il.CmpE (cmpop, optyp, exp_l, exp_r) $$ (at, stub_exp_note)
+    | _ -> error "@unboot_cmp_exp"
+
+  and unboot_upcast_exp (at : region) (values : V.t list) : Il.exp =
+    match values with
+    | [ value_typ; value_exp ] ->
+        let typ = unboot_typ value_typ in
+        let exp = unboot_exp value_exp in
+        Il.UpCastE (typ, exp) $$ (at, stub_exp_note)
+    | _ -> error "@unboot_upcast_exp"
+
+  and unboot_downcast_exp (at : region) (values : V.t list) : Il.exp =
+    match values with
+    | [ value_typ; value_exp ] ->
+        let typ = unboot_typ value_typ in
+        let exp = unboot_exp value_exp in
+        Il.DownCastE (typ, exp) $$ (at, stub_exp_note)
+    | _ -> error "@unboot_downcast_exp"
+
+  and unboot_sub_exp (at : region) (values : V.t list) : Il.exp =
+    match values with
+    | [ value_exp; value_typ ] ->
+        let exp = unboot_exp value_exp in
+        let typ = unboot_typ value_typ in
+        Il.SubE (exp, typ) $$ (at, stub_exp_note)
+    | _ -> error "@unboot_sub_exp"
+
+  and unboot_match_exp (at : region) (values : V.t list) : Il.exp =
+    match values with
+    | [ value_exp; value_pattern ] ->
+        let exp = unboot_exp value_exp in
+        let pattern = unboot_pattern value_pattern in
+        Il.MatchE (exp, pattern) $$ (at, stub_exp_note)
+    | _ -> error "@unboot_match_exp"
+
+  and unboot_tuple_exp (at : region) (values : V.t list) : Il.exp =
+    match values with
+    | [ value_exps ] ->
+        let exps = unboot_exps value_exps in
+        Il.TupleE exps $$ (at, stub_exp_note)
+    | _ -> error "@unboot_tuple_exp"
+
+  and unboot_expcase (value_expcase : V.t) : Il.mixop * Il.exp list =
+    let values =
+      Dispatch.case_exact value_expcase mop_expcase Il_typs.typ_expcase
+    in
+    let mixop = V.Get.nth 0 values |> unboot_mixop in
+    let exps = V.Get.nth 1 values |> unboot_exps in
+    (mixop, exps)
+
+  and unboot_case_exp (at : region) (values : V.t list) : Il.exp =
+    match values with
+    | [ value_expcase ] ->
+        let mixop, exps = unboot_expcase value_expcase in
+        let notexp = Mixfix.fill mixop exps in
+        Il.CaseE notexp $$ (at, stub_exp_note)
+    | _ -> error "@unboot_case_exp"
+
+  and unboot_str_exp (at : region) (values : V.t list) : Il.exp =
+    match values with
+    | [ value_expfields ] ->
+        let expfields = unboot_expfields value_expfields in
+        Il.StrE expfields $$ (at, stub_exp_note)
+    | _ -> error "@unboot_str_exp"
+
+  and unboot_opt_exp (at : region) (values : V.t list) : Il.exp =
+    match values with
+    | [ value_exp_opt ] ->
+        let exp_opt = unboot_exp_opt value_exp_opt in
+        Il.OptE exp_opt $$ (at, stub_exp_note)
+    | _ -> error "@unboot_opt_exp"
+
+  and unboot_list_exp (at : region) (values : V.t list) : Il.exp =
+    match values with
+    | [ value_exps ] ->
+        let exps = unboot_exps value_exps in
+        Il.ListE exps $$ (at, stub_exp_note)
+    | _ -> error "@unboot_list_exp"
+
+  and unboot_cons_exp (at : region) (values : V.t list) : Il.exp =
+    match values with
+    | [ value_exp_h; value_exp_t ] ->
+        let exp_h = unboot_exp value_exp_h in
+        let exp_t = unboot_exp value_exp_t in
+        Il.ConsE (exp_h, exp_t) $$ (at, stub_exp_note)
+    | _ -> error "@unboot_cons_exp"
+
+  and unboot_cat_exp (at : region) (values : V.t list) : Il.exp =
+    match values with
+    | [ value_exp_l; value_exp_r ] ->
+        let exp_l = unboot_exp value_exp_l in
+        let exp_r = unboot_exp value_exp_r in
+        Il.CatE (exp_l, exp_r) $$ (at, stub_exp_note)
+    | _ -> error "@unboot_cat_exp"
+
+  and unboot_mem_exp (at : region) (values : V.t list) : Il.exp =
+    match values with
+    | [ value_exp_e; value_exp_s ] ->
+        let exp_e = unboot_exp value_exp_e in
+        let exp_s = unboot_exp value_exp_s in
+        Il.MemE (exp_e, exp_s) $$ (at, stub_exp_note)
+    | _ -> error "@unboot_mem_exp"
+
+  and unboot_len_exp (at : region) (values : V.t list) : Il.exp =
+    match values with
+    | [ value_exp ] ->
+        let exp = unboot_exp value_exp in
+        Il.LenE exp $$ (at, stub_exp_note)
+    | _ -> error "@unboot_len_exp"
+
+  and unboot_dot_exp (at : region) (values : V.t list) : Il.exp =
+    match values with
+    | [ value_exp; value_atom ] ->
+        let exp = unboot_exp value_exp in
+        let atom = unboot_atom value_atom in
+        Il.DotE (exp, atom) $$ (at, stub_exp_note)
+    | _ -> error "@unboot_dot_exp"
+
+  and unboot_idx_exp (at : region) (values : V.t list) : Il.exp =
+    match values with
+    | [ value_exp_b; value_exp_i ] ->
+        let exp_b = unboot_exp value_exp_b in
+        let exp_i = unboot_exp value_exp_i in
+        Il.IdxE (exp_b, exp_i) $$ (at, stub_exp_note)
+    | _ -> error "@unboot_idx_exp"
+
+  and unboot_slice_exp (at : region) (values : V.t list) : Il.exp =
+    match values with
+    | [ value_exp_b; value_exp_i; value_exp_n ] ->
+        let exp_b = unboot_exp value_exp_b in
+        let exp_i = unboot_exp value_exp_i in
+        let exp_n = unboot_exp value_exp_n in
+        Il.SliceE (exp_b, exp_i, exp_n) $$ (at, stub_exp_note)
+    | _ -> error "@unboot_slice_exp"
+
+  and unboot_upd_exp (at : region) (values : V.t list) : Il.exp =
+    match values with
+    | [ value_exp_b; value_path; value_exp_n ] ->
+        let exp_b = unboot_exp value_exp_b in
+        let path = unboot_path value_path in
+        let exp_n = unboot_exp value_exp_n in
+        Il.UpdE (exp_b, path, exp_n) $$ (at, stub_exp_note)
+    | _ -> error "@unboot_upd_exp"
+
+  and unboot_call_exp (at : region) (values : V.t list) : Il.exp =
+    match values with
+    | [ value_id; value_targs; value_args ] ->
+        let id = unboot_id value_id in
+        let targs = unboot_targs value_targs in
+        let args = unboot_args value_args in
+        Il.CallE (id, targs, args) $$ (at, stub_exp_note)
+    | _ -> error "@unboot_call_exp"
+
+  and unboot_iter_exp (at : region) (values : V.t list) : Il.exp =
+    match values with
+    | [ value_exp; value_iterexp ] ->
+        let exp = unboot_exp value_exp in
+        let iterexp = unboot_iterexp value_iterexp in
+        Il.IterE (exp, iterexp) $$ (at, stub_exp_note)
+    | _ -> error "@unboot_iter_exp"
+
   (* Paths *)
-  unboot_path_mtchtbl :=
-    Value.Get.build_mtchtbl
-      [
-        (mop_root_path, unboot_root_path);
-        (mop_idx_path, unboot_idx_path);
-        (mop_slice_path, unboot_slice_path);
-        (mop_dot_path, unboot_dot_path);
-      ];
+
+  and unboot_path (value_path : V.t) : Il.path =
+    Dispatch.dispatch value_path Il_typs.typ_path !unboot_path_mtchtbl
+      (fun _ _ -> error "@unboot_path")
+
+  and unboot_root_path (at : region) (_ : V.t list) : Il.path =
+    Il.RootP $$ (at, stub_exp_note)
+
+  and unboot_idx_path (at : region) (values : V.t list) : Il.path =
+    match values with
+    | [ value_path; value_exp ] ->
+        let path = unboot_path value_path in
+        let exp = unboot_exp value_exp in
+        Il.IdxP (path, exp) $$ (at, stub_exp_note)
+    | _ -> error "@unboot_path/IDX"
+
+  and unboot_slice_path (at : region) (values : V.t list) : Il.path =
+    match values with
+    | [ value_path; value_exp_i; value_exp_n ] ->
+        let path = unboot_path value_path in
+        let exp_i = unboot_exp value_exp_i in
+        let exp_n = unboot_exp value_exp_n in
+        Il.SliceP (path, exp_i, exp_n) $$ (at, stub_exp_note)
+    | _ -> error "@unboot_path/SLICE"
+
+  and unboot_dot_path (at : region) (values : V.t list) : Il.path =
+    match values with
+    | [ value_path; value_atom ] ->
+        let path = unboot_path value_path in
+        let atom = unboot_atom value_atom in
+        Il.DotP (path, atom) $$ (at, stub_exp_note)
+    | _ -> error "@unboot_path/DOT"
+
   (* Patterns *)
-  unboot_pattern_mtchtbl :=
-    Value.Get.build_mtchtbl
-      [
-        (mop_case_pattern, unboot_inj_pattern);
-        (mop_list_cons_pattern, unboot_cons_pattern);
-        (mop_list_fixed_pattern, unboot_fixed_pattern);
-        (mop_list_nil_pattern, unboot_nil_pattern);
-        (mop_opt_some_pattern, unboot_some_pattern);
-        (mop_opt_none_pattern, unboot_none_pattern);
-      ]
+
+  and unboot_pattern (value_pattern : V.t) : Il.pattern =
+    Dispatch.dispatch value_pattern Il_typs.typ_pattern !unboot_pattern_mtchtbl
+      (fun _ _ -> error "@unboot_pattern")
+
+  and unboot_inj_pattern (_ : region) (values : V.t list) : Il.pattern =
+    match values with
+    | [ value_mixop ] ->
+        let mixop = unboot_mixop value_mixop in
+        Il.CaseP mixop
+    | _ -> error "@unboot_pattern/INJ"
+
+  and unboot_cons_pattern (_ : region) (_ : V.t list) : Il.pattern =
+    Il.ListP `Cons
+
+  and unboot_fixed_pattern (_ : region) (values : V.t list) : Il.pattern =
+    match values with
+    | [ value_nat ] ->
+        let n =
+          match V.Get.num value_nat with
+          | `Nat n -> n
+          | `Int _ -> error "@unboot_pattern/FIXED"
+        in
+        let n_int =
+          match Bigint.to_int n with
+          | Some i -> i
+          | None -> error "@unboot_pattern/FIXED"
+        in
+        Il.ListP (`Fixed n_int)
+    | _ -> error "@unboot_pattern/FIXED"
+
+  and unboot_nil_pattern (_ : region) (_ : V.t list) : Il.pattern =
+    Il.ListP `Nil
+
+  and unboot_some_pattern (_ : region) (_ : V.t list) : Il.pattern =
+    Il.OptP `Some
+
+  and unboot_none_pattern (_ : region) (_ : V.t list) : Il.pattern =
+    Il.OptP `None
+
+  (* Iter expressions *)
+
+  and unboot_iterexp (value_iterexp : V.t) : Il.iterexp =
+    let values =
+      Dispatch.case_exact value_iterexp mop_iterexp Il_typs.typ_iterexp
+    in
+    let iter = V.Get.nth 0 values |> unboot_iter in
+    let varis = V.Get.nth 1 values |> unboot_varis in
+    (iter, varis)
+
+  and unboot_iterexps (value_iterexps : V.t) : Il.iterexp list =
+    value_iterexps |> V.Get.list |> List.map unboot_iterexp
+
+  (* Initialize dispatch tables after all handler functions are defined *)
+
+  let () =
+    (* Values *)
+    unboot_value_mtchtbl :=
+      Dispatch.build_mtchtbl
+        [
+          (mop_bool_value, unboot_bool_value);
+          (mop_num_value_nat, unboot_num_value_nat);
+          (mop_num_value_int, unboot_num_value_int);
+          (mop_text_value, unboot_text_value);
+          (mop_struct_value, unboot_struct_value);
+          (mop_case_value, unboot_variant_value);
+          (mop_tuple_value, unboot_tuple_value);
+          (mop_opt_value, unboot_opt_value);
+          (mop_list_value, unboot_list_value);
+          (mop_func_value, unboot_func_value);
+          (mop_extern_value, unboot_extern_value);
+        ];
+    (* Types *)
+    unboot_typ_mtchtbl :=
+      Dispatch.build_mtchtbl
+        [
+          (mop_bool_typ, unboot_bool_typ);
+          (mop_num_typ_nat, unboot_num_typ_nat);
+          (mop_num_typ_int, unboot_num_typ_int);
+          (mop_text_typ, unboot_text_typ);
+          (mop_var_typ, unboot_var_typ);
+          (mop_tuple_typ, unboot_tuple_typ);
+          (mop_iter_typ, unboot_iter_typ);
+          (mop_func_typ, unboot_func_typ);
+        ];
+    (* Defined types *)
+    unboot_deftyp_mtchtbl :=
+      Dispatch.build_mtchtbl
+        [
+          (mop_plain_deftyp, unboot_plain_deftyp);
+          (mop_struct_deftyp, unboot_struct_deftyp);
+          (mop_variant_deftyp, unboot_variant_deftyp);
+        ];
+    (* Operators *)
+    unboot_unop_mtchtbl :=
+      Dispatch.build_mtchtbl
+        [
+          (mop_not_unop, unboot_not_unop);
+          (mop_plus_unop, unboot_plus_unop);
+          (mop_minus_unop, unboot_minus_unop);
+        ];
+    unboot_binop_mtchtbl :=
+      Dispatch.build_mtchtbl
+        [
+          (mop_and_binop, unboot_and_binop);
+          (mop_or_binop, unboot_or_binop);
+          (mop_impl_binop, unboot_impl_binop);
+          (mop_equiv_binop, unboot_equiv_binop);
+          (mop_add_binop, unboot_add_binop);
+          (mop_sub_binop, unboot_sub_binop);
+          (mop_mul_binop, unboot_mul_binop);
+          (mop_div_binop, unboot_div_binop);
+          (mop_mod_binop, unboot_mod_binop);
+          (mop_pow_binop, unboot_pow_binop);
+        ];
+    unboot_cmpop_mtchtbl :=
+      Dispatch.build_mtchtbl
+        [
+          (mop_eq_cmpop, unboot_eq_cmpop);
+          (mop_ne_cmpop, unboot_ne_cmpop);
+          (mop_lt_cmpop, unboot_lt_cmpop);
+          (mop_le_cmpop, unboot_le_cmpop);
+          (mop_gt_cmpop, unboot_gt_cmpop);
+          (mop_ge_cmpop, unboot_ge_cmpop);
+        ];
+    (* Arguments *)
+    unboot_arg_mtchtbl :=
+      Dispatch.build_mtchtbl
+        [ (mop_exp_arg, unboot_exp_arg); (mop_def_arg, unboot_def_arg) ];
+    (* Expressions *)
+    unboot_exp_mtchtbl :=
+      Dispatch.build_mtchtbl
+        [
+          (mop_bool_exp, unboot_bool_exp);
+          (mop_num_exp_nat, unboot_num_exp_nat);
+          (mop_num_exp_int, unboot_num_exp_int);
+          (mop_text_exp, unboot_text_exp);
+          (mop_var_exp, unboot_var_exp);
+          (mop_un_exp, unboot_un_exp);
+          (mop_bin_exp, unboot_bin_exp);
+          (mop_cmp_exp, unboot_cmp_exp);
+          (mop_upcast_exp, unboot_upcast_exp);
+          (mop_downcast_exp, unboot_downcast_exp);
+          (mop_sub_exp, unboot_sub_exp);
+          (mop_match_exp, unboot_match_exp);
+          (mop_tuple_exp, unboot_tuple_exp);
+          (mop_case_exp, unboot_case_exp);
+          (mop_struct_exp, unboot_str_exp);
+          (mop_opt_exp, unboot_opt_exp);
+          (mop_list_exp, unboot_list_exp);
+          (mop_cons_exp, unboot_cons_exp);
+          (mop_cat_exp, unboot_cat_exp);
+          (mop_mem_exp, unboot_mem_exp);
+          (mop_len_exp, unboot_len_exp);
+          (mop_dot_exp, unboot_dot_exp);
+          (mop_idx_exp, unboot_idx_exp);
+          (mop_slice_exp, unboot_slice_exp);
+          (mop_upd_exp, unboot_upd_exp);
+          (mop_call_exp, unboot_call_exp);
+          (mop_iter_exp, unboot_iter_exp);
+        ];
+    (* Paths *)
+    unboot_path_mtchtbl :=
+      Dispatch.build_mtchtbl
+        [
+          (mop_root_path, unboot_root_path);
+          (mop_idx_path, unboot_idx_path);
+          (mop_slice_path, unboot_slice_path);
+          (mop_dot_path, unboot_dot_path);
+        ];
+    (* Patterns *)
+    unboot_pattern_mtchtbl :=
+      Dispatch.build_mtchtbl
+        [
+          (mop_case_pattern, unboot_inj_pattern);
+          (mop_list_cons_pattern, unboot_cons_pattern);
+          (mop_list_fixed_pattern, unboot_fixed_pattern);
+          (mop_list_nil_pattern, unboot_nil_pattern);
+          (mop_opt_some_pattern, unboot_some_pattern);
+          (mop_opt_none_pattern, unboot_none_pattern);
+        ]
+end

--- a/p4spec/lib/interface/spectec/ili/boot.ml
+++ b/p4spec/lib/interface/spectec/ili/boot.ml
@@ -1,326 +1,318 @@
-open Common.Boot
+module Mixfix = Domain.Mixfix
 open Lang
 open Mixops
 open Typs
 open Util.Source
 
-(* Parameters *)
+module Make (V : Runtime.Valrep.SAFE) = struct
+  include Common.Boot.Make (V)
 
-let rec boot_param (param : Il.param) : Value.t =
-  let at = param.at in
-  match param.it with
-  | ExpP typ ->
-      let value_typ = boot_typ typ in
-      Value.Make.(mop_exp_param <|! [ value_typ ] <<|! typ_param <<<| at)
-  | DefP (id, tparams, params, typ) ->
-      let value_id = boot_id id in
-      let value_tparams = boot_tparams tparams in
-      let value_params = boot_params params in
-      let value_typ = boot_typ typ in
-      Value.Make.(
-        mop_def_param
-        <|! [ value_id; value_tparams; value_params; value_typ ]
-        <<|! typ_param <<<| at)
+  (* Parameters *)
 
-and boot_params (params : Il.param list) : Value.t =
-  let values_params = List.map boot_param params in
-  Value.Make.list (Runtime.Type.Typ.Make.list typ_param) values_params
+  let rec boot_param (param : Il.param) : V.t =
+    let at = param.at in
+    match param.it with
+    | ExpP typ ->
+        let value_typ = boot_typ typ in
+        case_at at (mop_exp_param <|! [ value_typ ]) typ_param
+    | DefP (id, tparams, params, typ) ->
+        let value_id = boot_id id in
+        let value_tparams = boot_tparams tparams in
+        let value_params = boot_params params in
+        let value_typ = boot_typ typ in
+        case_at at
+          (mop_def_param
+          <|! [ value_id; value_tparams; value_params; value_typ ])
+          typ_param
 
-(* Iter premises *)
+  and boot_params (params : Il.param list) : V.t =
+    let values_params = List.map boot_param params in
+    V.Make.list (Runtime.Type.Typ.Make.list typ_param) values_params
 
-and boot_iterprem ((iter, vars_in, vars_out) : Il.iterprem) : Value.t =
-  let value_iter = boot_iter iter in
-  let value_vars_in = boot_vars vars_in in
-  let value_vars_out = boot_vars vars_out in
-  Value.Make.(
+  (* Iter premises *)
+
+  and boot_iterprem ((iter, vars_in, vars_out) : Il.iterprem) : V.t =
+    let value_iter = boot_iter iter in
+    let value_vars_in = boot_vars vars_in in
+    let value_vars_out = boot_vars vars_out in
     mop_iterprem
     <|! [ value_iter; value_vars_in; value_vars_out ]
-    <<|! typ_iterprem)
+    <<|! typ_iterprem
 
-(* Premises *)
+  (* Premises *)
 
-and boot_prem (prem : Il.prem) : Value.t =
-  let at = prem.at in
-  match prem.it with
-  | RulePr (id, notexp, input) -> boot_rel_prem at id notexp input
-  | IfPr e -> boot_if_prem at e
-  | IfHoldPr (id, notexp) -> boot_if_hold_prem at id notexp
-  | IfNotHoldPr (id, notexp) -> boot_if_nothold_prem at id notexp
-  | LetPr (el, er) -> boot_let_prem at el er
-  | IterPr (p, ip) -> boot_iter_prem at p ip
-  | DebugPr e -> boot_debug_prem at e
+  and boot_prem (prem : Il.prem) : V.t =
+    let at = prem.at in
+    match prem.it with
+    | RulePr (id, notexp, input) -> boot_rel_prem at id notexp input
+    | IfPr e -> boot_if_prem at e
+    | IfHoldPr (id, notexp) -> boot_if_hold_prem at id notexp
+    | IfNotHoldPr (id, notexp) -> boot_if_nothold_prem at id notexp
+    | LetPr (el, er) -> boot_let_prem at el er
+    | IterPr (p, ip) -> boot_iter_prem at p ip
+    | DebugPr e -> boot_debug_prem at e
 
-and boot_rel_prem (at : region) (id : Il.id) (notexp : Il.notexp)
-    (input : Hints.Input.t) : Value.t =
-  let exps = Mixfix.args notexp in
-  let value_id = boot_id id in
-  let exps_in, exps_out = Hints.Input.split input exps in
-  let value_exps_in = boot_exps exps_in in
-  let value_exps_out = boot_exps exps_out in
-  Value.Make.(
-    mop_rel_prem
-    <|! [ value_id; value_exps_in; value_exps_out ]
-    <<|! typ_prem <<<| at)
+  and boot_rel_prem (at : region) (id : Il.id) (notexp : Il.notexp)
+      (input : Hints.Input.t) : V.t =
+    let exps = Mixfix.args notexp in
+    let value_id = boot_id id in
+    let exps_in, exps_out = Hints.Input.split input exps in
+    let value_exps_in = boot_exps exps_in in
+    let value_exps_out = boot_exps exps_out in
+    case_at at
+      (mop_rel_prem <|! [ value_id; value_exps_in; value_exps_out ])
+      typ_prem
 
-and boot_if_prem (at : region) (e : Il.exp) : Value.t =
-  let value_exp = boot_exp e in
-  Value.Make.(mop_if_prem <|! [ value_exp ] <<|! typ_prem <<<| at)
+  and boot_if_prem (at : region) (e : Il.exp) : V.t =
+    let value_exp = boot_exp e in
+    case_at at (mop_if_prem <|! [ value_exp ]) typ_prem
 
-and boot_if_hold_prem (at : region) (id : Il.id) (notexp : Il.notexp) : Value.t
-    =
-  let exps = Mixfix.args notexp in
-  let value_id = boot_id id in
-  let value_exps = boot_exps exps in
-  Value.Make.(
-    mop_if_hold_prem <|! [ value_id; value_exps ] <<|! typ_prem <<<| at)
+  and boot_if_hold_prem (at : region) (id : Il.id) (notexp : Il.notexp) : V.t =
+    let exps = Mixfix.args notexp in
+    let value_id = boot_id id in
+    let value_exps = boot_exps exps in
+    case_at at (mop_if_hold_prem <|! [ value_id; value_exps ]) typ_prem
 
-and boot_if_nothold_prem (at : region) (id : Il.id) (notexp : Il.notexp) :
-    Value.t =
-  let exps = Mixfix.args notexp in
-  let value_id = boot_id id in
-  let value_exps = boot_exps exps in
-  Value.Make.(
-    mop_if_nothold_prem <|! [ value_id; value_exps ] <<|! typ_prem <<<| at)
+  and boot_if_nothold_prem (at : region) (id : Il.id) (notexp : Il.notexp) : V.t
+      =
+    let exps = Mixfix.args notexp in
+    let value_id = boot_id id in
+    let value_exps = boot_exps exps in
+    case_at at (mop_if_nothold_prem <|! [ value_id; value_exps ]) typ_prem
 
-and boot_let_prem (at : region) (el : Il.exp) (er : Il.exp) : Value.t =
-  let value_el = boot_exp el in
-  let value_er = boot_exp er in
-  Value.Make.(mop_let_prem <|! [ value_el; value_er ] <<|! typ_prem <<<| at)
+  and boot_let_prem (at : region) (el : Il.exp) (er : Il.exp) : V.t =
+    let value_el = boot_exp el in
+    let value_er = boot_exp er in
+    case_at at (mop_let_prem <|! [ value_el; value_er ]) typ_prem
 
-and boot_iter_prem (at : region) (p : Il.prem) (ip : Il.iterprem) : Value.t =
-  let value_prem = boot_prem p in
-  let value_iterprem = boot_iterprem ip in
-  Value.Make.(
-    mop_iter_prem <|! [ value_prem; value_iterprem ] <<|! typ_prem <<<| at)
+  and boot_iter_prem (at : region) (p : Il.prem) (ip : Il.iterprem) : V.t =
+    let value_prem = boot_prem p in
+    let value_iterprem = boot_iterprem ip in
+    case_at at (mop_iter_prem <|! [ value_prem; value_iterprem ]) typ_prem
 
-and boot_debug_prem (at : region) (e : Il.exp) : Value.t =
-  let value_exp = boot_exp e in
-  Value.Make.(mop_debug_prem <|! [ value_exp ] <<|! typ_prem <<<| at)
+  and boot_debug_prem (at : region) (e : Il.exp) : V.t =
+    let value_exp = boot_exp e in
+    case_at at (mop_debug_prem <|! [ value_exp ]) typ_prem
 
-and boot_prems (prems : Il.prem list) : Value.t =
-  let values_prems = List.map boot_prem prems in
-  Value.Make.list (Runtime.Type.Typ.Make.list typ_prem) values_prems
+  and boot_prems (prems : Il.prem list) : V.t =
+    let values_prems = List.map boot_prem prems in
+    V.Make.list (Runtime.Type.Typ.Make.list typ_prem) values_prems
 
-(* Rule matching and paths *)
+  (* Rule matching and paths *)
 
-and boot_rulmatch ((_, exps_input, prems) : Il.rulematch) : Value.t =
-  let value_exps = boot_exps exps_input in
-  let value_prems = boot_prems prems in
-  Value.Make.(mop_rulematch <|! [ value_exps; value_prems ] <<|! typ_rulmatch)
+  and boot_rulmatch ((_, exps_input, prems) : Il.rulematch) : V.t =
+    let value_exps = boot_exps exps_input in
+    let value_prems = boot_prems prems in
+    mop_rulematch <|! [ value_exps; value_prems ] <<|! typ_rulmatch
 
-and boot_rulpath ((id, prems, exps_output) : Il.rulepath) : Value.t =
-  let value_id = boot_id id in
-  let value_exps_output = boot_exps exps_output in
-  let value_prems = boot_prems prems in
-  Value.Make.(
+  and boot_rulpath ((id, prems, exps_output) : Il.rulepath) : V.t =
+    let value_id = boot_id id in
+    let value_exps_output = boot_exps exps_output in
+    let value_prems = boot_prems prems in
     mop_rulepath
     <|! [ value_id; value_exps_output; value_prems ]
-    <<|! typ_rulpath)
+    <<|! typ_rulpath
 
-and boot_rulpaths (rulpaths : Il.rulepath list) : Value.t =
-  let values_rulpaths = List.map boot_rulpath rulpaths in
-  Value.Make.list (Runtime.Type.Typ.Make.list typ_rulpath) values_rulpaths
+  and boot_rulpaths (rulpaths : Il.rulepath list) : V.t =
+    let values_rulpaths = List.map boot_rulpath rulpaths in
+    V.Make.list (Runtime.Type.Typ.Make.list typ_rulpath) values_rulpaths
 
-and boot_rulgroup (rg : Il.rulegroup) : Value.t =
-  let at = rg.at in
-  let id, rulmatch_, rulpaths = rg.it in
-  let value_id = boot_id id in
-  let value_rulmatch = boot_rulmatch rulmatch_ in
-  let value_rulpaths = boot_rulpaths rulpaths in
-  Value.Make.(
-    mop_rulegroup
-    <|! [ value_id; value_rulmatch; value_rulpaths ]
-    <<|! typ_rulgroup <<<| at)
+  and boot_rulgroup (rg : Il.rulegroup) : V.t =
+    let at = rg.at in
+    let id, rulmatch_, rulpaths = rg.it in
+    let value_id = boot_id id in
+    let value_rulmatch = boot_rulmatch rulmatch_ in
+    let value_rulpaths = boot_rulpaths rulpaths in
+    case_at at
+      (mop_rulegroup <|! [ value_id; value_rulmatch; value_rulpaths ])
+      typ_rulgroup
 
-and boot_rulgroups (rulgroups : Il.rulegroup list) : Value.t =
-  let values_rulgroups = List.map boot_rulgroup rulgroups in
-  Value.Make.list (Runtime.Type.Typ.Make.list typ_rulgroup) values_rulgroups
+  and boot_rulgroups (rulgroups : Il.rulegroup list) : V.t =
+    let values_rulgroups = List.map boot_rulgroup rulgroups in
+    V.Make.list (Runtime.Type.Typ.Make.list typ_rulgroup) values_rulgroups
 
-and boot_elsgroup (elsegroup : Il.elsegroup) : Value.t =
-  let at = elsegroup.at in
-  let id, rulmatch_, rulpath_ = elsegroup.it in
-  let value_id = boot_id id in
-  let value_rulmatch = boot_rulmatch rulmatch_ in
-  let value_rulpath = boot_rulpath rulpath_ in
-  Value.Make.(
-    mop_elsegroup
-    <|! [ value_id; value_rulmatch; value_rulpath ]
-    <<|! typ_elsgroup <<<| at)
+  and boot_elsgroup (elsegroup : Il.elsegroup) : V.t =
+    let at = elsegroup.at in
+    let id, rulmatch_, rulpath_ = elsegroup.it in
+    let value_id = boot_id id in
+    let value_rulmatch = boot_rulmatch rulmatch_ in
+    let value_rulpath = boot_rulpath rulpath_ in
+    case_at at
+      (mop_elsegroup <|! [ value_id; value_rulmatch; value_rulpath ])
+      typ_elsgroup
 
-and boot_elsgroup_opt (elsegroup_opt : Il.elsegroup option) : Value.t =
-  Value.Make.opt
-    (Runtime.Type.Typ.Make.opt typ_elsgroup)
-    (Option.map boot_elsgroup elsegroup_opt)
+  and boot_elsgroup_opt (elsegroup_opt : Il.elsegroup option) : V.t =
+    V.Make.opt
+      (Runtime.Type.Typ.Make.opt typ_elsgroup)
+      (Option.map boot_elsgroup elsegroup_opt)
 
-(* Clauses *)
+  (* Clauses *)
 
-and boot_clause (clause : Il.clause) : Value.t =
-  let at = clause.at in
-  let args, exp, prems = clause.it in
-  let value_args = boot_args args in
-  let value_exp = boot_exp exp in
-  let value_prems = boot_prems prems in
-  Value.Make.(
-    mop_clause
-    <|! [ value_args; value_exp; value_prems ]
-    <<|! typ_clause <<<| at)
+  and boot_clause (clause : Il.clause) : V.t =
+    let at = clause.at in
+    let args, exp, prems = clause.it in
+    let value_args = boot_args args in
+    let value_exp = boot_exp exp in
+    let value_prems = boot_prems prems in
+    case_at at
+      (mop_clause <|! [ value_args; value_exp; value_prems ])
+      typ_clause
 
-and boot_clauses (clauses : Il.clause list) : Value.t =
-  let values_clauses = List.map boot_clause clauses in
-  Value.Make.list (Runtime.Type.Typ.Make.list typ_clause) values_clauses
+  and boot_clauses (clauses : Il.clause list) : V.t =
+    let values_clauses = List.map boot_clause clauses in
+    V.Make.list (Runtime.Type.Typ.Make.list typ_clause) values_clauses
 
-and boot_elsclause (elsclause : Il.elseclause) : Value.t = boot_clause elsclause
+  and boot_elsclause (elsclause : Il.elseclause) : V.t = boot_clause elsclause
 
-and boot_elsclause_opt (elsclause_opt : Il.elseclause option) : Value.t =
-  Value.Make.opt
-    (Runtime.Type.Typ.Make.opt
-       (Runtime.Type.Typ.Make.var ("elsclause" $ no_region) []))
-    (Option.map boot_elsclause elsclause_opt)
+  and boot_elsclause_opt (elsclause_opt : Il.elseclause option) : V.t =
+    V.Make.opt
+      (Runtime.Type.Typ.Make.opt
+         (Runtime.Type.Typ.Make.var ("elsclause" $ no_region) []))
+      (Option.map boot_elsclause elsclause_opt)
 
-(* Table rows *)
+  (* Table rows *)
 
-and boot_tablerow (tablerow : Il.tablerow) : Value.t =
-  let at = tablerow.at in
-  let _exps, args, exp, prems = tablerow.it in
-  let value_args = boot_args args in
-  let value_exp = boot_exp exp in
-  let value_prems = boot_prems prems in
-  Value.Make.(
-    mop_clause
-    <|! [ value_args; value_exp; value_prems ]
-    <<|! typ_tblrow <<<| at)
+  and boot_tablerow (tablerow : Il.tablerow) : V.t =
+    let at = tablerow.at in
+    let _exps, args, exp, prems = tablerow.it in
+    let value_args = boot_args args in
+    let value_exp = boot_exp exp in
+    let value_prems = boot_prems prems in
+    case_at at
+      (mop_clause <|! [ value_args; value_exp; value_prems ])
+      typ_tblrow
 
-and boot_tablerows (tablerows : Il.tablerow list) : Value.t =
-  let values_tablerows = List.map boot_tablerow tablerows in
-  Value.Make.list (Runtime.Type.Typ.Make.list typ_tblrow) values_tablerows
+  and boot_tablerows (tablerows : Il.tablerow list) : V.t =
+    let values_tablerows = List.map boot_tablerow tablerows in
+    V.Make.list (Runtime.Type.Typ.Make.list typ_tblrow) values_tablerows
 
-(* Definitions *)
+  (* Definitions *)
 
-let rec boot_def (def : Il.def) : Value.t option =
-  let wrap_some value = Some value in
-  let at = def.at in
-  match def.it with
-  | ExternTypD (id, _) -> boot_extern_typ_def at id |> wrap_some
-  | TypD (id, tparams, deftyp, _) ->
-      boot_typ_def at id tparams deftyp |> wrap_some
-  | VarD _ -> None
-  | ExternRelD (id, nottyp, input, _) ->
-      boot_extern_rel_def at id nottyp input |> wrap_some
-  | RelD (id, nottyp, input, rulgroups, elsegroup_opt, _) ->
-      boot_rel_def at id nottyp input rulgroups elsegroup_opt |> wrap_some
-  | ExternDecD (id, tparams, params, typ, _) ->
-      boot_extern_func_def at id tparams params typ |> wrap_some
-  | BuiltinDecD (id, tparams, params, typ, _) ->
-      boot_builtin_func_def at id tparams params typ |> wrap_some
-  | TableDecD (id, params, typ, tablerows, _) ->
-      boot_table_func_def at id params typ tablerows |> wrap_some
-  | FuncDecD (id, tparams, params, typ, clauses, elseclause_opt, _) ->
-      boot_func_def at id tparams params typ clauses elseclause_opt |> wrap_some
+  let rec boot_def (def : Il.def) : V.t option =
+    let wrap_some value = Some value in
+    let at = def.at in
+    match def.it with
+    | ExternTypD (id, _) -> boot_extern_typ_def at id |> wrap_some
+    | TypD (id, tparams, deftyp, _) ->
+        boot_typ_def at id tparams deftyp |> wrap_some
+    | VarD _ -> None
+    | ExternRelD (id, nottyp, input, _) ->
+        boot_extern_rel_def at id nottyp input |> wrap_some
+    | RelD (id, nottyp, input, rulgroups, elsegroup_opt, _) ->
+        boot_rel_def at id nottyp input rulgroups elsegroup_opt |> wrap_some
+    | ExternDecD (id, tparams, params, typ, _) ->
+        boot_extern_func_def at id tparams params typ |> wrap_some
+    | BuiltinDecD (id, tparams, params, typ, _) ->
+        boot_builtin_func_def at id tparams params typ |> wrap_some
+    | TableDecD (id, params, typ, tablerows, _) ->
+        boot_table_func_def at id params typ tablerows |> wrap_some
+    | FuncDecD (id, tparams, params, typ, clauses, elseclause_opt, _) ->
+        boot_func_def at id tparams params typ clauses elseclause_opt
+        |> wrap_some
 
-and boot_extern_typ_def (at : region) (id : Il.id) : Value.t =
-  let value_id = boot_id id in
-  Value.Make.(mop_extern_typ_def <|! [ value_id ] <<|! typ_defn <<<| at)
+  and boot_extern_typ_def (at : region) (id : Il.id) : V.t =
+    let value_id = boot_id id in
+    case_at at (mop_extern_typ_def <|! [ value_id ]) typ_defn
 
-and boot_typ_def (at : region) (id : Il.id) (tparams : Il.tparam list)
-    (deftyp : Il.deftyp) : Value.t =
-  let value_id = boot_id id in
-  let value_tparams = boot_tparams tparams in
-  let value_deftyp = boot_deftyp deftyp in
-  Value.Make.(
-    mop_typ_def
-    <|! [ value_id; value_tparams; value_deftyp ]
-    <<|! typ_defn <<<| at)
+  and boot_typ_def (at : region) (id : Il.id) (tparams : Il.tparam list)
+      (deftyp : Il.deftyp) : V.t =
+    let value_id = boot_id id in
+    let value_tparams = boot_tparams tparams in
+    let value_deftyp = boot_deftyp deftyp in
+    case_at at
+      (mop_typ_def <|! [ value_id; value_tparams; value_deftyp ])
+      typ_defn
 
-and boot_extern_rel_def (at : region) (id : Il.id) (nottyp : Il.nottyp)
-    (input : Hints.Input.t) : Value.t =
-  let typs = Mixfix.args nottyp.it in
-  let typs_in, typs_out = Hints.Input.split input typs in
-  let value_id = boot_id id in
-  let value_typs_in = boot_typs typs_in in
-  let value_typs_out = boot_typs typs_out in
-  Value.Make.(
-    mop_extern_rel_def
-    <|! [ value_id; value_typs_in; value_typs_out ]
-    <<|! typ_defn <<<| at)
+  and boot_extern_rel_def (at : region) (id : Il.id) (nottyp : Il.nottyp)
+      (input : Hints.Input.t) : V.t =
+    let typs = Mixfix.args nottyp.it in
+    let typs_in, typs_out = Hints.Input.split input typs in
+    let value_id = boot_id id in
+    let value_typs_in = boot_typs typs_in in
+    let value_typs_out = boot_typs typs_out in
+    case_at at
+      (mop_extern_rel_def <|! [ value_id; value_typs_in; value_typs_out ])
+      typ_defn
 
-and boot_rel_def (at : region) (id : Il.id) (nottyp : Il.nottyp)
-    (input : Hints.Input.t) (rulgroups : Il.rulegroup list)
-    (elsegroup_opt : Il.elsegroup option) : Value.t =
-  let typs = Mixfix.args nottyp.it in
-  let typs_in, typs_out = Hints.Input.split input typs in
-  let value_id = boot_id id in
-  let value_typs_in = boot_typs typs_in in
-  let value_typs_out = boot_typs typs_out in
-  let value_rulgroups = boot_rulgroups rulgroups in
-  let value_elsgroup = boot_elsgroup_opt elsegroup_opt in
-  Value.Make.(
-    mop_rel_def
-    <|! [
-          value_id;
-          value_typs_in;
-          value_typs_out;
-          value_rulgroups;
-          value_elsgroup;
-        ]
-    <<|! typ_defn <<<| at)
+  and boot_rel_def (at : region) (id : Il.id) (nottyp : Il.nottyp)
+      (input : Hints.Input.t) (rulgroups : Il.rulegroup list)
+      (elsegroup_opt : Il.elsegroup option) : V.t =
+    let typs = Mixfix.args nottyp.it in
+    let typs_in, typs_out = Hints.Input.split input typs in
+    let value_id = boot_id id in
+    let value_typs_in = boot_typs typs_in in
+    let value_typs_out = boot_typs typs_out in
+    let value_rulgroups = boot_rulgroups rulgroups in
+    let value_elsgroup = boot_elsgroup_opt elsegroup_opt in
+    case_at at
+      (mop_rel_def
+      <|! [
+            value_id;
+            value_typs_in;
+            value_typs_out;
+            value_rulgroups;
+            value_elsgroup;
+          ])
+      typ_defn
 
-and boot_extern_func_def (at : region) (id : Il.id) (tparams : Il.tparam list)
-    (params : Il.param list) (typ : Il.typ) : Value.t =
-  let value_id = boot_id id in
-  let value_tparams = boot_tparams tparams in
-  let value_params = boot_params params in
-  let value_typ = boot_typ typ in
-  Value.Make.(
-    mop_extern_func_def
-    <|! [ value_id; value_tparams; value_params; value_typ ]
-    <<|! typ_defn <<<| at)
+  and boot_extern_func_def (at : region) (id : Il.id) (tparams : Il.tparam list)
+      (params : Il.param list) (typ : Il.typ) : V.t =
+    let value_id = boot_id id in
+    let value_tparams = boot_tparams tparams in
+    let value_params = boot_params params in
+    let value_typ = boot_typ typ in
+    case_at at
+      (mop_extern_func_def
+      <|! [ value_id; value_tparams; value_params; value_typ ])
+      typ_defn
 
-and boot_builtin_func_def (at : region) (id : Il.id) (tparams : Il.tparam list)
-    (params : Il.param list) (typ : Il.typ) : Value.t =
-  let value_id = boot_id id in
-  let value_tparams = boot_tparams tparams in
-  let value_params = boot_params params in
-  let value_typ = boot_typ typ in
-  Value.Make.(
-    mop_builtin_func_def
-    <|! [ value_id; value_tparams; value_params; value_typ ]
-    <<|! typ_defn <<<| at)
+  and boot_builtin_func_def (at : region) (id : Il.id)
+      (tparams : Il.tparam list) (params : Il.param list) (typ : Il.typ) : V.t =
+    let value_id = boot_id id in
+    let value_tparams = boot_tparams tparams in
+    let value_params = boot_params params in
+    let value_typ = boot_typ typ in
+    case_at at
+      (mop_builtin_func_def
+      <|! [ value_id; value_tparams; value_params; value_typ ])
+      typ_defn
 
-and boot_table_func_def (at : region) (id : Il.id) (params : Il.param list)
-    (typ : Il.typ) (tablerows : Il.tablerow list) : Value.t =
-  let value_id = boot_id id in
-  let value_params = boot_params params in
-  let value_typ = boot_typ typ in
-  let value_tablerows = boot_tablerows tablerows in
-  Value.Make.(
-    mop_table_func_def
-    <|! [ value_id; value_params; value_typ; value_tablerows ]
-    <<|! typ_defn <<<| at)
+  and boot_table_func_def (at : region) (id : Il.id) (params : Il.param list)
+      (typ : Il.typ) (tablerows : Il.tablerow list) : V.t =
+    let value_id = boot_id id in
+    let value_params = boot_params params in
+    let value_typ = boot_typ typ in
+    let value_tablerows = boot_tablerows tablerows in
+    case_at at
+      (mop_table_func_def
+      <|! [ value_id; value_params; value_typ; value_tablerows ])
+      typ_defn
 
-and boot_func_def (at : region) (id : Il.id) (tparams : Il.tparam list)
-    (params : Il.param list) (typ : Il.typ) (clauses : Il.clause list)
-    (elseclause_opt : Il.elseclause option) : Value.t =
-  let value_id = boot_id id in
-  let value_tparams = boot_tparams tparams in
-  let value_params = boot_params params in
-  let value_typ = boot_typ typ in
-  let value_clauses = boot_clauses clauses in
-  let value_elsclause = boot_elsclause_opt elseclause_opt in
-  Value.Make.(
-    mop_func_def
-    <|! [
-          value_id;
-          value_tparams;
-          value_params;
-          value_typ;
-          value_clauses;
-          value_elsclause;
-        ]
-    <<|! typ_defn <<<| at)
+  and boot_func_def (at : region) (id : Il.id) (tparams : Il.tparam list)
+      (params : Il.param list) (typ : Il.typ) (clauses : Il.clause list)
+      (elseclause_opt : Il.elseclause option) : V.t =
+    let value_id = boot_id id in
+    let value_tparams = boot_tparams tparams in
+    let value_params = boot_params params in
+    let value_typ = boot_typ typ in
+    let value_clauses = boot_clauses clauses in
+    let value_elsclause = boot_elsclause_opt elseclause_opt in
+    case_at at
+      (mop_func_def
+      <|! [
+            value_id;
+            value_tparams;
+            value_params;
+            value_typ;
+            value_clauses;
+            value_elsclause;
+          ])
+      typ_defn
 
-(* Specification *)
+  (* Specification *)
 
-let boot_spec (spec : Il.spec) : Value.t =
-  let values_def = List.map boot_def spec |> List.filter_map Fun.id in
-  let typ_script = Runtime.Type.Typ.Make.var ("script" $ no_region) [] in
-  Value.Make.list typ_script values_def
+  let boot_spec (spec : Il.spec) : V.t =
+    let values_def = List.map boot_def spec |> List.filter_map Fun.id in
+    let typ_script = Runtime.Type.Typ.Make.var ("script" $ no_region) [] in
+    V.Make.list typ_script values_def
+end

--- a/p4spec/lib/interface/spectec/ili/il_typs.ml
+++ b/p4spec/lib/interface/spectec/ili/il_typs.ml
@@ -1,0 +1,17 @@
+module Il = Lang.Il
+open Util.Source
+
+let var (name : string) : Il.typ = Il.VarT (name $ no_region, []) $ no_region
+let typ_param = var "param"
+let typ_prem = var "prem"
+let typ_defn = var "defn"
+
+(* Constants used by ili/unboot.ml's dispatch-table call sites. *)
+
+let typ_iterprem = var "iterprem"
+let typ_rulmatch = var "rulmatch"
+let typ_rulpath = var "rulpath"
+let typ_rulgroup = var "rulgroup"
+let typ_elsgroup = var "elsgroup"
+let typ_clause = var "clause"
+let typ_tblrow = var "tblrow"

--- a/p4spec/lib/interface/spectec/ili/unboot.ml
+++ b/p4spec/lib/interface/spectec/ili/unboot.ml
@@ -1,333 +1,349 @@
-open Common.Unboot
 open Common.Stub
 open Lang
 open Mixops
 open Util.Source
 
-(* Forward references for IL dispatch tables,
-   populated after all sub-match functions are defined *)
+module Make (V : Runtime.Valrep.SAFE) = struct
+  include Common.Unboot.Make (V)
 
-let unboot_param_mtchtbl : Il.param Value.Get.mtchtbl ref =
-  ref (Value.Get.MtchTbl.create 0)
+  (* Forward references for IL dispatch tables,
+     populated after all sub-match functions are defined *)
 
-let unboot_prem_mtchtbl : Il.prem Value.Get.mtchtbl ref =
-  ref (Value.Get.MtchTbl.create 0)
+  let unboot_param_mtchtbl : Il.param Dispatch.mtchtbl ref =
+    ref (Dispatch.MtchTbl.create 0)
 
-let unboot_def_mtchtbl : Il.def Value.Get.mtchtbl ref =
-  ref (Value.Get.MtchTbl.create 0)
+  let unboot_prem_mtchtbl : Il.prem Dispatch.mtchtbl ref =
+    ref (Dispatch.MtchTbl.create 0)
 
-(* Iter premises *)
+  let unboot_def_mtchtbl : Il.def Dispatch.mtchtbl ref =
+    ref (Dispatch.MtchTbl.create 0)
 
-let unboot_iterprem (value_iterprem : Value.t) : Il.iterprem =
-  let values = Value.Get.(value_iterprem |>>! mop_iterprem) in
-  let iter = Value.Get.nth 0 values |> unboot_iter in
-  let varis_in = Value.Get.nth 1 values |> unboot_varis in
-  let varis_out = Value.Get.nth 2 values |> unboot_varis in
-  (iter, varis_in, varis_out)
+  (* Iter premises *)
 
-(* Parameters *)
+  let unboot_iterprem (value_iterprem : V.t) : Il.iterprem =
+    let values =
+      Dispatch.case_exact value_iterprem mop_iterprem Il_typs.typ_iterprem
+    in
+    let iter = V.Get.nth 0 values |> unboot_iter in
+    let varis_in = V.Get.nth 1 values |> unboot_varis in
+    let varis_out = V.Get.nth 2 values |> unboot_varis in
+    (iter, varis_in, varis_out)
 
-let rec unboot_param (value_param : Value.t) : Il.param =
-  Value.Get.mtch_dispatch value_param !unboot_param_mtchtbl (fun _ _ ->
-      error "@unboot_param")
-
-and unboot_exp_param (at : region) (values : Value.t list) : Il.param =
-  match values with
-  | [ value_typ ] ->
-      let typ = unboot_typ value_typ in
-      Il.ExpP typ $ at
-  | _ -> error "@unboot_exp_param"
-
-and unboot_def_param (at : region) (values : Value.t list) : Il.param =
-  match values with
-  | [ value_id; value_tparams; value_params; value_typ ] ->
-      let id = unboot_id value_id in
-      let tparams = unboot_tparams value_tparams in
-      let params = unboot_params value_params in
-      let typ = unboot_typ value_typ in
-      Il.DefP (id, tparams, params, typ) $ at
-  | _ -> error "@unboot_def_param"
-
-and unboot_params (value_params : Value.t) : Il.param list =
-  value_params |> Value.Get.list |> List.map unboot_param
-
-(* Premises *)
-
-and unboot_prem (value_prem : Value.t) : Il.prem =
-  Value.Get.mtch_dispatch value_prem !unboot_prem_mtchtbl (fun _ _ ->
-      error "@unboot_prem")
-
-and unboot_prems (value_prems : Value.t) : Il.prem list =
-  value_prems |> Value.Get.list |> List.map unboot_prem
-
-and unboot_rel_prem (at : region) (values : Value.t list) : Il.prem =
-  match values with
-  | [ value_id; value_exps_input; value_exps_output ] ->
-      let id = unboot_id value_id in
-      let exps_input = unboot_exps value_exps_input in
-      let exps_output = unboot_exps value_exps_output in
-      let notexp = stub_notexp exps_input exps_output in
-      let input = stub_input_hint (List.length exps_input) in
-      Il.RulePr (id, notexp, input) $ at
-  | _ -> error "@unboot_rel_prem"
-
-and unboot_if_prem (at : region) (values : Value.t list) : Il.prem =
-  match values with
-  | [ value_exp ] ->
-      let exp = unboot_exp value_exp in
-      Il.IfPr exp $ at
-  | _ -> error "@unboot_if_prem"
-
-and unboot_ifhold_prem (at : region) (values : Value.t list) : Il.prem =
-  match values with
-  | [ value_id; value_exps ] ->
-      let id = unboot_id value_id in
-      let exps = unboot_exps value_exps in
-      let notexp = stub_notexp exps [] in
-      Il.IfHoldPr (id, notexp) $ at
-  | _ -> error "@unboot_ifhold_prem"
-
-and unboot_ifnothold_prem (at : region) (values : Value.t list) : Il.prem =
-  match values with
-  | [ value_id; value_exps ] ->
-      let id = unboot_id value_id in
-      let exps = unboot_exps value_exps in
-      let notexp = stub_notexp exps [] in
-      Il.IfNotHoldPr (id, notexp) $ at
-  | _ -> error "@unboot_ifnothold_prem"
-
-and unboot_let_prem (at : region) (values : Value.t list) : Il.prem =
-  match values with
-  | [ value_exp_l; value_exp_r ] ->
-      let exp_l = unboot_exp value_exp_l in
-      let exp_r = unboot_exp value_exp_r in
-      Il.LetPr (exp_l, exp_r) $ at
-  | _ -> error "@unboot_let_prem"
-
-and unboot_iter_prem (at : region) (values : Value.t list) : Il.prem =
-  match values with
-  | [ value_prem; value_iterprem ] ->
-      let prem = unboot_prem value_prem in
-      let iterprem = unboot_iterprem value_iterprem in
-      Il.IterPr (prem, iterprem) $ at
-  | _ -> error "@unboot_iter_prem"
-
-and unboot_debug_prem (at : region) (values : Value.t list) : Il.prem =
-  match values with
-  | [ value_exp ] ->
-      let exp = unboot_exp value_exp in
-      Il.DebugPr exp $ at
-  | _ -> error "@unboot_debug_prem"
-
-(* Rule matching and paths *)
-
-and unboot_rulmatch (value_rulmatch : Value.t) : Il.rulematch =
-  let values = Value.Get.(value_rulmatch |>>! mop_rulematch) in
-  let exps = Value.Get.nth 0 values |> unboot_exps in
-  let prems = Value.Get.nth 1 values |> unboot_prems in
-  (exps, exps, prems)
-
-and unboot_rulpath (value_rulpath : Value.t) : Il.rulepath =
-  let values = Value.Get.(value_rulpath |>>! mop_rulepath) in
-  let id = Value.Get.nth 0 values |> unboot_id in
-  let exps = Value.Get.nth 1 values |> unboot_exps in
-  let prems = Value.Get.nth 2 values |> unboot_prems in
-  (id, prems, exps)
-
-and unboot_rulpaths (value_rulpaths : Value.t) : Il.rulepath list =
-  value_rulpaths |> Value.Get.list |> List.map unboot_rulpath
-
-and unboot_rulgroup (value_rulgroup : Value.t) : Il.rulegroup =
-  let at = value_rulgroup.at in
-  let values = Value.Get.(value_rulgroup |>>! mop_rulegroup) in
-  let id = Value.Get.nth 0 values |> unboot_id in
-  let rulmatch = Value.Get.nth 1 values |> unboot_rulmatch in
-  let rulpaths = Value.Get.nth 2 values |> unboot_rulpaths in
-  (id, rulmatch, rulpaths) $ at
-
-and unboot_rulgroups (value_rulgroups : Value.t) : Il.rulegroup list =
-  value_rulgroups |> Value.Get.list |> List.map unboot_rulgroup
-
-and unboot_elsgroup (value_elsgroup : Value.t) : Il.elsegroup =
-  let at = value_elsgroup.at in
-  let values = Value.Get.(value_elsgroup |>>! mop_elsegroup) in
-  let id = Value.Get.nth 0 values |> unboot_id in
-  let rulmatch = Value.Get.nth 1 values |> unboot_rulmatch in
-  let rulpath = Value.Get.nth 2 values |> unboot_rulpath in
-  (id, rulmatch, rulpath) $ at
-
-and unboot_elsgroup_opt (value_elsgroup_opt : Value.t) : Il.elsegroup option =
-  value_elsgroup_opt |> Value.Get.opt |> Option.map unboot_elsgroup
-
-(* Clauses *)
-
-and unboot_clause (value_clause : Value.t) : Il.clause =
-  let at = value_clause.at in
-  let values = Value.Get.(value_clause |>>! mop_clause) in
-  let args = Value.Get.nth 0 values |> unboot_args in
-  let exp = Value.Get.nth 1 values |> unboot_exp in
-  let prems = Value.Get.nth 2 values |> unboot_prems in
-  (args, exp, prems) $ at
-
-and unboot_clauses (value_clauses : Value.t) : Il.clause list =
-  value_clauses |> Value.Get.list |> List.map unboot_clause
-
-and unboot_elsclause (value_elsclause : Value.t) : Il.elseclause =
-  unboot_clause value_elsclause
-
-and unboot_elsclause_opt (value_elsclause_opt : Value.t) : Il.elseclause option
-    =
-  value_elsclause_opt |> Value.Get.opt |> Option.map unboot_elsclause
-
-(* Table rows *)
-
-and unboot_tablerow (value_tablerow : Value.t) : Il.tablerow =
-  let at = value_tablerow.at in
-  let values = Value.Get.(value_tablerow |>>! mop_tablerow) in
-  let args = Value.Get.nth 0 values |> unboot_args in
-  let exp = Value.Get.nth 1 values |> unboot_exp in
-  let prems = Value.Get.nth 2 values |> unboot_prems in
-  ([], args, exp, prems) $ at
-
-and unboot_tablerows (value_tablerows : Value.t) : Il.tablerow list =
-  value_tablerows |> Value.Get.list |> List.map unboot_tablerow
-
-(* Definitions *)
-
-let unboot_def (value_def : Value.t) : Il.def =
-  Value.Get.mtch_dispatch value_def !unboot_def_mtchtbl (fun _ _ ->
-      error "@unboot_def")
-
-and unboot_extern_typ_def (at : region) (values : Value.t list) : Il.def =
-  match values with
-  | [ value_id ] ->
-      let id = unboot_id value_id in
-      Il.ExternTypD (id, []) $ at
-  | _ -> error "@unboot_extern_typ_def"
-
-and unboot_typ_def (at : region) (values : Value.t list) : Il.def =
-  match values with
-  | [ value_id; value_tparams; value_deftyp ] ->
-      let id = unboot_id value_id in
-      let tparams = unboot_tparams value_tparams in
-      let deftyp = unboot_deftyp value_deftyp in
-      Il.TypD (id, tparams, deftyp, []) $ at
-  | _ -> error "@unboot_typ_def"
-
-and unboot_extern_rel_def (at : region) (values : Value.t list) : Il.def =
-  match values with
-  | [ value_id; value_typs_input; value_typs_output ] ->
-      let id = unboot_id value_id in
-      let typs_input = unboot_typs value_typs_input in
-      let typs_output = unboot_typs value_typs_output in
-      let nottyp = stub_nottyp typs_input typs_output in
-      let input = stub_input_hint (List.length typs_input) in
-      Il.ExternRelD (id, nottyp, input, []) $ at
-  | _ -> error "@unboot_extern_rel_def"
-
-and unboot_rel_def (at : region) (values : Value.t list) : Il.def =
-  match values with
-  | [
-   value_id;
-   value_typs_input;
-   value_typs_output;
-   value_rulgroups;
-   value_elsgroup;
-  ] ->
-      let id = unboot_id value_id in
-      let typs_input = unboot_typs value_typs_input in
-      let typs_output = unboot_typs value_typs_output in
-      let nottyp = stub_nottyp typs_input typs_output in
-      let input = stub_input_hint (List.length typs_input) in
-      let rulgroups = unboot_rulgroups value_rulgroups in
-      let elsgroup = unboot_elsgroup_opt value_elsgroup in
-      Il.RelD (id, nottyp, input, rulgroups, elsgroup, []) $ at
-  | _ -> error "@unboot_rel_def"
-
-and unboot_extern_func_def (at : region) (values : Value.t list) : Il.def =
-  match values with
-  | [ value_id; value_tparams; value_params; value_typ ] ->
-      let id = unboot_id value_id in
-      let tparams = unboot_tparams value_tparams in
-      let params = unboot_params value_params in
-      let typ = unboot_typ value_typ in
-      Il.ExternDecD (id, tparams, params, typ, []) $ at
-  | _ -> error "@unboot_extern_func_def"
-
-and unboot_builtin_func_def (at : region) (values : Value.t list) : Il.def =
-  match values with
-  | [ value_id; value_tparams; value_params; value_typ ] ->
-      let id = unboot_id value_id in
-      let tparams = unboot_tparams value_tparams in
-      let params = unboot_params value_params in
-      let typ = unboot_typ value_typ in
-      Il.BuiltinDecD (id, tparams, params, typ, []) $ at
-  | _ -> error "@unboot_builtin_func_def"
-
-and unboot_table_func_def (at : region) (values : Value.t list) : Il.def =
-  match values with
-  | [ value_id; value_params; value_typ; value_tablerows ] ->
-      let id = unboot_id value_id in
-      let params = unboot_params value_params in
-      let typ = unboot_typ value_typ in
-      let tablerows = unboot_tablerows value_tablerows in
-      Il.TableDecD (id, params, typ, tablerows, []) $ at
-  | _ -> error "@unboot_table_func_def"
-
-and unboot_func_def (at : region) (values : Value.t list) : Il.def =
-  match values with
-  | [
-   value_id;
-   value_tparams;
-   value_params;
-   value_typ;
-   value_clauses;
-   value_elsclause;
-  ] ->
-      let id = unboot_id value_id in
-      let tparams = unboot_tparams value_tparams in
-      let params = unboot_params value_params in
-      let typ = unboot_typ value_typ in
-      let clauses = unboot_clauses value_clauses in
-      let elsclause = unboot_elsclause_opt value_elsclause in
-      Il.FuncDecD (id, tparams, params, typ, clauses, elsclause, []) $ at
-  | _ -> error "@unboot_func_def"
-
-(* Specification *)
-
-let unboot_script (value_script : Value.t) : Il.spec =
-  let value_defs = Value.Get.list value_script in
-  List.map unboot_def value_defs
-
-(* Initialize IL dispatch tables after all handler functions are defined *)
-
-let () =
   (* Parameters *)
-  unboot_param_mtchtbl :=
-    Value.Get.build_mtchtbl
-      [ (mop_exp_param, unboot_exp_param); (mop_def_param, unboot_def_param) ];
+
+  let rec unboot_param (value_param : V.t) : Il.param =
+    Dispatch.dispatch value_param Il_typs.typ_param !unboot_param_mtchtbl
+      (fun _ _ -> error "@unboot_param")
+
+  and unboot_exp_param (at : region) (values : V.t list) : Il.param =
+    match values with
+    | [ value_typ ] ->
+        let typ = unboot_typ value_typ in
+        Il.ExpP typ $ at
+    | _ -> error "@unboot_exp_param"
+
+  and unboot_def_param (at : region) (values : V.t list) : Il.param =
+    match values with
+    | [ value_id; value_tparams; value_params; value_typ ] ->
+        let id = unboot_id value_id in
+        let tparams = unboot_tparams value_tparams in
+        let params = unboot_params value_params in
+        let typ = unboot_typ value_typ in
+        Il.DefP (id, tparams, params, typ) $ at
+    | _ -> error "@unboot_def_param"
+
+  and unboot_params (value_params : V.t) : Il.param list =
+    value_params |> V.Get.list |> List.map unboot_param
+
   (* Premises *)
-  unboot_prem_mtchtbl :=
-    Value.Get.build_mtchtbl
-      [
-        (mop_rel_prem, unboot_rel_prem);
-        (mop_if_prem, unboot_if_prem);
-        (mop_if_hold_prem, unboot_ifhold_prem);
-        (mop_if_nothold_prem, unboot_ifnothold_prem);
-        (mop_let_prem, unboot_let_prem);
-        (mop_iter_prem, unboot_iter_prem);
-        (mop_debug_prem, unboot_debug_prem);
-      ];
+
+  and unboot_prem (value_prem : V.t) : Il.prem =
+    Dispatch.dispatch value_prem Il_typs.typ_prem !unboot_prem_mtchtbl
+      (fun _ _ -> error "@unboot_prem")
+
+  and unboot_prems (value_prems : V.t) : Il.prem list =
+    value_prems |> V.Get.list |> List.map unboot_prem
+
+  and unboot_rel_prem (at : region) (values : V.t list) : Il.prem =
+    match values with
+    | [ value_id; value_exps_input; value_exps_output ] ->
+        let id = unboot_id value_id in
+        let exps_input = unboot_exps value_exps_input in
+        let exps_output = unboot_exps value_exps_output in
+        let notexp = stub_notexp exps_input exps_output in
+        let input = stub_input_hint (List.length exps_input) in
+        Il.RulePr (id, notexp, input) $ at
+    | _ -> error "@unboot_rel_prem"
+
+  and unboot_if_prem (at : region) (values : V.t list) : Il.prem =
+    match values with
+    | [ value_exp ] ->
+        let exp = unboot_exp value_exp in
+        Il.IfPr exp $ at
+    | _ -> error "@unboot_if_prem"
+
+  and unboot_ifhold_prem (at : region) (values : V.t list) : Il.prem =
+    match values with
+    | [ value_id; value_exps ] ->
+        let id = unboot_id value_id in
+        let exps = unboot_exps value_exps in
+        let notexp = stub_notexp exps [] in
+        Il.IfHoldPr (id, notexp) $ at
+    | _ -> error "@unboot_ifhold_prem"
+
+  and unboot_ifnothold_prem (at : region) (values : V.t list) : Il.prem =
+    match values with
+    | [ value_id; value_exps ] ->
+        let id = unboot_id value_id in
+        let exps = unboot_exps value_exps in
+        let notexp = stub_notexp exps [] in
+        Il.IfNotHoldPr (id, notexp) $ at
+    | _ -> error "@unboot_ifnothold_prem"
+
+  and unboot_let_prem (at : region) (values : V.t list) : Il.prem =
+    match values with
+    | [ value_exp_l; value_exp_r ] ->
+        let exp_l = unboot_exp value_exp_l in
+        let exp_r = unboot_exp value_exp_r in
+        Il.LetPr (exp_l, exp_r) $ at
+    | _ -> error "@unboot_let_prem"
+
+  and unboot_iter_prem (at : region) (values : V.t list) : Il.prem =
+    match values with
+    | [ value_prem; value_iterprem ] ->
+        let prem = unboot_prem value_prem in
+        let iterprem = unboot_iterprem value_iterprem in
+        Il.IterPr (prem, iterprem) $ at
+    | _ -> error "@unboot_iter_prem"
+
+  and unboot_debug_prem (at : region) (values : V.t list) : Il.prem =
+    match values with
+    | [ value_exp ] ->
+        let exp = unboot_exp value_exp in
+        Il.DebugPr exp $ at
+    | _ -> error "@unboot_debug_prem"
+
+  (* Rule matching and paths *)
+
+  and unboot_rulmatch (value_rulmatch : V.t) : Il.rulematch =
+    let values =
+      Dispatch.case_exact value_rulmatch mop_rulematch Il_typs.typ_rulmatch
+    in
+    let exps = V.Get.nth 0 values |> unboot_exps in
+    let prems = V.Get.nth 1 values |> unboot_prems in
+    (exps, exps, prems)
+
+  and unboot_rulpath (value_rulpath : V.t) : Il.rulepath =
+    let values =
+      Dispatch.case_exact value_rulpath mop_rulepath Il_typs.typ_rulpath
+    in
+    let id = V.Get.nth 0 values |> unboot_id in
+    let exps = V.Get.nth 1 values |> unboot_exps in
+    let prems = V.Get.nth 2 values |> unboot_prems in
+    (id, prems, exps)
+
+  and unboot_rulpaths (value_rulpaths : V.t) : Il.rulepath list =
+    value_rulpaths |> V.Get.list |> List.map unboot_rulpath
+
+  and unboot_rulgroup (value_rulgroup : V.t) : Il.rulegroup =
+    let at = V.at value_rulgroup in
+    let values =
+      Dispatch.case_exact value_rulgroup mop_rulegroup Il_typs.typ_rulgroup
+    in
+    let id = V.Get.nth 0 values |> unboot_id in
+    let rulmatch = V.Get.nth 1 values |> unboot_rulmatch in
+    let rulpaths = V.Get.nth 2 values |> unboot_rulpaths in
+    (id, rulmatch, rulpaths) $ at
+
+  and unboot_rulgroups (value_rulgroups : V.t) : Il.rulegroup list =
+    value_rulgroups |> V.Get.list |> List.map unboot_rulgroup
+
+  and unboot_elsgroup (value_elsgroup : V.t) : Il.elsegroup =
+    let at = V.at value_elsgroup in
+    let values =
+      Dispatch.case_exact value_elsgroup mop_elsegroup Il_typs.typ_elsgroup
+    in
+    let id = V.Get.nth 0 values |> unboot_id in
+    let rulmatch = V.Get.nth 1 values |> unboot_rulmatch in
+    let rulpath = V.Get.nth 2 values |> unboot_rulpath in
+    (id, rulmatch, rulpath) $ at
+
+  and unboot_elsgroup_opt (value_elsgroup_opt : V.t) : Il.elsegroup option =
+    value_elsgroup_opt |> V.Get.opt |> Option.map unboot_elsgroup
+
+  (* Clauses *)
+
+  and unboot_clause (value_clause : V.t) : Il.clause =
+    let at = V.at value_clause in
+    let values =
+      Dispatch.case_exact value_clause mop_clause Il_typs.typ_clause
+    in
+    let args = V.Get.nth 0 values |> unboot_args in
+    let exp = V.Get.nth 1 values |> unboot_exp in
+    let prems = V.Get.nth 2 values |> unboot_prems in
+    (args, exp, prems) $ at
+
+  and unboot_clauses (value_clauses : V.t) : Il.clause list =
+    value_clauses |> V.Get.list |> List.map unboot_clause
+
+  and unboot_elsclause (value_elsclause : V.t) : Il.elseclause =
+    unboot_clause value_elsclause
+
+  and unboot_elsclause_opt (value_elsclause_opt : V.t) : Il.elseclause option =
+    value_elsclause_opt |> V.Get.opt |> Option.map unboot_elsclause
+
+  (* Table rows *)
+
+  and unboot_tablerow (value_tablerow : V.t) : Il.tablerow =
+    let at = V.at value_tablerow in
+    let values =
+      Dispatch.case_exact value_tablerow mop_tablerow Il_typs.typ_tblrow
+    in
+    let args = V.Get.nth 0 values |> unboot_args in
+    let exp = V.Get.nth 1 values |> unboot_exp in
+    let prems = V.Get.nth 2 values |> unboot_prems in
+    ([], args, exp, prems) $ at
+
+  and unboot_tablerows (value_tablerows : V.t) : Il.tablerow list =
+    value_tablerows |> V.Get.list |> List.map unboot_tablerow
+
   (* Definitions *)
-  unboot_def_mtchtbl :=
-    Value.Get.build_mtchtbl
-      [
-        (mop_extern_typ_def, unboot_extern_typ_def);
-        (mop_typ_def, unboot_typ_def);
-        (mop_extern_rel_def, unboot_extern_rel_def);
-        (mop_rel_def, unboot_rel_def);
-        (mop_extern_func_def, unboot_extern_func_def);
-        (mop_builtin_func_def, unboot_builtin_func_def);
-        (mop_table_func_def, unboot_table_func_def);
-        (mop_func_def, unboot_func_def);
-      ]
+
+  let unboot_def (value_def : V.t) : Il.def =
+    Dispatch.dispatch value_def Il_typs.typ_defn !unboot_def_mtchtbl (fun _ _ ->
+        error "@unboot_def")
+
+  and unboot_extern_typ_def (at : region) (values : V.t list) : Il.def =
+    match values with
+    | [ value_id ] ->
+        let id = unboot_id value_id in
+        Il.ExternTypD (id, []) $ at
+    | _ -> error "@unboot_extern_typ_def"
+
+  and unboot_typ_def (at : region) (values : V.t list) : Il.def =
+    match values with
+    | [ value_id; value_tparams; value_deftyp ] ->
+        let id = unboot_id value_id in
+        let tparams = unboot_tparams value_tparams in
+        let deftyp = unboot_deftyp value_deftyp in
+        Il.TypD (id, tparams, deftyp, []) $ at
+    | _ -> error "@unboot_typ_def"
+
+  and unboot_extern_rel_def (at : region) (values : V.t list) : Il.def =
+    match values with
+    | [ value_id; value_typs_input; value_typs_output ] ->
+        let id = unboot_id value_id in
+        let typs_input = unboot_typs value_typs_input in
+        let typs_output = unboot_typs value_typs_output in
+        let nottyp = stub_nottyp typs_input typs_output in
+        let input = stub_input_hint (List.length typs_input) in
+        Il.ExternRelD (id, nottyp, input, []) $ at
+    | _ -> error "@unboot_extern_rel_def"
+
+  and unboot_rel_def (at : region) (values : V.t list) : Il.def =
+    match values with
+    | [
+     value_id;
+     value_typs_input;
+     value_typs_output;
+     value_rulgroups;
+     value_elsgroup;
+    ] ->
+        let id = unboot_id value_id in
+        let typs_input = unboot_typs value_typs_input in
+        let typs_output = unboot_typs value_typs_output in
+        let nottyp = stub_nottyp typs_input typs_output in
+        let input = stub_input_hint (List.length typs_input) in
+        let rulgroups = unboot_rulgroups value_rulgroups in
+        let elsgroup = unboot_elsgroup_opt value_elsgroup in
+        Il.RelD (id, nottyp, input, rulgroups, elsgroup, []) $ at
+    | _ -> error "@unboot_rel_def"
+
+  and unboot_extern_func_def (at : region) (values : V.t list) : Il.def =
+    match values with
+    | [ value_id; value_tparams; value_params; value_typ ] ->
+        let id = unboot_id value_id in
+        let tparams = unboot_tparams value_tparams in
+        let params = unboot_params value_params in
+        let typ = unboot_typ value_typ in
+        Il.ExternDecD (id, tparams, params, typ, []) $ at
+    | _ -> error "@unboot_extern_func_def"
+
+  and unboot_builtin_func_def (at : region) (values : V.t list) : Il.def =
+    match values with
+    | [ value_id; value_tparams; value_params; value_typ ] ->
+        let id = unboot_id value_id in
+        let tparams = unboot_tparams value_tparams in
+        let params = unboot_params value_params in
+        let typ = unboot_typ value_typ in
+        Il.BuiltinDecD (id, tparams, params, typ, []) $ at
+    | _ -> error "@unboot_builtin_func_def"
+
+  and unboot_table_func_def (at : region) (values : V.t list) : Il.def =
+    match values with
+    | [ value_id; value_params; value_typ; value_tablerows ] ->
+        let id = unboot_id value_id in
+        let params = unboot_params value_params in
+        let typ = unboot_typ value_typ in
+        let tablerows = unboot_tablerows value_tablerows in
+        Il.TableDecD (id, params, typ, tablerows, []) $ at
+    | _ -> error "@unboot_table_func_def"
+
+  and unboot_func_def (at : region) (values : V.t list) : Il.def =
+    match values with
+    | [
+     value_id;
+     value_tparams;
+     value_params;
+     value_typ;
+     value_clauses;
+     value_elsclause;
+    ] ->
+        let id = unboot_id value_id in
+        let tparams = unboot_tparams value_tparams in
+        let params = unboot_params value_params in
+        let typ = unboot_typ value_typ in
+        let clauses = unboot_clauses value_clauses in
+        let elsclause = unboot_elsclause_opt value_elsclause in
+        Il.FuncDecD (id, tparams, params, typ, clauses, elsclause, []) $ at
+    | _ -> error "@unboot_func_def"
+
+  (* Specification *)
+
+  let unboot_script (value_script : V.t) : Il.spec =
+    let value_defs = V.Get.list value_script in
+    List.map unboot_def value_defs
+
+  (* Initialize IL dispatch tables after all handler functions are defined *)
+
+  let () =
+    (* Parameters *)
+    unboot_param_mtchtbl :=
+      Dispatch.build_mtchtbl
+        [ (mop_exp_param, unboot_exp_param); (mop_def_param, unboot_def_param) ];
+    (* Premises *)
+    unboot_prem_mtchtbl :=
+      Dispatch.build_mtchtbl
+        [
+          (mop_rel_prem, unboot_rel_prem);
+          (mop_if_prem, unboot_if_prem);
+          (mop_if_hold_prem, unboot_ifhold_prem);
+          (mop_if_nothold_prem, unboot_ifnothold_prem);
+          (mop_let_prem, unboot_let_prem);
+          (mop_iter_prem, unboot_iter_prem);
+          (mop_debug_prem, unboot_debug_prem);
+        ];
+    (* Definitions *)
+    unboot_def_mtchtbl :=
+      Dispatch.build_mtchtbl
+        [
+          (mop_extern_typ_def, unboot_extern_typ_def);
+          (mop_typ_def, unboot_typ_def);
+          (mop_extern_rel_def, unboot_extern_rel_def);
+          (mop_rel_def, unboot_rel_def);
+          (mop_extern_func_def, unboot_extern_func_def);
+          (mop_builtin_func_def, unboot_builtin_func_def);
+          (mop_table_func_def, unboot_table_func_def);
+          (mop_func_def, unboot_func_def);
+        ]
+end

--- a/p4spec/lib/interface/spectec/parse.ml
+++ b/p4spec/lib/interface/spectec/parse.ml
@@ -1,24 +1,31 @@
 module Value = Runtime.Value
 module Run = Runtime.Dynamic_Runner.Signature
 
+(* Boot functors instantiated at [V_value]; a later task adds [V_native]. *)
+
+module Boot_ili_value = Ili.Boot.Make (Runtime.Valrep.V_value)
+module Boot_sli_value = Sli.Boot.Make (Runtime.Valrep.V_value)
+
 let parse_files (mode : Run.mode) (paths_spec : string list) : Value.t =
   match mode with
-  | IL_mode -> paths_spec |> Pass.elab |> Ili.Boot.boot_spec
-  | SL_mode -> paths_spec |> Pass.structure ~final:true |> Sli.Boot.boot_spec
-  | ML_mode -> paths_spec |> Pass.structure ~final:true |> Sli.Boot.boot_spec
+  | IL_mode -> paths_spec |> Pass.elab |> Boot_ili_value.boot_spec
+  | SL_mode ->
+      paths_spec |> Pass.structure ~final:true |> Boot_sli_value.boot_spec
+  | ML_mode ->
+      paths_spec |> Pass.structure ~final:true |> Boot_sli_value.boot_spec
   | Empty_mode -> assert false
 
 let parse_string (mode : Run.mode) (_path : string) (str : string) : Value.t =
   match mode with
   | IL_mode ->
       str |> Frontend.Parse.parse_string |> Pass.Elaborate.Elab.elab_spec
-      |> Ili.Boot.boot_spec
+      |> Boot_ili_value.boot_spec
   | SL_mode ->
       str |> Frontend.Parse.parse_string |> Pass.Elaborate.Elab.elab_spec
       |> Pass.Structure.Struct.struct_spec ~final:true
-      |> Sli.Boot.boot_spec
+      |> Boot_sli_value.boot_spec
   | ML_mode ->
       str |> Frontend.Parse.parse_string |> Pass.Elaborate.Elab.elab_spec
       |> Pass.Structure.Struct.struct_spec ~final:true
-      |> Sli.Boot.boot_spec
+      |> Boot_sli_value.boot_spec
   | Empty_mode -> assert false

--- a/p4spec/lib/interface/spectec/sli/boot.ml
+++ b/p4spec/lib/interface/spectec/sli/boot.ml
@@ -1,366 +1,366 @@
-open Common.Boot
+module Mixfix = Domain.Mixfix
 open Lang
 open Mixops
 open Typs
 open Util.Source
 
-(* Parameters *)
+module Make (V : Runtime.Valrep.SAFE) = struct
+  include Common.Boot.Make (V)
 
-let rec boot_param (param : Sl.param) : Value.t =
-  let at = param.at in
-  match param.it with
-  | ExpP (typ, exp) ->
-      let value_typ = boot_typ typ in
-      let value_exp = boot_exp exp in
-      Value.Make.(
-        mop_exp_param <|! [ value_typ; value_exp ] <<|! typ_param <<<| at)
-  | DefP (id, tparams, params, typ) ->
-      let value_id = boot_id id in
-      let value_tparams = boot_tparams tparams in
-      let value_params = boot_params params in
-      let value_typ = boot_typ typ in
-      Value.Make.(
-        mop_def_param
-        <|! [ value_id; value_tparams; value_params; value_typ ]
-        <<|! typ_param <<<| at)
+  (* Parameters *)
 
-and boot_params (params : Sl.param list) : Value.t =
-  let values_params = List.map boot_param params in
-  Value.Make.list (Runtime.Type.Typ.Make.list typ_param) values_params
+  let rec boot_param (param : Sl.param) : V.t =
+    let at = param.at in
+    match param.it with
+    | ExpP (typ, exp) ->
+        let value_typ = boot_typ typ in
+        let value_exp = boot_exp exp in
+        case_at at (mop_exp_param <|! [ value_typ; value_exp ]) typ_param
+    | DefP (id, tparams, params, typ) ->
+        let value_id = boot_id id in
+        let value_tparams = boot_tparams tparams in
+        let value_params = boot_params params in
+        let value_typ = boot_typ typ in
+        case_at at
+          (mop_def_param
+          <|! [ value_id; value_tparams; value_params; value_typ ])
+          typ_param
 
-(* Iter instructions *)
+  and boot_params (params : Sl.param list) : V.t =
+    let values_params = List.map boot_param params in
+    V.Make.list (Runtime.Type.Typ.Make.list typ_param) values_params
 
-and boot_iterinstr ((iter, vars_in, vars_out) : Sl.iterinstr) : Value.t =
-  let value_iter = boot_iter iter in
-  let value_vars_in = boot_vars vars_in in
-  let value_vars_out = boot_vars vars_out in
-  Value.Make.(
+  (* Iter instructions *)
+
+  and boot_iterinstr ((iter, vars_in, vars_out) : Sl.iterinstr) : V.t =
+    let value_iter = boot_iter iter in
+    let value_vars_in = boot_vars vars_in in
+    let value_vars_out = boot_vars vars_out in
     mop_iterinstr
     <|! [ value_iter; value_vars_in; value_vars_out ]
-    <<|! typ_iterinstr)
+    <<|! typ_iterinstr
 
-and boot_iterinstrs (iterinstrs : Sl.iterinstr list) : Value.t =
-  let values_iterinstrs = List.map boot_iterinstr iterinstrs in
-  Value.Make.list (Runtime.Type.Typ.Make.list typ_iterinstr) values_iterinstrs
+  and boot_iterinstrs (iterinstrs : Sl.iterinstr list) : V.t =
+    let values_iterinstrs = List.map boot_iterinstr iterinstrs in
+    V.Make.list (Runtime.Type.Typ.Make.list typ_iterinstr) values_iterinstrs
 
-(* Iter expressions *)
+  (* Iter expressions *)
 
-and boot_iterexps (iterexps : Sl.iterexp list) : Value.t =
-  let values_iterexps = List.map boot_iterexp iterexps in
-  Value.Make.list
-    (Runtime.Type.Typ.Make.list Common.Typs.typ_iterexp)
-    values_iterexps
+  and boot_iterexps (iterexps : Sl.iterexp list) : V.t =
+    let values_iterexps = List.map boot_iterexp iterexps in
+    V.Make.list
+      (Runtime.Type.Typ.Make.list Common.Typs.typ_iterexp)
+      values_iterexps
 
-(* Instructions *)
+  (* Instructions *)
 
-and boot_instr (instr : Sl.instr) : Value.t =
-  let at = instr.at in
-  match instr.it with
-  | IfI (exp, iterexps, block, _) -> boot_if_instr at exp iterexps block
-  | HoldI (id, notexp, iterexps, holdcase) ->
-      boot_hold_instr at id notexp iterexps holdcase
-  | CaseI (exp, cases, _) -> boot_case_instr at exp cases
-  | GroupI (id, (nottyp, inputs), exps, block) ->
-      boot_group_instr at id nottyp inputs exps block
-  | LetI (exp_l, exp_r, iterinstrs, block) ->
-      boot_let_instr at exp_l exp_r iterinstrs block
-  | RuleI (id, notexp, inputs, iterinstrs, block) ->
-      boot_rule_instr at id notexp inputs iterinstrs block
-  | ResultI ((nottyp, inputs), exps) -> boot_result_instr at nottyp inputs exps
-  | ReturnI exp -> boot_return_instr at exp
-  | DebugI exp -> boot_debug_instr at exp
+  and boot_instr (instr : Sl.instr) : V.t =
+    let at = instr.at in
+    match instr.it with
+    | IfI (exp, iterexps, block, _) -> boot_if_instr at exp iterexps block
+    | HoldI (id, notexp, iterexps, holdcase) ->
+        boot_hold_instr at id notexp iterexps holdcase
+    | CaseI (exp, cases, _) -> boot_case_instr at exp cases
+    | GroupI (id, (nottyp, inputs), exps, block) ->
+        boot_group_instr at id nottyp inputs exps block
+    | LetI (exp_l, exp_r, iterinstrs, block) ->
+        boot_let_instr at exp_l exp_r iterinstrs block
+    | RuleI (id, notexp, inputs, iterinstrs, block) ->
+        boot_rule_instr at id notexp inputs iterinstrs block
+    | ResultI ((nottyp, inputs), exps) ->
+        boot_result_instr at nottyp inputs exps
+    | ReturnI exp -> boot_return_instr at exp
+    | DebugI exp -> boot_debug_instr at exp
 
-and boot_if_instr (at : region) (exp : Sl.exp) (iterexps : Sl.iterexp list)
-    (block : Sl.block) : Value.t =
-  let value_exp = boot_exp exp in
-  let value_iterexps = boot_iterexps iterexps in
-  let value_block = boot_block block in
-  Value.Make.(
-    mop_if_instr
-    <|! [ value_exp; value_iterexps; value_block ]
-    <<|! typ_instr <<<| at)
+  and boot_if_instr (at : region) (exp : Sl.exp) (iterexps : Sl.iterexp list)
+      (block : Sl.block) : V.t =
+    let value_exp = boot_exp exp in
+    let value_iterexps = boot_iterexps iterexps in
+    let value_block = boot_block block in
+    case_at at
+      (mop_if_instr <|! [ value_exp; value_iterexps; value_block ])
+      typ_instr
 
-and boot_holdcase (holdcase : Sl.holdcase) : Value.t =
-  match holdcase with
-  | BothH (block_hold, block_nothold) ->
-      let value_block_hold = boot_block block_hold in
-      let value_block_nothold = boot_block block_nothold in
-      Value.Make.(
+  and boot_holdcase (holdcase : Sl.holdcase) : V.t =
+    match holdcase with
+    | BothH (block_hold, block_nothold) ->
+        let value_block_hold = boot_block block_hold in
+        let value_block_nothold = boot_block block_nothold in
         mop_both_holdcase
         <|! [ value_block_hold; value_block_nothold ]
-        <<|! typ_holdcase)
-  | HoldH (block_hold, _) ->
-      let value_block_hold = boot_block block_hold in
-      Value.Make.(mop_hold_holdcase <|! [ value_block_hold ] <<|! typ_holdcase)
-  | NotHoldH (block_nothold, _) ->
-      let value_block_nothold = boot_block block_nothold in
-      Value.Make.(
-        mop_nothold_holdcase <|! [ value_block_nothold ] <<|! typ_holdcase)
+        <<|! typ_holdcase
+    | HoldH (block_hold, _) ->
+        let value_block_hold = boot_block block_hold in
+        mop_hold_holdcase <|! [ value_block_hold ] <<|! typ_holdcase
+    | NotHoldH (block_nothold, _) ->
+        let value_block_nothold = boot_block block_nothold in
+        mop_nothold_holdcase <|! [ value_block_nothold ] <<|! typ_holdcase
 
-and boot_hold_instr (at : region) (id : Sl.id) (notexp : Sl.notexp)
-    (iterexps : Sl.iterexp list) (holdcase : Sl.holdcase) : Value.t =
-  let value_id = boot_id id in
-  let exps = Mixfix.args notexp in
-  let value_exps = boot_exps exps in
-  let value_iterexps = boot_iterexps iterexps in
-  let value_holdcase = boot_holdcase holdcase in
-  Value.Make.(
-    mop_hold_instr
-    <|! [ value_id; value_exps; value_iterexps; value_holdcase ]
-    <<|! typ_instr <<<| at)
+  and boot_hold_instr (at : region) (id : Sl.id) (notexp : Sl.notexp)
+      (iterexps : Sl.iterexp list) (holdcase : Sl.holdcase) : V.t =
+    let value_id = boot_id id in
+    let exps = Mixfix.args notexp in
+    let value_exps = boot_exps exps in
+    let value_iterexps = boot_iterexps iterexps in
+    let value_holdcase = boot_holdcase holdcase in
+    case_at at
+      (mop_hold_instr
+      <|! [ value_id; value_exps; value_iterexps; value_holdcase ])
+      typ_instr
 
-and boot_guard (guard : Sl.guard) : Value.t =
-  match guard with
-  | BoolG b ->
-      let value_b = Value.Make.bool b in
-      Value.Make.(mop_bool_guard <|! [ value_b ] <<|! typ_guard)
-  | CmpG (cmpop, _, exp) ->
-      let value_cmpop = boot_cmpop cmpop in
-      let value_exp = boot_exp exp in
-      Value.Make.(mop_cmp_guard <|! [ value_cmpop; value_exp ] <<|! typ_guard)
-  | SubG typ ->
-      let value_typ = boot_typ typ in
-      Value.Make.(mop_sub_guard <|! [ value_typ ] <<|! typ_guard)
-  | MatchG pattern ->
-      let value_pattern = boot_pattern pattern in
-      Value.Make.(mop_match_guard <|! [ value_pattern ] <<|! typ_guard)
-  | MemG exp ->
-      let value_exp = boot_exp exp in
-      Value.Make.(mop_mem_guard <|! [ value_exp ] <<|! typ_guard)
+  and boot_guard (guard : Sl.guard) : V.t =
+    match guard with
+    | BoolG b ->
+        let value_b = V.Make.bool b in
+        mop_bool_guard <|! [ value_b ] <<|! typ_guard
+    | CmpG (cmpop, _, exp) ->
+        let value_cmpop = boot_cmpop cmpop in
+        let value_exp = boot_exp exp in
+        mop_cmp_guard <|! [ value_cmpop; value_exp ] <<|! typ_guard
+    | SubG typ ->
+        let value_typ = boot_typ typ in
+        mop_sub_guard <|! [ value_typ ] <<|! typ_guard
+    | MatchG pattern ->
+        let value_pattern = boot_pattern pattern in
+        mop_match_guard <|! [ value_pattern ] <<|! typ_guard
+    | MemG exp ->
+        let value_exp = boot_exp exp in
+        mop_mem_guard <|! [ value_exp ] <<|! typ_guard
 
-and boot_case (case : Sl.case) : Value.t =
-  let guard, block = case in
-  let value_guard = boot_guard guard in
-  let value_block = boot_block block in
-  Value.Make.(mop_case <|! [ value_guard; value_block ] <<|! typ_case)
+  and boot_case (case : Sl.case) : V.t =
+    let guard, block = case in
+    let value_guard = boot_guard guard in
+    let value_block = boot_block block in
+    mop_case <|! [ value_guard; value_block ] <<|! typ_case
 
-and boot_cases (cases : Sl.case list) : Value.t =
-  let values_cases = List.map boot_case cases in
-  Value.Make.list (Runtime.Type.Typ.Make.list typ_case) values_cases
+  and boot_cases (cases : Sl.case list) : V.t =
+    let values_cases = List.map boot_case cases in
+    V.Make.list (Runtime.Type.Typ.Make.list typ_case) values_cases
 
-and boot_case_instr (at : region) (exp : Sl.exp) (cases : Sl.case list) :
-    Value.t =
-  let value_exp = boot_exp exp in
-  let value_cases = boot_cases cases in
-  Value.Make.(
-    mop_case_instr <|! [ value_exp; value_cases ] <<|! typ_instr <<<| at)
+  and boot_case_instr (at : region) (exp : Sl.exp) (cases : Sl.case list) : V.t
+      =
+    let value_exp = boot_exp exp in
+    let value_cases = boot_cases cases in
+    case_at at (mop_case_instr <|! [ value_exp; value_cases ]) typ_instr
 
-and boot_group_instr (at : region) (id : Sl.id) (nottyp : Sl.nottyp)
-    (inputs : Hints.Input.t) (exps : Sl.exp list) (block : Sl.block) : Value.t =
-  let value_id = boot_id id in
-  let typs = Mixfix.args nottyp.it in
-  let typs_in, typs_out = Hints.Input.split inputs typs in
-  let value_typs_in = boot_typs typs_in in
-  let value_typs_out = boot_typs typs_out in
-  let value_exps = boot_exps exps in
-  let value_block = boot_block block in
-  Value.Make.(
-    mop_group_instr
-    <|! [ value_id; value_exps; value_typs_in; value_typs_out; value_block ]
-    <<|! typ_instr <<<| at)
+  and boot_group_instr (at : region) (id : Sl.id) (nottyp : Sl.nottyp)
+      (inputs : Hints.Input.t) (exps : Sl.exp list) (block : Sl.block) : V.t =
+    let value_id = boot_id id in
+    let typs = Mixfix.args nottyp.it in
+    let typs_in, typs_out = Hints.Input.split inputs typs in
+    let value_typs_in = boot_typs typs_in in
+    let value_typs_out = boot_typs typs_out in
+    let value_exps = boot_exps exps in
+    let value_block = boot_block block in
+    case_at at
+      (mop_group_instr
+      <|! [ value_id; value_exps; value_typs_in; value_typs_out; value_block ])
+      typ_instr
 
-and boot_let_instr (at : region) (exp_l : Sl.exp) (exp_r : Sl.exp)
-    (iterinstrs : Sl.iterinstr list) (block : Sl.block) : Value.t =
-  let value_exp_l = boot_exp exp_l in
-  let value_exp_r = boot_exp exp_r in
-  let value_iterinstrs = boot_iterinstrs iterinstrs in
-  let value_block = boot_block block in
-  Value.Make.(
-    mop_let_instr
-    <|! [ value_exp_l; value_exp_r; value_iterinstrs; value_block ]
-    <<|! typ_instr <<<| at)
+  and boot_let_instr (at : region) (exp_l : Sl.exp) (exp_r : Sl.exp)
+      (iterinstrs : Sl.iterinstr list) (block : Sl.block) : V.t =
+    let value_exp_l = boot_exp exp_l in
+    let value_exp_r = boot_exp exp_r in
+    let value_iterinstrs = boot_iterinstrs iterinstrs in
+    let value_block = boot_block block in
+    case_at at
+      (mop_let_instr
+      <|! [ value_exp_l; value_exp_r; value_iterinstrs; value_block ])
+      typ_instr
 
-and boot_rule_instr (at : region) (id : Sl.id) (notexp : Sl.notexp)
-    (inputs : Hints.Input.t) (iterinstrs : Sl.iterinstr list) (block : Sl.block)
-    : Value.t =
-  let value_id = boot_id id in
-  let exps = Mixfix.args notexp in
-  let exps_in, exps_out = Hints.Input.split inputs exps in
-  let value_exps_in = boot_exps exps_in in
-  let value_exps_out = boot_exps exps_out in
-  let value_iterinstrs = boot_iterinstrs iterinstrs in
-  let value_block = boot_block block in
-  Value.Make.(
-    mop_rule_instr
-    <|! [
-          value_id; value_exps_in; value_exps_out; value_iterinstrs; value_block;
-        ]
-    <<|! typ_instr <<<| at)
+  and boot_rule_instr (at : region) (id : Sl.id) (notexp : Sl.notexp)
+      (inputs : Hints.Input.t) (iterinstrs : Sl.iterinstr list)
+      (block : Sl.block) : V.t =
+    let value_id = boot_id id in
+    let exps = Mixfix.args notexp in
+    let exps_in, exps_out = Hints.Input.split inputs exps in
+    let value_exps_in = boot_exps exps_in in
+    let value_exps_out = boot_exps exps_out in
+    let value_iterinstrs = boot_iterinstrs iterinstrs in
+    let value_block = boot_block block in
+    case_at at
+      (mop_rule_instr
+      <|! [
+            value_id;
+            value_exps_in;
+            value_exps_out;
+            value_iterinstrs;
+            value_block;
+          ])
+      typ_instr
 
-and boot_result_instr (at : region) (nottyp : Sl.nottyp)
-    (inputs : Hints.Input.t) (exps : Sl.exp list) : Value.t =
-  let typs = Mixfix.args nottyp.it in
-  let typs_in, typs_out = Hints.Input.split inputs typs in
-  let value_typs_in = boot_typs typs_in in
-  let value_typs_out = boot_typs typs_out in
-  let value_exps = boot_exps exps in
-  Value.Make.(
-    mop_result_instr
-    <|! [ value_typs_in; value_typs_out; value_exps ]
-    <<|! typ_instr <<<| at)
+  and boot_result_instr (at : region) (nottyp : Sl.nottyp)
+      (inputs : Hints.Input.t) (exps : Sl.exp list) : V.t =
+    let typs = Mixfix.args nottyp.it in
+    let typs_in, typs_out = Hints.Input.split inputs typs in
+    let value_typs_in = boot_typs typs_in in
+    let value_typs_out = boot_typs typs_out in
+    let value_exps = boot_exps exps in
+    case_at at
+      (mop_result_instr <|! [ value_typs_in; value_typs_out; value_exps ])
+      typ_instr
 
-and boot_return_instr (at : region) (exp : Sl.exp) : Value.t =
-  let value_exp = boot_exp exp in
-  Value.Make.(mop_return_instr <|! [ value_exp ] <<|! typ_instr <<<| at)
+  and boot_return_instr (at : region) (exp : Sl.exp) : V.t =
+    let value_exp = boot_exp exp in
+    case_at at (mop_return_instr <|! [ value_exp ]) typ_instr
 
-and boot_debug_instr (at : region) (exp : Sl.exp) : Value.t =
-  let value_exp = boot_exp exp in
-  Value.Make.(mop_debug_instr <|! [ value_exp ] <<|! typ_instr <<<| at)
+  and boot_debug_instr (at : region) (exp : Sl.exp) : V.t =
+    let value_exp = boot_exp exp in
+    case_at at (mop_debug_instr <|! [ value_exp ]) typ_instr
 
-and boot_instrs (instrs : Sl.instr list) : Value.t =
-  let values_instrs = List.map boot_instr instrs in
-  Value.Make.list (Runtime.Type.Typ.Make.list typ_instr) values_instrs
+  and boot_instrs (instrs : Sl.instr list) : V.t =
+    let values_instrs = List.map boot_instr instrs in
+    V.Make.list (Runtime.Type.Typ.Make.list typ_instr) values_instrs
 
-and boot_block (block : Sl.block) : Value.t = boot_instrs block
+  and boot_block (block : Sl.block) : V.t = boot_instrs block
 
-and boot_elsblock_opt (elseblock_opt : Sl.elseblock option) : Value.t =
-  Value.Make.opt
-    (Runtime.Type.Typ.Make.opt typ_block)
-    (Option.map boot_block elseblock_opt)
+  and boot_elsblock_opt (elseblock_opt : Sl.elseblock option) : V.t =
+    V.Make.opt
+      (Runtime.Type.Typ.Make.opt typ_block)
+      (Option.map boot_block elseblock_opt)
 
-(* Table rows *)
+  (* Table rows *)
 
-and boot_tablerow ((exps, exp, block) : Sl.tablerow) : Value.t =
-  let value_exps = boot_exps exps in
-  let value_exp = boot_exp exp in
-  let value_block = boot_block block in
-  Value.Make.(
-    mop_tablerow <|! [ value_exps; value_exp; value_block ] <<|! typ_tblrow)
+  and boot_tablerow ((exps, exp, block) : Sl.tablerow) : V.t =
+    let value_exps = boot_exps exps in
+    let value_exp = boot_exp exp in
+    let value_block = boot_block block in
+    mop_tablerow <|! [ value_exps; value_exp; value_block ] <<|! typ_tblrow
 
-and boot_tablerows (tablerows : Sl.tablerow list) : Value.t =
-  let values_tablerows = List.map boot_tablerow tablerows in
-  Value.Make.list (Runtime.Type.Typ.Make.list typ_tblrow) values_tablerows
+  and boot_tablerows (tablerows : Sl.tablerow list) : V.t =
+    let values_tablerows = List.map boot_tablerow tablerows in
+    V.Make.list (Runtime.Type.Typ.Make.list typ_tblrow) values_tablerows
 
-(* Definitions *)
+  (* Definitions *)
 
-let rec boot_def (def : Sl.def) : Value.t option =
-  let wrap_some value = Some value in
-  let at = def.at in
-  match def.it with
-  | ExternTypD (id, _) -> boot_extern_typ_def at id |> wrap_some
-  | TypD (id, tparams, deftyp, _) ->
-      boot_typ_def at id tparams deftyp |> wrap_some
-  | VarD _ -> None
-  | ExternRelD (id, (nottyp, input), exps, _) ->
-      boot_extern_rel_def at id nottyp input exps |> wrap_some
-  | RelD (id, (nottyp, input), exps, block, elseblock_opt, _) ->
-      boot_rel_def at id nottyp input exps block elseblock_opt |> wrap_some
-  | ExternDecD (id, tparams, params, typ, _) ->
-      boot_extern_func_def at id tparams params typ |> wrap_some
-  | BuiltinDecD (id, tparams, params, typ, _) ->
-      boot_builtin_func_def at id tparams params typ |> wrap_some
-  | TableDecD (id, params, typ, tablerows, _) ->
-      boot_table_func_def at id params typ tablerows |> wrap_some
-  | FuncDecD (id, tparams, params, typ, block, elseblock_opt, _) ->
-      boot_func_def at id tparams params typ block elseblock_opt |> wrap_some
+  let rec boot_def (def : Sl.def) : V.t option =
+    let wrap_some value = Some value in
+    let at = def.at in
+    match def.it with
+    | ExternTypD (id, _) -> boot_extern_typ_def at id |> wrap_some
+    | TypD (id, tparams, deftyp, _) ->
+        boot_typ_def at id tparams deftyp |> wrap_some
+    | VarD _ -> None
+    | ExternRelD (id, (nottyp, input), exps, _) ->
+        boot_extern_rel_def at id nottyp input exps |> wrap_some
+    | RelD (id, (nottyp, input), exps, block, elseblock_opt, _) ->
+        boot_rel_def at id nottyp input exps block elseblock_opt |> wrap_some
+    | ExternDecD (id, tparams, params, typ, _) ->
+        boot_extern_func_def at id tparams params typ |> wrap_some
+    | BuiltinDecD (id, tparams, params, typ, _) ->
+        boot_builtin_func_def at id tparams params typ |> wrap_some
+    | TableDecD (id, params, typ, tablerows, _) ->
+        boot_table_func_def at id params typ tablerows |> wrap_some
+    | FuncDecD (id, tparams, params, typ, block, elseblock_opt, _) ->
+        boot_func_def at id tparams params typ block elseblock_opt |> wrap_some
 
-and boot_extern_typ_def (at : region) (id : Sl.id) : Value.t =
-  let value_id = boot_id id in
-  Value.Make.(mop_extern_typ_def <|! [ value_id ] <<|! typ_defn <<<| at)
+  and boot_extern_typ_def (at : region) (id : Sl.id) : V.t =
+    let value_id = boot_id id in
+    case_at at (mop_extern_typ_def <|! [ value_id ]) typ_defn
 
-and boot_typ_def (at : region) (id : Sl.id) (tparams : Sl.tparam list)
-    (deftyp : Sl.deftyp) : Value.t =
-  let value_id = boot_id id in
-  let value_tparams = boot_tparams tparams in
-  let value_deftyp = boot_deftyp deftyp in
-  Value.Make.(
-    mop_typ_def
-    <|! [ value_id; value_tparams; value_deftyp ]
-    <<|! typ_defn <<<| at)
+  and boot_typ_def (at : region) (id : Sl.id) (tparams : Sl.tparam list)
+      (deftyp : Sl.deftyp) : V.t =
+    let value_id = boot_id id in
+    let value_tparams = boot_tparams tparams in
+    let value_deftyp = boot_deftyp deftyp in
+    case_at at
+      (mop_typ_def <|! [ value_id; value_tparams; value_deftyp ])
+      typ_defn
 
-and boot_extern_rel_def (at : region) (id : Sl.id) (nottyp : Sl.nottyp)
-    (input : Hints.Input.t) (exps : Sl.exp list) : Value.t =
-  let typs = Mixfix.args nottyp.it in
-  let typs_in, typs_out = Hints.Input.split input typs in
-  let value_id = boot_id id in
-  let value_exps = boot_exps exps in
-  let value_typs_in = boot_typs typs_in in
-  let value_typs_out = boot_typs typs_out in
-  Value.Make.(
-    mop_extern_rel_def
-    <|! [ value_id; value_exps; value_typs_in; value_typs_out ]
-    <<|! typ_defn <<<| at)
+  and boot_extern_rel_def (at : region) (id : Sl.id) (nottyp : Sl.nottyp)
+      (input : Hints.Input.t) (exps : Sl.exp list) : V.t =
+    let typs = Mixfix.args nottyp.it in
+    let typs_in, typs_out = Hints.Input.split input typs in
+    let value_id = boot_id id in
+    let value_exps = boot_exps exps in
+    let value_typs_in = boot_typs typs_in in
+    let value_typs_out = boot_typs typs_out in
+    case_at at
+      (mop_extern_rel_def
+      <|! [ value_id; value_exps; value_typs_in; value_typs_out ])
+      typ_defn
 
-and boot_rel_def (at : region) (id : Sl.id) (nottyp : Sl.nottyp)
-    (input : Hints.Input.t) (exps : Sl.exp list) (block : Sl.block)
-    (elseblock_opt : Sl.elseblock option) : Value.t =
-  let typs = Mixfix.args nottyp.it in
-  let typs_in, typs_out = Hints.Input.split input typs in
-  let value_id = boot_id id in
-  let value_exps = boot_exps exps in
-  let value_typs_in = boot_typs typs_in in
-  let value_typs_out = boot_typs typs_out in
-  let value_block = boot_block block in
-  let value_elsblock = boot_elsblock_opt elseblock_opt in
-  Value.Make.(
-    mop_rel_def
-    <|! [
-          value_id;
-          value_exps;
-          value_typs_in;
-          value_typs_out;
-          value_block;
-          value_elsblock;
-        ]
-    <<|! typ_defn <<<| at)
+  and boot_rel_def (at : region) (id : Sl.id) (nottyp : Sl.nottyp)
+      (input : Hints.Input.t) (exps : Sl.exp list) (block : Sl.block)
+      (elseblock_opt : Sl.elseblock option) : V.t =
+    let typs = Mixfix.args nottyp.it in
+    let typs_in, typs_out = Hints.Input.split input typs in
+    let value_id = boot_id id in
+    let value_exps = boot_exps exps in
+    let value_typs_in = boot_typs typs_in in
+    let value_typs_out = boot_typs typs_out in
+    let value_block = boot_block block in
+    let value_elsblock = boot_elsblock_opt elseblock_opt in
+    case_at at
+      (mop_rel_def
+      <|! [
+            value_id;
+            value_exps;
+            value_typs_in;
+            value_typs_out;
+            value_block;
+            value_elsblock;
+          ])
+      typ_defn
 
-and boot_extern_func_def (at : region) (id : Sl.id) (tparams : Sl.tparam list)
-    (params : Sl.param list) (typ : Sl.typ) : Value.t =
-  let value_id = boot_id id in
-  let value_tparams = boot_tparams tparams in
-  let value_params = boot_params params in
-  let value_typ = boot_typ typ in
-  Value.Make.(
-    mop_extern_func_def
-    <|! [ value_id; value_tparams; value_params; value_typ ]
-    <<|! typ_defn <<<| at)
+  and boot_extern_func_def (at : region) (id : Sl.id) (tparams : Sl.tparam list)
+      (params : Sl.param list) (typ : Sl.typ) : V.t =
+    let value_id = boot_id id in
+    let value_tparams = boot_tparams tparams in
+    let value_params = boot_params params in
+    let value_typ = boot_typ typ in
+    case_at at
+      (mop_extern_func_def
+      <|! [ value_id; value_tparams; value_params; value_typ ])
+      typ_defn
 
-and boot_builtin_func_def (at : region) (id : Sl.id) (tparams : Sl.tparam list)
-    (params : Sl.param list) (typ : Sl.typ) : Value.t =
-  let value_id = boot_id id in
-  let value_tparams = boot_tparams tparams in
-  let value_params = boot_params params in
-  let value_typ = boot_typ typ in
-  Value.Make.(
-    mop_builtin_func_def
-    <|! [ value_id; value_tparams; value_params; value_typ ]
-    <<|! typ_defn <<<| at)
+  and boot_builtin_func_def (at : region) (id : Sl.id)
+      (tparams : Sl.tparam list) (params : Sl.param list) (typ : Sl.typ) : V.t =
+    let value_id = boot_id id in
+    let value_tparams = boot_tparams tparams in
+    let value_params = boot_params params in
+    let value_typ = boot_typ typ in
+    case_at at
+      (mop_builtin_func_def
+      <|! [ value_id; value_tparams; value_params; value_typ ])
+      typ_defn
 
-and boot_table_func_def (at : region) (id : Sl.id) (params : Sl.param list)
-    (typ : Sl.typ) (tablerows : Sl.tablerow list) : Value.t =
-  let value_id = boot_id id in
-  let value_params = boot_params params in
-  let value_typ = boot_typ typ in
-  let value_tablerows = boot_tablerows tablerows in
-  Value.Make.(
-    mop_table_func_def
-    <|! [ value_id; value_params; value_typ; value_tablerows ]
-    <<|! typ_defn <<<| at)
+  and boot_table_func_def (at : region) (id : Sl.id) (params : Sl.param list)
+      (typ : Sl.typ) (tablerows : Sl.tablerow list) : V.t =
+    let value_id = boot_id id in
+    let value_params = boot_params params in
+    let value_typ = boot_typ typ in
+    let value_tablerows = boot_tablerows tablerows in
+    case_at at
+      (mop_table_func_def
+      <|! [ value_id; value_params; value_typ; value_tablerows ])
+      typ_defn
 
-and boot_func_def (at : region) (id : Sl.id) (tparams : Sl.tparam list)
-    (params : Sl.param list) (typ : Sl.typ) (block : Sl.block)
-    (elseblock_opt : Sl.elseblock option) : Value.t =
-  let value_id = boot_id id in
-  let value_tparams = boot_tparams tparams in
-  let value_params = boot_params params in
-  let value_typ = boot_typ typ in
-  let value_block = boot_block block in
-  let value_elsblock = boot_elsblock_opt elseblock_opt in
-  Value.Make.(
-    mop_func_def
-    <|! [
-          value_id;
-          value_tparams;
-          value_params;
-          value_typ;
-          value_block;
-          value_elsblock;
-        ]
-    <<|! typ_defn <<<| at)
+  and boot_func_def (at : region) (id : Sl.id) (tparams : Sl.tparam list)
+      (params : Sl.param list) (typ : Sl.typ) (block : Sl.block)
+      (elseblock_opt : Sl.elseblock option) : V.t =
+    let value_id = boot_id id in
+    let value_tparams = boot_tparams tparams in
+    let value_params = boot_params params in
+    let value_typ = boot_typ typ in
+    let value_block = boot_block block in
+    let value_elsblock = boot_elsblock_opt elseblock_opt in
+    case_at at
+      (mop_func_def
+      <|! [
+            value_id;
+            value_tparams;
+            value_params;
+            value_typ;
+            value_block;
+            value_elsblock;
+          ])
+      typ_defn
 
-(* Specification *)
+  (* Specification *)
 
-let boot_spec (spec : Sl.spec) : Value.t =
-  let values_def = List.map boot_def spec |> List.filter_map Fun.id in
-  let typ_script = Runtime.Type.Typ.Make.var ("script" $ no_region) [] in
-  Value.Make.list typ_script values_def
+  let boot_spec (spec : Sl.spec) : V.t =
+    let values_def = List.map boot_def spec |> List.filter_map Fun.id in
+    let typ_script = Runtime.Type.Typ.Make.var ("script" $ no_region) [] in
+    V.Make.list typ_script values_def
+end

--- a/p4spec/lib/interface/spectec/sli/il_typs.ml
+++ b/p4spec/lib/interface/spectec/sli/il_typs.ml
@@ -1,0 +1,15 @@
+module Il = Lang.Il
+open Util.Source
+
+let var (name : string) : Il.typ = Il.VarT (name $ no_region, []) $ no_region
+let typ_param = var "param"
+let typ_holdcase = var "holdcase"
+let typ_guard = var "guard"
+let typ_instr = var "instr"
+let typ_defn = var "defn"
+
+(* Constants used by sli/unboot.ml's dispatch-table call sites. *)
+
+let typ_iterinstr = var "iterinstr"
+let typ_case = var "case"
+let typ_tblrow = var "tblrow"

--- a/p4spec/lib/interface/spectec/sli/unboot.ml
+++ b/p4spec/lib/interface/spectec/sli/unboot.ml
@@ -1,421 +1,431 @@
-open Common.Unboot
 open Common.Stub
 open Lang
 open Mixops
 open Stub
 open Util.Source
 
-(* Forward references for SL dispatch tables,
-   populated after all sub-match functions are defined *)
+module Make (V : Runtime.Valrep.SAFE) = struct
+  include Common.Unboot.Make (V)
 
-let unboot_param_mtchtbl : Sl.param Value.Get.mtchtbl ref =
-  ref (Value.Get.MtchTbl.create 0)
+  (* Forward references for SL dispatch tables,
+     populated after all sub-match functions are defined *)
 
-let unboot_holdcase_mtchtbl : Sl.holdcase Value.Get.mtchtbl ref =
-  ref (Value.Get.MtchTbl.create 0)
+  let unboot_param_mtchtbl : Sl.param Dispatch.mtchtbl ref =
+    ref (Dispatch.MtchTbl.create 0)
 
-let unboot_guard_mtchtbl : Sl.guard Value.Get.mtchtbl ref =
-  ref (Value.Get.MtchTbl.create 0)
+  let unboot_holdcase_mtchtbl : Sl.holdcase Dispatch.mtchtbl ref =
+    ref (Dispatch.MtchTbl.create 0)
 
-let unboot_instr_mtchtbl : Sl.instr Value.Get.mtchtbl ref =
-  ref (Value.Get.MtchTbl.create 0)
+  let unboot_guard_mtchtbl : Sl.guard Dispatch.mtchtbl ref =
+    ref (Dispatch.MtchTbl.create 0)
 
-let unboot_def_mtchtbl : Sl.def Value.Get.mtchtbl ref =
-  ref (Value.Get.MtchTbl.create 0)
+  let unboot_instr_mtchtbl : Sl.instr Dispatch.mtchtbl ref =
+    ref (Dispatch.MtchTbl.create 0)
 
-(* Iter instrises *)
+  let unboot_def_mtchtbl : Sl.def Dispatch.mtchtbl ref =
+    ref (Dispatch.MtchTbl.create 0)
 
-let unboot_iterinstr (value_iterinstr : Value.t) : Sl.iterinstr =
-  let values = Value.Get.(value_iterinstr |>>! mop_iterinstr) in
-  let iter = Value.Get.nth 0 values |> unboot_iter in
-  let varis_in = Value.Get.nth 1 values |> unboot_varis in
-  let varis_out = Value.Get.nth 2 values |> unboot_varis in
-  (iter, varis_in, varis_out)
+  (* Iter instrises *)
 
-let unboot_iterinstrs (value_iterinstrs : Value.t) : Sl.iterinstr list =
-  value_iterinstrs |> Value.Get.list |> List.map unboot_iterinstr
+  let unboot_iterinstr (value_iterinstr : V.t) : Sl.iterinstr =
+    let values =
+      Dispatch.case_exact value_iterinstr mop_iterinstr Il_typs.typ_iterinstr
+    in
+    let iter = V.Get.nth 0 values |> unboot_iter in
+    let varis_in = V.Get.nth 1 values |> unboot_varis in
+    let varis_out = V.Get.nth 2 values |> unboot_varis in
+    (iter, varis_in, varis_out)
 
-(* Parameters *)
+  let unboot_iterinstrs (value_iterinstrs : V.t) : Sl.iterinstr list =
+    value_iterinstrs |> V.Get.list |> List.map unboot_iterinstr
 
-let rec unboot_param (value_param : Value.t) : Sl.param =
-  Value.Get.mtch_dispatch value_param !unboot_param_mtchtbl (fun _ _ ->
-      error "@unboot_param")
-
-and unboot_exp_param (at : region) (values : Value.t list) : Sl.param =
-  match values with
-  | [ value_typ; value_exp ] ->
-      let typ = unboot_typ value_typ in
-      let exp = unboot_exp value_exp in
-      Sl.ExpP (typ, exp) $ at
-  | _ -> error "@unboot_exp_param"
-
-and unboot_def_param (at : region) (values : Value.t list) : Sl.param =
-  match values with
-  | [ value_id; value_tparams; value_params; value_typ ] ->
-      let id = unboot_id value_id in
-      let tparams = unboot_tparams value_tparams in
-      let params = unboot_params value_params in
-      let typ = unboot_typ value_typ in
-      Sl.DefP (id, tparams, params, typ) $ at
-  | _ -> error "@unboot_def_param"
-
-and unboot_params (value_params : Value.t) : Sl.param list =
-  value_params |> Value.Get.list |> List.map unboot_param
-
-(* Instructions *)
-
-let rec unboot_instr (value_instr : Value.t) : Sl.instr =
-  Value.Get.mtch_dispatch value_instr !unboot_instr_mtchtbl (fun _ _ ->
-      error "@unboot_instr")
-
-and unboot_if_instr (at : region) (values : Value.t list) : Sl.instr =
-  match values with
-  | [ value_exp; value_iterexps; value_block ] ->
-      let exp = unboot_exp value_exp in
-      let iterexps = unboot_iterexps value_iterexps in
-      let block = unboot_block value_block in
-      let dangle = stub_dangle in
-      Sl.IfI (exp, iterexps, block, dangle) $$ (at, stub_instr_note)
-  | _ -> error "@unboot_if_instr"
-
-and unboot_holdcase (value_holdcase : Value.t) : Sl.holdcase =
-  Value.Get.mtch_dispatch value_holdcase !unboot_holdcase_mtchtbl (fun _ _ ->
-      error "@unboot_holdcase")
-
-and unboot_both_holdcase (_at : region) (values : Value.t list) : Sl.holdcase =
-  match values with
-  | [ value_block_hold; value_block_nothold ] ->
-      let block_hold = unboot_block value_block_hold in
-      let block_nothold = unboot_block value_block_nothold in
-      Sl.BothH (block_hold, block_nothold)
-  | _ -> error "@unboot_both_holdcase"
-
-and unboot_hold_holdcase (_at : region) (values : Value.t list) : Sl.holdcase =
-  match values with
-  | [ value_block ] ->
-      let block = unboot_block value_block in
-      let dangle = stub_dangle in
-      Sl.HoldH (block, dangle)
-  | _ -> error "@unboot_hold_holdcase"
-
-and unboot_nothold_holdcase (_at : region) (values : Value.t list) : Sl.holdcase
-    =
-  match values with
-  | [ value_block ] ->
-      let block = unboot_block value_block in
-      let dangle = stub_dangle in
-      Sl.NotHoldH (block, dangle)
-  | _ -> error "@unboot_nothold_holdcase"
-
-and unboot_hold_instr (at : region) (values : Value.t list) : Sl.instr =
-  match values with
-  | [ value_id; value_exps; value_iterexps; value_holdcase ] ->
-      let id = unboot_id value_id in
-      let exps = unboot_exps value_exps in
-      let notexp = stub_notexp exps [] in
-      let iterexps = unboot_iterexps value_iterexps in
-      let holdcase = unboot_holdcase value_holdcase in
-      Sl.HoldI (id, notexp, iterexps, holdcase) $$ (at, stub_instr_note)
-  | _ -> error "@unboot_hold_instr"
-
-and unboot_guard (value_guard : Value.t) : Sl.guard =
-  Value.Get.mtch_dispatch value_guard !unboot_guard_mtchtbl (fun _ _ ->
-      error "@unboot_guard")
-
-and unboot_bool_guard (_at : region) (values : Value.t list) : Sl.guard =
-  match values with
-  | [ value_bool ] ->
-      let b = Value.Get.bool value_bool in
-      Sl.BoolG b
-  | _ -> error "@unboot_bool_guard"
-
-and unboot_cmp_guard (_at : region) (values : Value.t list) : Sl.guard =
-  let optyp_of_cmpop : Sl.cmpop -> Sl.optyp = function
-    | `EqOp | `NeOp -> (`BoolT : Sl.optyp)
-    | _ -> `NatT
-  in
-  match values with
-  | [ value_cmpop; value_exp ] ->
-      let cmpop = unboot_cmpop value_cmpop in
-      let optyp = optyp_of_cmpop cmpop in
-      let exp = unboot_exp value_exp in
-      Sl.CmpG (cmpop, optyp, exp)
-  | _ -> error "@unboot_cmp_guard"
-
-and unboot_sub_guard (_at : region) (values : Value.t list) : Sl.guard =
-  match values with
-  | [ value_typ ] ->
-      let typ = unboot_typ value_typ in
-      Sl.SubG typ
-  | _ -> error "@unboot_sub_guard"
-
-and unboot_match_guard (_at : region) (values : Value.t list) : Sl.guard =
-  match values with
-  | [ value_pattern ] ->
-      let pattern = unboot_pattern value_pattern in
-      Sl.MatchG pattern
-  | _ -> error "@unboot_match_guard"
-
-and unboot_mem_guard (_at : region) (values : Value.t list) : Sl.guard =
-  match values with
-  | [ value_exp ] ->
-      let exp = unboot_exp value_exp in
-      Sl.MemG exp
-  | _ -> error "@unboot_mem_guard"
-
-and unboot_case (value_case : Value.t) : Sl.case =
-  let values = Value.Get.(value_case |>>! mop_case) in
-  let guard = Value.Get.nth 0 values |> unboot_guard in
-  let block = Value.Get.nth 1 values |> unboot_block in
-  (guard, block)
-
-and unboot_cases (value_cases : Value.t) : Sl.case list =
-  value_cases |> Value.Get.list |> List.map unboot_case
-
-and unboot_case_instr (at : region) (values : Value.t list) : Sl.instr =
-  match values with
-  | [ value_exp; value_cases ] ->
-      let exp = unboot_exp value_exp in
-      let cases = unboot_cases value_cases in
-      let dangle = stub_dangle in
-      Sl.CaseI (exp, cases, dangle) $$ (at, stub_instr_note)
-  | _ -> error "@unboot_case_instr"
-
-and unboot_group_instr (at : region) (values : Value.t list) : Sl.instr =
-  match values with
-  | [ value_id; value_exps; value_typs_in; value_typs_out; value_block ] ->
-      let id = unboot_id value_id in
-      let exps = unboot_exps value_exps in
-      let typs_in = unboot_typs value_typs_in in
-      let typs_out = unboot_typs value_typs_out in
-      let nottyp = stub_nottyp typs_in typs_out in
-      let inputs = stub_input_hint (List.length typs_in) in
-      let block = unboot_block value_block in
-      Sl.GroupI (id, (nottyp, inputs), exps, block) $$ (at, stub_instr_note)
-  | _ -> error "@unboot_group_instr"
-
-and unboot_let_instr (at : region) (values : Value.t list) : Sl.instr =
-  match values with
-  | [ value_exp_l; value_exp_r; value_iterinstrs; value_block ] ->
-      let exp_l = unboot_exp value_exp_l in
-      let exp_r = unboot_exp value_exp_r in
-      let iterinstrs = unboot_iterinstrs value_iterinstrs in
-      let block = unboot_block value_block in
-      Sl.LetI (exp_l, exp_r, iterinstrs, block) $$ (at, stub_instr_note)
-  | _ -> error "@unboot_let_instr"
-
-and unboot_rule_instr (at : region) (values : Value.t list) : Sl.instr =
-  match values with
-  | [ value_id; value_exps_in; value_exps_out; value_iterinstrs; value_block ]
-    ->
-      let id = unboot_id value_id in
-      let exps_in = unboot_exps value_exps_in in
-      let exps_out = unboot_exps value_exps_out in
-      let notexp = stub_notexp exps_in exps_out in
-      let inputs = stub_input_hint (List.length exps_in) in
-      let iterinstrs = unboot_iterinstrs value_iterinstrs in
-      let block = unboot_block value_block in
-      Sl.RuleI (id, notexp, inputs, iterinstrs, block) $$ (at, stub_instr_note)
-  | _ -> error "@unboot_rule_instr"
-
-and unboot_result_instr (at : region) (values : Value.t list) : Sl.instr =
-  match values with
-  | [ value_typs_in; value_typs_out; value_exps ] ->
-      let typs_in = unboot_typs value_typs_in in
-      let typs_out = unboot_typs value_typs_out in
-      let nottyp = stub_nottyp typs_in typs_out in
-      let inputs = stub_input_hint (List.length typs_in) in
-      let exps = unboot_exps value_exps in
-      Sl.ResultI ((nottyp, inputs), exps) $$ (at, stub_instr_note)
-  | _ -> error "@unboot_result_instr"
-
-and unboot_return_instr (at : region) (values : Value.t list) : Sl.instr =
-  match values with
-  | [ value_exp ] ->
-      let exp = unboot_exp value_exp in
-      Sl.ReturnI exp $$ (at, stub_instr_note)
-  | _ -> error "@unboot_return_instr"
-
-and unboot_debug_instr (at : region) (values : Value.t list) : Sl.instr =
-  match values with
-  | [ value_exp ] ->
-      let exp = unboot_exp value_exp in
-      Sl.DebugI exp $$ (at, stub_instr_note)
-  | _ -> error "@unboot_debug_instr"
-
-and unboot_instrs (value_instrs : Value.t) : Sl.instr list =
-  value_instrs |> Value.Get.list |> List.map unboot_instr
-
-and unboot_block (value_block : Value.t) : Sl.block =
-  value_block |> unboot_instrs
-
-and unboot_block_opt (value_block_opt : Value.t) : Sl.block option =
-  value_block_opt |> Value.Get.opt |> Option.map unboot_block
-
-(* Table rows *)
-
-let rec unboot_tablerow (value_tablerow : Value.t) : Sl.tablerow =
-  let values = Value.Get.(value_tablerow |>>! mop_tablerow) in
-  let exps = Value.Get.nth 0 values |> unboot_exps in
-  let exp = Value.Get.nth 1 values |> unboot_exp in
-  let block = Value.Get.nth 2 values |> unboot_block in
-  (exps, exp, block)
-
-and unboot_tablerows (value_tablerows : Value.t) : Sl.tablerow list =
-  value_tablerows |> Value.Get.list |> List.map unboot_tablerow
-
-(* Definitions *)
-
-let unboot_def (value_def : Value.t) : Sl.def =
-  Value.Get.mtch_dispatch value_def !unboot_def_mtchtbl (fun _ _ ->
-      error "@unboot_def")
-
-let unboot_extern_typ_def (at : region) (values : Value.t list) : Sl.def =
-  match values with
-  | [ value_id ] ->
-      let id = unboot_id value_id in
-      Sl.ExternTypD (id, []) $ at
-  | _ -> error "@unboot_extern_typ_def"
-
-let unboot_typ_def (at : region) (values : Value.t list) : Sl.def =
-  match values with
-  | [ value_id; value_tparams; value_deftyp ] ->
-      let id = unboot_id value_id in
-      let tparams = unboot_tparams value_tparams in
-      let deftyp = unboot_deftyp value_deftyp in
-      Sl.TypD (id, tparams, deftyp, []) $ at
-  | _ -> error "@unboot_typ_def"
-
-let unboot_extern_rel_def (at : region) (values : Value.t list) : Sl.def =
-  match values with
-  | [ value_id; value_exps; value_typs_in; value_typs_out ] ->
-      let id = unboot_id value_id in
-      let exps = unboot_exps value_exps in
-      let typs_in = unboot_typs value_typs_in in
-      let typs_out = unboot_typs value_typs_out in
-      let nottyp = stub_nottyp typs_in typs_out in
-      let inputs = stub_input_hint (List.length typs_in) in
-      Sl.ExternRelD (id, (nottyp, inputs), exps, []) $ at
-  | _ -> error "@unboot_extern_rel_def"
-
-let unboot_rel_def (at : region) (values : Value.t list) : Sl.def =
-  match values with
-  | [
-   value_id;
-   value_exps;
-   value_typs_in;
-   value_typs_out;
-   value_block;
-   value_elsblock;
-  ] ->
-      let id = unboot_id value_id in
-      let exps = unboot_exps value_exps in
-      let typs_in = unboot_typs value_typs_in in
-      let typs_out = unboot_typs value_typs_out in
-      let nottyp = stub_nottyp typs_in typs_out in
-      let inputs = stub_input_hint (List.length typs_in) in
-      let block = unboot_block value_block in
-      let elseblock_opt = unboot_block_opt value_elsblock in
-      Sl.RelD (id, (nottyp, inputs), exps, block, elseblock_opt, []) $ at
-  | _ -> error "@unboot_rel_def"
-
-let unboot_extern_func_def (at : region) (values : Value.t list) : Sl.def =
-  match values with
-  | [ value_id; value_tparams; value_params; value_typ ] ->
-      let id = unboot_id value_id in
-      let tparams = unboot_tparams value_tparams in
-      let params = unboot_params value_params in
-      let typ = unboot_typ value_typ in
-      Sl.ExternDecD (id, tparams, params, typ, []) $ at
-  | _ -> error "@unboot_extern_func_def"
-
-let unboot_builtin_func_def (at : region) (values : Value.t list) : Sl.def =
-  match values with
-  | [ value_id; value_tparams; value_params; value_typ ] ->
-      let id = unboot_id value_id in
-      let tparams = unboot_tparams value_tparams in
-      let params = unboot_params value_params in
-      let typ = unboot_typ value_typ in
-      Sl.BuiltinDecD (id, tparams, params, typ, []) $ at
-  | _ -> error "@unboot_builtin_func_def"
-
-let unboot_table_func_def (at : region) (values : Value.t list) : Sl.def =
-  match values with
-  | [ value_id; value_params; value_typ; value_tablerows ] ->
-      let id = unboot_id value_id in
-      let params = unboot_params value_params in
-      let typ = unboot_typ value_typ in
-      let tablerows = unboot_tablerows value_tablerows in
-      Sl.TableDecD (id, params, typ, tablerows, []) $ at
-  | _ -> error "@unboot_table_func_def"
-
-let unboot_func_def (at : region) (values : Value.t list) : Sl.def =
-  match values with
-  | [
-   value_id; value_tparams; value_params; value_typ; value_block; value_elsblock;
-  ] ->
-      let id = unboot_id value_id in
-      let tparams = unboot_tparams value_tparams in
-      let params = unboot_params value_params in
-      let typ = unboot_typ value_typ in
-      let block = unboot_block value_block in
-      let elseblock_opt = unboot_block_opt value_elsblock in
-      Sl.FuncDecD (id, tparams, params, typ, block, elseblock_opt, []) $ at
-  | _ -> error "@unboot_func_def"
-
-(* Specification *)
-
-let unboot_script (value_script : Value.t) : Sl.spec =
-  let value_defs = Value.Get.list value_script in
-  List.map unboot_def value_defs
-
-(* Initialize SL dispatch tables after all handler functions are defined *)
-
-let () =
   (* Parameters *)
-  unboot_param_mtchtbl :=
-    Value.Get.build_mtchtbl
-      [ (mop_exp_param, unboot_exp_param); (mop_def_param, unboot_def_param) ];
+
+  let rec unboot_param (value_param : V.t) : Sl.param =
+    Dispatch.dispatch value_param Il_typs.typ_param !unboot_param_mtchtbl
+      (fun _ _ -> error "@unboot_param")
+
+  and unboot_exp_param (at : region) (values : V.t list) : Sl.param =
+    match values with
+    | [ value_typ; value_exp ] ->
+        let typ = unboot_typ value_typ in
+        let exp = unboot_exp value_exp in
+        Sl.ExpP (typ, exp) $ at
+    | _ -> error "@unboot_exp_param"
+
+  and unboot_def_param (at : region) (values : V.t list) : Sl.param =
+    match values with
+    | [ value_id; value_tparams; value_params; value_typ ] ->
+        let id = unboot_id value_id in
+        let tparams = unboot_tparams value_tparams in
+        let params = unboot_params value_params in
+        let typ = unboot_typ value_typ in
+        Sl.DefP (id, tparams, params, typ) $ at
+    | _ -> error "@unboot_def_param"
+
+  and unboot_params (value_params : V.t) : Sl.param list =
+    value_params |> V.Get.list |> List.map unboot_param
+
   (* Instructions *)
-  unboot_holdcase_mtchtbl :=
-    Value.Get.build_mtchtbl
-      [
-        (mop_both_holdcase, unboot_both_holdcase);
-        (mop_hold_holdcase, unboot_hold_holdcase);
-        (mop_nothold_holdcase, unboot_nothold_holdcase);
-      ];
-  unboot_guard_mtchtbl :=
-    Value.Get.build_mtchtbl
-      [
-        (mop_bool_guard, unboot_bool_guard);
-        (mop_cmp_guard, unboot_cmp_guard);
-        (mop_sub_guard, unboot_sub_guard);
-        (mop_match_guard, unboot_match_guard);
-        (mop_mem_guard, unboot_mem_guard);
-      ];
-  unboot_instr_mtchtbl :=
-    Value.Get.build_mtchtbl
-      [
-        (mop_if_instr, unboot_if_instr);
-        (mop_hold_instr, unboot_hold_instr);
-        (mop_case_instr, unboot_case_instr);
-        (mop_group_instr, unboot_group_instr);
-        (mop_let_instr, unboot_let_instr);
-        (mop_rule_instr, unboot_rule_instr);
-        (mop_result_instr, unboot_result_instr);
-        (mop_return_instr, unboot_return_instr);
-        (mop_debug_instr, unboot_debug_instr);
-      ];
+
+  let rec unboot_instr (value_instr : V.t) : Sl.instr =
+    Dispatch.dispatch value_instr Il_typs.typ_instr !unboot_instr_mtchtbl
+      (fun _ _ -> error "@unboot_instr")
+
+  and unboot_if_instr (at : region) (values : V.t list) : Sl.instr =
+    match values with
+    | [ value_exp; value_iterexps; value_block ] ->
+        let exp = unboot_exp value_exp in
+        let iterexps = unboot_iterexps value_iterexps in
+        let block = unboot_block value_block in
+        let dangle = stub_dangle in
+        Sl.IfI (exp, iterexps, block, dangle) $$ (at, stub_instr_note)
+    | _ -> error "@unboot_if_instr"
+
+  and unboot_holdcase (value_holdcase : V.t) : Sl.holdcase =
+    Dispatch.dispatch value_holdcase Il_typs.typ_holdcase
+      !unboot_holdcase_mtchtbl (fun _ _ -> error "@unboot_holdcase")
+
+  and unboot_both_holdcase (_at : region) (values : V.t list) : Sl.holdcase =
+    match values with
+    | [ value_block_hold; value_block_nothold ] ->
+        let block_hold = unboot_block value_block_hold in
+        let block_nothold = unboot_block value_block_nothold in
+        Sl.BothH (block_hold, block_nothold)
+    | _ -> error "@unboot_both_holdcase"
+
+  and unboot_hold_holdcase (_at : region) (values : V.t list) : Sl.holdcase =
+    match values with
+    | [ value_block ] ->
+        let block = unboot_block value_block in
+        let dangle = stub_dangle in
+        Sl.HoldH (block, dangle)
+    | _ -> error "@unboot_hold_holdcase"
+
+  and unboot_nothold_holdcase (_at : region) (values : V.t list) : Sl.holdcase =
+    match values with
+    | [ value_block ] ->
+        let block = unboot_block value_block in
+        let dangle = stub_dangle in
+        Sl.NotHoldH (block, dangle)
+    | _ -> error "@unboot_nothold_holdcase"
+
+  and unboot_hold_instr (at : region) (values : V.t list) : Sl.instr =
+    match values with
+    | [ value_id; value_exps; value_iterexps; value_holdcase ] ->
+        let id = unboot_id value_id in
+        let exps = unboot_exps value_exps in
+        let notexp = stub_notexp exps [] in
+        let iterexps = unboot_iterexps value_iterexps in
+        let holdcase = unboot_holdcase value_holdcase in
+        Sl.HoldI (id, notexp, iterexps, holdcase) $$ (at, stub_instr_note)
+    | _ -> error "@unboot_hold_instr"
+
+  and unboot_guard (value_guard : V.t) : Sl.guard =
+    Dispatch.dispatch value_guard Il_typs.typ_guard !unboot_guard_mtchtbl
+      (fun _ _ -> error "@unboot_guard")
+
+  and unboot_bool_guard (_at : region) (values : V.t list) : Sl.guard =
+    match values with
+    | [ value_bool ] ->
+        let b = V.Get.bool value_bool in
+        Sl.BoolG b
+    | _ -> error "@unboot_bool_guard"
+
+  and unboot_cmp_guard (_at : region) (values : V.t list) : Sl.guard =
+    let optyp_of_cmpop : Sl.cmpop -> Sl.optyp = function
+      | `EqOp | `NeOp -> (`BoolT : Sl.optyp)
+      | _ -> `NatT
+    in
+    match values with
+    | [ value_cmpop; value_exp ] ->
+        let cmpop = unboot_cmpop value_cmpop in
+        let optyp = optyp_of_cmpop cmpop in
+        let exp = unboot_exp value_exp in
+        Sl.CmpG (cmpop, optyp, exp)
+    | _ -> error "@unboot_cmp_guard"
+
+  and unboot_sub_guard (_at : region) (values : V.t list) : Sl.guard =
+    match values with
+    | [ value_typ ] ->
+        let typ = unboot_typ value_typ in
+        Sl.SubG typ
+    | _ -> error "@unboot_sub_guard"
+
+  and unboot_match_guard (_at : region) (values : V.t list) : Sl.guard =
+    match values with
+    | [ value_pattern ] ->
+        let pattern = unboot_pattern value_pattern in
+        Sl.MatchG pattern
+    | _ -> error "@unboot_match_guard"
+
+  and unboot_mem_guard (_at : region) (values : V.t list) : Sl.guard =
+    match values with
+    | [ value_exp ] ->
+        let exp = unboot_exp value_exp in
+        Sl.MemG exp
+    | _ -> error "@unboot_mem_guard"
+
+  and unboot_case (value_case : V.t) : Sl.case =
+    let values = Dispatch.case_exact value_case mop_case Il_typs.typ_case in
+    let guard = V.Get.nth 0 values |> unboot_guard in
+    let block = V.Get.nth 1 values |> unboot_block in
+    (guard, block)
+
+  and unboot_cases (value_cases : V.t) : Sl.case list =
+    value_cases |> V.Get.list |> List.map unboot_case
+
+  and unboot_case_instr (at : region) (values : V.t list) : Sl.instr =
+    match values with
+    | [ value_exp; value_cases ] ->
+        let exp = unboot_exp value_exp in
+        let cases = unboot_cases value_cases in
+        let dangle = stub_dangle in
+        Sl.CaseI (exp, cases, dangle) $$ (at, stub_instr_note)
+    | _ -> error "@unboot_case_instr"
+
+  and unboot_group_instr (at : region) (values : V.t list) : Sl.instr =
+    match values with
+    | [ value_id; value_exps; value_typs_in; value_typs_out; value_block ] ->
+        let id = unboot_id value_id in
+        let exps = unboot_exps value_exps in
+        let typs_in = unboot_typs value_typs_in in
+        let typs_out = unboot_typs value_typs_out in
+        let nottyp = stub_nottyp typs_in typs_out in
+        let inputs = stub_input_hint (List.length typs_in) in
+        let block = unboot_block value_block in
+        Sl.GroupI (id, (nottyp, inputs), exps, block) $$ (at, stub_instr_note)
+    | _ -> error "@unboot_group_instr"
+
+  and unboot_let_instr (at : region) (values : V.t list) : Sl.instr =
+    match values with
+    | [ value_exp_l; value_exp_r; value_iterinstrs; value_block ] ->
+        let exp_l = unboot_exp value_exp_l in
+        let exp_r = unboot_exp value_exp_r in
+        let iterinstrs = unboot_iterinstrs value_iterinstrs in
+        let block = unboot_block value_block in
+        Sl.LetI (exp_l, exp_r, iterinstrs, block) $$ (at, stub_instr_note)
+    | _ -> error "@unboot_let_instr"
+
+  and unboot_rule_instr (at : region) (values : V.t list) : Sl.instr =
+    match values with
+    | [ value_id; value_exps_in; value_exps_out; value_iterinstrs; value_block ]
+      ->
+        let id = unboot_id value_id in
+        let exps_in = unboot_exps value_exps_in in
+        let exps_out = unboot_exps value_exps_out in
+        let notexp = stub_notexp exps_in exps_out in
+        let inputs = stub_input_hint (List.length exps_in) in
+        let iterinstrs = unboot_iterinstrs value_iterinstrs in
+        let block = unboot_block value_block in
+        Sl.RuleI (id, notexp, inputs, iterinstrs, block) $$ (at, stub_instr_note)
+    | _ -> error "@unboot_rule_instr"
+
+  and unboot_result_instr (at : region) (values : V.t list) : Sl.instr =
+    match values with
+    | [ value_typs_in; value_typs_out; value_exps ] ->
+        let typs_in = unboot_typs value_typs_in in
+        let typs_out = unboot_typs value_typs_out in
+        let nottyp = stub_nottyp typs_in typs_out in
+        let inputs = stub_input_hint (List.length typs_in) in
+        let exps = unboot_exps value_exps in
+        Sl.ResultI ((nottyp, inputs), exps) $$ (at, stub_instr_note)
+    | _ -> error "@unboot_result_instr"
+
+  and unboot_return_instr (at : region) (values : V.t list) : Sl.instr =
+    match values with
+    | [ value_exp ] ->
+        let exp = unboot_exp value_exp in
+        Sl.ReturnI exp $$ (at, stub_instr_note)
+    | _ -> error "@unboot_return_instr"
+
+  and unboot_debug_instr (at : region) (values : V.t list) : Sl.instr =
+    match values with
+    | [ value_exp ] ->
+        let exp = unboot_exp value_exp in
+        Sl.DebugI exp $$ (at, stub_instr_note)
+    | _ -> error "@unboot_debug_instr"
+
+  and unboot_instrs (value_instrs : V.t) : Sl.instr list =
+    value_instrs |> V.Get.list |> List.map unboot_instr
+
+  and unboot_block (value_block : V.t) : Sl.block = value_block |> unboot_instrs
+
+  and unboot_block_opt (value_block_opt : V.t) : Sl.block option =
+    value_block_opt |> V.Get.opt |> Option.map unboot_block
+
+  (* Table rows *)
+
+  let rec unboot_tablerow (value_tablerow : V.t) : Sl.tablerow =
+    let values =
+      Dispatch.case_exact value_tablerow mop_tablerow Il_typs.typ_tblrow
+    in
+    let exps = V.Get.nth 0 values |> unboot_exps in
+    let exp = V.Get.nth 1 values |> unboot_exp in
+    let block = V.Get.nth 2 values |> unboot_block in
+    (exps, exp, block)
+
+  and unboot_tablerows (value_tablerows : V.t) : Sl.tablerow list =
+    value_tablerows |> V.Get.list |> List.map unboot_tablerow
+
   (* Definitions *)
-  unboot_def_mtchtbl :=
-    Value.Get.build_mtchtbl
-      [
-        (mop_extern_typ_def, unboot_extern_typ_def);
-        (mop_typ_def, unboot_typ_def);
-        (mop_extern_rel_def, unboot_extern_rel_def);
-        (mop_rel_def, unboot_rel_def);
-        (mop_extern_func_def, unboot_extern_func_def);
-        (mop_builtin_func_def, unboot_builtin_func_def);
-        (mop_table_func_def, unboot_table_func_def);
-        (mop_func_def, unboot_func_def);
-      ]
+
+  let unboot_def (value_def : V.t) : Sl.def =
+    Dispatch.dispatch value_def Il_typs.typ_defn !unboot_def_mtchtbl (fun _ _ ->
+        error "@unboot_def")
+
+  let unboot_extern_typ_def (at : region) (values : V.t list) : Sl.def =
+    match values with
+    | [ value_id ] ->
+        let id = unboot_id value_id in
+        Sl.ExternTypD (id, []) $ at
+    | _ -> error "@unboot_extern_typ_def"
+
+  let unboot_typ_def (at : region) (values : V.t list) : Sl.def =
+    match values with
+    | [ value_id; value_tparams; value_deftyp ] ->
+        let id = unboot_id value_id in
+        let tparams = unboot_tparams value_tparams in
+        let deftyp = unboot_deftyp value_deftyp in
+        Sl.TypD (id, tparams, deftyp, []) $ at
+    | _ -> error "@unboot_typ_def"
+
+  let unboot_extern_rel_def (at : region) (values : V.t list) : Sl.def =
+    match values with
+    | [ value_id; value_exps; value_typs_in; value_typs_out ] ->
+        let id = unboot_id value_id in
+        let exps = unboot_exps value_exps in
+        let typs_in = unboot_typs value_typs_in in
+        let typs_out = unboot_typs value_typs_out in
+        let nottyp = stub_nottyp typs_in typs_out in
+        let inputs = stub_input_hint (List.length typs_in) in
+        Sl.ExternRelD (id, (nottyp, inputs), exps, []) $ at
+    | _ -> error "@unboot_extern_rel_def"
+
+  let unboot_rel_def (at : region) (values : V.t list) : Sl.def =
+    match values with
+    | [
+     value_id;
+     value_exps;
+     value_typs_in;
+     value_typs_out;
+     value_block;
+     value_elsblock;
+    ] ->
+        let id = unboot_id value_id in
+        let exps = unboot_exps value_exps in
+        let typs_in = unboot_typs value_typs_in in
+        let typs_out = unboot_typs value_typs_out in
+        let nottyp = stub_nottyp typs_in typs_out in
+        let inputs = stub_input_hint (List.length typs_in) in
+        let block = unboot_block value_block in
+        let elseblock_opt = unboot_block_opt value_elsblock in
+        Sl.RelD (id, (nottyp, inputs), exps, block, elseblock_opt, []) $ at
+    | _ -> error "@unboot_rel_def"
+
+  let unboot_extern_func_def (at : region) (values : V.t list) : Sl.def =
+    match values with
+    | [ value_id; value_tparams; value_params; value_typ ] ->
+        let id = unboot_id value_id in
+        let tparams = unboot_tparams value_tparams in
+        let params = unboot_params value_params in
+        let typ = unboot_typ value_typ in
+        Sl.ExternDecD (id, tparams, params, typ, []) $ at
+    | _ -> error "@unboot_extern_func_def"
+
+  let unboot_builtin_func_def (at : region) (values : V.t list) : Sl.def =
+    match values with
+    | [ value_id; value_tparams; value_params; value_typ ] ->
+        let id = unboot_id value_id in
+        let tparams = unboot_tparams value_tparams in
+        let params = unboot_params value_params in
+        let typ = unboot_typ value_typ in
+        Sl.BuiltinDecD (id, tparams, params, typ, []) $ at
+    | _ -> error "@unboot_builtin_func_def"
+
+  let unboot_table_func_def (at : region) (values : V.t list) : Sl.def =
+    match values with
+    | [ value_id; value_params; value_typ; value_tablerows ] ->
+        let id = unboot_id value_id in
+        let params = unboot_params value_params in
+        let typ = unboot_typ value_typ in
+        let tablerows = unboot_tablerows value_tablerows in
+        Sl.TableDecD (id, params, typ, tablerows, []) $ at
+    | _ -> error "@unboot_table_func_def"
+
+  let unboot_func_def (at : region) (values : V.t list) : Sl.def =
+    match values with
+    | [
+     value_id;
+     value_tparams;
+     value_params;
+     value_typ;
+     value_block;
+     value_elsblock;
+    ] ->
+        let id = unboot_id value_id in
+        let tparams = unboot_tparams value_tparams in
+        let params = unboot_params value_params in
+        let typ = unboot_typ value_typ in
+        let block = unboot_block value_block in
+        let elseblock_opt = unboot_block_opt value_elsblock in
+        Sl.FuncDecD (id, tparams, params, typ, block, elseblock_opt, []) $ at
+    | _ -> error "@unboot_func_def"
+
+  (* Specification *)
+
+  let unboot_script (value_script : V.t) : Sl.spec =
+    let value_defs = V.Get.list value_script in
+    List.map unboot_def value_defs
+
+  (* Initialize SL dispatch tables after all handler functions are defined *)
+
+  let () =
+    (* Parameters *)
+    unboot_param_mtchtbl :=
+      Dispatch.build_mtchtbl
+        [ (mop_exp_param, unboot_exp_param); (mop_def_param, unboot_def_param) ];
+    (* Instructions *)
+    unboot_holdcase_mtchtbl :=
+      Dispatch.build_mtchtbl
+        [
+          (mop_both_holdcase, unboot_both_holdcase);
+          (mop_hold_holdcase, unboot_hold_holdcase);
+          (mop_nothold_holdcase, unboot_nothold_holdcase);
+        ];
+    unboot_guard_mtchtbl :=
+      Dispatch.build_mtchtbl
+        [
+          (mop_bool_guard, unboot_bool_guard);
+          (mop_cmp_guard, unboot_cmp_guard);
+          (mop_sub_guard, unboot_sub_guard);
+          (mop_match_guard, unboot_match_guard);
+          (mop_mem_guard, unboot_mem_guard);
+        ];
+    unboot_instr_mtchtbl :=
+      Dispatch.build_mtchtbl
+        [
+          (mop_if_instr, unboot_if_instr);
+          (mop_hold_instr, unboot_hold_instr);
+          (mop_case_instr, unboot_case_instr);
+          (mop_group_instr, unboot_group_instr);
+          (mop_let_instr, unboot_let_instr);
+          (mop_rule_instr, unboot_rule_instr);
+          (mop_result_instr, unboot_result_instr);
+          (mop_return_instr, unboot_return_instr);
+          (mop_debug_instr, unboot_debug_instr);
+        ];
+    (* Definitions *)
+    unboot_def_mtchtbl :=
+      Dispatch.build_mtchtbl
+        [
+          (mop_extern_typ_def, unboot_extern_typ_def);
+          (mop_typ_def, unboot_typ_def);
+          (mop_extern_rel_def, unboot_extern_rel_def);
+          (mop_rel_def, unboot_rel_def);
+          (mop_extern_func_def, unboot_extern_func_def);
+          (mop_builtin_func_def, unboot_builtin_func_def);
+          (mop_table_func_def, unboot_table_func_def);
+          (mop_func_def, unboot_func_def);
+        ]
+end

--- a/p4spec/lib/runtime/valrep/dispatch.ml
+++ b/p4spec/lib/runtime/valrep/dispatch.ml
@@ -1,0 +1,46 @@
+module Mixop = Domain.Mixop
+module Mixfix = Domain.Mixfix
+module Il = Lang.Il
+open Util.Source
+
+(* [V]-generic dispatch over spec variant values. Replaces the [Value.t]-
+   specific helpers ([build_mtchtbl]/[mtch_dispatch]) used in the interpreter;
+   threads the spec-level type so [V.Get.case] works under [V_native]. *)
+module Make (V : Sig.SAFE) = struct
+  module MixopHashed = struct
+    type t = Mixop.t
+
+    let equal = Mixop.eq
+
+    let hash (m : Mixop.t) : int =
+      Hashtbl.hash (Mixop.string_of_mixop m) land 0x7FFFFFFF
+  end
+
+  module MtchTbl = Hashtbl.Make (MixopHashed)
+
+  type 'a mtch = region -> V.t list -> 'a
+  type 'a mtchtbl = 'a mtch MtchTbl.t
+
+  let build_mtchtbl (cases : (Mixop.t * 'a mtch) list) : 'a mtchtbl =
+    let tbl = MtchTbl.create (List.length cases) in
+    List.iter (fun (mixop, f) -> MtchTbl.add tbl mixop f) cases;
+    tbl
+
+  let dispatch (value : V.t) (typ : Il.typ) (tbl : 'a mtchtbl)
+      (case_default : 'a mtch) : 'a =
+    let at = V.at value in
+    let mixop, args = Mixfix.split (V.Get.case value typ) in
+    match MtchTbl.find_opt tbl mixop with
+    | Some f -> f at args
+    | None -> case_default at args
+
+  (* Assert [value] has exactly the given mixop; return its args or error. *)
+  let case_exact (value : V.t) (mixop_expect : Mixop.t) (typ : Il.typ) :
+      V.t list =
+    match V.Get.(value |>>? (mixop_expect, typ)) with
+    | Some args -> args
+    | None ->
+        Util.Error.error_unparse
+          (Format.asprintf "expected case with %s"
+             (Mixop.string_of_mixop mixop_expect))
+end

--- a/p4spec/lib/runtime/valrep/valrep.ml
+++ b/p4spec/lib/runtime/valrep/valrep.ml
@@ -9,3 +9,4 @@ module type UNSAFE = Sig.UNSAFE
 module type VAL = Sig.VAL
 
 module V_value = Val_value.V_value
+module Dispatch = Dispatch

--- a/towers/il-comp.json
+++ b/towers/il-comp.json
@@ -1,7 +1,6 @@
 {
-  "mode": "ml",
   "levels": [
-    { "specdir": "spec-meta/il", "rel": "Entry", "interface": "il" },
-    { "specdir": "spec/p4-comp", "rel": "Program_ok", "interface": "p4" }
+    { "specdir": "spec-meta/il", "rel": "Entry", "interface": "il", "mode": "ml" },
+    { "specdir": "spec/p4-comp", "rel": "Program_ok", "interface": "p4", "mode": "sl" }
   ]
 }

--- a/towers/il-il-comp.json
+++ b/towers/il-il-comp.json
@@ -1,8 +1,7 @@
 {
-  "mode": "ml",
   "levels": [
-    { "specdir": "spec-meta/il", "rel": "Entry", "interface": "il" },
-    { "specdir": "spec-meta/il", "rel": "Entry", "interface": "il" },
-    { "specdir": "spec/p4-comp", "rel": "Program_ok", "interface": "p4" }
+    { "specdir": "spec-meta/il", "rel": "Entry", "interface": "il", "mode": "ml" },
+    { "specdir": "spec-meta/il", "rel": "Entry", "interface": "il", "mode": "sl" },
+    { "specdir": "spec/p4-comp", "rel": "Program_ok", "interface": "p4", "mode": "sl" }
   ]
 }

--- a/towers/il-il.json
+++ b/towers/il-il.json
@@ -1,8 +1,7 @@
 {
-  "mode": "sl",
   "levels": [
-    { "specdir": "spec-meta/il", "rel": "Entry", "interface": "il" },
-    { "specdir": "spec-meta/il", "rel": "Entry", "interface": "il" },
-    { "specdir": "spec",      "rel": "Program_ok", "interface": "p4" }
+    { "specdir": "spec-meta/il", "rel": "Entry", "interface": "il", "mode": "sl" },
+    { "specdir": "spec-meta/il", "rel": "Entry", "interface": "il", "mode": "sl" },
+    { "specdir": "spec",      "rel": "Program_ok", "interface": "p4", "mode": "sl" }
   ]
 }

--- a/towers/il-sl-comp.json
+++ b/towers/il-sl-comp.json
@@ -1,8 +1,7 @@
 {
-  "mode": "ml",
   "levels": [
-    { "specdir": "spec-meta/il", "rel": "Entry", "interface": "il" },
-    { "specdir": "spec-meta/sl", "rel": "Entry", "interface": "sl" },
-    { "specdir": "spec/p4-comp", "rel": "Program_ok", "interface": "p4" }
+    { "specdir": "spec-meta/il", "rel": "Entry", "interface": "il", "mode": "ml" },
+    { "specdir": "spec-meta/sl", "rel": "Entry", "interface": "sl", "mode": "sl" },
+    { "specdir": "spec/p4-comp", "rel": "Program_ok", "interface": "p4", "mode": "sl" }
   ]
 }

--- a/towers/il-sl.json
+++ b/towers/il-sl.json
@@ -1,8 +1,7 @@
 {
-  "mode": "sl",
   "levels": [
-    { "specdir": "spec-meta/il", "rel": "Entry", "interface": "il" },
-    { "specdir": "spec-meta/sl", "rel": "Entry", "interface": "sl" },
-    { "specdir": "spec",      "rel": "Program_ok", "interface": "p4" }
+    { "specdir": "spec-meta/il", "rel": "Entry", "interface": "il", "mode": "sl" },
+    { "specdir": "spec-meta/sl", "rel": "Entry", "interface": "sl", "mode": "sl" },
+    { "specdir": "spec",      "rel": "Program_ok", "interface": "p4", "mode": "sl" }
   ]
 }

--- a/towers/il.json
+++ b/towers/il.json
@@ -1,7 +1,6 @@
 {
-  "mode": "sl",
   "levels": [
-    { "specdir": "spec-meta/il", "rel": "Entry", "interface": "il" },
-    { "specdir": "spec",      "rel": "Program_ok", "interface": "p4" }
+    { "specdir": "spec-meta/il", "rel": "Entry", "interface": "il", "mode": "sl" },
+    { "specdir": "spec",      "rel": "Program_ok", "interface": "p4", "mode": "sl" }
   ]
 }

--- a/towers/sl-comp.json
+++ b/towers/sl-comp.json
@@ -1,7 +1,6 @@
 {
-  "mode": "ml",
   "levels": [
-    { "specdir": "spec-meta/sl", "rel": "Entry", "interface": "sl" },
-    { "specdir": "spec/p4-comp", "rel": "Program_ok", "interface": "p4" }
+    { "specdir": "spec-meta/sl", "rel": "Entry", "interface": "sl", "mode": "ml" },
+    { "specdir": "spec/p4-comp", "rel": "Program_ok", "interface": "p4", "mode": "sl" }
   ]
 }

--- a/towers/sl-il-comp.json
+++ b/towers/sl-il-comp.json
@@ -1,8 +1,7 @@
 {
-  "mode": "ml",
   "levels": [
-    { "specdir": "spec-meta/sl", "rel": "Entry", "interface": "sl" },
-    { "specdir": "spec-meta/il", "rel": "Entry", "interface": "il" },
-    { "specdir": "spec/p4-comp", "rel": "Program_ok", "interface": "p4" }
+    { "specdir": "spec-meta/sl", "rel": "Entry", "interface": "sl", "mode": "ml" },
+    { "specdir": "spec-meta/il", "rel": "Entry", "interface": "il", "mode": "sl" },
+    { "specdir": "spec/p4-comp", "rel": "Program_ok", "interface": "p4", "mode": "sl" }
   ]
 }

--- a/towers/sl-il.json
+++ b/towers/sl-il.json
@@ -1,8 +1,7 @@
 {
-  "mode": "sl",
   "levels": [
-    { "specdir": "spec-meta/sl", "rel": "Entry", "interface": "sl" },
-    { "specdir": "spec-meta/il", "rel": "Entry", "interface": "il" },
-    { "specdir": "spec",      "rel": "Program_ok", "interface": "p4" }
+    { "specdir": "spec-meta/sl", "rel": "Entry", "interface": "sl", "mode": "sl" },
+    { "specdir": "spec-meta/il", "rel": "Entry", "interface": "il", "mode": "sl" },
+    { "specdir": "spec",      "rel": "Program_ok", "interface": "p4", "mode": "sl" }
   ]
 }

--- a/towers/sl-sl-comp.json
+++ b/towers/sl-sl-comp.json
@@ -1,8 +1,7 @@
 {
-  "mode": "ml",
   "levels": [
-    { "specdir": "spec-meta/sl", "rel": "Entry", "interface": "sl" },
-    { "specdir": "spec-meta/sl", "rel": "Entry", "interface": "sl" },
-    { "specdir": "spec/p4-comp", "rel": "Program_ok", "interface": "p4" }
+    { "specdir": "spec-meta/sl", "rel": "Entry", "interface": "sl", "mode": "ml" },
+    { "specdir": "spec-meta/sl", "rel": "Entry", "interface": "sl", "mode": "sl" },
+    { "specdir": "spec/p4-comp", "rel": "Program_ok", "interface": "p4", "mode": "sl" }
   ]
 }

--- a/towers/sl-sl.json
+++ b/towers/sl-sl.json
@@ -1,8 +1,7 @@
 {
-  "mode": "sl",
   "levels": [
-    { "specdir": "spec-meta/sl", "rel": "Entry", "interface": "sl" },
-    { "specdir": "spec-meta/sl", "rel": "Entry", "interface": "sl" },
-    { "specdir": "spec",      "rel": "Program_ok", "interface": "p4" }
+    { "specdir": "spec-meta/sl", "rel": "Entry", "interface": "sl", "mode": "sl" },
+    { "specdir": "spec-meta/sl", "rel": "Entry", "interface": "sl", "mode": "sl" },
+    { "specdir": "spec",      "rel": "Program_ok", "interface": "p4", "mode": "sl" }
   ]
 }

--- a/towers/sl.json
+++ b/towers/sl.json
@@ -1,7 +1,6 @@
 {
-  "mode": "sl",
   "levels": [
-    { "specdir": "spec-meta/sl", "rel": "Entry", "interface": "sl" },
-    { "specdir": "spec",      "rel": "Program_ok", "interface": "p4" }
+    { "specdir": "spec-meta/sl", "rel": "Entry", "interface": "sl", "mode": "sl" },
+    { "specdir": "spec",      "rel": "Program_ok", "interface": "p4", "mode": "sl" }
   ]
 }


### PR DESCRIPTION
> Stacked on #185 (the compiled-P4-sim VAL abstraction) — base branch is that PR's branch, so this diff shows only the boot-tower commits. Review #185 first.

## What this does

`spectec-boot-comp` runs a *tower* of specs: the P4 spec at the bottom, and above
it `spec-meta/il` / `spec-meta/sl` — the formal semantics of SpecTec itself —
each interpreting the level below. Those meta levels were always tree-walked. This
change lets a meta level run as **compiled native OCaml** (`ML_mode`), the same way
the P4 simulator already does after the base change this stacks on.

The hard part is that the meta interpreter and the compiled code below it speak two
different value representations — the self-describing `Value.t` and the raw `Obj.t`
of compiled code. This reuses the `Valrep.VAL` interface from the base change: the
same boot/unboot, interface, and boot-layer code is made generic over the
representation, and each tower level picks the representation its mode needs.

## How it works

Four things had to become generic over `V`, and one routing had to change:

- **boot/unboot** (`interface/spectec/{common,ili,sli}`) — the translation between an
  OCaml AST node (`Il.exp`, `Il.value`, …) and a value in whichever representation is
  running. Now `Make (V : Valrep.SAFE)` functors, threading `V` through construction
  (`V.Make`) and destruction (a generic `Dispatch` over the type's mixop).
- **the SpecTec interface** (`interface/interface.ml`) — split into a fixed
  boot-time part plus `Make (V : Valrep.VAL)` for the mode-dependent members.
- **the boot-layer externs** (`backend-boot/spectec.ml`) — `Make_null`/`Make_parametric`
  and `INTERFACE_SPECTEC` gain an abstract `vt`; the pairing constraint
  `INTERFACE_SPECTEC with type vt = V.t` turns a mispaired functor into a compile
  error instead of a silent representation-confusion bug.
- **the per-target native representation** — `backend-ocaml-il`/`backend-ocaml-sl` each
  get their own `V_native`, bound to their own generated `Spec_parts_*` tables.

`build.ml` then picks the representation once per level: `ML_mode` at a given
interface selects that interface's `V_native`, everything else selects `V_value`.

## Example

A boot/unboot layer, before — hardcoded to `Value.t`:

```ocaml
let rec unboot_iter (value_iter : Value.t) : Il.iter = ...
```

after — generic, threading `V` and dispatching through the type witness:

```ocaml
module Make (V : Runtime.Valrep.SAFE) = struct
  module Dispatch = Runtime.Valrep.Dispatch.Make (V)
  let unboot_iter (value_iter : V.t) : Il.iter =
    Dispatch.dispatch value_iter Il_typs.typ_iter unboot_iter_tbl
      (fun _ _ -> error "@unboot_iter")
end
```

## The changes, in order

**1. Generic dispatch helper + type witnesses.** `Runtime.Valrep.Dispatch` splits a
value's mixop shell (given its spec type) and runs the matching handler. `Il_typs`
adds the `Il.typ` constants that key those dispatches.

**2. boot/unboot functorized over `V`** across the `common`, `ili`, and `sli` layers.

**3. Per-target `V_native` for il/sl**, each bound to its own `Spec_parts_*`; the
`compiled_stub` gains the typed-bridge entries so the surface stays stable under
`make build`.

**4. The SpecTec interface split** into a fixed part plus `Make (V)`.

**5. The boot-layer externs functorized** over `Valrep`, and `build.ml` picks the
representation per (mode, interface).

**6. Per-level tower mode.** Each tower level carries its own mode instead of one
tower-wide mode, so the boot level can run `ml` while the target runs `sl`.

**7. Builtin calls resolve through the interpreter.** A builtin call (`$add_map`,
`$find_map`, a script's own `$print_*`) is routed through `Runner.Interp.eval_func`,
which walks the tower level by level and re-enters itself at each hop — so a builtin
owned two levels down is reached transitively, not by a single hop that only works
for a two-level tower.

**8. The meta-cache under `ML_mode`.** It hashes a call's argument values as keys; a
native argument tree must be marshalled to a real `Value.t` first (identity under
`V_value`). Because that marshal costs more than recomputing, `init_mode` turns the
meta-cache off under `ML_mode` and keeps it for the interpreted modes.

## Verification

The debug instruction (`-- debug`) prints under `ML_mode`, which is how the tower
runs were checked. On `spectec-boot-comp`:

- `il-comp.json` (boot `spec-meta/il` compiled, P4 target interpreted) on
  `action-bind.p4` and `action-synth.p4` — both run to `passed`, matching the
  interpreted tower.
- `il-il-comp.json` (two compiled meta levels) on `action-bind.p4` — the builtin
  relay reaches two levels down and runs without fault.

`make test-fast` — the interpreted `IL`/`SL` paths are unchanged.