### PR TITLE
IL interpreter perf: defer failtrace message construction until rendered

### DIFF
--- a/p4spec/lib/interp/interp-al/backtrack.ml
+++ b/p4spec/lib/interp/interp-al/backtrack.ml
@@ -12,23 +12,19 @@ type 'a backtrack =
 (* Backtracing *)
 
 let back_err (at : region) (msg : string) : 'a backtrack =
-  Err [ Failtrace (at, msg, []) ]
+  Err [ Failtrace (at, (fun () -> msg), []) ]
 
 let back_unmatch_silent : 'a backtrack = Unmatch []
 
 let back_unmatch (at : region) (msg : string) : 'a backtrack =
-  Unmatch [ Failtrace (at, msg, []) ]
+  Unmatch [ Failtrace (at, (fun () -> msg), []) ]
 
-let back_nest (at : region) (msg : string) (backtrack : 'a backtrack) :
+let back_nest (at : region) (msg : unit -> string) (backtrack : 'a backtrack) :
     'a backtrack =
   match backtrack with
   | Ok a -> Ok a
-  | Err failtraces ->
-      let failtrace = Failtrace (at, msg, failtraces) in
-      Err [ failtrace ]
-  | Unmatch failtraces ->
-      let failtrace = Failtrace (at, msg, failtraces) in
-      Unmatch [ failtrace ]
+  | Err failtraces -> Err [ Failtrace (at, msg, failtraces) ]
+  | Unmatch failtraces -> Unmatch [ Failtrace (at, msg, failtraces) ]
 
 (* Check *)
 

--- a/p4spec/lib/interp/interp-al/interp.ml
+++ b/p4spec/lib/interp/interp-al/interp.ml
@@ -1113,7 +1113,8 @@ module Make (Interface : Run.INTERFACE) (Extern : Run.EXTERN) () :
     | Err _ as backtrack -> backtrack
     | Unmatch _ as backtrack ->
         backtrack
-        |> back_nest id.at (F.asprintf "condition hold %s was not met" id.it)
+        |> back_nest id.at (fun () ->
+               F.asprintf "condition hold %s was not met" id.it)
 
   (* If-not-hold premise evaluation *)
 
@@ -1293,7 +1294,8 @@ module Make (Interface : Run.INTERFACE) (Extern : Run.EXTERN) () :
     in
     Hook.on_rel_exit id;
     result
-    |> back_nest id.at (F.asprintf "invocation of relation %s failed" id.it)
+    |> back_nest id.at (fun () ->
+           F.asprintf "invocation of relation %s failed" id.it)
 
   and invoke_extern_rel (ctx : Ctx.t) (id : id) (nottyp : nottyp)
       (inputs : Hints.Input.t) (values_input : value list) :
@@ -1333,9 +1335,9 @@ module Make (Interface : Run.INTERFACE) (Extern : Run.EXTERN) () :
       let id_rulepath, prems, exps_output = rulepath in
       do_backtrack_rulepath_inner ctx id_rulegroup rulematch id_rulepath prems
         exps_output ()
-      |> back_nest id.at
-           (F.asprintf "application of rule %s/%s/%s failed" id.it
-              id_rulegroup.it id_rulepath.it)
+      |> back_nest id.at (fun () ->
+             F.asprintf "application of rule %s/%s/%s failed" id.it
+               id_rulegroup.it id_rulepath.it)
     in
     (* Backtrack a rule group *)
     let do_backtrack_rulegroup (ctx : Ctx.t) (rulegroup : rulegroup) :
@@ -1424,10 +1426,10 @@ module Make (Interface : Run.INTERFACE) (Extern : Run.EXTERN) () :
     in
     Hook.on_func_exit id;
     result
-    |> back_nest id.at
-         (F.asprintf "invocation of function %s%s failed"
-            (Il.Print.string_of_defid id)
-            (Il.Print.string_of_targs targs))
+    |> back_nest id.at (fun () ->
+           F.asprintf "invocation of function %s%s failed"
+             (Il.Print.string_of_defid id)
+             (Il.Print.string_of_targs targs))
 
   and invoke_func_body (ctx : Ctx.t) (id : id) (func : Func.t)
       (targs : targ list) (values_input : value list) : value backtrack =
@@ -1493,9 +1495,9 @@ module Make (Interface : Run.INTERFACE) (Extern : Run.EXTERN) () :
              in
              (* Try evaluating the row *)
              backtrack_tablerow' ctx_local prems exp_output
-             |> back_nest id.at
-                  (F.asprintf "application of table row %s%s failed" id.it
-                     (Il.Print.string_of_args args_input))
+             |> back_nest id.at (fun () ->
+                    F.asprintf "application of table row %s%s failed" id.it
+                      (Il.Print.string_of_args args_input))
            in
            backtrack_tablerow)
     |> choose_sequential
@@ -1543,11 +1545,11 @@ module Make (Interface : Run.INTERFACE) (Extern : Run.EXTERN) () :
         unit -> value backtrack =
      fun () ->
       do_backtrack_clause_inner ctx idx_clause clause ()
-      |> back_nest id.at
-           (F.asprintf "application of clause %s%s failed" id.it
-              (Il.Print.string_of_args
-                 (let args_input, _, _ = clause.it in
-                  args_input)))
+      |> back_nest id.at (fun () ->
+             F.asprintf "application of clause %s%s failed" id.it
+               (Il.Print.string_of_args
+                  (let args_input, _, _ = clause.it in
+                   args_input)))
     in
     let idxs_clause = clauses |> List.mapi (fun idx _ -> idx) in
     let backtracks_clause =

--- a/p4spec/lib/interp/interp-common/backtrace.ml
+++ b/p4spec/lib/interp/interp-common/backtrace.ml
@@ -16,7 +16,7 @@ let back_failtraces (backtrace : backtrace) : failtrace list =
     | [] -> []
     | (at, msg) :: traces_t ->
         let failtraces = back_failtraces traces_t in
-        [ Failtrace (at, msg (), failtraces) ]
+        [ Failtrace (at, msg, failtraces) ]
   in
   match backtrace with Err traces | Unmatch traces -> back_failtraces traces
 

--- a/p4spec/lib/util/attempt.ml
+++ b/p4spec/lib/util/attempt.ml
@@ -2,7 +2,7 @@ open Source
 
 (* Backtracking *)
 
-type failtrace = Failtrace of region * string * failtrace list
+type failtrace = Failtrace of region * (unit -> string) * failtrace list
 type 'a attempt = Ok of 'a | Fail of failtrace list
 
 (* Failures *)
@@ -13,7 +13,7 @@ let rec depth_of (failtrace : failtrace) : int =
   depth_sub + 1
 
 let fail (at : region) (msg : string) : 'a attempt =
-  Fail [ Failtrace (at, msg, []) ]
+  Fail [ Failtrace (at, (fun () -> msg), []) ]
 
 let fail_silent : 'a attempt = Fail []
 
@@ -34,13 +34,14 @@ let rec choose_sequential = function
 let nest at msg attempt =
   match attempt with
   | Ok a -> Ok a
-  | Fail failtraces -> Fail [ Failtrace (at, msg, failtraces) ]
+  | Fail failtraces -> Fail [ Failtrace (at, (fun () -> msg), failtraces) ]
 
 (* Error with backfailtraces *)
 
 let rec string_of_failtrace ?(indent = "") ?(level = 0) ~(last : bool)
     ~(limit : int) ~(bullet : string) (failtrace : failtrace) : string =
   let (Failtrace (region, msg, failtraces_sub)) = failtrace in
+  let msg = msg () in
   let root = level = 0 in
   let root_limit = level = limit in
   let sfailtrace =

--- a/p4spec/test/run/run_neg_pl.expected
+++ b/p4spec/test/run/run_neg_pl.expected
@@ -26,7 +26,7 @@ Excluding file: ../../../p4c/testdata/p4_16_errors/actions-with-duplicate-contro
 Excluding file: ../../../p4c/testdata/p4_16_errors/annotation.p4
 
 >>> Running interpreter test (Program_ok) on ../../../p4c/testdata/p4_16_errors/array4.p4
-Error on run: ../../../p4c/testdata/p4_16_errors/array4.p4
+Excluding file: ../../../p4c/testdata/p4_16_errors/array4.p4
 
 >>> Running interpreter test (Program_ok) on ../../../p4c/testdata/p4_16_errors/assign.p4
 Error on run: ../../../p4c/testdata/p4_16_errors/assign.p4
@@ -1693,6 +1693,6 @@ Error on run: ../../../p4c/testdata/p4_16_errors/width_e.p4
 >>> Running interpreter test (Program_ok) on ../../../p4c/testdata/p4_16_errors/wrong-cast.p4
 Error on run: ../../../p4c/testdata/p4_16_errors/wrong-cast.p4
 
-Running interpreter test (Program_ok): [EXCLUDE] 43/564 (7.62%) [PASS] 4/564 (0.71%) [FAIL] 517/564 (91.67%) [PATCH] 0/564 (0.00%)
+Running interpreter test (Program_ok): [EXCLUDE] 44/564 (7.80%) [PASS] 4/564 (0.71%) [FAIL] 516/564 (91.49%) [PATCH] 0/564 (0.00%)
 
 Running interpreter test (Program_ok): [PATCH]: [EXCLUDE] 0/0 (0.00%) [PASS] 0/0 (0.00%) [FAIL] 0/0 (0.00%)

--- a/p4spec/test/run/run_pos_pl.expected
+++ b/p4spec/test/run/run_pos_pl.expected
@@ -125,16 +125,16 @@ Run success: ../../../p4c/testdata/p4_16_samples/arith5-bmv2.p4
 Run success: ../../../p4c/testdata/p4_16_samples/array-copy-bmv2.p4
 
 >>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/array1.p4
-Excluding file: ../../../p4c/testdata/p4_16_samples/array1.p4
+Run success: ../../../p4c/testdata/p4_16_samples/array1.p4
 
 >>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/array2.p4
 Excluding file: ../../../p4c/testdata/p4_16_samples/array2.p4
 
 >>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/array3.p4
-Excluding file: ../../../p4c/testdata/p4_16_samples/array3.p4
+Run success: ../../../p4c/testdata/p4_16_samples/array3.p4
 
 >>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/array5.p4
-Excluding file: ../../../p4c/testdata/p4_16_samples/array5.p4
+Run success: ../../../p4c/testdata/p4_16_samples/array5.p4
 
 >>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/array_field.p4
 Run success: ../../../p4c/testdata/p4_16_samples/array_field.p4
@@ -2195,10 +2195,10 @@ Run success: ../../../p4c/testdata/p4_16_samples/issue5331-explicit-cast-overflo
 Run success: ../../../p4c/testdata/p4_16_samples/issue5331_srcinfo.p4
 
 >>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/issue5335_default_initialized_non_header_stack.p4
-Excluding file: ../../../p4c/testdata/p4_16_samples/issue5335_default_initialized_non_header_stack.p4
+Run success: ../../../p4c/testdata/p4_16_samples/issue5335_default_initialized_non_header_stack.p4
 
 >>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/issue5335_default_initialized_non_header_stack_nested.p4
-Excluding file: ../../../p4c/testdata/p4_16_samples/issue5335_default_initialized_non_header_stack_nested.p4
+Run success: ../../../p4c/testdata/p4_16_samples/issue5335_default_initialized_non_header_stack_nested.p4
 
 >>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/issue561-1-bmv2.p4
 Run success: ../../../p4c/testdata/p4_16_samples/issue561-1-bmv2.p4
@@ -3922,6 +3922,6 @@ Run success: ../../../p4c/testdata/p4_16_samples/xdp_vlan_push_pop_ebpf-kernel.p
 >>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/xor_test.p4
 Run success: ../../../p4c/testdata/p4_16_samples/xor_test.p4
 
-Running interpreter test (Program_inst): [EXCLUDE] 69/1307 (5.28%) [PASS] 1238/1307 (94.72%) [FAIL] 0/1307 (0.00%) [PATCH] 0/1307 (0.00%)
+Running interpreter test (Program_inst): [EXCLUDE] 64/1307 (4.90%) [PASS] 1243/1307 (95.10%) [FAIL] 0/1307 (0.00%) [PATCH] 0/1307 (0.00%)
 
 Running interpreter test (Program_inst): [PATCH]: [EXCLUDE] 0/0 (0.00%) [PASS] 0/0 (0.00%) [FAIL] 0/0 (0.00%)


### PR DESCRIPTION
Defers interpreter error-message construction, extending commit 420320d5 (which covered SL/PL) to the IL/AL interpreter, which had its own backtrack module.

Rule-match backtracking uses `Unmatch`/`Fail` as ordinary control flow on the hot path. Every frame it unwinds through eagerly ran `F.asprintf` + `string_of_*` to build a trace message that, on the success path, is discarded unread.

Made the message a thunk in the shared `failtrace` type, forced only when a failtrace is actually rendered:

```diff
-type failtrace = Failtrace of region * string * failtrace list
+type failtrace = Failtrace of region * (unit -> string) * failtrace list
```

Forced once at render time:

```ocaml
let (Failtrace (region, msg, failtraces_sub)) = failtrace in
let msg = msg () in
```

`fail`/`nest` keep their `string` signatures (wrap the thunk internally), so the ~36 elab/algo call sites are unchanged. Sites that want the deferral pass a thunk to the constructor — e.g. the IL/AL `back_nest` frames:

```diff
-    |> back_nest id.at (F.asprintf "invocation of relation %s failed" id.it)
+    |> back_nest id.at (fun () ->
+           F.asprintf "invocation of relation %s failed" id.it)
```

The SL/PL shared `back_failtraces` now threads the thunk through instead of forcing it.

## Test

`make build` green. `test-speclang`, `test-run-al`, `test-run-sl` pass; diagnostics unchanged. The two `run_pos_pl`/`run_neg_pl` baseline updates are a pre-existing exclude-list drift on `concrete` (reproduces with these changes stashed), not from this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
