### PR TITLE
Fix SL higher-order function tail calls

### DIFF
--- a/p4spec/lib/interp/interp-sl/interp.ml
+++ b/p4spec/lib/interp/interp-sl/interp.ml
@@ -1847,7 +1847,8 @@ module Make (Interface : Run.INTERFACE) (Extern : Run.EXTERN) () :
       | Il.CallE (id, targs, args) when tail ->
           let targs = resolve_targs ctx targs in
           let values_args = eval_args ctx args in
-          Flow.Tailcall_func (id, targs, values_args)
+          if is_high_order_func values_args then Flow.Ret (invoke_func ctx id targs values_args)
+          else Flow.Tailcall_func (id, targs, values_args)
       | _ -> Flow.Ret (eval_exp ctx exp)
     with Backtrace (Unmatch traces) -> Flow.Cont traces
 


### PR DESCRIPTION
## Summary

This PR fixes a bug in the SL interpreter where tail-call optimization could drop local function aliases passed through higher-order `def` parameters.

The issue shows up when a function receives another function as a `def` parameter and then performs a tail call while passing that local function alias onward.

For example:

```watsup
dec $fold_left<X, Y>(def $f(X, Y) : X, X, Y*) : X
def $fold_left<X, Y>(def $f, X, eps) = X
def $fold_left<X, Y>(def $f, X, Y_h :: Y_t*) = $fold_left<X, Y>(def $f, $f(X, Y_h), Y_t*)
```

Here, `$f` is bound in the local function environment of `$fold_left`. Previously, the recursive call in tail position was converted to `Tailcall_func(id, targs, values)` unconditionally. That tail-call payload only preserves the callee id, type arguments, and evaluated argument values; it does not preserve the current local function environment. As a result, when the next call tried to bind `def $f` from `FuncV f`, lookup happened in the outer context rather than the previous $fold_left local context, and failed with:

```text
function `f` is undefined
```

## Fix 

The SL interpreter now keeps ordinary tail-call optimization for first-order calls, but avoids it when the evaluated argument list contains a function value (`FuncV`). In that higher-order case, the call is evaluated normally in the current context so local function aliases remain available.

Concretely:
```OCaml
if is_high_order_func values_args then Flow.Ret (invoke_func ctx id targs values_args)
else Flow.Tailcall_func (id, targs, values_args)
```
This keeps the change narrow: first-order tail-recursive calls still use `Tailcall_func`, while higher-order calls that depend on local function aliases preserve the caller context.