### PR TITLE
Preserve local function aliases in SL tail calls

### DIFF
--- a/p4spec/lib/interp/interp-sl/interp.ml
+++ b/p4spec/lib/interp/interp-sl/interp.ml
@@ -1847,7 +1847,8 @@ module Make (Interface : Run.INTERFACE) (Extern : Run.EXTERN) () :
       | Il.CallE (id, targs, args) when tail ->
           let targs = resolve_targs ctx targs in
           let values_args = eval_args ctx args in
-          if is_high_order_func values_args then Flow.Ret (invoke_func ctx id targs values_args)
+          if is_local_func ctx id || is_high_order_func values_args then
+            Flow.Ret (invoke_func ctx id targs values_args)
           else Flow.Tailcall_func (id, targs, values_args)
       | _ -> Flow.Ret (eval_exp ctx exp)
     with Backtrace (Unmatch traces) -> Flow.Cont traces
@@ -1984,6 +1985,10 @@ module Make (Interface : Run.INTERFACE) (Extern : Run.EXTERN) () :
       (fun value_input ->
         match value_input.it with Il.FuncV _ -> true | _ -> false)
       values_input
+
+  and is_local_func (ctx : Ctx.t) (id : id) : bool =
+    let cursor, _ = Ctx.find_func ctx id in
+    cursor = Ctx.Local
 
   and invoke_func ?(internal : bool = true) (ctx : Ctx.t) (id : id)
       (targs : targ list) (values_input : value list) : value =


### PR DESCRIPTION
## Summary

This is a follow-up to the higher-order tail-call fix.

The previous patch preserves the current SL context when a tail-position
call receives a function value (`FuncV`) as an argument. This fixes calls
such as `$fold_left(def $f, ...)`, but it does not cover calls where the
callee itself is a local function alias.

For example:

```watsup
dec $subst_heaptype<X>(
  X,
  def $s(typevar, X) : heaptype,
  heaptype
) : heaptype

def $subst_heaptype<X>(X, def $s, ht) = $s(tv, X)
  -- if ht = VarHT tv
```

At runtime, a function such as `$subst_of` is passed as `def $s` and
registered under `s` in `$subst_heaptype`'s local function environment.

## Root Cause

A tail call does not have to be recursive. `$s(tv, X)` is a tail call
because its result is returned directly, even though `$s` itself is not
recursive.

The SL interpreter represents a deferred tail call as:

```ocaml
Tailcall_func of id * targ list * value list
```

This carries only the callee ID and arguments, not the callee function
object or its local environment.

The previous guard only inspected the evaluated arguments:

```ocaml
if is_high_order_func values_args then
  Flow.Ret (invoke_func ctx id targs values_args)
else
  Flow.Tailcall_func (id, targs, values_args)
```

For `$s(tv, X)`, neither argument is a `FuncV`, so the call was converted
to:

```text
Tailcall_func("s", ..., [tv, X])
```

This defers the actual call until after `$subst_heaptype`'s local frame
has been unwound. The tail-call loop then resolves `s` again using its
captured outer context. Since `s` only existed in the discarded local
function environment and is not a global function name, lookup failed
with:

```text
function `s` is undefined
```

## Fix

Skip the tail-call loop when either the callee is local or the evaluated
arguments contain a function value:

```ocaml
if is_local_func ctx id || is_high_order_func values_args then
  Flow.Ret (invoke_func ctx id targs values_args)
else
  Flow.Tailcall_func (id, targs, values_args)
```

This invokes local function aliases while their defining context is
still available. Global first-order tail calls continue to use the
existing tail-call optimization.