### PR TITLE
Avoid variable capture in structuring substitution

### DIFF
--- a/p4spec/lib/pass/structure/re/renamer.ml
+++ b/p4spec/lib/pass/structure/re/renamer.ml
@@ -23,6 +23,31 @@ let add (id : Id.t) (id_renamed : Id.t) (renamer : t) : t =
 let of_list (pairs : (Id.t * Id.t) list) : t = Rename.of_list pairs
 let filter (p : Id.t -> 'a -> bool) (renamer : t) : t = Rename.filter p renamer
 
+(* Capture avoidance *)
+
+let freshen_binders (renamer : t) (frees : IdSet.t) (block : block) : t =
+  let ids_collide =
+    renamer |> values
+    |> List.filter (fun id -> IdSet.mem id frees)
+    |> IdSet.of_list
+  in
+  let ids_avoid =
+    frees
+    |> IdSet.union (Ol.Free.free_block block)
+    |> IdSet.union (dom renamer)
+    |> IdSet.union (IdSet.of_list (values renamer))
+  in
+  let fresher, _ =
+    IdSet.fold
+      (fun id (fresher, ids_avoid) ->
+        let id_fresh = Il.Fresh.id ids_avoid id in
+        let fresher = add id id_fresh fresher in
+        let ids_avoid = IdSet.add id_fresh ids_avoid in
+        (fresher, ids_avoid))
+      ids_collide (empty, ids_avoid)
+  in
+  fresher
+
 (* Renaming *)
 
 (* Expressions *)
@@ -215,6 +240,9 @@ and rename_instr (renamer : t) (instr : instr) : instr =
       let exp_r = rename_exp renamer exp_r in
       let frees_l = Ol.Free.free_exp exp_l in
       let renamer = filter (fun id _ -> not (IdSet.mem id frees_l)) renamer in
+      let freshen = freshen_binders renamer frees_l block in
+      let exp_l = rename_exp freshen exp_l in
+      let renamer = Rename.fold add freshen renamer in
       let iterinstrs = rename_iterinstrs_bound renamer iterinstrs in
       let block = rename_block renamer block in
       LetI (exp_l, exp_r, iterinstrs, block) $ at
@@ -226,6 +254,9 @@ and rename_instr (renamer : t) (instr : instr) : instr =
       let renamer =
         filter (fun id _ -> not (IdSet.mem id frees_output)) renamer
       in
+      let freshen = freshen_binders renamer frees_output block in
+      let exps_output = rename_exps freshen exps_output in
+      let renamer = Rename.fold add freshen renamer in
       let exps = Hints.Input.combine inputs exps_input exps_output in
       let iterinstrs = rename_iterinstrs_bound renamer iterinstrs in
       let block = rename_block renamer block in

--- a/p4spec/lib/pass/structure/re/replacer.ml
+++ b/p4spec/lib/pass/structure/re/replacer.ml
@@ -26,6 +26,32 @@ let add (id : Id.t) (exp : Exp.t) (replacer : t) : t =
 let filter (p : Id.t -> 'a -> bool) (replacer : t) : t =
   Replace.filter p replacer
 
+(* Capture avoidance *)
+
+let freshen_binders (replacer : t) (frees : IdSet.t) (block : block) : Renamer.t
+    =
+  let ids_codom =
+    replacer |> Replace.values |> List.map Ol.Free.free_exp
+    |> List.fold_left IdSet.union IdSet.empty
+  in
+  let ids_collide = IdSet.inter frees ids_codom in
+  let ids_avoid =
+    frees
+    |> IdSet.union (Ol.Free.free_block block)
+    |> IdSet.union (dom replacer)
+    |> IdSet.union ids_codom
+  in
+  let fresher, _ =
+    IdSet.fold
+      (fun id (fresher, ids_avoid) ->
+        let id_fresh = Il.Fresh.id ids_avoid id in
+        let fresher = Renamer.add id id_fresh fresher in
+        let ids_avoid = IdSet.add id_fresh ids_avoid in
+        (fresher, ids_avoid))
+      ids_collide (Renamer.empty, ids_avoid)
+  in
+  fresher
+
 (* Replacement *)
 
 (* Expressions *)
@@ -210,6 +236,10 @@ and replace_instr (replacer : t) (instr : instr) : instr =
   | LetI (exp_l, exp_r, iterinstrs, block) ->
       let frees_l = Ol.Free.free_exp exp_l in
       let replacer = filter (fun id _ -> not (IdSet.mem id frees_l)) replacer in
+      let freshen = freshen_binders replacer frees_l block in
+      let exp_l = Renamer.rename_exp freshen exp_l in
+      let iterinstrs = Renamer.rename_iterinstrs_bound freshen iterinstrs in
+      let block = Renamer.rename_block freshen block in
       let exp_r = replace_exp replacer exp_r in
       let iterinstrs = replace_iterinstrs_bound replacer iterinstrs in
       let block = replace_block replacer block in
@@ -222,6 +252,10 @@ and replace_instr (replacer : t) (instr : instr) : instr =
       let replacer =
         filter (fun id _ -> not (IdSet.mem id frees_output)) replacer
       in
+      let freshen = freshen_binders replacer frees_output block in
+      let exps_output = Renamer.rename_exps freshen exps_output in
+      let iterinstrs = Renamer.rename_iterinstrs_bound freshen iterinstrs in
+      let block = Renamer.rename_block freshen block in
       let exps = Hints.Input.combine inputs exps_input exps_output in
       let iterinstrs = replace_iterinstrs_bound replacer iterinstrs in
       let block = replace_block replacer block in


### PR DESCRIPTION
Originally reported by @sanguineman, thanks!

## Summary

`Renamer` and `Replacer` perform variable substitution over structured blocks, but did not avoid capture. When the name a variable is substituted to coincides with a binder inside the substitution scope, the substituted variable is captured by that inner binder.

Substituting `a -> x` into:

```
Let x = e
  Return a
```

produced:

```
Let x = e
  Return x    ; x now refers to the inner Let, not the intended outer x
```

## Root Cause

`rename_instr`/`replace_instr` filtered the substitution map only on the domain (source) side, to stop substituting once a binder shadows a source variable:

```ocaml
let renamer = filter (fun id _ -> not (IdSet.mem id frees_l)) renamer in
```

Nothing handled the codomain (target) side. When a mapping `a -> x` was carried into a block that binds `x`, the substitution was applied as-is and `a` landed on the inner `x`.

This is latent in `$reduce_serenum_binary`: the left cast used the right operand's compile-time-known-ness because the left `ctk` binder was captured.

```diff
  1. (Let (_expressionIR  `# (`( typeIR_l ctk  ))) be typedExpressionIR_l)
  1. (Let (_expressionIR' `# (`( typeIR_r _ctk ))) be typedExpressionIR_r)
     ...
-  1. (Let typedExpressionIR_l_cast be (... `# (`( typeIR_l_underlying _ctk ))))
+  1. (Let typedExpressionIR_l_cast be (... `# (`( typeIR_l_underlying ctk  ))))
```

## Fix

Before descending into a binder, freshen any binder whose name collides with the substitution codomain, rename that binder's own occurrences to the fresh name, and keep the mapping pointed at the outer variable. The substituted variable then lands on the outer binding.

```
Let x' = e
  Return x    ; a -> x lands on the outer x; the inner binder is x'
```

Fresh names go through `Il.Fresh`, so they are the original name with appended primes (`x`, `x'`, `x''`), avoiding the free variables of the block, the map domain, and the map codomain.

```ocaml
let freshen_binders (renamer : t) (frees : IdSet.t) (block : block) : t =
  let ids_collide =
    renamer |> values
    |> List.filter (fun id -> IdSet.mem id frees)
    |> IdSet.of_list
  in
  let ids_avoid =
    frees
    |> IdSet.union (Ol.Free.free_block block)
    |> IdSet.union (dom renamer)
    |> IdSet.union (IdSet.of_list (values renamer))
  in
  ... IdSet.fold (fun id ... -> add id (Il.Fresh.id ids_avoid id) ...) ids_collide ...
```

At each `LetI`/`RuleI` the freshening is applied to the binder and composed into the map used for the body:

```ocaml
let freshen = freshen_binders renamer frees_l block in
let exp_l = rename_exp freshen exp_l in
let renamer = Rename.fold add freshen renamer in
```

`Replacer` maps identifiers to expressions, so its codomain is the union of the free variables of the replacement expressions. Binder freshening is delegated to `Renamer` (an identifier-to-identifier renaming), which preserves the type annotations on the renamed occurrences.

The domain-side filter is unchanged: substitution still stops when a source variable is shadowed.
