### PR TITLE
Remove menhir conflicts and warnings from the parsers

### DIFF
--- a/p4spec/lib/frontend/parser.mly
+++ b/p4spec/lib/frontend/parser.mly
@@ -194,7 +194,7 @@ hintid : id { $1 }
 
 synid :
   | varid { ($1, []) }
-  | varid_langle_bind enter_scope comma_list(tparam) exit_scope RANGLE { ($1, $3) }
+  | varid_langle_bind enter_scope comma_list(tparam) RANGLE exit_scope { ($1, $3) }
 
 (* Atoms *)
 

--- a/p4spec/lib/frontend/parser.mly
+++ b/p4spec/lib/frontend/parser.mly
@@ -92,7 +92,7 @@ let exit_scope () = vars := List.hd !scopes; scopes := List.tl !scopes
 %nonassoc TURNSTILE
 %nonassoc TILESTURN
 %right SQARROW SQARROW_STAR
-%left COLON SUB TILDE2
+%left COLON COLON_EQ SUB TILDE2
 %right EQ NEQ LANGLE RANGLE LANGLE_EQ RANGLE_EQ LANGLE_DASH
 %right COLON2
 %right ARROW ARROW_SUB

--- a/p4spec/lib/frontend/parser.mly
+++ b/p4spec/lib/frontend/parser.mly
@@ -745,8 +745,9 @@ rule_ :
 
 rules :
   | (* empty *) { [] }
+  | NL2 rules { $2 }
   | NL3 rules { $2 }
-  | NL2* rule NL2* rules { $2 :: $4 }
+  | rule rules { $1 :: $2 }
 
 (* Definitions *)
 

--- a/p4spec/lib/interface/p4/parser.mly
+++ b/p4spec/lib/interface/p4/parser.mly
@@ -183,7 +183,7 @@
   (* >>>> Parser Declarations *)
   parserBlockElementStatement parserBlockElementStatementList parserBlockStatement 
   parserConditionalStatement
-  parserStatement parserStatementList parserState
+  parserStatement parserState
   parserStateList parserLocalDeclaration parserLocalDeclarationList parserDeclaration
   (* >> Control statements and declarations *)
   (* >>>> Table declarations *) constOpt
@@ -662,7 +662,7 @@ namedExpressionList:
 ;
 
 %inline memberAccessExpression:
-	| e = memberAccessBase DOT set_parent_namespace m = member clear_parent_namespace %prec DOT
+	| e = memberAccessBase DOT set_parent_namespace m = member clear_parent_namespace
 		{ "memberAccessBase `. member" <| [ e; m ] <<| "memberAccessExpression" <<<| (at $sloc) }
 ;
 
@@ -691,7 +691,7 @@ namedExpressionList:
 ;
 
 %inline memberAccessExpressionNonBrace:
-	| e = memberAccessBaseNonBrace DOT set_parent_namespace m = member clear_parent_namespace %prec DOT
+	| e = memberAccessBaseNonBrace DOT set_parent_namespace m = member clear_parent_namespace
 		{ "memberAccessBaseNonBrace `. member" <| [ e; m ] <<| "memberAccessExpressionNonBrace" <<<| (at $sloc) }
 ;
 
@@ -936,7 +936,7 @@ argumentList:
 lvalue:
 	| e = referenceExpression
     { e }
-	| lv = lvalue DOT set_parent_namespace m = member clear_parent_namespace %prec DOT
+	| lv = lvalue DOT set_parent_namespace m = member clear_parent_namespace
 		{ "lvalue `. member" <| [ lv; m ] <<| "lvalue" <<<| (at $sloc) }
 	| lv = lvalue L_BRACKET i = expression R_BRACKET
 		{ "lvalue `[ expression ]" <| [ lv; i ] <<| "lvalue" <<<| (at $sloc) }
@@ -1447,13 +1447,6 @@ parserStatement:
   | s = parserBlockStatement
   | s = parserConditionalStatement
     { s }
-;
-
-parserStatementList:
-  | (* empty *)
-    { "`EMPTY" <| [] <<| "parserStatementList" <<<| (at $sloc) }
-  | sl = parserStatementList s = parserStatement
-    { "parserStatementList parserStatement" <| [ sl; s ] <<| "parserStatementList" <<<| (at $sloc) }
 ;
 
 parserState:

--- a/p4spec/lib/interface/p4/parser.mly
+++ b/p4spec/lib/interface/p4/parser.mly
@@ -1088,7 +1088,7 @@ forStatement:
     t = typeRef n = name IN e = forCollectionExpression R_PAREN b = statement
     { "annotationList FOR `( typeRef name IN forCollectionExpression ) statement" <| [ al; t; n; e; b ] <<| "forStatement" <<<| (at $sloc) }
   | al = annotationList FOR L_PAREN
-    al_in = annotationList t = typeRef n = name IN e = forCollectionExpression R_PAREN b = statement
+    al_in = annotationListNonEmpty t = typeRef n = name IN e = forCollectionExpression R_PAREN b = statement
     { "annotationList FOR `( annotationList typeRef name IN forCollectionExpression ) statement" <| [ al; al_in; t; n; e; b ] <<| "forStatement" <<<| (at $sloc) }
 ;
 


### PR DESCRIPTION
## Summary

A fresh build emitted menhir conflict and warning messages from two grammars:

```
p4spec/lib/frontend/parser.mly:
  Warning: 31 states have shift/reduce conflicts.
  Warning: 55 shift/reduce conflicts were arbitrarily resolved.

p4spec/lib/interface/p4/parser.mly:
  Warning: 2 states have reduce/reduce conflicts.
  Warning: 68 reduce/reduce conflicts were arbitrarily resolved.
  Warning: symbol parserStatementList is unreachable from any of the start symbol(s).
  Warning: this %prec declaration is never useful. (x3)
```

Each was a real grammar defect (missing precedence, misplaced scope marker, ambiguous list, a production duplicated through a nullable list) or dead grammar text. This PR removes all of them. After the change both grammars, and `stf/parser.mly`, build with no menhir warnings.

No accepted language changes except one for-in case (below) that is realigned to the surface spec and to `p4c`. `make build`, `elab spec`, and `make test-fast` (`speclang`, `p4parse`, `run-sl`, `sim-sl`) pass with no test-expectation changes.

The two grammars are independent, so the fixes are split into separate commits.

---

## `frontend/parser.mly` (spec DSL) — 31 states, 55 conflicts → 0

### 1. `COLON_EQ` has no precedence (24 conflicts)

`typ_rel_` uses `relop` both as a prefix and as an infix operator:

```ocaml
typ_rel_ :
  | typ_bin_ { $1 }
  | relop typ_rel            (* prefix *)
  | typ_rel relop typ_rel    (* infix  *)
```

`relop` is `%inline`, so each production inherits the precedence of its terminal. Every relop terminal is declared in the precedence table except `COLON_EQ` (`:=`), so menhir cannot order shift against reduce for it — e.g. in state 188, reduce `typ_rel_ -> TURNSTILE typ_rel` versus shift `COLON_EQ`. `COLON_EQ` is used only in `relop`, so declaring its precedence affects nothing else.

```diff
-%left COLON SUB TILDE2
+%left COLON COLON_EQ SUB TILDE2
```

### 2. `synid` closes its scope before `RANGLE` (1 conflict)

`synid` and the parametric `syntax` definition share the prefix
`varid_langle_bind enter_scope comma_list(tparam)`, then differ only in where `exit_scope` sits:

```ocaml
synid :
  | varid_langle_bind enter_scope comma_list(tparam) exit_scope RANGLE { ($1, $3) }
(* def_ *)
  | SYNTAX varid_langle_bind enter_scope comma_list(tparam) RANGLE hint* EQ deftyp exit_scope
```

`exit_scope` is empty, so on lookahead `RANGLE` the parser must choose between reducing the empty `exit_scope` (for `synid`) and shifting `RANGLE` (for the definition). The disambiguator (`EQ deftyp` vs comma/newline) only appears after `RANGLE`, so LR(1) cannot decide before it. `RANGLE` binds no variable, so exiting the scope after it is equivalent and lets both share a prefix; the choice then happens one token later.

```diff
-  | varid_langle_bind enter_scope comma_list(tparam) exit_scope RANGLE { ($1, $3) }
+  | varid_langle_bind enter_scope comma_list(tparam) RANGLE exit_scope { ($1, $3) }
```

### 3. `rules` has two adjacent nullable newline lists (2 conflicts)

```ocaml
rules :
  | (* empty *) { [] }
  | NL3 rules { $2 }
  | NL2* rule NL2* rules { $2 :: $4 }
```

The trailing `NL2*` and the leading `NL2*` of the recursive `rules` both accept the same `NL2` run, so menhir cannot decide which absorbs a separator. The `NL2*` values are discarded, so every split yields the same result. Consuming `NL2`/`NL3` one token at a time removes the adjacency:

```diff
 rules :
   | (* empty *) { [] }
-  | NL3 rules { $2 }
-  | NL2* rule NL2* rules { $2 :: $4 }
+  | NL2 rules { $2 }
+  | NL3 rules { $2 }
+  | rule rules { $1 :: $2 }
```

---

## `interface/p4/parser.mly` (P4 program parser) — 2 states, 68 conflicts + 4 warnings → 0

### 4. `for-in` wraps its inner annotations in a nullable list (68 conflicts)

The two `for-in` forms of `forStatement` differ only by an inner annotation list before `typeRef`:

```ocaml
forStatement:
  | annotationList FOR L_PAREN                       typeRef name IN forCollectionExpression R_PAREN statement
  | annotationList FOR L_PAREN annotationList        typeRef name IN forCollectionExpression R_PAREN statement
```

`annotationList` is nullable, so the second form with an empty inner list is identical to the first: two productions with the same right-hand side, giving reduce/reduce conflicts in states 853 and 873 and two never-reduced productions.

`p4c` uses the non-empty `annotations` in this position, and the surface spec already uses `annotationListNonEmpty`:

```
// spec/1-p4-surface/1-syntax.watsup
syntax forStatement =
  | ...
  | annotationList FOR `( type name IN forCollectionExpression ) statement
  | annotationList FOR `( annotationListNonEmpty type name IN forCollectionExpression ) statement
```

```
// p4c/frontends/parsers/p4/p4parser.ypp
| optAnnotations FOR "(" typeRef name IN forCollectionExpr ")" statement
| optAnnotations FOR "(" annotations typeRef name IN forCollectionExpr ")" statement   // annotations is non-empty
```

The parser had drifted to the nullable list. Matching the spec and `p4c` makes the two forms disjoint (`for (T x in c)` → first form; `for (@a T x in c)` → second form) and removes the duplication:

```diff
-    al_in = annotationList t = typeRef n = name IN e = forCollectionExpression R_PAREN b = statement
+    al_in = annotationListNonEmpty t = typeRef n = name IN e = forCollectionExpression R_PAREN b = statement
```

The node arity is unchanged, so `Value.t` construction is unchanged; both forms round-trip:

```
$ p4spectec parse spec -p forloop.p4       -i p4c/p4include -r   # for (bit<64> i in 1 .. 63)
Roundtrip successful
$ p4spectec parse spec -p forloop_anno.p4  -i p4c/p4include -r   # for (@name("i") bit<64> i in 1 .. 63)
Roundtrip successful
```

### 5. Dead rule and useless precedence (4 warnings)

`parserStatementList` is referenced by no production (parser bodies use `parserBlockElementStatementList`), so it is unreachable. The three `%prec DOT` annotations sit on member-access productions that have no conflict for the precedence to resolve. Removing either leaves the automaton unchanged.

```diff
-  | e = memberAccessBase DOT set_parent_namespace m = member clear_parent_namespace %prec DOT
+  | e = memberAccessBase DOT set_parent_namespace m = member clear_parent_namespace
```

```diff
-parserStatementList:
-  | (* empty *)
-    { "`EMPTY" <| [] <<| "parserStatementList" <<<| (at $sloc) }
-  | sl = parserStatementList s = parserStatement
-    { "parserStatementList parserStatement" <| [ sl; s ] <<| "parserStatementList" <<<| (at $sloc) }
-;
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
