### PR TITLE
Pin the opam switch in the make targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,24 +11,21 @@ EXEBOOT = _build/default/p4spec/bin/boot.exe
 build:
 	rm -f ./$(SPEC)
 	rm -f ./p4spec/lib/parsing/parser.ml ./p4spec/lib/parsing/parser.mli
-	opam switch 5.1.0
-	cd p4spec && opam exec -- dune build bin/main.exe && echo
+	cd p4spec && opam exec --switch=5.1.0 -- dune build bin/main.exe && echo
 	ln -f $(EXESPEC) ./$(SPEC)
-	cd p4spec && opam exec -- dune build test/lang/test.exe test/run/test.exe test/sim/test.exe test/parse/test.exe test/boot/test.exe && echo
+	cd p4spec && opam exec --switch=5.1.0 -- dune build test/lang/test.exe test/run/test.exe test/sim/test.exe test/parse/test.exe test/boot/test.exe && echo
 
 boot:
-	opam switch 5.1.0
-	cd p4spec && opam exec -- dune build bin/boot.exe && echo
+	cd p4spec && opam exec --switch=5.1.0 -- dune build bin/boot.exe && echo
 	ln -f $(EXEBOOT) ./$(BOOT)
-	cd p4spec && opam exec -- dune build test/lang/test.exe test/run/test.exe test/sim/test.exe test/parse/test.exe test/boot/test.exe && echo
+	cd p4spec && opam exec --switch=5.1.0 -- dune build test/lang/test.exe test/run/test.exe test/sim/test.exe test/parse/test.exe test/boot/test.exe && echo
 
 release:
 	rm -f ./$(SPEC)
 	rm -f ./p4spec/lib/parsing/parser.ml ./p4spec/lib/parsing/parser.mli
-	opam switch 5.1.0
-	cd p4spec && opam exec -- dune build --profile=release bin/main.exe && echo
+	cd p4spec && opam exec --switch=5.1.0 -- dune build --profile=release bin/main.exe && echo
 	ln -f $(EXESPEC) ./$(SPEC)
-	cd p4spec && opam exec -- dune build --profile=release bin/boot.exe && echo
+	cd p4spec && opam exec --switch=5.1.0 -- dune build --profile=release bin/boot.exe && echo
 	ln -f $(EXEBOOT) ./$(BOOT)
 
 # Spec
@@ -58,8 +55,7 @@ ilspec-html:
 .PHONY: fmt
 
 fmt:
-	opam switch 5.1.0
-	cd p4spec && opam exec dune fmt
+	cd p4spec && opam exec --switch=5.1.0 -- dune fmt
 
 # Tests
 
@@ -68,8 +64,7 @@ define dune-alias-test
 .PHONY: test-$(1)
 test-$(1):
 	echo "#### Running (dune build @$(1))"
-	opam switch 5.1.0
-	cd p4spec && opam exec -- dune build @$(1) --profile=release && echo OK || \
+	cd p4spec && opam exec --switch=5.1.0 -- dune build @$(1) --profile=release && echo OK || \
 	  (echo "####>" Failure running dune build @$(1). && \
 	   echo "####>" Run \`make promote\` to accept changes in test expectations. && false)
 endef
@@ -108,39 +103,34 @@ $(foreach a,$(DET_ALIASES),$(eval $(call dune-alias-test,$(a))))
 .PHONY: test-micro
 test-micro:
 	echo "#### Running (dune build @speclang @micro @micro-det)"
-	opam switch 5.1.0
-	cd p4spec && opam exec -- dune build @speclang @micro @micro-det --profile=release && echo OK || \
+	cd p4spec && opam exec --switch=5.1.0 -- dune build @speclang @micro @micro-det --profile=release && echo OK || \
 	  (echo "####>" Failure running dune build @speclang @micro @micro-det. && \
 	   echo "####>" Run \`make promote\` to accept changes in test expectations. && false)
 
 .PHONY: test-fast
 test-fast:
 	echo "#### Running fast tests (speclang, p4parse, run-sl, sim-sl)"
-	opam switch 5.1.0
-	cd p4spec && opam exec -- dune build @speclang @p4parse @run-sl @sim-sl --profile=release && echo OK || \
+	cd p4spec && opam exec --switch=5.1.0 -- dune build @speclang @p4parse @run-sl @sim-sl --profile=release && echo OK || \
 	  (echo "####>" Failure running fast tests. && \
 	   echo "####>" Run \`make promote\` to accept changes in test expectations. && false)
 
 .PHONY: test-all
 test-all:
 	echo "#### Running all tests (without -det)"
-	opam switch 5.1.0
-	cd p4spec && opam exec -- dune runtest test --profile=release && echo OK || \
+	cd p4spec && opam exec --switch=5.1.0 -- dune runtest test --profile=release && echo OK || \
 	  (echo "####>" Failure running dune test. && \
 	   echo "####>" Run \`make promote\` to accept changes in test expectations. && false)
 
 .PHONY: test-all-det
 test-all-det:
 	echo "#### Running all tests (with -det)"
-	opam switch 5.1.0
-	cd p4spec && opam exec -- dune build @speclang @p4parse @run-det @sim-al-det @sim-sl-det --profile=release && echo OK || \
+	cd p4spec && opam exec --switch=5.1.0 -- dune build @speclang @p4parse @run-det @sim-al-det @sim-sl-det --profile=release && echo OK || \
 	  (echo "####>" Failure running det tests. && \
 	   echo "####>" Run \`make promote\` to accept changes in test expectations. && false)
 
 .PHONY: promote
 promote:
-	opam switch 5.1.0
-	cd p4spec && opam exec -- dune promote
+	cd p4spec && opam exec --switch=5.1.0 -- dune promote
 
 # Cleanup
 
@@ -148,4 +138,4 @@ promote:
 
 clean:
 	rm -f ./$(SPEC)
-	cd p4spec && dune clean
+	cd p4spec && opam exec --switch=5.1.0 -- dune clean


### PR DESCRIPTION
## Motivation

When a machine has multiple opam switches, the make targets ran under whichever switch the caller has active. The current `Makefile` doesn't handle this correctly: the `opam exec` calls names no switch, so it uses the caller's active switch instead. The `opam switch 5.1.0` line preceding each command mutates opam's global default as a side effect, but does not override the active switch that `opam exec` resolves against. Thus, two switches with different package versions can lead to local builds failing while CI succeeds or vice versa, or formatting shift when the active switch has a different version of `ocamlformat`.

## Core Concept
Opam resolves the switch in the following precedence:
explicit `--switch` > active switch > global default
The active switch is established by `eval $(opam env)`, and the global is set by `opam switch <name>`.

Each opam invocation is pinned with `opam exec --switch=5.1.0`, and the standalone `opam switch 5.1.0` lines are removed. Now, `make fmt` and `make build` behave the same regardless of the caller's active switch. This has the added advantage of leaving the global default alone, which causes confusion when working with multiple switches. 

## Commit Log

- chore(make): pin the opam switch