### PR TITLE
Bump p4c to v1.2.5.16

### DIFF
--- a/excludes/static/p4-spec/pending/instance-array-declarator.exclude
+++ b/excludes/static/p4-spec/pending/instance-array-declarator.exclude
@@ -1,0 +1,1 @@
+p4c/testdata/p4_16_samples/generic-extern-inference.p4

--- a/excludes/static/p4-spec/pending/nonparenthesized-bit-int-width.exclude
+++ b/excludes/static/p4-spec/pending/nonparenthesized-bit-int-width.exclude
@@ -1,0 +1,2 @@
+p4c/testdata/p4_16_samples/bitexpr1.p4
+p4c/testdata/p4_16_samples/cfoldBitTypedefs.p4

--- a/excludes/static/p4c-specific/implicit/header-union-stack-nonconst-index.exclude
+++ b/excludes/static/p4c-specific/implicit/header-union-stack-nonconst-index.exclude
@@ -1,0 +1,1 @@
+p4c/testdata/p4_16_errors/issue5703_header_union_stack.p4

--- a/excludes/static/p4c-specific/implicit/v1model-version-check.exclude
+++ b/excludes/static/p4c-specific/implicit/v1model-version-check.exclude
@@ -1,0 +1,2 @@
+p4c/testdata/p4_16_errors/issue5296_invalid_version.p4
+p4c/testdata/p4_16_errors/issue5296_unknown_version.p4

--- a/p4spec/test/boot/boot_2_neg_sl.expected
+++ b/p4spec/test/boot/boot_2_neg_sl.expected
@@ -1,4 +1,4 @@
-Running boot test (Entry/Program_ok) on 577 files
+Running boot test (Entry/Program_ok) on 584 files
 
 
 >>> Running boot test (Entry/Program_ok) on ../../../p4c/testdata/p4_16_errors/accept_e.p4
@@ -1888,6 +1888,33 @@ load complete
 into call
 Error on run: ../../../p4c/testdata/p4_16_errors/functors3_e.p4
 
+>>> Running boot test (Entry/Program_ok) on ../../../p4c/testdata/p4_16_errors/generic-extern-inference-abstract_e.p4
+../../../spec-meta/al/6-entry.watsup:7.12-7.22: "entry-al"
+entry-al
+../../../spec-meta/al/6-entry.watsup:9.12-9.27: "load complete"
+load complete
+../../../spec-meta/al/6-entry.watsup:11.12-11.23: "into call"
+into call
+Error on run: ../../../p4c/testdata/p4_16_errors/generic-extern-inference-abstract_e.p4
+
+>>> Running boot test (Entry/Program_ok) on ../../../p4c/testdata/p4_16_errors/generic-extern-inference-typedef_e.p4
+../../../spec-meta/al/6-entry.watsup:7.12-7.22: "entry-al"
+entry-al
+../../../spec-meta/al/6-entry.watsup:9.12-9.27: "load complete"
+load complete
+../../../spec-meta/al/6-entry.watsup:11.12-11.23: "into call"
+into call
+Error on run: ../../../p4c/testdata/p4_16_errors/generic-extern-inference-typedef_e.p4
+
+>>> Running boot test (Entry/Program_ok) on ../../../p4c/testdata/p4_16_errors/generic-extern-inference_e.p4
+../../../spec-meta/al/6-entry.watsup:7.12-7.22: "entry-al"
+entry-al
+../../../spec-meta/al/6-entry.watsup:9.12-9.27: "load complete"
+load complete
+../../../spec-meta/al/6-entry.watsup:11.12-11.23: "into call"
+into call
+Error on run: ../../../p4c/testdata/p4_16_errors/generic-extern-inference_e.p4
+
 >>> Running boot test (Entry/Program_ok) on ../../../p4c/testdata/p4_16_errors/generic-struct-self-nested.p4
 ../../../spec-meta/al/6-entry.watsup:7.12-7.22: "entry-al"
 entry-al
@@ -2758,6 +2785,15 @@ Error on run: ../../../p4c/testdata/p4_16_errors/issue3282.p4
 >>> Running boot test (Entry/Program_ok) on ../../../p4c/testdata/p4_16_errors/issue3285.p4
 Error on run: ../../../p4c/testdata/p4_16_errors/issue3285.p4 (unknown)
 
+>>> Running boot test (Entry/Program_ok) on ../../../p4c/testdata/p4_16_errors/issue3291-1.p4
+../../../spec-meta/al/6-entry.watsup:7.12-7.22: "entry-al"
+entry-al
+../../../spec-meta/al/6-entry.watsup:9.12-9.27: "load complete"
+load complete
+../../../spec-meta/al/6-entry.watsup:11.12-11.23: "into call"
+into call
+Error on run: ../../../p4c/testdata/p4_16_errors/issue3291-1.p4
+
 >>> Running boot test (Entry/Program_ok) on ../../../p4c/testdata/p4_16_errors/issue3291.p4
 Excluding file: ../../../p4c/testdata/p4_16_errors/issue3291.p4
 
@@ -3235,6 +3271,15 @@ load complete
 into call
 Error on run: ../../../p4c/testdata/p4_16_errors/issue5094-type-bmv2.p4
 
+>>> Running boot test (Entry/Program_ok) on ../../../p4c/testdata/p4_16_errors/issue5253.p4
+../../../spec-meta/al/6-entry.watsup:7.12-7.22: "entry-al"
+entry-al
+../../../spec-meta/al/6-entry.watsup:9.12-9.27: "load complete"
+load complete
+../../../spec-meta/al/6-entry.watsup:11.12-11.23: "into call"
+into call
+Error on run: ../../../p4c/testdata/p4_16_errors/issue5253.p4
+
 >>> Running boot test (Entry/Program_ok) on ../../../p4c/testdata/p4_16_errors/issue5254_dup_switch_case_label_error.p4
 ../../../spec-meta/al/6-entry.watsup:7.12-7.22: "entry-al"
 entry-al
@@ -3309,6 +3354,9 @@ load complete
 ../../../spec-meta/al/6-entry.watsup:11.12-11.23: "into call"
 into call
 Error on run: ../../../p4c/testdata/p4_16_errors/issue561-1.p4
+
+>>> Running boot test (Entry/Program_ok) on ../../../p4c/testdata/p4_16_errors/issue5703_header_union_stack.p4
+Excluding file: ../../../p4c/testdata/p4_16_errors/issue5703_header_union_stack.p4
 
 >>> Running boot test (Entry/Program_ok) on ../../../p4c/testdata/p4_16_errors/issue584.p4
 ../../../spec-meta/al/6-entry.watsup:7.12-7.22: "entry-al"
@@ -4120,6 +4168,15 @@ Excluding file: ../../../p4c/testdata/p4_16_errors/structured-annotation-e2.p4
 >>> Running boot test (Entry/Program_ok) on ../../../p4c/testdata/p4_16_errors/structured-annotation-e3.p4
 Excluding file: ../../../p4c/testdata/p4_16_errors/structured-annotation-e3.p4
 
+>>> Running boot test (Entry/Program_ok) on ../../../p4c/testdata/p4_16_errors/switch_string.p4
+../../../spec-meta/al/6-entry.watsup:7.12-7.22: "entry-al"
+entry-al
+../../../spec-meta/al/6-entry.watsup:9.12-9.27: "load complete"
+load complete
+../../../spec-meta/al/6-entry.watsup:11.12-11.23: "into call"
+into call
+Error on run: ../../../p4c/testdata/p4_16_errors/switch_string.p4
+
 >>> Running boot test (Entry/Program_ok) on ../../../p4c/testdata/p4_16_errors/table-action-duplicate-actions.p4
 ../../../spec-meta/al/6-entry.watsup:7.12-7.22: "entry-al"
 entry-al
@@ -4702,6 +4759,6 @@ load complete
 into call
 Error on run: ../../../p4c/testdata/p4_16_errors/wrong-cast.p4
 
-Running boot test (Entry/Program_ok): [EXCLUDE] 48/577 (8.32%) [PASS] 0/577 (0.00%) [FAIL] 529/577 (91.68%) [PATCH] 0/577 (0.00%)
+Running boot test (Entry/Program_ok): [EXCLUDE] 49/584 (8.39%) [PASS] 0/584 (0.00%) [FAIL] 535/584 (91.61%) [PATCH] 0/584 (0.00%)
 
 Running boot test (Entry/Program_ok): [PATCH]: [EXCLUDE] 0/0 (0.00%) [PASS] 0/0 (0.00%) [FAIL] 0/0 (0.00%)

--- a/p4spec/test/boot/boot_2_neg_sl.expected
+++ b/p4spec/test/boot/boot_2_neg_sl.expected
@@ -1,4 +1,4 @@
-Running boot test (Entry/Program_ok) on 564 files
+Running boot test (Entry/Program_ok) on 577 files
 
 
 >>> Running boot test (Entry/Program_ok) on ../../../p4c/testdata/p4_16_errors/accept_e.p4
@@ -185,15 +185,7 @@ into call
 Error on run: ../../../p4c/testdata/p4_16_errors/call1_e.p4
 
 >>> Running boot test (Entry/Program_ok) on ../../../p4c/testdata/p4_16_errors/compound-assignment.p4
-../../../spec-meta/al/6-entry.watsup:7.12-7.22: "entry-al"
-entry-al
-../../../spec-meta/al/6-entry.watsup:9.12-9.27: "load complete"
-load complete
-../../../spec-meta/al/6-entry.watsup:11.12-11.23: "into call"
-into call
-../../../spec-meta/al/6-entry.watsup:13.12-13.15: val
-TEXT pass
-Error on run: ../../../p4c/testdata/p4_16_errors/compound-assignment.p4 (should fail)
+Excluding file: ../../../p4c/testdata/p4_16_errors/compound-assignment.p4
 
 >>> Running boot test (Entry/Program_ok) on ../../../p4c/testdata/p4_16_errors/conditional_e.p4
 ../../../spec-meta/al/6-entry.watsup:7.12-7.22: "entry-al"
@@ -580,26 +572,10 @@ into call
 Error on run: ../../../p4c/testdata/p4_16_errors/div0.p4
 
 >>> Running boot test (Entry/Program_ok) on ../../../p4c/testdata/p4_16_errors/div1.p4
-../../../spec-meta/al/6-entry.watsup:7.12-7.22: "entry-al"
-entry-al
-../../../spec-meta/al/6-entry.watsup:9.12-9.27: "load complete"
-load complete
-../../../spec-meta/al/6-entry.watsup:11.12-11.23: "into call"
-into call
-../../../spec-meta/al/6-entry.watsup:13.12-13.15: val
-TEXT pass
-Error on run: ../../../p4c/testdata/p4_16_errors/div1.p4 (should fail)
+Excluding file: ../../../p4c/testdata/p4_16_errors/div1.p4
 
 >>> Running boot test (Entry/Program_ok) on ../../../p4c/testdata/p4_16_errors/div3.p4
-../../../spec-meta/al/6-entry.watsup:7.12-7.22: "entry-al"
-entry-al
-../../../spec-meta/al/6-entry.watsup:9.12-9.27: "load complete"
-load complete
-../../../spec-meta/al/6-entry.watsup:11.12-11.23: "into call"
-into call
-../../../spec-meta/al/6-entry.watsup:13.12-13.15: val
-TEXT pass
-Error on run: ../../../p4c/testdata/p4_16_errors/div3.p4 (should fail)
+Excluding file: ../../../p4c/testdata/p4_16_errors/div3.p4
 
 >>> Running boot test (Entry/Program_ok) on ../../../p4c/testdata/p4_16_errors/dup-param.p4
 ../../../spec-meta/al/6-entry.watsup:7.12-7.22: "entry-al"
@@ -2737,9 +2713,6 @@ load complete
 into call
 Error on run: ../../../p4c/testdata/p4_16_errors/issue3221.p4
 
->>> Running boot test (Entry/Program_ok) on ../../../p4c/testdata/p4_16_errors/issue3233.p4
-Excluding file: ../../../p4c/testdata/p4_16_errors/issue3233.p4
-
 >>> Running boot test (Entry/Program_ok) on ../../../p4c/testdata/p4_16_errors/issue3246.p4
 ../../../spec-meta/al/6-entry.watsup:7.12-7.22: "entry-al"
 entry-al
@@ -3226,6 +3199,42 @@ Excluding file: ../../../p4c/testdata/p4_16_errors/issue477.p4
 >>> Running boot test (Entry/Program_ok) on ../../../p4c/testdata/p4_16_errors/issue478.p4
 Excluding file: ../../../p4c/testdata/p4_16_errors/issue478.p4
 
+>>> Running boot test (Entry/Program_ok) on ../../../p4c/testdata/p4_16_errors/issue5085.p4
+../../../spec-meta/al/6-entry.watsup:7.12-7.22: "entry-al"
+entry-al
+../../../spec-meta/al/6-entry.watsup:9.12-9.27: "load complete"
+load complete
+../../../spec-meta/al/6-entry.watsup:11.12-11.23: "into call"
+into call
+Error on run: ../../../p4c/testdata/p4_16_errors/issue5085.p4
+
+>>> Running boot test (Entry/Program_ok) on ../../../p4c/testdata/p4_16_errors/issue5094-meta-bmv2.p4
+../../../spec-meta/al/6-entry.watsup:7.12-7.22: "entry-al"
+entry-al
+../../../spec-meta/al/6-entry.watsup:9.12-9.27: "load complete"
+load complete
+../../../spec-meta/al/6-entry.watsup:11.12-11.23: "into call"
+into call
+Error on run: ../../../p4c/testdata/p4_16_errors/issue5094-meta-bmv2.p4
+
+>>> Running boot test (Entry/Program_ok) on ../../../p4c/testdata/p4_16_errors/issue5094-string-bmv2.p4
+../../../spec-meta/al/6-entry.watsup:7.12-7.22: "entry-al"
+entry-al
+../../../spec-meta/al/6-entry.watsup:9.12-9.27: "load complete"
+load complete
+../../../spec-meta/al/6-entry.watsup:11.12-11.23: "into call"
+into call
+Error on run: ../../../p4c/testdata/p4_16_errors/issue5094-string-bmv2.p4
+
+>>> Running boot test (Entry/Program_ok) on ../../../p4c/testdata/p4_16_errors/issue5094-type-bmv2.p4
+../../../spec-meta/al/6-entry.watsup:7.12-7.22: "entry-al"
+entry-al
+../../../spec-meta/al/6-entry.watsup:9.12-9.27: "load complete"
+load complete
+../../../spec-meta/al/6-entry.watsup:11.12-11.23: "into call"
+into call
+Error on run: ../../../p4c/testdata/p4_16_errors/issue5094-type-bmv2.p4
+
 >>> Running boot test (Entry/Program_ok) on ../../../p4c/testdata/p4_16_errors/issue5254_dup_switch_case_label_error.p4
 ../../../spec-meta/al/6-entry.watsup:7.12-7.22: "entry-al"
 entry-al
@@ -3235,8 +3244,62 @@ load complete
 into call
 Error on run: ../../../p4c/testdata/p4_16_errors/issue5254_dup_switch_case_label_error.p4
 
+>>> Running boot test (Entry/Program_ok) on ../../../p4c/testdata/p4_16_errors/issue5268.p4
+../../../spec-meta/al/6-entry.watsup:7.12-7.22: "entry-al"
+entry-al
+../../../spec-meta/al/6-entry.watsup:9.12-9.27: "load complete"
+load complete
+../../../spec-meta/al/6-entry.watsup:11.12-11.23: "into call"
+into call
+Error on run: ../../../p4c/testdata/p4_16_errors/issue5268.p4
+
+>>> Running boot test (Entry/Program_ok) on ../../../p4c/testdata/p4_16_errors/issue5296_invalid_version.p4
+Excluding file: ../../../p4c/testdata/p4_16_errors/issue5296_invalid_version.p4
+
+>>> Running boot test (Entry/Program_ok) on ../../../p4c/testdata/p4_16_errors/issue5296_unknown_version.p4
+Excluding file: ../../../p4c/testdata/p4_16_errors/issue5296_unknown_version.p4
+
 >>> Running boot test (Entry/Program_ok) on ../../../p4c/testdata/p4_16_errors/issue532.p4
 Excluding file: ../../../p4c/testdata/p4_16_errors/issue532.p4
+
+>>> Running boot test (Entry/Program_ok) on ../../../p4c/testdata/p4_16_errors/issue5437_action.p4
+../../../spec-meta/al/6-entry.watsup:7.12-7.22: "entry-al"
+entry-al
+../../../spec-meta/al/6-entry.watsup:9.12-9.27: "load complete"
+load complete
+../../../spec-meta/al/6-entry.watsup:11.12-11.23: "into call"
+into call
+Error on run: ../../../p4c/testdata/p4_16_errors/issue5437_action.p4
+
+>>> Running boot test (Entry/Program_ok) on ../../../p4c/testdata/p4_16_errors/issue5437_instantiation.p4
+../../../spec-meta/al/6-entry.watsup:7.12-7.22: "entry-al"
+entry-al
+../../../spec-meta/al/6-entry.watsup:9.12-9.27: "load complete"
+load complete
+../../../spec-meta/al/6-entry.watsup:11.12-11.23: "into call"
+into call
+Error on run: ../../../p4c/testdata/p4_16_errors/issue5437_instantiation.p4
+
+>>> Running boot test (Entry/Program_ok) on ../../../p4c/testdata/p4_16_errors/issue5437_table.p4
+Error on run: ../../../p4c/testdata/p4_16_errors/issue5437_table.p4 (unknown)
+
+>>> Running boot test (Entry/Program_ok) on ../../../p4c/testdata/p4_16_errors/issue5441.p4
+../../../spec-meta/al/6-entry.watsup:7.12-7.22: "entry-al"
+entry-al
+../../../spec-meta/al/6-entry.watsup:9.12-9.27: "load complete"
+load complete
+../../../spec-meta/al/6-entry.watsup:11.12-11.23: "into call"
+into call
+Error on run: ../../../p4c/testdata/p4_16_errors/issue5441.p4
+
+>>> Running boot test (Entry/Program_ok) on ../../../p4c/testdata/p4_16_errors/issue5443.p4
+../../../spec-meta/al/6-entry.watsup:7.12-7.22: "entry-al"
+entry-al
+../../../spec-meta/al/6-entry.watsup:9.12-9.27: "load complete"
+load complete
+../../../spec-meta/al/6-entry.watsup:11.12-11.23: "into call"
+into call
+Error on run: ../../../p4c/testdata/p4_16_errors/issue5443.p4
 
 >>> Running boot test (Entry/Program_ok) on ../../../p4c/testdata/p4_16_errors/issue561-1.p4
 ../../../spec-meta/al/6-entry.watsup:7.12-7.22: "entry-al"
@@ -3293,9 +3356,7 @@ entry-al
 load complete
 ../../../spec-meta/al/6-entry.watsup:11.12-11.23: "into call"
 into call
-../../../spec-meta/al/6-entry.watsup:13.12-13.15: val
-TEXT pass
-Error on run: ../../../p4c/testdata/p4_16_errors/issue774-2.p4 (should fail)
+Error on run: ../../../p4c/testdata/p4_16_errors/issue774-2.p4
 
 >>> Running boot test (Entry/Program_ok) on ../../../p4c/testdata/p4_16_errors/issue803-1.p4
 ../../../spec-meta/al/6-entry.watsup:7.12-7.22: "entry-al"
@@ -3392,6 +3453,15 @@ Error on run: ../../../p4c/testdata/p4_16_errors/loop2-err.p4
 
 >>> Running boot test (Entry/Program_ok) on ../../../p4c/testdata/p4_16_errors/loop3-err.p4
 Error on run: ../../../p4c/testdata/p4_16_errors/loop3-err.p4 (unknown)
+
+>>> Running boot test (Entry/Program_ok) on ../../../p4c/testdata/p4_16_errors/loop4-err.p4
+../../../spec-meta/al/6-entry.watsup:7.12-7.22: "entry-al"
+entry-al
+../../../spec-meta/al/6-entry.watsup:9.12-9.27: "load complete"
+load complete
+../../../spec-meta/al/6-entry.watsup:11.12-11.23: "into call"
+into call
+Error on run: ../../../p4c/testdata/p4_16_errors/loop4-err.p4
 
 >>> Running boot test (Entry/Program_ok) on ../../../p4c/testdata/p4_16_errors/lvalue-assign-to-unsupported-type.p4
 ../../../spec-meta/al/6-entry.watsup:7.12-7.22: "entry-al"
@@ -4542,6 +4612,15 @@ Error on run: ../../../p4c/testdata/p4_16_errors/underscore3_e.p4 (unknown)
 >>> Running boot test (Entry/Program_ok) on ../../../p4c/testdata/p4_16_errors/underscore_e.p4
 Error on run: ../../../p4c/testdata/p4_16_errors/underscore_e.p4 (unknown)
 
+>>> Running boot test (Entry/Program_ok) on ../../../p4c/testdata/p4_16_errors/unknown-struct1.p4
+../../../spec-meta/al/6-entry.watsup:7.12-7.22: "entry-al"
+entry-al
+../../../spec-meta/al/6-entry.watsup:9.12-9.27: "load complete"
+load complete
+../../../spec-meta/al/6-entry.watsup:11.12-11.23: "into call"
+into call
+Error on run: ../../../p4c/testdata/p4_16_errors/unknown-struct1.p4
+
 >>> Running boot test (Entry/Program_ok) on ../../../p4c/testdata/p4_16_errors/virtual1.p4
 ../../../spec-meta/al/6-entry.watsup:7.12-7.22: "entry-al"
 entry-al
@@ -4623,6 +4702,6 @@ load complete
 into call
 Error on run: ../../../p4c/testdata/p4_16_errors/wrong-cast.p4
 
-Running boot test (Entry/Program_ok): [EXCLUDE] 44/564 (7.80%) [PASS] 4/564 (0.71%) [FAIL] 516/564 (91.49%) [PATCH] 0/564 (0.00%)
+Running boot test (Entry/Program_ok): [EXCLUDE] 48/577 (8.32%) [PASS] 0/577 (0.00%) [FAIL] 529/577 (91.68%) [PATCH] 0/577 (0.00%)
 
 Running boot test (Entry/Program_ok): [PATCH]: [EXCLUDE] 0/0 (0.00%) [PASS] 0/0 (0.00%) [FAIL] 0/0 (0.00%)

--- a/p4spec/test/boot/boot_2_pos_sl.expected
+++ b/p4spec/test/boot/boot_2_pos_sl.expected
@@ -1,4 +1,4 @@
-Running boot test (Entry/Program_ok) on 1331 files
+Running boot test (Entry/Program_ok) on 1334 files
 
 
 >>> Running boot test (Entry/Program_ok) on ../../../p4c/testdata/p4_16_samples/action-bind.p4
@@ -3136,6 +3136,9 @@ Run success: ../../../p4c/testdata/p4_16_samples/gauntlet_variable_shadowing-bmv
 
 >>> Running boot test (Entry/Program_ok) on ../../../p4c/testdata/p4_16_samples/gauntlet_various_ops-bmv2.p4
 Excluding file: ../../../p4c/testdata/p4_16_samples/gauntlet_various_ops-bmv2.p4
+
+>>> Running boot test (Entry/Program_ok) on ../../../p4c/testdata/p4_16_samples/generic-extern-inference.p4
+Excluding file: ../../../p4c/testdata/p4_16_samples/generic-extern-inference.p4
 
 >>> Running boot test (Entry/Program_ok) on ../../../p4c/testdata/p4_16_samples/generic-struct-tuple.p4
 ../../../spec-meta/al/6-entry.watsup:7.12-7.22: "entry-al"
@@ -6802,9 +6805,6 @@ into call
 TEXT pass
 Run success: ../../../p4c/testdata/p4_16_samples/issue3289.p4
 
->>> Running boot test (Entry/Program_ok) on ../../../p4c/testdata/p4_16_samples/issue3291-1.p4
-Excluding file: ../../../p4c/testdata/p4_16_samples/issue3291-1.p4
-
 >>> Running boot test (Entry/Program_ok) on ../../../p4c/testdata/p4_16_samples/issue3292.p4
 ../../../spec-meta/al/6-entry.watsup:7.12-7.22: "entry-al"
 entry-al
@@ -7794,6 +7794,17 @@ into call
 TEXT pass
 Run success: ../../../p4c/testdata/p4_16_samples/issue5237-folding-unused-minsizeinbits.p4
 
+>>> Running boot test (Entry/Program_ok) on ../../../p4c/testdata/p4_16_samples/issue5253_legal_overloads.p4
+../../../spec-meta/al/6-entry.watsup:7.12-7.22: "entry-al"
+entry-al
+../../../spec-meta/al/6-entry.watsup:9.12-9.27: "load complete"
+load complete
+../../../spec-meta/al/6-entry.watsup:11.12-11.23: "into call"
+into call
+../../../spec-meta/al/6-entry.watsup:13.12-13.15: val
+TEXT pass
+Run success: ../../../p4c/testdata/p4_16_samples/issue5253_legal_overloads.p4
+
 >>> Running boot test (Entry/Program_ok) on ../../../p4c/testdata/p4_16_samples/issue529.p4
 ../../../spec-meta/al/6-entry.watsup:7.12-7.22: "entry-al"
 entry-al
@@ -8013,6 +8024,17 @@ into call
 ../../../spec-meta/al/6-entry.watsup:13.12-13.15: val
 TEXT pass
 Run success: ../../../p4c/testdata/p4_16_samples/issue5653.p4
+
+>>> Running boot test (Entry/Program_ok) on ../../../p4c/testdata/p4_16_samples/issue5706_header_union_stack.p4
+../../../spec-meta/al/6-entry.watsup:7.12-7.22: "entry-al"
+entry-al
+../../../spec-meta/al/6-entry.watsup:9.12-9.27: "load complete"
+load complete
+../../../spec-meta/al/6-entry.watsup:11.12-11.23: "into call"
+into call
+../../../spec-meta/al/6-entry.watsup:13.12-13.15: val
+TEXT pass
+Run success: ../../../p4c/testdata/p4_16_samples/issue5706_header_union_stack.p4
 
 >>> Running boot test (Entry/Program_ok) on ../../../p4c/testdata/p4_16_samples/issue584-1-bmv2.p4
 ../../../spec-meta/al/6-entry.watsup:7.12-7.22: "entry-al"
@@ -13318,6 +13340,17 @@ into call
 TEXT pass
 Run success: ../../../p4c/testdata/p4_16_samples/switch_ebpf.p4
 
+>>> Running boot test (Entry/Program_ok) on ../../../p4c/testdata/p4_16_samples/switch_p4_16.p4
+../../../spec-meta/al/6-entry.watsup:7.12-7.22: "entry-al"
+entry-al
+../../../spec-meta/al/6-entry.watsup:9.12-9.27: "load complete"
+load complete
+../../../spec-meta/al/6-entry.watsup:11.12-11.23: "into call"
+into call
+../../../spec-meta/al/6-entry.watsup:13.12-13.15: val
+TEXT pass
+Run success: ../../../p4c/testdata/p4_16_samples/switch_p4_16.p4
+
 >>> Running boot test (Entry/Program_ok) on ../../../p4c/testdata/p4_16_samples/synth-action.p4
 ../../../spec-meta/al/6-entry.watsup:7.12-7.22: "entry-al"
 entry-al
@@ -14106,6 +14139,6 @@ into call
 TEXT pass
 Run success: ../../../p4c/testdata/p4_16_samples/xor_test.p4
 
-Running boot test (Entry/Program_ok): [EXCLUDE] 67/1331 (5.03%) [PASS] 1264/1331 (94.97%) [FAIL] 0/1331 (0.00%) [PATCH] 0/1331 (0.00%)
+Running boot test (Entry/Program_ok): [EXCLUDE] 67/1334 (5.02%) [PASS] 1267/1334 (94.98%) [FAIL] 0/1334 (0.00%) [PATCH] 0/1334 (0.00%)
 
 Running boot test (Entry/Program_ok): [PATCH]: [EXCLUDE] 0/0 (0.00%) [PASS] 0/0 (0.00%) [FAIL] 0/0 (0.00%)

--- a/p4spec/test/boot/boot_2_pos_sl.expected
+++ b/p4spec/test/boot/boot_2_pos_sl.expected
@@ -1,4 +1,4 @@
-Running boot test (Entry/Program_ok) on 1307 files
+Running boot test (Entry/Program_ok) on 1331 files
 
 
 >>> Running boot test (Entry/Program_ok) on ../../../p4c/testdata/p4_16_samples/action-bind.p4
@@ -576,6 +576,9 @@ into call
 TEXT pass
 Run success: ../../../p4c/testdata/p4_16_samples/bitExtract.p4
 
+>>> Running boot test (Entry/Program_ok) on ../../../p4c/testdata/p4_16_samples/bitexpr1.p4
+Excluding file: ../../../p4c/testdata/p4_16_samples/bitexpr1.p4
+
 >>> Running boot test (Entry/Program_ok) on ../../../p4c/testdata/p4_16_samples/bitwise-and.p4
 ../../../spec-meta/al/6-entry.watsup:7.12-7.22: "entry-al"
 entry-al
@@ -729,6 +732,9 @@ into call
 ../../../spec-meta/al/6-entry.watsup:13.12-13.15: val
 TEXT pass
 Run success: ../../../p4c/testdata/p4_16_samples/cast_noop.p4
+
+>>> Running boot test (Entry/Program_ok) on ../../../p4c/testdata/p4_16_samples/cfoldBitTypedefs.p4
+Excluding file: ../../../p4c/testdata/p4_16_samples/cfoldBitTypedefs.p4
 
 >>> Running boot test (Entry/Program_ok) on ../../../p4c/testdata/p4_16_samples/chain.p4
 ../../../spec-meta/al/6-entry.watsup:7.12-7.22: "entry-al"
@@ -1465,6 +1471,17 @@ into call
 TEXT pass
 Run success: ../../../p4c/testdata/p4_16_samples/elimActRun1.p4
 
+>>> Running boot test (Entry/Program_ok) on ../../../p4c/testdata/p4_16_samples/elimActRun2.p4
+../../../spec-meta/al/6-entry.watsup:7.12-7.22: "entry-al"
+entry-al
+../../../spec-meta/al/6-entry.watsup:9.12-9.27: "load complete"
+load complete
+../../../spec-meta/al/6-entry.watsup:11.12-11.23: "into call"
+into call
+../../../spec-meta/al/6-entry.watsup:13.12-13.15: val
+TEXT pass
+Run success: ../../../p4c/testdata/p4_16_samples/elimActRun2.p4
+
 >>> Running boot test (Entry/Program_ok) on ../../../p4c/testdata/p4_16_samples/empty-bmv2.p4
 ../../../spec-meta/al/6-entry.watsup:7.12-7.22: "entry-al"
 entry-al
@@ -1807,6 +1824,17 @@ into call
 TEXT pass
 Run success: ../../../p4c/testdata/p4_16_samples/fold_match.p4
 
+>>> Running boot test (Entry/Program_ok) on ../../../p4c/testdata/p4_16_samples/forloop-bmv2.p4
+../../../spec-meta/al/6-entry.watsup:7.12-7.22: "entry-al"
+entry-al
+../../../spec-meta/al/6-entry.watsup:9.12-9.27: "load complete"
+load complete
+../../../spec-meta/al/6-entry.watsup:11.12-11.23: "into call"
+into call
+../../../spec-meta/al/6-entry.watsup:13.12-13.15: val
+TEXT pass
+Run success: ../../../p4c/testdata/p4_16_samples/forloop-bmv2.p4
+
 >>> Running boot test (Entry/Program_ok) on ../../../p4c/testdata/p4_16_samples/forloop1.p4
 ../../../spec-meta/al/6-entry.watsup:7.12-7.22: "entry-al"
 entry-al
@@ -1839,6 +1867,17 @@ into call
 ../../../spec-meta/al/6-entry.watsup:13.12-13.15: val
 TEXT pass
 Run success: ../../../p4c/testdata/p4_16_samples/forloop11.p4
+
+>>> Running boot test (Entry/Program_ok) on ../../../p4c/testdata/p4_16_samples/forloop12.p4
+../../../spec-meta/al/6-entry.watsup:7.12-7.22: "entry-al"
+entry-al
+../../../spec-meta/al/6-entry.watsup:9.12-9.27: "load complete"
+load complete
+../../../spec-meta/al/6-entry.watsup:11.12-11.23: "into call"
+into call
+../../../spec-meta/al/6-entry.watsup:13.12-13.15: val
+TEXT pass
+Run success: ../../../p4c/testdata/p4_16_samples/forloop12.p4
 
 >>> Running boot test (Entry/Program_ok) on ../../../p4c/testdata/p4_16_samples/forloop2.p4
 ../../../spec-meta/al/6-entry.watsup:7.12-7.22: "entry-al"
@@ -3264,6 +3303,17 @@ into call
 TEXT pass
 Run success: ../../../p4c/testdata/p4_16_samples/header-bool-bmv2.p4
 
+>>> Running boot test (Entry/Program_ok) on ../../../p4c/testdata/p4_16_samples/header-stack-cast-init.p4
+../../../spec-meta/al/6-entry.watsup:7.12-7.22: "entry-al"
+entry-al
+../../../spec-meta/al/6-entry.watsup:9.12-9.27: "load complete"
+load complete
+../../../spec-meta/al/6-entry.watsup:11.12-11.23: "into call"
+into call
+../../../spec-meta/al/6-entry.watsup:13.12-13.15: val
+TEXT pass
+Run success: ../../../p4c/testdata/p4_16_samples/header-stack-cast-init.p4
+
 >>> Running boot test (Entry/Program_ok) on ../../../p4c/testdata/p4_16_samples/header-stack-ops-bmv2.p4
 ../../../spec-meta/al/6-entry.watsup:7.12-7.22: "entry-al"
 entry-al
@@ -3285,6 +3335,17 @@ into call
 ../../../spec-meta/al/6-entry.watsup:13.12-13.15: val
 TEXT pass
 Run success: ../../../p4c/testdata/p4_16_samples/header.p4
+
+>>> Running boot test (Entry/Program_ok) on ../../../p4c/testdata/p4_16_samples/header_union_is_valid_in_parser.p4
+../../../spec-meta/al/6-entry.watsup:7.12-7.22: "entry-al"
+entry-al
+../../../spec-meta/al/6-entry.watsup:9.12-9.27: "load complete"
+load complete
+../../../spec-meta/al/6-entry.watsup:11.12-11.23: "into call"
+into call
+../../../spec-meta/al/6-entry.watsup:13.12-13.15: val
+TEXT pass
+Run success: ../../../p4c/testdata/p4_16_samples/header_union_is_valid_in_parser.p4
 
 >>> Running boot test (Entry/Program_ok) on ../../../p4c/testdata/p4_16_samples/highorder.p4
 ../../../spec-meta/al/6-entry.watsup:7.12-7.22: "entry-al"
@@ -3417,6 +3478,28 @@ into call
 ../../../spec-meta/al/6-entry.watsup:13.12-13.15: val
 TEXT pass
 Run success: ../../../p4c/testdata/p4_16_samples/inline-control1.p4
+
+>>> Running boot test (Entry/Program_ok) on ../../../p4c/testdata/p4_16_samples/inline-function-to-array-index-chained.p4
+../../../spec-meta/al/6-entry.watsup:7.12-7.22: "entry-al"
+entry-al
+../../../spec-meta/al/6-entry.watsup:9.12-9.27: "load complete"
+load complete
+../../../spec-meta/al/6-entry.watsup:11.12-11.23: "into call"
+into call
+../../../spec-meta/al/6-entry.watsup:13.12-13.15: val
+TEXT pass
+Run success: ../../../p4c/testdata/p4_16_samples/inline-function-to-array-index-chained.p4
+
+>>> Running boot test (Entry/Program_ok) on ../../../p4c/testdata/p4_16_samples/inline-function-to-array-index.p4
+../../../spec-meta/al/6-entry.watsup:7.12-7.22: "entry-al"
+entry-al
+../../../spec-meta/al/6-entry.watsup:9.12-9.27: "load complete"
+load complete
+../../../spec-meta/al/6-entry.watsup:11.12-11.23: "into call"
+into call
+../../../spec-meta/al/6-entry.watsup:13.12-13.15: val
+TEXT pass
+Run success: ../../../p4c/testdata/p4_16_samples/inline-function-to-array-index.p4
 
 >>> Running boot test (Entry/Program_ok) on ../../../p4c/testdata/p4_16_samples/inline-function.p4
 ../../../spec-meta/al/6-entry.watsup:7.12-7.22: "entry-al"
@@ -3670,6 +3753,17 @@ into call
 ../../../spec-meta/al/6-entry.watsup:13.12-13.15: val
 TEXT pass
 Run success: ../../../p4c/testdata/p4_16_samples/invalid-union.p4
+
+>>> Running boot test (Entry/Program_ok) on ../../../p4c/testdata/p4_16_samples/invalid_header_default_action_arg.p4
+../../../spec-meta/al/6-entry.watsup:7.12-7.22: "entry-al"
+entry-al
+../../../spec-meta/al/6-entry.watsup:9.12-9.27: "load complete"
+load complete
+../../../spec-meta/al/6-entry.watsup:11.12-11.23: "into call"
+into call
+../../../spec-meta/al/6-entry.watsup:13.12-13.15: val
+TEXT pass
+Run success: ../../../p4c/testdata/p4_16_samples/invalid_header_default_action_arg.p4
 
 >>> Running boot test (Entry/Program_ok) on ../../../p4c/testdata/p4_16_samples/inverted-range.p4
 ../../../spec-meta/al/6-entry.watsup:7.12-7.22: "entry-al"
@@ -4911,15 +5005,7 @@ TEXT pass
 Run success: ../../../p4c/testdata/p4_16_samples/issue2104.p4
 
 >>> Running boot test (Entry/Program_ok) on ../../../p4c/testdata/p4_16_samples/issue2105.p4
-../../../spec-meta/al/6-entry.watsup:7.12-7.22: "entry-al"
-entry-al
-../../../spec-meta/al/6-entry.watsup:9.12-9.27: "load complete"
-load complete
-../../../spec-meta/al/6-entry.watsup:11.12-11.23: "into call"
-into call
-../../../spec-meta/al/6-entry.watsup:13.12-13.15: val
-TEXT pass
-Run success: ../../../p4c/testdata/p4_16_samples/issue2105.p4
+Excluding file: ../../../p4c/testdata/p4_16_samples/issue2105.p4
 
 >>> Running boot test (Entry/Program_ok) on ../../../p4c/testdata/p4_16_samples/issue2126.p4
 ../../../spec-meta/al/6-entry.watsup:7.12-7.22: "entry-al"
@@ -6622,6 +6708,17 @@ into call
 TEXT pass
 Run success: ../../../p4c/testdata/p4_16_samples/issue323.p4
 
+>>> Running boot test (Entry/Program_ok) on ../../../p4c/testdata/p4_16_samples/issue3233.p4
+../../../spec-meta/al/6-entry.watsup:7.12-7.22: "entry-al"
+entry-al
+../../../spec-meta/al/6-entry.watsup:9.12-9.27: "load complete"
+load complete
+../../../spec-meta/al/6-entry.watsup:11.12-11.23: "into call"
+into call
+../../../spec-meta/al/6-entry.watsup:13.12-13.15: val
+TEXT pass
+Run success: ../../../p4c/testdata/p4_16_samples/issue3233.p4
+
 >>> Running boot test (Entry/Program_ok) on ../../../p4c/testdata/p4_16_samples/issue3238.p4
 Excluding file: ../../../p4c/testdata/p4_16_samples/issue3238.p4
 
@@ -7609,6 +7706,28 @@ into call
 TEXT pass
 Run success: ../../../p4c/testdata/p4_16_samples/issue5035.p4
 
+>>> Running boot test (Entry/Program_ok) on ../../../p4c/testdata/p4_16_samples/issue5085.p4
+../../../spec-meta/al/6-entry.watsup:7.12-7.22: "entry-al"
+entry-al
+../../../spec-meta/al/6-entry.watsup:9.12-9.27: "load complete"
+load complete
+../../../spec-meta/al/6-entry.watsup:11.12-11.23: "into call"
+into call
+../../../spec-meta/al/6-entry.watsup:13.12-13.15: val
+TEXT pass
+Run success: ../../../p4c/testdata/p4_16_samples/issue5085.p4
+
+>>> Running boot test (Entry/Program_ok) on ../../../p4c/testdata/p4_16_samples/issue5094-typedef-bmv2.p4
+../../../spec-meta/al/6-entry.watsup:7.12-7.22: "entry-al"
+entry-al
+../../../spec-meta/al/6-entry.watsup:9.12-9.27: "load complete"
+load complete
+../../../spec-meta/al/6-entry.watsup:11.12-11.23: "into call"
+into call
+../../../spec-meta/al/6-entry.watsup:13.12-13.15: val
+TEXT pass
+Run success: ../../../p4c/testdata/p4_16_samples/issue5094-typedef-bmv2.p4
+
 >>> Running boot test (Entry/Program_ok) on ../../../p4c/testdata/p4_16_samples/issue510-bmv2.p4
 ../../../spec-meta/al/6-entry.watsup:7.12-7.22: "entry-al"
 entry-al
@@ -7752,6 +7871,28 @@ into call
 TEXT pass
 Run success: ../../../p4c/testdata/p4_16_samples/issue5335_default_initialized_non_header_stack_nested.p4
 
+>>> Running boot test (Entry/Program_ok) on ../../../p4c/testdata/p4_16_samples/issue5439.p4
+../../../spec-meta/al/6-entry.watsup:7.12-7.22: "entry-al"
+entry-al
+../../../spec-meta/al/6-entry.watsup:9.12-9.27: "load complete"
+load complete
+../../../spec-meta/al/6-entry.watsup:11.12-11.23: "into call"
+into call
+../../../spec-meta/al/6-entry.watsup:13.12-13.15: val
+TEXT pass
+Run success: ../../../p4c/testdata/p4_16_samples/issue5439.p4
+
+>>> Running boot test (Entry/Program_ok) on ../../../p4c/testdata/p4_16_samples/issue5499.p4
+../../../spec-meta/al/6-entry.watsup:7.12-7.22: "entry-al"
+entry-al
+../../../spec-meta/al/6-entry.watsup:9.12-9.27: "load complete"
+load complete
+../../../spec-meta/al/6-entry.watsup:11.12-11.23: "into call"
+into call
+../../../spec-meta/al/6-entry.watsup:13.12-13.15: val
+TEXT pass
+Run success: ../../../p4c/testdata/p4_16_samples/issue5499.p4
+
 >>> Running boot test (Entry/Program_ok) on ../../../p4c/testdata/p4_16_samples/issue561-1-bmv2.p4
 ../../../spec-meta/al/6-entry.watsup:7.12-7.22: "entry-al"
 entry-al
@@ -7861,6 +8002,17 @@ into call
 ../../../spec-meta/al/6-entry.watsup:13.12-13.15: val
 TEXT pass
 Run success: ../../../p4c/testdata/p4_16_samples/issue562-bmv2.p4
+
+>>> Running boot test (Entry/Program_ok) on ../../../p4c/testdata/p4_16_samples/issue5653.p4
+../../../spec-meta/al/6-entry.watsup:7.12-7.22: "entry-al"
+entry-al
+../../../spec-meta/al/6-entry.watsup:9.12-9.27: "load complete"
+load complete
+../../../spec-meta/al/6-entry.watsup:11.12-11.23: "into call"
+into call
+../../../spec-meta/al/6-entry.watsup:13.12-13.15: val
+TEXT pass
+Run success: ../../../p4c/testdata/p4_16_samples/issue5653.p4
 
 >>> Running boot test (Entry/Program_ok) on ../../../p4c/testdata/p4_16_samples/issue584-1-bmv2.p4
 ../../../spec-meta/al/6-entry.watsup:7.12-7.22: "entry-al"
@@ -8995,6 +9147,28 @@ into call
 ../../../spec-meta/al/6-entry.watsup:13.12-13.15: val
 TEXT pass
 Run success: ../../../p4c/testdata/p4_16_samples/noMatch.p4
+
+>>> Running boot test (Entry/Program_ok) on ../../../p4c/testdata/p4_16_samples/noWarn-unknown-diagnostic.p4
+../../../spec-meta/al/6-entry.watsup:7.12-7.22: "entry-al"
+entry-al
+../../../spec-meta/al/6-entry.watsup:9.12-9.27: "load complete"
+load complete
+../../../spec-meta/al/6-entry.watsup:11.12-11.23: "into call"
+into call
+../../../spec-meta/al/6-entry.watsup:13.12-13.15: val
+TEXT pass
+Run success: ../../../p4c/testdata/p4_16_samples/noWarn-unknown-diagnostic.p4
+
+>>> Running boot test (Entry/Program_ok) on ../../../p4c/testdata/p4_16_samples/non_header_array_access_in_parser.p4
+../../../spec-meta/al/6-entry.watsup:7.12-7.22: "entry-al"
+entry-al
+../../../spec-meta/al/6-entry.watsup:9.12-9.27: "load complete"
+load complete
+../../../spec-meta/al/6-entry.watsup:11.12-11.23: "into call"
+into call
+../../../spec-meta/al/6-entry.watsup:13.12-13.15: val
+TEXT pass
+Run success: ../../../p4c/testdata/p4_16_samples/non_header_array_access_in_parser.p4
 
 >>> Running boot test (Entry/Program_ok) on ../../../p4c/testdata/p4_16_samples/nonstandard_table_names-bmv2.p4
 ../../../spec-meta/al/6-entry.watsup:7.12-7.22: "entry-al"
@@ -12401,6 +12575,28 @@ into call
 TEXT pass
 Run success: ../../../p4c/testdata/p4_16_samples/simple-firewall_ubpf.p4
 
+>>> Running boot test (Entry/Program_ok) on ../../../p4c/testdata/p4_16_samples/simplify-select-cases1.p4
+../../../spec-meta/al/6-entry.watsup:7.12-7.22: "entry-al"
+entry-al
+../../../spec-meta/al/6-entry.watsup:9.12-9.27: "load complete"
+load complete
+../../../spec-meta/al/6-entry.watsup:11.12-11.23: "into call"
+into call
+../../../spec-meta/al/6-entry.watsup:13.12-13.15: val
+TEXT pass
+Run success: ../../../p4c/testdata/p4_16_samples/simplify-select-cases1.p4
+
+>>> Running boot test (Entry/Program_ok) on ../../../p4c/testdata/p4_16_samples/simplify-select-cases2.p4
+../../../spec-meta/al/6-entry.watsup:7.12-7.22: "entry-al"
+entry-al
+../../../spec-meta/al/6-entry.watsup:9.12-9.27: "load complete"
+load complete
+../../../spec-meta/al/6-entry.watsup:11.12-11.23: "into call"
+into call
+../../../spec-meta/al/6-entry.watsup:13.12-13.15: val
+TEXT pass
+Run success: ../../../p4c/testdata/p4_16_samples/simplify-select-cases2.p4
+
 >>> Running boot test (Entry/Program_ok) on ../../../p4c/testdata/p4_16_samples/simplify.p4
 ../../../spec-meta/al/6-entry.watsup:7.12-7.22: "entry-al"
 entry-al
@@ -12434,6 +12630,17 @@ into call
 TEXT pass
 Run success: ../../../p4c/testdata/p4_16_samples/simplify_slice.p4
 
+>>> Running boot test (Entry/Program_ok) on ../../../p4c/testdata/p4_16_samples/singleton_range_select.p4
+../../../spec-meta/al/6-entry.watsup:7.12-7.22: "entry-al"
+entry-al
+../../../spec-meta/al/6-entry.watsup:9.12-9.27: "load complete"
+load complete
+../../../spec-meta/al/6-entry.watsup:11.12-11.23: "into call"
+into call
+../../../spec-meta/al/6-entry.watsup:13.12-13.15: val
+TEXT pass
+Run success: ../../../p4c/testdata/p4_16_samples/singleton_range_select.p4
+
 >>> Running boot test (Entry/Program_ok) on ../../../p4c/testdata/p4_16_samples/slice-def-use.p4
 ../../../spec-meta/al/6-entry.watsup:7.12-7.22: "entry-al"
 entry-al
@@ -12455,6 +12662,28 @@ into call
 ../../../spec-meta/al/6-entry.watsup:13.12-13.15: val
 TEXT pass
 Run success: ../../../p4c/testdata/p4_16_samples/slice-def-use1.p4
+
+>>> Running boot test (Entry/Program_ok) on ../../../p4c/testdata/p4_16_samples/slice-def-use2.p4
+../../../spec-meta/al/6-entry.watsup:7.12-7.22: "entry-al"
+entry-al
+../../../spec-meta/al/6-entry.watsup:9.12-9.27: "load complete"
+load complete
+../../../spec-meta/al/6-entry.watsup:11.12-11.23: "into call"
+into call
+../../../spec-meta/al/6-entry.watsup:13.12-13.15: val
+TEXT pass
+Run success: ../../../p4c/testdata/p4_16_samples/slice-def-use2.p4
+
+>>> Running boot test (Entry/Program_ok) on ../../../p4c/testdata/p4_16_samples/slice1.p4
+../../../spec-meta/al/6-entry.watsup:7.12-7.22: "entry-al"
+entry-al
+../../../spec-meta/al/6-entry.watsup:9.12-9.27: "load complete"
+load complete
+../../../spec-meta/al/6-entry.watsup:11.12-11.23: "into call"
+into call
+../../../spec-meta/al/6-entry.watsup:13.12-13.15: val
+TEXT pass
+Run success: ../../../p4c/testdata/p4_16_samples/slice1.p4
 
 >>> Running boot test (Entry/Program_ok) on ../../../p4c/testdata/p4_16_samples/spec-ex01.p4
 ../../../spec-meta/al/6-entry.watsup:7.12-7.22: "entry-al"
@@ -12923,6 +13152,17 @@ into call
 ../../../spec-meta/al/6-entry.watsup:13.12-13.15: val
 TEXT pass
 Run success: ../../../p4c/testdata/p4_16_samples/strength6.p4
+
+>>> Running boot test (Entry/Program_ok) on ../../../p4c/testdata/p4_16_samples/strength7.p4
+../../../spec-meta/al/6-entry.watsup:7.12-7.22: "entry-al"
+entry-al
+../../../spec-meta/al/6-entry.watsup:9.12-9.27: "load complete"
+load complete
+../../../spec-meta/al/6-entry.watsup:11.12-11.23: "into call"
+into call
+../../../spec-meta/al/6-entry.watsup:13.12-13.15: val
+TEXT pass
+Run success: ../../../p4c/testdata/p4_16_samples/strength7.p4
 
 >>> Running boot test (Entry/Program_ok) on ../../../p4c/testdata/p4_16_samples/string.p4
 ../../../spec-meta/al/6-entry.watsup:7.12-7.22: "entry-al"
@@ -13866,6 +14106,6 @@ into call
 TEXT pass
 Run success: ../../../p4c/testdata/p4_16_samples/xor_test.p4
 
-Running boot test (Entry/Program_ok): [EXCLUDE] 64/1307 (4.90%) [PASS] 1243/1307 (95.10%) [FAIL] 0/1307 (0.00%) [PATCH] 0/1307 (0.00%)
+Running boot test (Entry/Program_ok): [EXCLUDE] 67/1331 (5.03%) [PASS] 1264/1331 (94.97%) [FAIL] 0/1331 (0.00%) [PATCH] 0/1331 (0.00%)
 
 Running boot test (Entry/Program_ok): [PATCH]: [EXCLUDE] 0/0 (0.00%) [PASS] 0/0 (0.00%) [FAIL] 0/0 (0.00%)

--- a/p4spec/test/lang/algo.expected
+++ b/p4spec/test/lang/algo.expected
@@ -15689,7 +15689,7 @@ relation Expr_ok: cursor typingContext |- expression : typedExpressionIR
     -- let ctk_l_reduced = $ctk_of_typedExpressionIR(typedExpressionIR_l_reduced)
     -- let typeIR_r_reduced = $type_of_typedExpressionIR(typedExpressionIR_r_reduced)
     -- let ctk_r_reduced = $ctk_of_typedExpressionIR(typedExpressionIR_r_reduced)
-    -- let typeIR = typeIR_r_reduced
+    -- let typeIR = $unroll_typeIR(typeIR_r_reduced)
     -- if typeIR <: fixedBitTypeIR
     -- let BIT `< _nat `> = typeIR as fixedBitTypeIR
     -- if ((typeIR_l_reduced = INT as typeIR) => (ctk_r_reduced = LCTK))
@@ -16474,7 +16474,7 @@ relation Expr_ok: cursor typingContext |- expression : typedExpressionIR
     -- let typeIR_w_reduced = $type_of_typedExpressionIR(typedExpressionIR_w_reduced)
     -- let ctk_w_reduced = $ctk_of_typedExpressionIR(typedExpressionIR_w_reduced)
     -- if (ctk_l_reduced =/= LCTK)
-    -- let typeIR' = typeIR_l_reduced
+    -- let typeIR' = $unroll_typeIR(typeIR_l_reduced)
     -- if typeIR' <: fixedBitTypeIR
     -- let BIT `< _nat `> = typeIR' as fixedBitTypeIR
     -- if (ctk_w_reduced = LCTK)

--- a/p4spec/test/lang/annotate.expected
+++ b/p4spec/test/lang/annotate.expected
@@ -9634,20 +9634,24 @@ xref:Expr_ok[Typing ``expression~l~`` ``binop`` ``expression~r~``, under context
 . Let ``ctk~l_reduced~`` be xref:ctk_of_typedExpressionIR[the compile-time known-ness of ``typedExpressionIR~l_reduced~``].
 . Let ``typeIR~r_reduced~`` be xref:type_of_typedExpressionIR[the type of ``typedExpressionIR~r_reduced~``].
 . Let ``ctk~r_reduced~`` be xref:ctk_of_typedExpressionIR[the compile-time known-ness of ``typedExpressionIR~r_reduced~``].
-. If ``typeIR~r_reduced~`` has type ``fixedBitTypeIR``:
- .. Check that if ``typeIR~l_reduced~`` is equal to ``+INT+``, then ``ctk~r_reduced~`` is equal to ``+LCTK+``.
- .. Let ``ctk~reduced~`` be xref:join_ctk[the join of ``ctk~l_reduced~`` and ``ctk~r_reduced~``].
- .. Let ``expressionNoteIR`` be xref:expressionNoteIR[a pair of type ``typeIR~l_reduced~`` and compile-time known-ness ``ctk~reduced~``].
- .. The result is xref:typedExpressionIR[``typedExpressionIR~l_reduced~`` ``binop`` ``typedExpressionIR~r_reduced~`` annotated with ``expressionNoteIR``].
-. Else:
- .. Check that ``ctk~r_reduced~`` is ``+LCTK+``.
- .. Let ``value`` be the result of xref:Expr_eval_lctk[local compile-time evaluation of ``typedExpressionIR~r_reduced~``, under context ``TC`` at ``p``].
- .. Let!~type~ ``integerValue~r~`` be ``value``.
- .. Let ``i~r~`` be xref:int_of_integerValue[the integer representation of  ``integerValue~r~``].
- .. Check that ``i~r~`` is greater than or equal to ``0``.
- .. Let ``ctk~reduced~`` be xref:join_ctk[the join of ``ctk~l_reduced~`` and ``ctk~r_reduced~``].
- .. Let ``expressionNoteIR`` be xref:expressionNoteIR[a pair of type ``typeIR~l_reduced~`` and compile-time known-ness ``ctk~reduced~``].
- .. The result is xref:typedExpressionIR[``typedExpressionIR~l_reduced~`` ``binop`` ``typedExpressionIR~r_reduced~`` annotated with ``expressionNoteIR``].
+. Try pass:[<strong id="bk-Expr_ok-6" class="bk-label">#6</strong>]:
+ .. {empty}+++<span class="bk-arm-anchor" id="bk-Expr_ok-6-a"></span>+++
+  ... Let ``typeIR`` be xref:unroll_typeIR[``typeIR~r_reduced~`` with typedefs unrolled].+++<sub class="bk-mark">[<a href="#bk-Expr_ok-6-b">else #6-b</a>]</sub>+++
+  ... Check that ``typeIR`` has type ``fixedBitTypeIR``.+++<sub class="bk-mark">[<a href="#bk-Expr_ok-6-b">else #6-b</a>]</sub>+++
+  ... Check that if ``typeIR~l_reduced~`` is equal to ``+INT+``, then ``ctk~r_reduced~`` is equal to ``+LCTK+``.+++<sub class="bk-mark">[<a href="#bk-Expr_ok-6-b">else #6-b</a>]</sub>+++
+  ... Let ``ctk~reduced~`` be xref:join_ctk[the join of ``ctk~l_reduced~`` and ``ctk~r_reduced~``].+++<sub class="bk-mark">[<a href="#bk-Expr_ok-6-b">else #6-b</a>]</sub>+++
+  ... Let ``expressionNoteIR`` be xref:expressionNoteIR[a pair of type ``typeIR~l_reduced~`` and compile-time known-ness ``ctk~reduced~``].+++<sub class="bk-mark">[<a href="#bk-Expr_ok-6-b">else #6-b</a>]</sub>+++
+  ... The result is xref:typedExpressionIR[``typedExpressionIR~l_reduced~`` ``binop`` ``typedExpressionIR~r_reduced~`` annotated with ``expressionNoteIR``].
+ .. {empty}+++<span class="bk-arm-anchor" id="bk-Expr_ok-6-b"></span>+++
+  ... Check that ``typeIR~r_reduced~`` does not have type ``fixedBitTypeIR``.+++<sub class="bk-mark">[<a href="#bk-Expr_ok-6">fail #6</a>]</sub>+++
+  ... Check that ``ctk~r_reduced~`` is ``+LCTK+``.+++<sub class="bk-mark">[<a href="#bk-Expr_ok-6">fail #6</a>]</sub>+++
+  ... Let ``value`` be the result of xref:Expr_eval_lctk[local compile-time evaluation of ``typedExpressionIR~r_reduced~``, under context ``TC`` at ``p``].+++<sub class="bk-mark">[<a href="#bk-Expr_ok-6">fail #6</a>]</sub>+++
+  ... Let!~type~ ``integerValue~r~`` be ``value``.+++<sub class="bk-mark">[<a href="#bk-Expr_ok-6">fail #6</a>]</sub>+++
+  ... Let ``i~r~`` be xref:int_of_integerValue[the integer representation of  ``integerValue~r~``].+++<sub class="bk-mark">[<a href="#bk-Expr_ok-6">fail #6</a>]</sub>+++
+  ... Check that ``i~r~`` is greater than or equal to ``0``.+++<sub class="bk-mark">[<a href="#bk-Expr_ok-6">fail #6</a>]</sub>+++
+  ... Let ``ctk~reduced~`` be xref:join_ctk[the join of ``ctk~l_reduced~`` and ``ctk~r_reduced~``].+++<sub class="bk-mark">[<a href="#bk-Expr_ok-6">fail #6</a>]</sub>+++
+  ... Let ``expressionNoteIR`` be xref:expressionNoteIR[a pair of type ``typeIR~l_reduced~`` and compile-time known-ness ``ctk~reduced~``].+++<sub class="bk-mark">[<a href="#bk-Expr_ok-6">fail #6</a>]</sub>+++
+  ... The result is xref:typedExpressionIR[``typedExpressionIR~l_reduced~`` ``binop`` ``typedExpressionIR~r_reduced~`` annotated with ``expressionNoteIR``].
 
 xref:Expr_ok[Typing ``expression~l~`` ``binop`` ``expression~r~``, under context ``TC`` at ``p``]:
 
@@ -9942,60 +9946,60 @@ xref:Expr_ok[Typing ``expression~base~`` ``+'.'+`` ``member``, under context ``T
 
 . Let ``typedExpressionIR~base~`` be the result of xref:Expr_ok[typing ``expression~base~``, under context ``TC`` at ``p``].
 . Let ``typeIR~base~`` be xref:type_of_typedExpressionIR[the type of ``typedExpressionIR~base~``].
-. Try pass:[<strong id="bk-Expr_ok-6" class="bk-label">#6</strong>]:
- .. {empty}+++<span class="bk-arm-anchor" id="bk-Expr_ok-6-a"></span>+++
-  ... Let ``typeIR'`` be xref:unroll_typeIR[``typeIR~base~`` with typedefs unrolled].+++<sub class="bk-mark">[<a href="#bk-Expr_ok-6-b">else #6-b</a>]</sub>+++
-  ... Let!~type~ ``+HEADER_STACK+`` ``typeIR`` ``+`[+`` ``n~size~`` ``+`]+`` be ``typeIR'``.+++<sub class="bk-mark">[<a href="#bk-Expr_ok-6-b">else #6-b</a>]</sub>+++
-  ... Try pass:[<strong id="bk-Expr_ok-7" class="bk-label">#7</strong>]:
-   .... {empty}+++<span class="bk-arm-anchor" id="bk-Expr_ok-7-A"></span>+++
-    ..... Check that ``"size"`` is equal to xref:name[the name of ``member``].+++<sub class="bk-mark">[<a href="#bk-Expr_ok-7-B">else #7-B</a>]</sub>+++
-    ..... Let ``expressionNoteIR`` be xref:expressionNoteIR[a pair of type ``+BIT+`` ``+`<+`` ``32`` ``+`>+`` and compile-time known-ness ``+LCTK+``].+++<sub class="bk-mark">[<a href="#bk-Expr_ok-7-B">else #7-B</a>]</sub>+++
+. Try pass:[<strong id="bk-Expr_ok-7" class="bk-label">#7</strong>]:
+ .. {empty}+++<span class="bk-arm-anchor" id="bk-Expr_ok-7-a"></span>+++
+  ... Let ``typeIR'`` be xref:unroll_typeIR[``typeIR~base~`` with typedefs unrolled].+++<sub class="bk-mark">[<a href="#bk-Expr_ok-7-b">else #7-b</a>]</sub>+++
+  ... Let!~type~ ``+HEADER_STACK+`` ``typeIR`` ``+`[+`` ``n~size~`` ``+`]+`` be ``typeIR'``.+++<sub class="bk-mark">[<a href="#bk-Expr_ok-7-b">else #7-b</a>]</sub>+++
+  ... Try pass:[<strong id="bk-Expr_ok-8" class="bk-label">#8</strong>]:
+   .... {empty}+++<span class="bk-arm-anchor" id="bk-Expr_ok-8-A"></span>+++
+    ..... Check that ``"size"`` is equal to xref:name[the name of ``member``].+++<sub class="bk-mark">[<a href="#bk-Expr_ok-8-B">else #8-B</a>]</sub>+++
+    ..... Let ``expressionNoteIR`` be xref:expressionNoteIR[a pair of type ``+BIT+`` ``+`<+`` ``32`` ``+`>+`` and compile-time known-ness ``+LCTK+``].+++<sub class="bk-mark">[<a href="#bk-Expr_ok-8-B">else #8-B</a>]</sub>+++
     ..... The result is xref:typedExpressionIR[``typedExpressionIR~base~`` ``+'.'+`` ``"size"`` annotated with ``expressionNoteIR``].
-   .... {empty}+++<span class="bk-arm-anchor" id="bk-Expr_ok-7-B"></span>+++
-    ..... Check that ``"lastIndex"`` is equal to xref:name[the name of ``member``].+++<sub class="bk-mark">[<a href="#bk-Expr_ok-7-C">else #7-C</a>]</sub>+++
-    ..... Check that ``p`` is equal to ``+BLOCK+`` and ``TC.+BLOCK+.+KIND+`` is equal to ``+PARSER+`` or ``p`` is equal to ``+LOCAL+`` and ``TC.+LOCAL+.+KIND+`` is equal to ``+PARSER_STATE+``.+++<sub class="bk-mark">[<a href="#bk-Expr_ok-7-C">else #7-C</a>]</sub>+++
-    ..... Let ``expressionNoteIR`` be xref:expressionNoteIR[a pair of type ``+BIT+`` ``+`<+`` ``32`` ``+`>+`` and compile-time known-ness ``+DYN+``].+++<sub class="bk-mark">[<a href="#bk-Expr_ok-7-C">else #7-C</a>]</sub>+++
+   .... {empty}+++<span class="bk-arm-anchor" id="bk-Expr_ok-8-B"></span>+++
+    ..... Check that ``"lastIndex"`` is equal to xref:name[the name of ``member``].+++<sub class="bk-mark">[<a href="#bk-Expr_ok-8-C">else #8-C</a>]</sub>+++
+    ..... Check that ``p`` is equal to ``+BLOCK+`` and ``TC.+BLOCK+.+KIND+`` is equal to ``+PARSER+`` or ``p`` is equal to ``+LOCAL+`` and ``TC.+LOCAL+.+KIND+`` is equal to ``+PARSER_STATE+``.+++<sub class="bk-mark">[<a href="#bk-Expr_ok-8-C">else #8-C</a>]</sub>+++
+    ..... Let ``expressionNoteIR`` be xref:expressionNoteIR[a pair of type ``+BIT+`` ``+`<+`` ``32`` ``+`>+`` and compile-time known-ness ``+DYN+``].+++<sub class="bk-mark">[<a href="#bk-Expr_ok-8-C">else #8-C</a>]</sub>+++
     ..... The result is xref:typedExpressionIR[``typedExpressionIR~base~`` ``+'.'+`` ``"lastIndex"`` annotated with ``expressionNoteIR``].
-   .... {empty}+++<span class="bk-arm-anchor" id="bk-Expr_ok-7-C"></span>+++
-    ..... Check that ``"last"`` is equal to xref:name[the name of ``member``].+++<sub class="bk-mark">[<a href="#bk-Expr_ok-7-D">else #7-D</a>]</sub>+++
-    ..... Check that ``p`` is equal to ``+BLOCK+`` and ``TC.+BLOCK+.+KIND+`` is equal to ``+PARSER+`` or ``p`` is equal to ``+LOCAL+`` and ``TC.+LOCAL+.+KIND+`` is equal to ``+PARSER_STATE+``.+++<sub class="bk-mark">[<a href="#bk-Expr_ok-7-D">else #7-D</a>]</sub>+++
-    ..... Let ``expressionNoteIR`` be xref:expressionNoteIR[a pair of type ``typeIR`` and compile-time known-ness ``+DYN+``].+++<sub class="bk-mark">[<a href="#bk-Expr_ok-7-D">else #7-D</a>]</sub>+++
+   .... {empty}+++<span class="bk-arm-anchor" id="bk-Expr_ok-8-C"></span>+++
+    ..... Check that ``"last"`` is equal to xref:name[the name of ``member``].+++<sub class="bk-mark">[<a href="#bk-Expr_ok-8-D">else #8-D</a>]</sub>+++
+    ..... Check that ``p`` is equal to ``+BLOCK+`` and ``TC.+BLOCK+.+KIND+`` is equal to ``+PARSER+`` or ``p`` is equal to ``+LOCAL+`` and ``TC.+LOCAL+.+KIND+`` is equal to ``+PARSER_STATE+``.+++<sub class="bk-mark">[<a href="#bk-Expr_ok-8-D">else #8-D</a>]</sub>+++
+    ..... Let ``expressionNoteIR`` be xref:expressionNoteIR[a pair of type ``typeIR`` and compile-time known-ness ``+DYN+``].+++<sub class="bk-mark">[<a href="#bk-Expr_ok-8-D">else #8-D</a>]</sub>+++
     ..... The result is xref:typedExpressionIR[``typedExpressionIR~base~`` ``+'.'+`` ``"last"`` annotated with ``expressionNoteIR``].
-   .... {empty}+++<span class="bk-arm-anchor" id="bk-Expr_ok-7-D"></span>+++
-    ..... Check that ``"next"`` is equal to xref:name[the name of ``member``].+++<sub class="bk-mark">[<a href="#bk-Expr_ok-7">fail #7</a>]</sub>+++
-    ..... Check that ``p`` is equal to ``+BLOCK+`` and ``TC.+BLOCK+.+KIND+`` is equal to ``+PARSER+`` or ``p`` is equal to ``+LOCAL+`` and ``TC.+LOCAL+.+KIND+`` is equal to ``+PARSER_STATE+``.+++<sub class="bk-mark">[<a href="#bk-Expr_ok-7">fail #7</a>]</sub>+++
-    ..... Let ``expressionNoteIR`` be xref:expressionNoteIR[a pair of type ``typeIR`` and compile-time known-ness ``+DYN+``].+++<sub class="bk-mark">[<a href="#bk-Expr_ok-7">fail #7</a>]</sub>+++
+   .... {empty}+++<span class="bk-arm-anchor" id="bk-Expr_ok-8-D"></span>+++
+    ..... Check that ``"next"`` is equal to xref:name[the name of ``member``].+++<sub class="bk-mark">[<a href="#bk-Expr_ok-8">fail #8</a>]</sub>+++
+    ..... Check that ``p`` is equal to ``+BLOCK+`` and ``TC.+BLOCK+.+KIND+`` is equal to ``+PARSER+`` or ``p`` is equal to ``+LOCAL+`` and ``TC.+LOCAL+.+KIND+`` is equal to ``+PARSER_STATE+``.+++<sub class="bk-mark">[<a href="#bk-Expr_ok-8">fail #8</a>]</sub>+++
+    ..... Let ``expressionNoteIR`` be xref:expressionNoteIR[a pair of type ``typeIR`` and compile-time known-ness ``+DYN+``].+++<sub class="bk-mark">[<a href="#bk-Expr_ok-8">fail #8</a>]</sub>+++
     ..... The result is xref:typedExpressionIR[``typedExpressionIR~base~`` ``+'.'+`` ``"next"`` annotated with ``expressionNoteIR``].
- .. {empty}+++<span class="bk-arm-anchor" id="bk-Expr_ok-6-b"></span>+++
-  ... Let ``ctk~base~`` be xref:ctk_of_typedExpressionIR[the compile-time known-ness of ``typedExpressionIR~base~``].+++<sub class="bk-mark">[<a href="#bk-Expr_ok-6-c">else #6-c</a>]</sub>+++
-  ... Let ``typeIR'`` be xref:unroll_typeIR[``typeIR~base~`` with typedefs unrolled].+++<sub class="bk-mark">[<a href="#bk-Expr_ok-6-c">else #6-c</a>]</sub>+++
+ .. {empty}+++<span class="bk-arm-anchor" id="bk-Expr_ok-7-b"></span>+++
+  ... Let ``ctk~base~`` be xref:ctk_of_typedExpressionIR[the compile-time known-ness of ``typedExpressionIR~base~``].+++<sub class="bk-mark">[<a href="#bk-Expr_ok-7-c">else #7-c</a>]</sub>+++
+  ... Let ``typeIR'`` be xref:unroll_typeIR[``typeIR~base~`` with typedefs unrolled].+++<sub class="bk-mark">[<a href="#bk-Expr_ok-7-c">else #7-c</a>]</sub>+++
   ... If let ``+STRUCT+`` ``++_++`` ``+`<+`` ``++_++^{asterisk}^`` ``+`>+`` ``+`{+`` ``(`` ``++_++`` ``typeIR~f~`` ``nameIR~f~`` ``+';'+`` ``)^{asterisk}^`` ``+`}+`` be ``typeIR'``:
-   .... Let ``nameIR`` be xref:name[the name of ``member``].+++<sub class="bk-mark">[<a href="#bk-Expr_ok-6-c">else #6-c</a>]</sub>+++
-   .... Let ``typeIR`` be xref:option_get[*!*] xref:assoc_[the value associated to ``nameIR`` in ``(`` ``nameIR~f~,`` ``typeIR~f~`` ``)^{asterisk}^``].+++<sub class="bk-mark">[<a href="#bk-Expr_ok-6-c">else #6-c</a>]</sub>+++
-   .... Let ``expressionNoteIR`` be xref:expressionNoteIR[a pair of type ``typeIR`` and compile-time known-ness ``ctk~base~``].+++<sub class="bk-mark">[<a href="#bk-Expr_ok-6-c">else #6-c</a>]</sub>+++
+   .... Let ``nameIR`` be xref:name[the name of ``member``].+++<sub class="bk-mark">[<a href="#bk-Expr_ok-7-c">else #7-c</a>]</sub>+++
+   .... Let ``typeIR`` be xref:option_get[*!*] xref:assoc_[the value associated to ``nameIR`` in ``(`` ``nameIR~f~,`` ``typeIR~f~`` ``)^{asterisk}^``].+++<sub class="bk-mark">[<a href="#bk-Expr_ok-7-c">else #7-c</a>]</sub>+++
+   .... Let ``expressionNoteIR`` be xref:expressionNoteIR[a pair of type ``typeIR`` and compile-time known-ness ``ctk~base~``].+++<sub class="bk-mark">[<a href="#bk-Expr_ok-7-c">else #7-c</a>]</sub>+++
    .... The result is xref:typedExpressionIR[``typedExpressionIR~base~`` ``+'.'+`` ``nameIR`` annotated with ``expressionNoteIR``].
   ... Else if let ``+HEADER+`` ``++_++`` ``+`<+`` ``++_++^{asterisk}^`` ``+`>+`` ``+`{+`` ``(`` ``++_++`` ``typeIR~f~`` ``nameIR~f~`` ``+';'+`` ``)^{asterisk}^`` ``+`}+`` be ``typeIR'``:
-   .... Let ``nameIR`` be xref:name[the name of ``member``].+++<sub class="bk-mark">[<a href="#bk-Expr_ok-6-c">else #6-c</a>]</sub>+++
-   .... Let ``typeIR`` be xref:option_get[*!*] xref:assoc_[the value associated to ``nameIR`` in ``(`` ``nameIR~f~,`` ``typeIR~f~`` ``)^{asterisk}^``].+++<sub class="bk-mark">[<a href="#bk-Expr_ok-6-c">else #6-c</a>]</sub>+++
-   .... Let ``expressionNoteIR`` be xref:expressionNoteIR[a pair of type ``typeIR`` and compile-time known-ness ``ctk~base~``].+++<sub class="bk-mark">[<a href="#bk-Expr_ok-6-c">else #6-c</a>]</sub>+++
+   .... Let ``nameIR`` be xref:name[the name of ``member``].+++<sub class="bk-mark">[<a href="#bk-Expr_ok-7-c">else #7-c</a>]</sub>+++
+   .... Let ``typeIR`` be xref:option_get[*!*] xref:assoc_[the value associated to ``nameIR`` in ``(`` ``nameIR~f~,`` ``typeIR~f~`` ``)^{asterisk}^``].+++<sub class="bk-mark">[<a href="#bk-Expr_ok-7-c">else #7-c</a>]</sub>+++
+   .... Let ``expressionNoteIR`` be xref:expressionNoteIR[a pair of type ``typeIR`` and compile-time known-ness ``ctk~base~``].+++<sub class="bk-mark">[<a href="#bk-Expr_ok-7-c">else #7-c</a>]</sub>+++
    .... The result is xref:typedExpressionIR[``typedExpressionIR~base~`` ``+'.'+`` ``nameIR`` annotated with ``expressionNoteIR``].
   ... Else if let ``+HEADER_UNION+`` ``++_++`` ``+`<+`` ``++_++^{asterisk}^`` ``+`>+`` ``+`{+`` ``(`` ``++_++`` ``typeIR~f~`` ``nameIR~f~`` ``+';'+`` ``)^{asterisk}^`` ``+`}+`` be ``typeIR'``:
-   .... Let ``nameIR`` be xref:name[the name of ``member``].+++<sub class="bk-mark">[<a href="#bk-Expr_ok-6-c">else #6-c</a>]</sub>+++
-   .... Let ``typeIR`` be xref:option_get[*!*] xref:assoc_[the value associated to ``nameIR`` in ``(`` ``nameIR~f~,`` ``typeIR~f~`` ``)^{asterisk}^``].+++<sub class="bk-mark">[<a href="#bk-Expr_ok-6-c">else #6-c</a>]</sub>+++
-   .... Let ``expressionNoteIR`` be xref:expressionNoteIR[a pair of type ``typeIR`` and compile-time known-ness ``ctk~base~``].+++<sub class="bk-mark">[<a href="#bk-Expr_ok-6-c">else #6-c</a>]</sub>+++
+   .... Let ``nameIR`` be xref:name[the name of ``member``].+++<sub class="bk-mark">[<a href="#bk-Expr_ok-7-c">else #7-c</a>]</sub>+++
+   .... Let ``typeIR`` be xref:option_get[*!*] xref:assoc_[the value associated to ``nameIR`` in ``(`` ``nameIR~f~,`` ``typeIR~f~`` ``)^{asterisk}^``].+++<sub class="bk-mark">[<a href="#bk-Expr_ok-7-c">else #7-c</a>]</sub>+++
+   .... Let ``expressionNoteIR`` be xref:expressionNoteIR[a pair of type ``typeIR`` and compile-time known-ness ``ctk~base~``].+++<sub class="bk-mark">[<a href="#bk-Expr_ok-7-c">else #7-c</a>]</sub>+++
    .... The result is xref:typedExpressionIR[``typedExpressionIR~base~`` ``+'.'+`` ``nameIR`` annotated with ``expressionNoteIR``].
- .. {empty}+++<span class="bk-arm-anchor" id="bk-Expr_ok-6-c"></span>+++
-  ... Let ``typeIR`` be xref:unroll_typeIR[``typeIR~base~`` with typedefs unrolled].+++<sub class="bk-mark">[<a href="#bk-Expr_ok-6">fail #6</a>]</sub>+++
-  ... Let!~type~ ``+TABLE_STRUCT+`` ``++_++`` ``+`{+`` ``+HIT+`` ``boolTypeIR`` ``+';'+`` ``+MISS+`` ``++_++`` ``+';'+`` ``+ACTION_RUN+`` ``++_++`` ``+';'+`` ``+`}+`` be ``typeIR``.+++<sub class="bk-mark">[<a href="#bk-Expr_ok-6">fail #6</a>]</sub>+++
-  ... Let ``nameIR`` be xref:name[the name of ``member``].+++<sub class="bk-mark">[<a href="#bk-Expr_ok-6">fail #6</a>]</sub>+++
+ .. {empty}+++<span class="bk-arm-anchor" id="bk-Expr_ok-7-c"></span>+++
+  ... Let ``typeIR`` be xref:unroll_typeIR[``typeIR~base~`` with typedefs unrolled].+++<sub class="bk-mark">[<a href="#bk-Expr_ok-7">fail #7</a>]</sub>+++
+  ... Let!~type~ ``+TABLE_STRUCT+`` ``++_++`` ``+`{+`` ``+HIT+`` ``boolTypeIR`` ``+';'+`` ``+MISS+`` ``++_++`` ``+';'+`` ``+ACTION_RUN+`` ``++_++`` ``+';'+`` ``+`}+`` be ``typeIR``.+++<sub class="bk-mark">[<a href="#bk-Expr_ok-7">fail #7</a>]</sub>+++
+  ... Let ``nameIR`` be xref:name[the name of ``member``].+++<sub class="bk-mark">[<a href="#bk-Expr_ok-7">fail #7</a>]</sub>+++
   ... If ``nameIR`` is equal to ``"hit"``:
-   .... Let ``expressionNoteIR`` be xref:expressionNoteIR[a pair of type ``boolTypeIR`` and compile-time known-ness ``+DYN+``].+++<sub class="bk-mark">[<a href="#bk-Expr_ok-6">fail #6</a>]</sub>+++
+   .... Let ``expressionNoteIR`` be xref:expressionNoteIR[a pair of type ``boolTypeIR`` and compile-time known-ness ``+DYN+``].+++<sub class="bk-mark">[<a href="#bk-Expr_ok-7">fail #7</a>]</sub>+++
    .... The result is xref:typedExpressionIR[``typedExpressionIR~base~`` ``+'.'+`` ``nameIR`` annotated with ``expressionNoteIR``].
   ... Else if ``nameIR`` is equal to ``"miss"``:
-   .... Let ``expressionNoteIR`` be xref:expressionNoteIR[a pair of type ``++_++`` and compile-time known-ness ``+DYN+``].+++<sub class="bk-mark">[<a href="#bk-Expr_ok-6">fail #6</a>]</sub>+++
+   .... Let ``expressionNoteIR`` be xref:expressionNoteIR[a pair of type ``++_++`` and compile-time known-ness ``+DYN+``].+++<sub class="bk-mark">[<a href="#bk-Expr_ok-7">fail #7</a>]</sub>+++
    .... The result is xref:typedExpressionIR[``typedExpressionIR~base~`` ``+'.'+`` ``nameIR`` annotated with ``expressionNoteIR``].
   ... Else if ``nameIR`` is equal to ``"action_run"``:
-   .... Let ``expressionNoteIR`` be xref:expressionNoteIR[a pair of type ``++_++`` and compile-time known-ness ``+DYN+``].+++<sub class="bk-mark">[<a href="#bk-Expr_ok-6">fail #6</a>]</sub>+++
+   .... Let ``expressionNoteIR`` be xref:expressionNoteIR[a pair of type ``++_++`` and compile-time known-ness ``+DYN+``].+++<sub class="bk-mark">[<a href="#bk-Expr_ok-7">fail #7</a>]</sub>+++
    .... The result is xref:typedExpressionIR[``typedExpressionIR~base~`` ``+'.'+`` ``nameIR`` annotated with ``expressionNoteIR``].
 
 <<Expr_ok,Typing ``expression~base~`` ``+`[+`` ``expression~index~`` ``+`]+``, under context ``TC`` at ``p``>>:
@@ -10099,7 +10103,8 @@ xref:Expr_ok[Typing ``expression~base~`` ``+'.'+`` ``member``, under context ``T
   ... Let ``expressionNoteIR`` be xref:expressionNoteIR[a pair of type ``typeIR`` and compile-time known-ness ``ctk~base_reduced~``].
   ... The result is <<typedExpressionIR,``typedExpressionIR~base~`` ``+`[+`` ``typedExpressionIR~l_reduced~`` ``+'+:'+`` ``typedExpressionIR~w_reduced~`` ``+`]+`` annotated with ``expressionNoteIR``>>.
  .. Else:
-  ... Check that ``typeIR~l_reduced~`` has type ``fixedBitTypeIR``.
+  ... Let ``typeIR'`` be xref:unroll_typeIR[``typeIR~l_reduced~`` with typedefs unrolled].
+  ... Check that ``typeIR'`` has type ``fixedBitTypeIR``.
   ... Check that ``ctk~w_reduced~`` is ``+LCTK+``.
   ... Let ``value`` be the result of xref:Expr_eval_lctk[local compile-time evaluation of ``typedExpressionIR~w_reduced~``, under context ``TC`` at ``p``].
   ... Let!~type~ ``integerValue~w~`` be ``value``.

--- a/p4spec/test/lang/elab.expected
+++ b/p4spec/test/lang/elab.expected
@@ -9736,7 +9736,7 @@ relation Expr_ok: cursor typingContext |- expression : typedExpressionIR
     -- if (ctk_l_reduced = $ctk_of_typedExpressionIR(typedExpressionIR_l_reduced))
     -- if (typeIR_r_reduced = $type_of_typedExpressionIR(typedExpressionIR_r_reduced))
     -- if (ctk_r_reduced = $ctk_of_typedExpressionIR(typedExpressionIR_r_reduced))
-    -- if (BIT `< _nat `> as typeIR = typeIR_r_reduced)
+    -- if (BIT `< _nat `> as typeIR = $unroll_typeIR(typeIR_r_reduced))
     -- if ((typeIR_l_reduced = INT as typeIR) => (ctk_r_reduced = LCTK))
     -- if (ctk_reduced = $join_ctk(ctk_l_reduced, ctk_r_reduced))
     -- if (expressionNoteIR = `( typeIR_l_reduced ctk_reduced `))
@@ -10182,7 +10182,7 @@ relation Expr_ok: cursor typingContext |- expression : typedExpressionIR
     -- if (typeIR_w_reduced = $type_of_typedExpressionIR(typedExpressionIR_w_reduced))
     -- if (ctk_w_reduced = $ctk_of_typedExpressionIR(typedExpressionIR_w_reduced))
     -- if (ctk_l_reduced =/= LCTK)
-    -- if (BIT `< _nat `> as typeIR = typeIR_l_reduced)
+    -- if (BIT `< _nat `> as typeIR = $unroll_typeIR(typeIR_l_reduced))
     -- if (ctk_w_reduced = LCTK)
     -- Expr_eval_lctk: p TC |- typedExpressionIR_w_reduced ~> integerValue_w as value
     -- if (?(n_w) = $nat_of_integerValue(integerValue_w))

--- a/p4spec/test/lang/struct.expected
+++ b/p4spec/test/lang/struct.expected
@@ -21431,9 +21431,9 @@ relation Expr_ok: p TC |- expression'' : %
 
                           1. (Let ctk_r_reduced be $ctk_of_typedExpressionIR(typedExpressionIR_r_reduced))
 
-                            1. Case analysis on (typeIR_r_reduced has type fixedBitTypeIR)
+                            1. (Let typeIR be $unroll_typeIR(typeIR_r_reduced))
 
-                              1. Case true
+                              1. If ((typeIR has type fixedBitTypeIR)), then
 
                                 1. If (((typeIR_l_reduced = ((INT) as typeIR)) => (ctk_r_reduced = (LCTK)))), then
 
@@ -21443,33 +21443,37 @@ relation Expr_ok: p TC |- expression'' : %
 
                                       1. Result in: % % |- % : (((typedExpressionIR_l_reduced binop typedExpressionIR_r_reduced) as expressionIR) '#' expressionNoteIR)
 
-                                1. Else Dangling#6066
+                                1. Else Dangling#6067
 
-                              2. Case false
+                              1. Else Dangling#6066
 
-                                1. If ((ctk_r_reduced matches pattern `LCTK`)), then
+                            2. If (~(typeIR_r_reduced has type fixedBitTypeIR)), then
 
-                                  1. (Expr_eval_lctk: p TC |- typedExpressionIR_r_reduced ~> value)
+                              1. If ((ctk_r_reduced matches pattern `LCTK`)), then
 
-                                    1. If ((value has type integerValue)), then
+                                1. (Expr_eval_lctk: p TC |- typedExpressionIR_r_reduced ~> value)
 
-                                      1. (Let integerValue_r be (value as integerValue))
+                                  1. If ((value has type integerValue)), then
 
-                                        1. (Let i_r be $int_of_integerValue(integerValue_r))
+                                    1. (Let integerValue_r be (value as integerValue))
 
-                                          1. If ((i_r >= (0 as int))), then
+                                      1. (Let i_r be $int_of_integerValue(integerValue_r))
 
-                                            1. (Let ctk_reduced be $join_ctk(ctk_l_reduced, ctk_r_reduced))
+                                        1. If ((i_r >= (0 as int))), then
 
-                                              1. (Let expressionNoteIR be (`( typeIR_l_reduced ctk_reduced `)))
+                                          1. (Let ctk_reduced be $join_ctk(ctk_l_reduced, ctk_r_reduced))
 
-                                                1. Result in: % % |- % : (((typedExpressionIR_l_reduced binop typedExpressionIR_r_reduced) as expressionIR) '#' expressionNoteIR)
+                                            1. (Let expressionNoteIR be (`( typeIR_l_reduced ctk_reduced `)))
 
-                                          1. Else Dangling#6075
+                                              1. Result in: % % |- % : (((typedExpressionIR_l_reduced binop typedExpressionIR_r_reduced) as expressionIR) '#' expressionNoteIR)
 
-                                    1. Else Dangling#6072
+                                        1. Else Dangling#6077
 
-                                1. Else Dangling#6070
+                                  1. Else Dangling#6074
+
+                              1. Else Dangling#6072
+
+                            2. Else Dangling#6071
 
                 1. Else Dangling#6059
 
@@ -21499,9 +21503,9 @@ relation Expr_ok: p TC |- expression'' : %
 
                                 1. Result in: % % |- % : (((typedExpressionIR_l_cast binop typedExpressionIR_r_cast) as expressionIR) '#' expressionNoteIR)
 
-                          1. Else Dangling#6087
+                          1. Else Dangling#6089
 
-                1. Else Dangling#6082
+                1. Else Dangling#6084
 
         6. Case (% is in [('<='), ('>='), ('<'), ('>')])
 
@@ -21533,9 +21537,9 @@ relation Expr_ok: p TC |- expression'' : %
 
                                     1. Result in: % % |- % : (((typedExpressionIR_l_reduced binop typedExpressionIR_r_reduced) as expressionIR) '#' expressionNoteIR)
 
-                      1. Else Dangling#6097
+                      1. Else Dangling#6099
 
-                1. Else Dangling#6094
+                1. Else Dangling#6096
 
         7. Case (% is in [('&'), ('^'), ('|')])
 
@@ -21567,9 +21571,9 @@ relation Expr_ok: p TC |- expression'' : %
 
                                     1. Result in: % % |- % : (((typedExpressionIR_l_reduced binop typedExpressionIR_r_reduced) as expressionIR) '#' expressionNoteIR)
 
-                      1. Else Dangling#6111
+                      1. Else Dangling#6113
 
-                1. Else Dangling#6108
+                1. Else Dangling#6110
 
         8. Case (% is in [('&&'), ('||')])
 
@@ -21601,9 +21605,9 @@ relation Expr_ok: p TC |- expression'' : %
 
                                     1. Result in: % % |- % : (((typedExpressionIR_l_reduced binop typedExpressionIR_r_reduced) as expressionIR) '#' expressionNoteIR)
 
-                      1. Else Dangling#6125
+                      1. Else Dangling#6127
 
-                1. Else Dangling#6122
+                1. Else Dangling#6124
 
       1. Else Dangling#6002
 
@@ -21637,11 +21641,11 @@ relation Expr_ok: p TC |- expression'' : %
 
                                   1. Result in: % % |- % : (((typedExpressionIR_l_reduced ('++') typedExpressionIR_r_reduced) as expressionIR) '#' expressionNoteIR)
 
-                          1. Else Dangling#6143
+                          1. Else Dangling#6145
 
-              1. Else Dangling#6137
+              1. Else Dangling#6139
 
-      2. Else Dangling#6133
+      2. Else Dangling#6135
 
   8. Case (% has type ternaryExpression)
 
@@ -21679,11 +21683,11 @@ relation Expr_ok: p TC |- expression'' : %
 
                                     1. Result in: % % |- % : (((typedExpressionIR_cond '?' typedExpressionIR_true_cast ':' typedExpressionIR_false_cast) as expressionIR) '#' expressionNoteIR)
 
-                              1. Else Dangling#6161
+                              1. Else Dangling#6163
 
-                    1. Else Dangling#6156
+                    1. Else Dangling#6158
 
-            1. Else Dangling#6152
+            1. Else Dangling#6154
 
   9. Case (% has type castExpression)
 
@@ -21707,11 +21711,11 @@ relation Expr_ok: p TC |- expression'' : %
 
                       1. Result in: % % |- % : (((`( typeIR_t `) typedExpressionIR) as expressionIR) '#' expressionNoteIR)
 
-                  1. Else Dangling#6172
+                  1. Else Dangling#6174
 
-          1. Else Dangling#6168
+          1. Else Dangling#6170
 
-        1. Else Dangling#6167
+        1. Else Dangling#6169
 
   10. Case (% has type invalidHeaderExpression)
 
@@ -21781,11 +21785,11 @@ relation Expr_ok: p TC |- expression'' : %
 
                                             1. Result in: % % |- % : (((SEQ `{ (typedExpressionIR_e_h)*{typedExpressionIR_e_h <- typedExpressionIR_e_h*} ',' '...' `}) as expressionIR) '#' expressionNoteIR)
 
-                              1. Else Dangling#6196
+                              1. Else Dangling#6198
 
-                        1. Else Dangling#6193
+                        1. Else Dangling#6195
 
-                    1. Else Dangling#6191
+                    1. Else Dangling#6193
 
         2. Case (% has type recordElementExpression)
 
@@ -21859,9 +21863,9 @@ relation Expr_ok: p TC |- expression'' : %
 
                                           1. Result in: % % |- % : (((RECORD `{ ((nameIR_f '=' typedExpressionIR_f))*{nameIR_f <- nameIR_f*, typedExpressionIR_f <- typedExpressionIR_f*} `}) as expressionIR) '#' expressionNoteIR)
 
-                                  1. Else Dangling#6231
+                                  1. Else Dangling#6233
 
-                        1. Else Dangling#6226
+                        1. Else Dangling#6228
 
               4. Case (% matches pattern `% = % , % , ...`)
 
@@ -21893,9 +21897,9 @@ relation Expr_ok: p TC |- expression'' : %
 
                                           1. Result in: % % |- % : (((RECORD `{ ((nameIR_f '=' typedExpressionIR_f))*{nameIR_f <- nameIR_f*, typedExpressionIR_f <- typedExpressionIR_f*} ',' '...' `}) as expressionIR) '#' expressionNoteIR)
 
-                                  1. Else Dangling#6245
+                                  1. Else Dangling#6247
 
-                        1. Else Dangling#6240
+                        1. Else Dangling#6242
 
   12. Case (% has type errorAccessExpression)
 
@@ -21911,7 +21915,7 @@ relation Expr_ok: p TC |- expression'' : %
 
               1. Result in: % % |- % : (((ERROR '.' nameIR) as expressionIR) '#' expressionNoteIR)
 
-          1. Else Dangling#6253
+          1. Else Dangling#6255
 
   13. Case (% has type memberAccessExpression)
 
@@ -21951,7 +21955,7 @@ relation Expr_ok: p TC |- expression'' : %
 
                                       1. Result in: % % |- % : ((((TYPE prefixedNameIR_base) '.' nameIR) as expressionIR) '#' expressionNoteIR)
 
-                                  1. Else Dangling#6269
+                                  1. Else Dangling#6271
 
                             2. Case (% has type serializableEnumTypeIR)
 
@@ -21965,13 +21969,13 @@ relation Expr_ok: p TC |- expression'' : %
 
                                       1. Result in: % % |- % : ((((TYPE prefixedNameIR_base) '.' nameIR) as expressionIR) '#' expressionNoteIR)
 
-                                  1. Else Dangling#6274
+                                  1. Else Dangling#6276
 
-                          1. Else Dangling#6266
+                          1. Else Dangling#6268
 
-                    1. Else Dangling#6263
+                    1. Else Dangling#6265
 
-                1. Else Dangling#6261
+                1. Else Dangling#6263
 
         2. Case (% has type expression)
 
@@ -21993,7 +21997,7 @@ relation Expr_ok: p TC |- expression'' : %
 
                           1. Result in: % % |- % : ((((typedExpressionIR_base as memberAccessBaseIR) '.' "size") as expressionIR) '#' expressionNoteIR)
 
-                      1. Else Dangling#6283
+                      1. Else Dangling#6285
 
                       2. If (("lastIndex" = $name(member))), then
 
@@ -22003,9 +22007,9 @@ relation Expr_ok: p TC |- expression'' : %
 
                             1. Result in: % % |- % : ((((typedExpressionIR_base as memberAccessBaseIR) '.' "lastIndex") as expressionIR) '#' expressionNoteIR)
 
-                        1. Else Dangling#6287
+                        1. Else Dangling#6289
 
-                      2. Else Dangling#6286
+                      2. Else Dangling#6288
 
                       3. If (("last" = $name(member))), then
 
@@ -22015,9 +22019,9 @@ relation Expr_ok: p TC |- expression'' : %
 
                             1. Result in: % % |- % : ((((typedExpressionIR_base as memberAccessBaseIR) '.' "last") as expressionIR) '#' expressionNoteIR)
 
-                        1. Else Dangling#6291
+                        1. Else Dangling#6293
 
-                      3. Else Dangling#6290
+                      3. Else Dangling#6292
 
                       4. If (("next" = $name(member))), then
 
@@ -22027,11 +22031,11 @@ relation Expr_ok: p TC |- expression'' : %
 
                             1. Result in: % % |- % : ((((typedExpressionIR_base as memberAccessBaseIR) '.' "next") as expressionIR) '#' expressionNoteIR)
 
-                        1. Else Dangling#6295
+                        1. Else Dangling#6297
 
-                      4. Else Dangling#6294
+                      4. Else Dangling#6296
 
-                  1. Else Dangling#6281
+                  1. Else Dangling#6283
 
                 2. (Let ctk_base be $ctk_of_typedExpressionIR(typedExpressionIR_base))
 
@@ -22055,7 +22059,7 @@ relation Expr_ok: p TC |- expression'' : %
 
                                     1. Result in: % % |- % : ((((typedExpressionIR_base as memberAccessBaseIR) '.' nameIR) as expressionIR) '#' expressionNoteIR)
 
-                              1. Else Dangling#6304
+                              1. Else Dangling#6306
 
                       2. Case (% has type headerTypeIR)
 
@@ -22073,7 +22077,7 @@ relation Expr_ok: p TC |- expression'' : %
 
                                     1. Result in: % % |- % : ((((typedExpressionIR_base as memberAccessBaseIR) '.' nameIR) as expressionIR) '#' expressionNoteIR)
 
-                              1. Else Dangling#6311
+                              1. Else Dangling#6313
 
                       3. Case (% has type headerUnionTypeIR)
 
@@ -22091,9 +22095,9 @@ relation Expr_ok: p TC |- expression'' : %
 
                                     1. Result in: % % |- % : ((((typedExpressionIR_base as memberAccessBaseIR) '.' nameIR) as expressionIR) '#' expressionNoteIR)
 
-                              1. Else Dangling#6318
+                              1. Else Dangling#6320
 
-                    1. Else Dangling#6300
+                    1. Else Dangling#6302
 
                 3. (Let typeIR be $unroll_typeIR(typeIR_base))
 
@@ -22123,9 +22127,9 @@ relation Expr_ok: p TC |- expression'' : %
 
                               1. Result in: % % |- % : ((((typedExpressionIR_base as memberAccessBaseIR) '.' nameIR) as expressionIR) '#' expressionNoteIR)
 
-                        1. Else Dangling#6326
+                        1. Else Dangling#6328
 
-                  1. Else Dangling#6323
+                  1. Else Dangling#6325
 
   14. Case (% has type indexAccessExpression)
 
@@ -22179,15 +22183,15 @@ relation Expr_ok: p TC |- expression'' : %
 
                                                     1. Result in: % % |- % : (((typedExpressionIR_base `[ typedExpressionIR_index_reduced `]) as expressionIR) '#' expressionNoteIR)
 
-                                                1. Else Dangling#6354
+                                                1. Else Dangling#6356
 
-                                              1. Else Dangling#6353
+                                              1. Else Dangling#6355
 
-                                          1. Else Dangling#6351
+                                          1. Else Dangling#6353
 
-                                    1. Else Dangling#6348
+                                    1. Else Dangling#6350
 
-                                1. Else Dangling#6346
+                                1. Else Dangling#6348
 
                             2. Case (% has type arrayTypeIR)
 
@@ -22215,11 +22219,11 @@ relation Expr_ok: p TC |- expression'' : %
 
                                                     1. Result in: % % |- % : (((typedExpressionIR_base `[ typedExpressionIR_index_reduced `]) as expressionIR) '#' expressionNoteIR)
 
-                                                1. Else Dangling#6365
+                                                1. Else Dangling#6367
 
-                                            1. Else Dangling#6363
+                                            1. Else Dangling#6365
 
-                                      1. Else Dangling#6360
+                                      1. Else Dangling#6362
 
                                   2. Case false
 
@@ -22255,11 +22259,11 @@ relation Expr_ok: p TC |- expression'' : %
 
                                                     1. Result in: % % |- % : (((typedExpressionIR_base `[ typedExpressionIR_index_reduced `]) as expressionIR) '#' expressionNoteIR)
 
-                                                1. Else Dangling#6379
+                                                1. Else Dangling#6381
 
-                                            1. Else Dangling#6377
+                                            1. Else Dangling#6379
 
-                                      1. Else Dangling#6374
+                                      1. Else Dangling#6376
 
                                   2. Case false
 
@@ -22269,9 +22273,9 @@ relation Expr_ok: p TC |- expression'' : %
 
                                         1. Result in: % % |- % : (((typedExpressionIR_base `[ typedExpressionIR_index_reduced `]) as expressionIR) '#' expressionNoteIR)
 
-                          1. Else Dangling#6344
+                          1. Else Dangling#6346
 
-                    1. Else Dangling#6341
+                    1. Else Dangling#6343
 
   15. Case (% has type sliceAccessExpression)
 
@@ -22359,27 +22363,27 @@ relation Expr_ok: p TC |- expression'' : %
 
                                                                                       1. Result in: % % |- % : (((typedExpressionIR_base `[ typedExpressionIR_hi_reduced (':') typedExpressionIR_lo_reduced `]) as expressionIR) '#' expressionNoteIR)
 
-                                                                              1. Else Dangling#6421
+                                                                              1. Else Dangling#6423
 
-                                                                          1. Else Dangling#6419
+                                                                          1. Else Dangling#6421
 
-                                                                      1. Else Dangling#6417
+                                                                      1. Else Dangling#6419
 
-                                                                1. Else Dangling#6414
+                                                                1. Else Dangling#6416
 
-                                                            1. Else Dangling#6412
+                                                            1. Else Dangling#6414
 
-                                                        1. Else Dangling#6410
+                                                        1. Else Dangling#6412
 
-                                                  1. Else Dangling#6407
+                                                  1. Else Dangling#6409
 
-                                              1. Else Dangling#6405
+                                              1. Else Dangling#6407
 
-                                  1. Else Dangling#6399
+                                  1. Else Dangling#6401
 
-                            1. Else Dangling#6396
+                            1. Else Dangling#6398
 
-                  1. Else Dangling#6391
+                  1. Else Dangling#6393
 
         2. Case (% matches pattern `+:`)
 
@@ -22463,59 +22467,61 @@ relation Expr_ok: p TC |- expression'' : %
 
                                                                                         1. Result in: % % |- % : (((typedExpressionIR_base `[ typedExpressionIR_l_reduced ('+:') typedExpressionIR_w_reduced `]) as expressionIR) '#' expressionNoteIR)
 
-                                                                                  1. Else Dangling#6461
+                                                                                  1. Else Dangling#6463
 
-                                                                              1. Else Dangling#6459
+                                                                              1. Else Dangling#6461
 
-                                                                        1. Else Dangling#6456
+                                                                        1. Else Dangling#6458
 
-                                                                  1. Else Dangling#6453
+                                                                  1. Else Dangling#6455
 
-                                                              1. Else Dangling#6451
+                                                              1. Else Dangling#6453
 
-                                                          1. Else Dangling#6449
+                                                          1. Else Dangling#6451
 
-                                                    1. Else Dangling#6446
+                                                    1. Else Dangling#6448
 
                                                 2. Case false
 
-                                                  1. If ((typeIR_l_reduced has type fixedBitTypeIR)), then
+                                                  1. (Let typeIR' be $unroll_typeIR(typeIR_l_reduced))
 
-                                                    1. If ((ctk_w_reduced matches pattern `LCTK`)), then
+                                                    1. If ((typeIR' has type fixedBitTypeIR)), then
 
-                                                      1. (Expr_eval_lctk: p TC |- typedExpressionIR_w_reduced ~> value)
+                                                      1. If ((ctk_w_reduced matches pattern `LCTK`)), then
 
-                                                        1. If ((value has type integerValue)), then
+                                                        1. (Expr_eval_lctk: p TC |- typedExpressionIR_w_reduced ~> value)
 
-                                                          1. (Let integerValue_w be (value as integerValue))
+                                                          1. If ((value has type integerValue)), then
 
-                                                            1. (Let (nat)?{nat <- nat?} be $nat_of_integerValue(integerValue_w))
+                                                            1. (Let integerValue_w be (value as integerValue))
 
-                                                              1. If (((nat)?{nat <- nat?} matches pattern (_))), then
+                                                              1. (Let (nat)?{nat <- nat?} be $nat_of_integerValue(integerValue_w))
 
-                                                                1. (Let ?(n_w) be (nat)?{nat <- nat?})
+                                                                1. If (((nat)?{nat <- nat?} matches pattern (_))), then
 
-                                                                  1. (Let typeIR be ((BIT `< n_w `>) as typeIR))
+                                                                  1. (Let ?(n_w) be (nat)?{nat <- nat?})
 
-                                                                    1. (Let ctk be $joins_ctk([ctk_base_reduced, ctk_l_reduced, ctk_w_reduced]))
+                                                                    1. (Let typeIR be ((BIT `< n_w `>) as typeIR))
 
-                                                                      1. (Let expressionNoteIR be (`( typeIR ctk `)))
+                                                                      1. (Let ctk be $joins_ctk([ctk_base_reduced, ctk_l_reduced, ctk_w_reduced]))
 
-                                                                        1. Result in: % % |- % : (((typedExpressionIR_base `[ typedExpressionIR_l_reduced ('+:') typedExpressionIR_w_reduced `]) as expressionIR) '#' expressionNoteIR)
+                                                                        1. (Let expressionNoteIR be (`( typeIR ctk `)))
 
-                                                              1. Else Dangling#6471
+                                                                          1. Result in: % % |- % : (((typedExpressionIR_base `[ typedExpressionIR_l_reduced ('+:') typedExpressionIR_w_reduced `]) as expressionIR) '#' expressionNoteIR)
 
-                                                        1. Else Dangling#6468
+                                                                1. Else Dangling#6474
 
-                                                    1. Else Dangling#6466
+                                                          1. Else Dangling#6471
 
-                                                  1. Else Dangling#6465
+                                                      1. Else Dangling#6469
 
-                                  1. Else Dangling#6438
+                                                    1. Else Dangling#6468
 
-                            1. Else Dangling#6435
+                                  1. Else Dangling#6440
 
-                  1. Else Dangling#6430
+                            1. Else Dangling#6437
+
+                  1. Else Dangling#6432
 
   16. Case (% has type callExpression)
 
@@ -22553,7 +22559,7 @@ relation Expr_ok: p TC |- expression'' : %
 
                                     1. Result in: % % |- % : ((callExpressionIR as expressionIR) '#' expressionNoteIR)
 
-                              1. Else Dangling#6488
+                              1. Else Dangling#6491
 
               2. Case (% has type specializedType)
 
@@ -22583,7 +22589,7 @@ relation Expr_ok: p TC |- expression'' : %
 
                                         1. Result in: % % |- % : ((callExpressionIR as expressionIR) '#' expressionNoteIR)
 
-                                  1. Else Dangling#6501
+                                  1. Else Dangling#6504
 
               3. Case (% has type callableTarget)
 
@@ -22619,7 +22625,7 @@ relation Expr_ok: p TC |- expression'' : %
 
                                               1. Result in: % % |- % : ((literalExpressionIR as expressionIR) '#' expressionNoteIR)
 
-                                          1. Else Dangling#6517
+                                          1. Else Dangling#6520
 
                                   2. Case false
 
@@ -22629,7 +22635,7 @@ relation Expr_ok: p TC |- expression'' : %
 
                                         1. Result in: % % |- % : ((callExpressionIR as expressionIR) '#' expressionNoteIR)
 
-                            1. Else Dangling#6511
+                            1. Else Dangling#6514
 
         2. Case (% matches pattern `% <%> (%)`)
 
@@ -22661,7 +22667,7 @@ relation Expr_ok: p TC |- expression'' : %
 
                                     1. Result in: % % |- % : ((callExpressionIR as expressionIR) '#' expressionNoteIR)
 
-                            1. Else Dangling#6532
+                            1. Else Dangling#6535
 
   17. Case (% has type parenthesizedExpression)
 
@@ -22693,9 +22699,9 @@ relation Expr_ok: p TC |- expression'' : %
 
             1. Result in: % % |- % : ((prefixedNameIR as expressionIR) '#' expressionNoteIR)
 
-      1. Else Dangling#6546
+      1. Else Dangling#6549
 
-2. Else Dangling#6543
+2. Else Dangling#6546
 
 relation Argument_ok: p TC |- argument : %
 
@@ -22763,13 +22769,13 @@ relation Lvalue_ok: p TC |- lvalue : %
 
                     1. Result in: % % |- % : ((prefixedNameIR as lvalueIR) '#' (`( typeIR `)))
 
-                  1. Else Dangling#6573
+                  1. Else Dangling#6576
 
-                1. Else Dangling#6572
+                1. Else Dangling#6575
 
-              1. Else Dangling#6571
+              1. Else Dangling#6574
 
-          1. Else Dangling#6569
+          1. Else Dangling#6572
 
   2. Case (% matches pattern `% . %`)
 
@@ -22797,9 +22803,9 @@ relation Lvalue_ok: p TC |- lvalue : %
 
                           1. Result in: % % |- % : typedLvalueIR
 
-                      1. Else Dangling#6583
+                      1. Else Dangling#6586
 
-                    1. Else Dangling#6582
+                    1. Else Dangling#6585
 
               2. Case (% has type structTypeIR)
 
@@ -22817,7 +22823,7 @@ relation Lvalue_ok: p TC |- lvalue : %
 
                             1. Result in: % % |- % : typedLvalueIR
 
-                      1. Else Dangling#6589
+                      1. Else Dangling#6592
 
               3. Case (% has type headerTypeIR)
 
@@ -22835,7 +22841,7 @@ relation Lvalue_ok: p TC |- lvalue : %
 
                             1. Result in: % % |- % : typedLvalueIR
 
-                      1. Else Dangling#6596
+                      1. Else Dangling#6599
 
               4. Case (% has type headerUnionTypeIR)
 
@@ -22853,9 +22859,9 @@ relation Lvalue_ok: p TC |- lvalue : %
 
                             1. Result in: % % |- % : typedLvalueIR
 
-                      1. Else Dangling#6603
+                      1. Else Dangling#6606
 
-            1. Else Dangling#6579
+            1. Else Dangling#6582
 
   3. Case (% matches pattern `% [%]`)
 
@@ -22905,11 +22911,11 @@ relation Lvalue_ok: p TC |- lvalue : %
 
                                                 1. Result in: % % |- % : typedLvalueIR
 
-                                            1. Else Dangling#6625
+                                            1. Else Dangling#6628
 
-                                        1. Else Dangling#6623
+                                        1. Else Dangling#6626
 
-                                  1. Else Dangling#6620
+                                  1. Else Dangling#6623
 
                               2. Case false
 
@@ -22917,7 +22923,7 @@ relation Lvalue_ok: p TC |- lvalue : %
 
                                   1. Result in: % % |- % : typedLvalueIR
 
-                        1. Else Dangling#6616
+                        1. Else Dangling#6619
 
               2. Case (% has type headerStackTypeIR)
 
@@ -22955,11 +22961,11 @@ relation Lvalue_ok: p TC |- lvalue : %
 
                                                 1. Result in: % % |- % : typedLvalueIR
 
-                                            1. Else Dangling#6643
+                                            1. Else Dangling#6646
 
-                                        1. Else Dangling#6641
+                                        1. Else Dangling#6644
 
-                                  1. Else Dangling#6638
+                                  1. Else Dangling#6641
 
                               2. Case false
 
@@ -22967,9 +22973,9 @@ relation Lvalue_ok: p TC |- lvalue : %
 
                                   1. Result in: % % |- % : typedLvalueIR
 
-                        1. Else Dangling#6634
+                        1. Else Dangling#6637
 
-            1. Else Dangling#6611
+            1. Else Dangling#6614
 
   4. Case (% matches pattern `% [% % %]`)
 
@@ -23047,27 +23053,27 @@ relation Lvalue_ok: p TC |- lvalue : %
 
                                                                             1. Result in: % % |- % : typedLvalueIR
 
-                                                                    1. Else Dangling#6679
+                                                                    1. Else Dangling#6682
 
-                                                                1. Else Dangling#6677
+                                                                1. Else Dangling#6680
 
-                                                            1. Else Dangling#6675
+                                                            1. Else Dangling#6678
 
-                                                      1. Else Dangling#6672
+                                                      1. Else Dangling#6675
 
-                                                  1. Else Dangling#6670
+                                                  1. Else Dangling#6673
 
-                                              1. Else Dangling#6668
+                                              1. Else Dangling#6671
 
-                                        1. Else Dangling#6665
+                                        1. Else Dangling#6668
 
-                                    1. Else Dangling#6663
+                                    1. Else Dangling#6666
 
-                            1. Else Dangling#6659
+                            1. Else Dangling#6662
 
-                      1. Else Dangling#6656
+                      1. Else Dangling#6659
 
-              1. Else Dangling#6652
+              1. Else Dangling#6655
 
         2. Case (% matches pattern `+:`)
 
@@ -23115,17 +23121,17 @@ relation Lvalue_ok: p TC |- lvalue : %
 
                                                     1. Result in: % % |- % : typedLvalueIR
 
-                                            1. Else Dangling#6701
+                                            1. Else Dangling#6704
 
-                                      1. Else Dangling#6698
+                                      1. Else Dangling#6701
 
-                                  1. Else Dangling#6696
+                                  1. Else Dangling#6699
 
-                            1. Else Dangling#6693
+                            1. Else Dangling#6696
 
-                      1. Else Dangling#6690
+                      1. Else Dangling#6693
 
-              1. Else Dangling#6686
+              1. Else Dangling#6689
 
   5. Case (% matches pattern `(%)`)
 
@@ -23139,7 +23145,7 @@ relation Lvalue_ok: p TC |- lvalue : %
 
             1. Result in: % % |- % : typedLvalueIR
 
-1. Else Dangling#6565
+1. Else Dangling#6568
 
 relation Stmt_ok: p TC |- statement' : % %
 
@@ -23175,7 +23181,7 @@ relation Stmt_ok: p TC |- statement' : % %
 
                         1. Result in: % % |- % : TC ((typedLvalueIR ('=') typedExpressionIR_cast ';') as statementIR)
 
-                    1. Else Dangling#6721
+                    1. Else Dangling#6724
 
         2. Case false
 
@@ -23209,13 +23215,13 @@ relation Stmt_ok: p TC |- statement' : % %
 
                                       1. Result in: % % |- % : TC ((typedLvalueIR assignop typedExpressionIR_cast ';') as statementIR)
 
-                                    1. Else Dangling#6737
+                                    1. Else Dangling#6740
 
-                                1. Else Dangling#6735
+                                1. Else Dangling#6738
 
-                            1. Else Dangling#6733
+                            1. Else Dangling#6736
 
-            1. Else Dangling#6725
+            1. Else Dangling#6728
 
   3. Case (% has type callStatement)
 
@@ -23253,7 +23259,7 @@ relation Stmt_ok: p TC |- statement' : % %
 
                                     1. Result in: % % |- % : TC (emptyStatementIR as statementIR)
 
-                                1. Else Dangling#6751
+                                1. Else Dangling#6754
 
                         2. Case false
 
@@ -23335,25 +23341,25 @@ relation Stmt_ok: p TC |- statement' : % %
 
                                                     1. Result in: % % |- % : TC (directApplicationStatementIR as statementIR)
 
-                                                1. Else Dangling#6788
+                                                1. Else Dangling#6791
 
-                                              1. Else Dangling#6787
+                                              1. Else Dangling#6790
 
-                                            1. Else Dangling#6786
+                                            1. Else Dangling#6789
 
-                                          1. Else Dangling#6785
+                                          1. Else Dangling#6788
 
-                                      1. Else Dangling#6783
+                                      1. Else Dangling#6786
 
-                                1. Else Dangling#6780
+                                1. Else Dangling#6783
 
-                      1. Else Dangling#6775
+                      1. Else Dangling#6778
 
-                1. Else Dangling#6772
+                1. Else Dangling#6775
 
-            1. Else Dangling#6770
+            1. Else Dangling#6773
 
-        1. Else Dangling#6768
+        1. Else Dangling#6771
 
   5. Case (% has type exitStatement)
 
@@ -23385,7 +23391,7 @@ relation Stmt_ok: p TC |- statement' : % %
 
                         1. Result in: % % |- % : TC_post (conditionalStatementIR as statementIR)
 
-                1. Else Dangling#6798
+                1. Else Dangling#6801
 
         2. Case (% matches pattern `IF (%) % ELSE %`)
 
@@ -23409,9 +23415,9 @@ relation Stmt_ok: p TC |- statement' : % %
 
                             1. Result in: % % |- % : TC_post (conditionalStatementIR as statementIR)
 
-                1. Else Dangling#6806
+                1. Else Dangling#6809
 
-1. Else Dangling#6711
+1. Else Dangling#6714
 
 2. If ((p matches pattern `LOCAL`)), then
 
@@ -23431,7 +23437,7 @@ relation Stmt_ok: p TC |- statement' : % %
 
                 1. Result in: % % |- % : TC_1 ((RETURN ';') as statementIR)
 
-            1. Else Dangling#6817
+            1. Else Dangling#6820
 
           2. Case (% matches pattern `RETURN % ;`)
 
@@ -23457,9 +23463,9 @@ relation Stmt_ok: p TC |- statement' : % %
 
                                 1. Result in: % % |- % : TC_1 ((RETURN typedExpressionIR_cast ';') as statementIR)
 
-                          1. Else Dangling#6827
+                          1. Else Dangling#6830
 
-                    1. Else Dangling#6824
+                    1. Else Dangling#6827
 
     2. Case (% has type blockStatement)
 
@@ -23513,11 +23519,11 @@ relation Stmt_ok: p TC |- statement' : % %
 
                                           1. Result in: % % |- % : TC_7 (forStatementIR as statementIR)
 
-                    1. Else Dangling#6842
+                    1. Else Dangling#6845
 
-                  1. Else Dangling#6841
+                  1. Else Dangling#6844
 
-                1. Else Dangling#6840
+                1. Else Dangling#6843
 
           2. Case (% matches pattern `% FOR (% % % IN %) %`)
 
@@ -23531,7 +23537,7 @@ relation Stmt_ok: p TC |- statement' : % %
 
                     1. Result in: % % |- % : TC_1 (forStatementIR as statementIR)
 
-                1. Else Dangling#6856
+                1. Else Dangling#6859
 
           3. Case (% matches pattern `% FOR (% ; % ; %) %`)
 
@@ -23563,7 +23569,7 @@ relation Stmt_ok: p TC |- statement' : % %
 
                                       1. Result in: % % |- % : TC_7 (forStatementIR as statementIR)
 
-                      1. Else Dangling#6864
+                      1. Else Dangling#6867
 
     4. Case (% has type breakStatement)
 
@@ -23573,7 +23579,7 @@ relation Stmt_ok: p TC |- statement' : % %
 
           1. Result in: % % |- % : TC (breakStatement as statementIR)
 
-        1. Else Dangling#6874
+        1. Else Dangling#6877
 
     5. Case (% has type continueStatement)
 
@@ -23583,7 +23589,7 @@ relation Stmt_ok: p TC |- statement' : % %
 
           1. Result in: % % |- % : TC (continueStatement as statementIR)
 
-        1. Else Dangling#6877
+        1. Else Dangling#6880
 
     6. Case (% has type switchStatement)
 
@@ -23613,11 +23619,11 @@ relation Stmt_ok: p TC |- statement' : % %
 
                               1. Result in: % % |- % : TC_1 (switchStatementIR as statementIR)
 
-                          1. Else Dangling#6889
+                          1. Else Dangling#6892
 
-                        1. Else Dangling#6888
+                        1. Else Dangling#6891
 
-                1. Else Dangling#6884
+                1. Else Dangling#6887
 
               2. If (~($unroll_typeIR(typeIR_switch) has type tableMetadataEnumTypeIR)), then
 
@@ -23633,17 +23639,17 @@ relation Stmt_ok: p TC |- statement' : % %
 
                           1. Result in: % % |- % : TC_1 (switchStatementIR as statementIR)
 
-                      1. Else Dangling#6896
+                      1. Else Dangling#6899
 
-                    1. Else Dangling#6895
+                    1. Else Dangling#6898
 
-              2. Else Dangling#6892
+              2. Else Dangling#6895
 
-        1. Else Dangling#6880
+        1. Else Dangling#6883
 
-  1. Else Dangling#6814
+  1. Else Dangling#6817
 
-2. Else Dangling#6813
+2. Else Dangling#6816
 
 relation BlockElementStmt_ok: TC_0 |- blockElementStatement : % %
 
@@ -23707,7 +23713,7 @@ relation Parameter_ok: p TC |- (annotationList direction type name initializerOp
 
               1. Result in: % % |- % : parameterIR '#' (typeId_fresh)*{typeId_fresh <- typeId_fresh*}
 
-        1. Else Dangling#6918
+        1. Else Dangling#6921
 
   2. Case (% has type initializer)
 
@@ -23741,7 +23747,7 @@ relation Parameter_ok: p TC |- (annotationList direction type name initializerOp
 
                                 1. Result in: % % |- % : parameterIR '#' (typeId_fresh)*{typeId_fresh <- typeId_fresh*}
 
-                      1. Else Dangling#6930
+                      1. Else Dangling#6933
 
                   2. Case (% matches pattern `LCTK`)
 
@@ -23761,11 +23767,11 @@ relation Parameter_ok: p TC |- (annotationList direction type name initializerOp
 
                                   1. Result in: % % |- % : parameterIR '#' (typeId_fresh)*{typeId_fresh <- typeId_fresh*}
 
-                      1. Else Dangling#6937
+                      1. Else Dangling#6940
 
-                1. Else Dangling#6928
+                1. Else Dangling#6931
 
-          1. Else Dangling#6925
+          1. Else Dangling#6928
 
 relation ParameterList_ok: p TC_0 |- parameterList : % % '#' %
 
@@ -23859,11 +23865,11 @@ relation ExternMethod_ok: TC_0 typeId_extern |- externMethodPrototype : %
 
                             1. Result in: % % |- % : externMethodPrototypeIR
 
-                        1. Else Dangling#6976
+                        1. Else Dangling#6979
 
-                1. Else Dangling#6972
+                1. Else Dangling#6975
 
-          1. Else Dangling#6969
+          1. Else Dangling#6972
 
   2. Case (% matches pattern `% ABSTRACT % ;`)
 
@@ -23893,11 +23899,11 @@ relation ExternMethod_ok: TC_0 typeId_extern |- externMethodPrototype : %
 
                             1. Result in: % % |- % : externMethodPrototypeIR
 
-                        1. Else Dangling#6989
+                        1. Else Dangling#6992
 
-                1. Else Dangling#6985
+                1. Else Dangling#6988
 
-          1. Else Dangling#6982
+          1. Else Dangling#6985
 
 relation ExternConstructor_ok: TC_0 typeId_extern |- (annotationList typeIdentifier `( parameterList `) ';') : %
 
@@ -23931,15 +23937,15 @@ relation ExternConstructor_ok: TC_0 typeId_extern |- (annotationList typeIdentif
 
                             1. Result in: % % |- % : externConstructorPrototypeIR
 
-                        1. Else Dangling#7004
+                        1. Else Dangling#7007
 
-                  1. Else Dangling#7001
+                  1. Else Dangling#7004
 
-            1. Else Dangling#6998
+            1. Else Dangling#7001
 
-        1. Else Dangling#6996
+        1. Else Dangling#6999
 
-  1. Else Dangling#6993
+  1. Else Dangling#6996
 
 relation ParserSelect_ok: TC_0 (nameIR_state)*{nameIR_state <- nameIR_state*} |- (SELECT `( expressionList_key `) `{ selectCaseList `}) : %
 
@@ -23961,7 +23967,7 @@ relation ParserSelect_ok: TC_0 (nameIR_state)*{nameIR_state <- nameIR_state*} |-
 
                 1. Result in: % % |- % : selectExpressionIR
 
-        1. Else Dangling#7011
+        1. Else Dangling#7014
 
 relation ParserTransition_ok: TC_0 (nameIR_state)*{nameIR_state <- nameIR_state*} |- transitionStatement : %
 
@@ -23989,7 +23995,7 @@ relation ParserTransition_ok: TC_0 (nameIR_state)*{nameIR_state <- nameIR_state*
 
                   1. Result in: % % |- % : transitionStatementIR
 
-              1. Else Dangling#7022
+              1. Else Dangling#7025
 
         2. Case (% has type selectExpression)
 
@@ -24017,9 +24023,9 @@ relation ParserStmt_ok: TC |- parserStatement : % %
 
               1. Result in: % |- % : TC (emptyStatementIR as parserStatementIR)
 
-          1. Else Dangling#7032
+          1. Else Dangling#7035
 
-        1. Else Dangling#7031
+        1. Else Dangling#7034
 
   2. Case (% has type assignmentStatement)
 
@@ -24033,7 +24039,7 @@ relation ParserStmt_ok: TC |- parserStatement : % %
 
             1. Result in: % |- % : TC_1 (assignmentStatementIR as parserStatementIR)
 
-        1. Else Dangling#7037
+        1. Else Dangling#7040
 
   3. Case (% has type callStatement)
 
@@ -24047,7 +24053,7 @@ relation ParserStmt_ok: TC |- parserStatement : % %
 
             1. Result in: % |- % : TC_1 (callStatementIR as parserStatementIR)
 
-        1. Else Dangling#7042
+        1. Else Dangling#7045
 
   4. Case (% has type directApplicationStatement)
 
@@ -24061,7 +24067,7 @@ relation ParserStmt_ok: TC |- parserStatement : % %
 
             1. Result in: % |- % : TC_1 (directApplicationStatementIR as parserStatementIR)
 
-        1. Else Dangling#7047
+        1. Else Dangling#7050
 
   5. Case (% has type parserBlockStatement)
 
@@ -24095,7 +24101,7 @@ relation ParserStmt_ok: TC |- parserStatement : % %
 
                     1. Result in: % |- % : TC ((IF `( typedExpressionIR_cond `) parserStatementIR_then) as parserStatementIR)
 
-                1. Else Dangling#7060
+                1. Else Dangling#7063
 
         2. Case (% matches pattern `IF (%) % ELSE %`)
 
@@ -24113,7 +24119,7 @@ relation ParserStmt_ok: TC |- parserStatement : % %
 
                       1. Result in: % |- % : TC ((IF `( typedExpressionIR_cond `) parserStatementIR_then ELSE parserStatementIR_else) as parserStatementIR)
 
-                1. Else Dangling#7066
+                1. Else Dangling#7069
 
 relation ParserBlockElementStmt_ok: TC_0 |- parserBlockElementStatement : % %
 
@@ -24197,11 +24203,11 @@ relation ParserStateList_ok: TC |- parserStateList : %
 
                 1. Result in: % |- % : (parserStateIR)*{parserStateIR <- parserStateIR*}
 
-          1. Else Dangling#7099
+          1. Else Dangling#7102
 
-        1. Else Dangling#7098
+        1. Else Dangling#7101
 
-      1. Else Dangling#7097
+      1. Else Dangling#7100
 
 relation ParserLocalDecl_ok: TC_0 |- parserLocalDeclaration : % %
 
@@ -24255,11 +24261,11 @@ relation ParserLocalDecl_ok: TC_0 |- parserLocalDeclaration : % %
 
                         1. Result in: % |- % : TC_1 (valueSetDeclarationIR as parserLocalDeclarationIR)
 
-              1. Else Dangling#7118
+              1. Else Dangling#7121
 
-          1. Else Dangling#7116
+          1. Else Dangling#7119
 
-        1. Else Dangling#7115
+        1. Else Dangling#7118
 
 relation ParserLocalDeclList_ok: TC_0 |- parserLocalDeclarationList : % %
 
@@ -24293,11 +24299,11 @@ relation TableKey_ok: TC TBLC_0 |- (expression ':' name_matchkind annotationList
 
                     1. Result in: % % |- % : TBLC_1 tableKeyIR
 
-              1. Else Dangling#7134
+              1. Else Dangling#7137
 
-            1. Else Dangling#7133
+            1. Else Dangling#7136
 
-    1. Else Dangling#7129
+    1. Else Dangling#7132
 
 relation TableKeys_ok: TC TBLC |- (tableKey)*{tableKey <- tableKey*} : % %
 
@@ -24331,9 +24337,9 @@ relation Call_action_partial_ok: TC |- (parameterIR)*{parameterIR <- parameterIR
 
           1. Result in: % |- % '@' % : (parameterIR_data)*{parameterIR_data <- parameterIR_data*} ',' (parameterIR_control)*{parameterIR_control <- parameterIR_control*} '@' (argumentIR_cast)*{argumentIR_cast <- argumentIR_cast*}
 
-      1. Else Dangling#7147
+      1. Else Dangling#7150
 
-  1. Else Dangling#7145
+  1. Else Dangling#7148
 
 relation TableAction_ok: TC TBLC_0 |- (annotationList tableActionReference ';') : % %
 
@@ -24369,11 +24375,11 @@ relation TableAction_ok: TC TBLC_0 |- (annotationList tableActionReference ';') 
 
                               1. Result in: % % |- % : TBLC_1 tableActionIR
 
-                        1. Else Dangling#7161
+                        1. Else Dangling#7164
 
-              1. Else Dangling#7156
+              1. Else Dangling#7159
 
-          1. Else Dangling#7154
+          1. Else Dangling#7157
 
   2. Case (% matches pattern `% (%)`)
 
@@ -24405,9 +24411,9 @@ relation TableAction_ok: TC TBLC_0 |- (annotationList tableActionReference ';') 
 
                               1. Result in: % % |- % : TBLC_1 tableActionIR
 
-              1. Else Dangling#7170
+              1. Else Dangling#7173
 
-          1. Else Dangling#7168
+          1. Else Dangling#7171
 
 relation TableActions_ok: TC TBLC |- (tableAction)*{tableAction <- tableAction*} : % %
 
@@ -24439,7 +24445,7 @@ relation Call_action_default_ok: TC |- (parameterIR)*{parameterIR <- parameterIR
 
         1. Result in: % |- % '@' % : (parameterIR_data)*{parameterIR_data <- parameterIR_data*} ',' (parameterIR_control)*{parameterIR_control <- parameterIR_control*} '@' (argumentIR_cast)*{argumentIR_cast <- argumentIR_cast*}
 
-    1. Else Dangling#7187
+    1. Else Dangling#7190
 
 relation TableDefaultAction_ok: TC TBLC |- ('=' expression) : %
 
@@ -24455,7 +24461,7 @@ relation TableDefaultAction_ok: TC TBLC |- ('=' expression) : %
 
           1. Result in: % % |- % : (prefixedNameIR ?() `( [] `))
 
-        1. Else Dangling#7193
+        1. Else Dangling#7196
 
   2. Case (% has type callExpression)
 
@@ -24491,17 +24497,17 @@ relation TableDefaultAction_ok: TC TBLC |- ('=' expression) : %
 
                                   1. Result in: % % |- % : (prefixedNameIR ?() `( (argumentIR_cast)*{argumentIR_cast <- argumentIR_cast*} `))
 
-                                1. Else Dangling#7209
+                                1. Else Dangling#7212
 
-                              1. Else Dangling#7208
+                              1. Else Dangling#7211
 
-                  1. Else Dangling#7202
+                  1. Else Dangling#7205
 
-          1. Else Dangling#7198
+          1. Else Dangling#7201
 
-      1. Else Dangling#7196
+      1. Else Dangling#7199
 
-1. Else Dangling#7190
+1. Else Dangling#7193
 
 relation TableEntry_keyset_ok: TC TBLC |- keysetExpression : % %
 
@@ -24521,9 +24527,9 @@ relation TableEntry_keyset_ok: TC TBLC |- keysetExpression : % %
 
               1. Result in: % % |- % : TBLS (simpleKeysetExpressionIR as keysetExpressionIR)
 
-          1. Else Dangling#7215
+          1. Else Dangling#7218
 
-      1. Else Dangling#7213
+      1. Else Dangling#7216
 
   2. Case (% has type tupleKeysetExpression)
 
@@ -24545,9 +24551,9 @@ relation TableEntry_keyset_ok: TC TBLC |- keysetExpression : % %
 
                     1. Result in: % % |- % : TBLS ((`( [simpleKeysetExpressionIR] `)) as keysetExpressionIR)
 
-                1. Else Dangling#7223
+                1. Else Dangling#7226
 
-            1. Else Dangling#7221
+            1. Else Dangling#7224
 
         2. Case (% matches pattern `(% .. %)`)
 
@@ -24563,9 +24569,9 @@ relation TableEntry_keyset_ok: TC TBLC |- keysetExpression : % %
 
                     1. Result in: % % |- % : TBLS ((`( [simpleKeysetExpressionIR] `)) as keysetExpressionIR)
 
-                1. Else Dangling#7229
+                1. Else Dangling#7232
 
-            1. Else Dangling#7227
+            1. Else Dangling#7230
 
         3. Case (% matches pattern `(% , %)`)
 
@@ -24581,11 +24587,11 @@ relation TableEntry_keyset_ok: TC TBLC |- keysetExpression : % %
 
                     1. Result in: % % |- % : TBLS ((`( (simpleKeysetExpressionIR)*{simpleKeysetExpressionIR <- simpleKeysetExpressionIR*} `)) as keysetExpressionIR)
 
-                1. Else Dangling#7235
+                1. Else Dangling#7238
 
-      1. Else Dangling#7219
+      1. Else Dangling#7222
 
-1. Else Dangling#7211
+1. Else Dangling#7214
 
 2. If ((keysetExpression has type simpleKeysetExpression)), then
 
@@ -24607,9 +24613,9 @@ relation TableEntry_keyset_ok: TC TBLC |- keysetExpression : % %
 
                   1. Result in: % % |- % : TBLS (simpleKeysetExpressionIR as keysetExpressionIR)
 
-              1. Else Dangling#7244
+              1. Else Dangling#7247
 
-          1. Else Dangling#7242
+          1. Else Dangling#7245
 
       2. Case (% matches pattern `% .. %`)
 
@@ -24625,13 +24631,13 @@ relation TableEntry_keyset_ok: TC TBLC |- keysetExpression : % %
 
                   1. Result in: % % |- % : TBLS (simpleKeysetExpressionIR as keysetExpressionIR)
 
-              1. Else Dangling#7250
+              1. Else Dangling#7253
 
-          1. Else Dangling#7248
+          1. Else Dangling#7251
 
-    1. Else Dangling#7240
+    1. Else Dangling#7243
 
-2. Else Dangling#7238
+2. Else Dangling#7241
 
 3. Case analysis on keysetExpression
 
@@ -24647,7 +24653,7 @@ relation TableEntry_keyset_ok: TC TBLC |- keysetExpression : % %
 
             1. Result in: % % |- % : TBLS ((DEFAULT) as keysetExpressionIR)
 
-      1. Else Dangling#7255
+      1. Else Dangling#7258
 
     2. If (((TBLC.MODE = (NONE)) \/ (TBLC.MODE = (PRI)))), then
 
@@ -24655,7 +24661,7 @@ relation TableEntry_keyset_ok: TC TBLC |- keysetExpression : % %
 
         1. Result in: % % |- % : TBLS ((DEFAULT) as keysetExpressionIR)
 
-    2. Else Dangling#7259
+    2. Else Dangling#7262
 
   2. Case (% = ((`( DEFAULT `)) as keysetExpression))
 
@@ -24669,7 +24675,7 @@ relation TableEntry_keyset_ok: TC TBLC |- keysetExpression : % %
 
             1. Result in: % % |- % : TBLS ((`( [(DEFAULT)] `)) as keysetExpressionIR)
 
-      1. Else Dangling#7263
+      1. Else Dangling#7266
 
     2. If (((TBLC.MODE = (NONE)) \/ (TBLC.MODE = (PRI)))), then
 
@@ -24677,7 +24683,7 @@ relation TableEntry_keyset_ok: TC TBLC |- keysetExpression : % %
 
         1. Result in: % % |- % : TBLS ((`( [(DEFAULT)] `)) as keysetExpressionIR)
 
-    2. Else Dangling#7267
+    2. Else Dangling#7270
 
   3. Case (% = (('_') as keysetExpression))
 
@@ -24689,7 +24695,7 @@ relation TableEntry_keyset_ok: TC TBLC |- keysetExpression : % %
 
           1. Result in: % % |- % : TBLS (('_') as keysetExpressionIR)
 
-      1. Else Dangling#7271
+      1. Else Dangling#7274
 
     2. If (((TBLC.MODE = (NONE)) \/ (TBLC.MODE = (PRI)))), then
 
@@ -24697,7 +24703,7 @@ relation TableEntry_keyset_ok: TC TBLC |- keysetExpression : % %
 
         1. Result in: % % |- % : TBLS (('_') as keysetExpressionIR)
 
-    2. Else Dangling#7274
+    2. Else Dangling#7277
 
   4. Case (% = ((`( '_' `)) as keysetExpression))
 
@@ -24709,7 +24715,7 @@ relation TableEntry_keyset_ok: TC TBLC |- keysetExpression : % %
 
           1. Result in: % % |- % : TBLS ((`( [('_')] `)) as keysetExpressionIR)
 
-      1. Else Dangling#7278
+      1. Else Dangling#7281
 
     2. If (((TBLC.MODE = (NONE)) \/ (TBLC.MODE = (PRI)))), then
 
@@ -24717,9 +24723,9 @@ relation TableEntry_keyset_ok: TC TBLC |- keysetExpression : % %
 
         1. Result in: % % |- % : TBLS ((`( [('_')] `)) as keysetExpressionIR)
 
-    2. Else Dangling#7281
+    2. Else Dangling#7284
 
-3. Else Dangling#7253
+3. Else Dangling#7256
 
 relation TableEntry_action_ok: TC TBLC |- tableActionReference : %
 
@@ -24735,7 +24741,7 @@ relation TableEntry_action_ok: TC TBLC |- tableActionReference : %
 
           1. Result in: % % |- % : (prefixedNameIR ?() `( [] `))
 
-        1. Else Dangling#7287
+        1. Else Dangling#7290
 
   2. Case (% matches pattern `% (%)`)
 
@@ -24763,11 +24769,11 @@ relation TableEntry_action_ok: TC TBLC |- tableActionReference : %
 
                           1. Result in: % % |- % : (prefixedNameIR ?() `( (argumentIR_cast)*{argumentIR_cast <- argumentIR_cast*} `))
 
-                        1. Else Dangling#7299
+                        1. Else Dangling#7302
 
-                      1. Else Dangling#7298
+                      1. Else Dangling#7301
 
-          1. Else Dangling#7292
+          1. Else Dangling#7295
 
 relation TableEntry_priority_ok: TC |- tableEntryPriority : %
 
@@ -24801,11 +24807,11 @@ relation TableEntry_priority_ok: TC |- tableEntryPriority : %
 
                       1. Result in: % |- % : (PRIORITY '=' (D (n as int)) ':')
 
-                  1. Else Dangling#7311
+                  1. Else Dangling#7314
 
-            1. Else Dangling#7308
+            1. Else Dangling#7311
 
-        1. Else Dangling#7306
+        1. Else Dangling#7309
 
 relation TableEntry_ok: TC TBLC |- tableEntry : % %
 
@@ -24889,7 +24895,7 @@ relation TableProperty_ok: TC TBLC_0 |- tableProperty : % %
 
                     1. Result in: % % |- % : TBLC_2 ((annotationList constOptIR ENTRIES '=' `{ (tableEntryIR_pri)*{tableEntryIR_pri <- tableEntryIR_pri*} `}) as tablePropertyIR)
 
-        1. Else Dangling#7341
+        1. Else Dangling#7344
 
   4. Case (% matches pattern `% % % % ;`)
 
@@ -24905,7 +24911,7 @@ relation TableProperty_ok: TC TBLC_0 |- tableProperty : % %
 
               1. Result in: % % |- % : TBLC_0 tablePropertyIR
 
-      1. Else Dangling#7349
+      1. Else Dangling#7352
 
     2. (Let (annotationList constOpt tableCustomName ('=' expression) ';') be tableProperty)
 
@@ -24933,13 +24939,13 @@ relation TableProperty_ok: TC TBLC_0 |- tableProperty : % %
 
                             1. Result in: % % |- % : TBLC_1 tablePropertyIR
 
-                  1. Else Dangling#7361
+                  1. Else Dangling#7364
 
-              1. Else Dangling#7359
+              1. Else Dangling#7362
 
-            1. Else Dangling#7358
+            1. Else Dangling#7361
 
-      1. Else Dangling#7355
+      1. Else Dangling#7358
 
       2. If (("priority_delta" = $tableCustomName(tableCustomName))), then
 
@@ -24975,17 +24981,17 @@ relation TableProperty_ok: TC TBLC_0 |- tableProperty : % %
 
                                       1. Result in: % % |- % : TBLC_1 tablePropertyIR
 
-                              1. Else Dangling#7379
+                              1. Else Dangling#7382
 
-                          1. Else Dangling#7377
+                          1. Else Dangling#7380
 
-                    1. Else Dangling#7374
+                    1. Else Dangling#7377
 
-                1. Else Dangling#7372
+                1. Else Dangling#7375
 
-            1. Else Dangling#7370
+            1. Else Dangling#7373
 
-      2. Else Dangling#7367
+      2. Else Dangling#7370
 
       3. If (("size" = $tableCustomName(tableCustomName))), then
 
@@ -25005,11 +25011,11 @@ relation TableProperty_ok: TC TBLC_0 |- tableProperty : % %
 
                       1. Result in: % % |- % : TBLC_0 tablePropertyIR
 
-                1. Else Dangling#7389
+                1. Else Dangling#7392
 
-              1. Else Dangling#7388
+              1. Else Dangling#7391
 
-      3. Else Dangling#7384
+      3. Else Dangling#7387
 
       4. (Let nameIR be $tableCustomName(tableCustomName))
 
@@ -25023,7 +25029,7 @@ relation TableProperty_ok: TC TBLC_0 |- tableProperty : % %
 
                 1. Result in: % % |- % : TBLC_0 tablePropertyIR
 
-        1. Else Dangling#7394
+        1. Else Dangling#7397
 
 relation TableProperties_ok: TC TBLC |- (tableProperty)*{tableProperty <- tableProperty*} : % %
 
@@ -25065,7 +25071,7 @@ relation Table_ok: TC |- (tableProperty)*{tableProperty <- tableProperty*} : % %
 
                   1. Result in: % |- % : TBLC_2 (tablePropertyIR_updated)*{tablePropertyIR_updated <- tablePropertyIR_updated*} ++ [tablePropertyIR_default_action]
 
-        1. Else Dangling#7408
+        1. Else Dangling#7411
 
       2. Case (% = 1)
 
@@ -25077,13 +25083,13 @@ relation Table_ok: TC |- (tableProperty)*{tableProperty <- tableProperty*} : % %
 
               1. Result in: % |- % : TBLC_1 (tablePropertyIR)*{tablePropertyIR <- tablePropertyIR*}
 
-        1. Else Dangling#7414
+        1. Else Dangling#7417
 
-    1. Else Dangling#7407
+    1. Else Dangling#7410
 
-  1. Else Dangling#7406
+  1. Else Dangling#7409
 
-1. Else Dangling#7405
+1. Else Dangling#7408
 
 relation TableType_ok: TC_0 TBLC |- name : % %
 
@@ -25199,11 +25205,11 @@ relation VarDecl_ok: p TC_0 |- (annotationList type name initializerOpt ';') : %
 
                   1. Result in: % % |- % : TC_1 variableDeclarationIR
 
-          1. Else Dangling#7460
+          1. Else Dangling#7463
 
-        1. Else Dangling#7459
+        1. Else Dangling#7462
 
-      1. Else Dangling#7458
+      1. Else Dangling#7461
 
   2. Case (% has type initializer)
 
@@ -25233,13 +25239,13 @@ relation VarDecl_ok: p TC_0 |- (annotationList type name initializerOpt ';') : %
 
                             1. Result in: % % |- % : TC_1 variableDeclarationIR
 
-                  1. Else Dangling#7472
+                  1. Else Dangling#7475
 
-            1. Else Dangling#7469
+            1. Else Dangling#7472
 
-          1. Else Dangling#7468
+          1. Else Dangling#7471
 
-        1. Else Dangling#7467
+        1. Else Dangling#7470
 
 relation ConstDecl_ok: p TC_0 |- (annotationList CONST type name ('=' expression_value) ';') : % %
 
@@ -25269,13 +25275,13 @@ relation ConstDecl_ok: p TC_0 |- (annotationList CONST type name ('=' expression
 
                         1. Result in: % % |- % : TC_1 constantDeclarationIR
 
-            1. Else Dangling#7484
+            1. Else Dangling#7487
 
-        1. Else Dangling#7482
+        1. Else Dangling#7485
 
-    1. Else Dangling#7480
+    1. Else Dangling#7483
 
-  1. Else Dangling#7479
+  1. Else Dangling#7482
 
 relation InstDecl_ok: p TC_0 |- instantiation : % %
 
@@ -25303,7 +25309,7 @@ relation InstDecl_ok: p TC_0 |- instantiation : % %
 
               1. Result in: % % |- % : TC_1 instantiationIR
 
-      1. Else Dangling#7493
+      1. Else Dangling#7496
 
   2. Case (% matches pattern `% % (%) % % ;`)
 
@@ -25327,7 +25333,7 @@ relation InstDecl_ok: p TC_0 |- instantiation : % %
 
               1. Result in: % % |- % : TC_1 instantiationIR
 
-      1. Else Dangling#7501
+      1. Else Dangling#7504
 
 relation FuncDecl_ok: p TC_0 |- (annotationList (typeOrVoid name typeParameterListOpt `( parameterList `)) blockStatement) : % %
 
@@ -25361,11 +25367,11 @@ relation FuncDecl_ok: p TC_0 |- (annotationList (typeOrVoid name typeParameterLi
 
                             1. Result in: % % |- % : TC_6 functionDeclarationIR
 
-                      1. Else Dangling#7519
+                      1. Else Dangling#7522
 
-              1. Else Dangling#7515
+              1. Else Dangling#7518
 
-    1. Else Dangling#7510
+    1. Else Dangling#7513
 
 relation ActionDecl_ok: p TC_0 |- (annotationList ACTION name `( parameterList `) blockStatement) : % %
 
@@ -25393,9 +25399,9 @@ relation ActionDecl_ok: p TC_0 |- (annotationList ACTION name `( parameterList `
 
                       1. Result in: % % |- % : TC_4 actionDeclarationIR
 
-                1. Else Dangling#7531
+                1. Else Dangling#7534
 
-      1. Else Dangling#7526
+      1. Else Dangling#7529
 
 relation Decl_ok: TC_0 |- declaration : % %
 
@@ -25453,7 +25459,7 @@ relation Decl_ok: TC_0 |- declaration : % %
 
                     1. Result in: % |- % : TC_1 ((ERROR `{ (nameIR)*{nameIR <- nameIR*} `}) as declarationIR)
 
-          1. Else Dangling#7551
+          1. Else Dangling#7554
 
   6. Case (% has type matchKindDeclaration)
 
@@ -25473,7 +25479,7 @@ relation Decl_ok: TC_0 |- declaration : % %
 
                   1. Result in: % |- % : TC_1 ((MATCH_KIND `{ (nameIR)*{nameIR <- nameIR*} `}) as declarationIR)
 
-          1. Else Dangling#7560
+          1. Else Dangling#7563
 
   7. Case (% has type externFunctionDeclaration)
 
@@ -25501,9 +25507,9 @@ relation Decl_ok: TC_0 |- declaration : % %
 
                           1. Result in: % |- % : TC_4 (externFunctionDeclarationIR as declarationIR)
 
-                    1. Else Dangling#7573
+                    1. Else Dangling#7576
 
-            1. Else Dangling#7569
+            1. Else Dangling#7572
 
   8. Case (% has type externObjectDeclaration)
 
@@ -25549,7 +25555,7 @@ relation Decl_ok: TC_0 |- declaration : % %
 
                                             1. Result in: % |- % : TC_6 (externObjectDeclarationIR as declarationIR)
 
-                  1. Else Dangling#7584
+                  1. Else Dangling#7587
 
   9. Case (% has type parserDeclaration)
 
@@ -25595,15 +25601,15 @@ relation Decl_ok: TC_0 |- declaration : % %
 
                                             1. Result in: % |- % : TC_6 (parserDeclarationIR as declarationIR)
 
-                                      1. Else Dangling#7615
+                                      1. Else Dangling#7618
 
-                          1. Else Dangling#7609
+                          1. Else Dangling#7612
 
-                1. Else Dangling#7604
+                1. Else Dangling#7607
 
-            1. Else Dangling#7602
+            1. Else Dangling#7605
 
-        1. Else Dangling#7600
+        1. Else Dangling#7603
 
   10. Case (% has type controlDeclaration)
 
@@ -25651,15 +25657,15 @@ relation Decl_ok: TC_0 |- declaration : % %
 
                                               1. Result in: % |- % : TC_7 (controlDeclarationIR as declarationIR)
 
-                                        1. Else Dangling#7637
+                                        1. Else Dangling#7640
 
-                            1. Else Dangling#7631
+                            1. Else Dangling#7634
 
-                1. Else Dangling#7625
+                1. Else Dangling#7628
 
-            1. Else Dangling#7623
+            1. Else Dangling#7626
 
-        1. Else Dangling#7621
+        1. Else Dangling#7624
 
   11. Case (% has type enumTypeDeclaration)
 
@@ -25695,7 +25701,7 @@ relation Decl_ok: TC_0 |- declaration : % %
 
                                   1. Result in: % |- % : TC_2 (enumTypeDeclarationIR as declarationIR)
 
-                    1. Else Dangling#7648
+                    1. Else Dangling#7651
 
         2. Case (% matches pattern `% ENUM % % {% %}`)
 
@@ -25731,11 +25737,11 @@ relation Decl_ok: TC_0 |- declaration : % %
 
                                         1. Result in: % |- % : TC_3 (enumTypeDeclarationIR as declarationIR)
 
-                                  1. Else Dangling#7668
+                                  1. Else Dangling#7671
 
-                  1. Else Dangling#7660
+                  1. Else Dangling#7663
 
-                1. Else Dangling#7659
+                1. Else Dangling#7662
 
   12. Case (% has type structTypeDeclaration)
 
@@ -25763,9 +25769,9 @@ relation Decl_ok: TC_0 |- declaration : % %
 
                           1. Result in: % |- % : TC_2 (structTypeDeclarationIR as declarationIR)
 
-                    1. Else Dangling#7680
+                    1. Else Dangling#7683
 
-            1. Else Dangling#7676
+            1. Else Dangling#7679
 
   13. Case (% has type headerTypeDeclaration)
 
@@ -25793,9 +25799,9 @@ relation Decl_ok: TC_0 |- declaration : % %
 
                           1. Result in: % |- % : TC_2 (headerTypeDeclarationIR as declarationIR)
 
-                    1. Else Dangling#7692
+                    1. Else Dangling#7695
 
-            1. Else Dangling#7688
+            1. Else Dangling#7691
 
   14. Case (% has type headerUnionTypeDeclaration)
 
@@ -25823,9 +25829,9 @@ relation Decl_ok: TC_0 |- declaration : % %
 
                           1. Result in: % |- % : TC_2 (headerUnionTypeDeclarationIR as declarationIR)
 
-                    1. Else Dangling#7704
+                    1. Else Dangling#7707
 
-            1. Else Dangling#7700
+            1. Else Dangling#7703
 
   15. Case (% has type typedefDeclaration)
 
@@ -25863,11 +25869,11 @@ relation Decl_ok: TC_0 |- declaration : % %
 
                                     1. Result in: % |- % : TC_1 (typedefDeclarationIR as declarationIR)
 
-                              1. Else Dangling#7719
+                              1. Else Dangling#7722
 
-                        1. Else Dangling#7716
+                        1. Else Dangling#7719
 
-                      1. Else Dangling#7715
+                      1. Else Dangling#7718
 
               2. Case (% has type derivedTypeDeclaration)
 
@@ -25909,7 +25915,7 @@ relation Decl_ok: TC_0 |- declaration : % %
 
                                                     1. Result in: % |- % : TC_2 (typedefDeclarationIR as declarationIR)
 
-                                              1. Else Dangling#7737
+                                              1. Else Dangling#7740
 
                                       2. Case false
 
@@ -25929,15 +25935,15 @@ relation Decl_ok: TC_0 |- declaration : % %
 
                                                       1. Result in: % |- % : TC_2 (typedefDeclarationIR as declarationIR)
 
-                                                1. Else Dangling#7745
+                                                1. Else Dangling#7748
 
-                                        1. Else Dangling#7741
+                                        1. Else Dangling#7744
 
-                                1. Else Dangling#7731
+                                1. Else Dangling#7734
 
-                          1. Else Dangling#7728
+                          1. Else Dangling#7731
 
-                    1. Else Dangling#7725
+                    1. Else Dangling#7728
 
         2. Case (% matches pattern `% TYPE % % ;`)
 
@@ -25963,11 +25969,11 @@ relation Decl_ok: TC_0 |- declaration : % %
 
                               1. Result in: % |- % : TC_1 (typedefDeclarationIR as declarationIR)
 
-                        1. Else Dangling#7756
+                        1. Else Dangling#7759
 
-                  1. Else Dangling#7753
+                  1. Else Dangling#7756
 
-                1. Else Dangling#7752
+                1. Else Dangling#7755
 
   16. Case (% has type parserTypeDeclaration)
 
@@ -25991,7 +25997,7 @@ relation Decl_ok: TC_0 |- declaration : % %
 
                       1. Result in: % |- % : TC_4 (parserTypeDeclarationIR as declarationIR)
 
-                1. Else Dangling#7766
+                1. Else Dangling#7769
 
   17. Case (% has type controlTypeDeclaration)
 
@@ -26015,7 +26021,7 @@ relation Decl_ok: TC_0 |- declaration : % %
 
                       1. Result in: % |- % : TC_4 (controlTypeDeclarationIR as declarationIR)
 
-                1. Else Dangling#7776
+                1. Else Dangling#7779
 
   18. Case (% has type packageTypeDeclaration)
 
@@ -26053,9 +26059,9 @@ relation Decl_ok: TC_0 |- declaration : % %
 
                                     1. Result in: % |- % : TC_5 (packageTypeDeclarationIR as declarationIR)
 
-                              1. Else Dangling#7793
+                              1. Else Dangling#7796
 
-                    1. Else Dangling#7788
+                    1. Else Dangling#7791
 
 relation Decls_ok: TC |- (declaration)*{declaration <- declaration*} : % %
 
@@ -26103,7 +26109,7 @@ relation Call_convention_expr_ok: p TC actctxt |- (_annotationList direction typ
 
           1. Result in: % % % |- % '@' % : typedExpressionIR_arg_cast
 
-      1. Else Dangling#7809
+      1. Else Dangling#7812
 
   2. Case (% matches pattern `/* empty */`)
 
@@ -26119,7 +26125,7 @@ relation Call_convention_expr_ok: p TC actctxt |- (_annotationList direction typ
 
               1. Result in: % % % |- % '@' % : typedExpressionIR_arg_cast
 
-          1. Else Dangling#7814
+          1. Else Dangling#7817
 
       2. Case (% matches pattern `NOACTION`)
 
@@ -26133,11 +26139,11 @@ relation Call_convention_expr_ok: p TC actctxt |- (_annotationList direction typ
 
                 1. Result in: % % % |- % '@' % : typedExpressionIR_arg_cast
 
-              1. Else Dangling#7820
+              1. Else Dangling#7823
 
-          1. Else Dangling#7818
+          1. Else Dangling#7821
 
-1. Else Dangling#7807
+1. Else Dangling#7810
 
 2. If (((direction = (OUT)) \/ (direction = (INOUT)))), then
 
@@ -26157,11 +26163,11 @@ relation Call_convention_expr_ok: p TC actctxt |- (_annotationList direction typ
 
                 1. Result in: % % % |- % '@' % : typedExpressionIR_arg
 
-        1. Else Dangling#7826
+        1. Else Dangling#7829
 
-    1. Else Dangling#7824
+    1. Else Dangling#7827
 
-2. Else Dangling#7822
+2. Else Dangling#7825
 
 relation Call_convention_arg_ok: p TC actctxt |- parameterIR '@' argumentIR : %
 
@@ -26193,7 +26199,7 @@ relation Call_convention_arg_ok: p TC actctxt |- parameterIR '@' argumentIR : %
 
           1. Result in: % % % |- % '@' % : (nameIR '=' '_')
 
-        1. Else Dangling#7840
+        1. Else Dangling#7843
 
   4. Case (% matches pattern `_`)
 
@@ -26203,7 +26209,7 @@ relation Call_convention_arg_ok: p TC actctxt |- parameterIR '@' argumentIR : %
 
         1. Result in: % % % |- % '@' % : ('_')
 
-      1. Else Dangling#7843
+      1. Else Dangling#7846
 
 relation Call_convention_ok: p TC actctxt |- (parameterIR)*{parameterIR <- parameterIR*} '@' (argumentIR)*{argumentIR <- argumentIR*} : %
 
@@ -26215,7 +26221,7 @@ relation Call_convention_ok: p TC actctxt |- (parameterIR)*{parameterIR <- param
 
       1. Result in: % % % |- % '@' % : []
 
-    1. Else Dangling#7846
+    1. Else Dangling#7849
 
   2. Case (% matches pattern _ :: _)
 
@@ -26231,7 +26237,7 @@ relation Call_convention_ok: p TC actctxt |- (parameterIR)*{parameterIR <- param
 
               1. Result in: % % % |- % '@' % : argumentIR_h_cast :: (argumentIR_t_cast)*{argumentIR_t_cast <- argumentIR_t_cast*}
 
-      1. Else Dangling#7849
+      1. Else Dangling#7852
 
 def $is_static_callableTypeIR(callableTypeIR)
 
@@ -26313,13 +26319,13 @@ relation CallableTarget_ok: p TC |- callableTarget : %
 
         1. Result in: % % |- % : (`( callableTargetIR `))
 
-1. Else Dangling#7865
+1. Else Dangling#7868
 
 2. If ((callableTarget = ((THIS) as expression))), then
 
   1. Result in: % % |- % : ((_BARE "this") as callableTargetIR)
 
-2. Else Dangling#7882
+2. Else Dangling#7885
 
 relation CallableTarget_lvalue_ok: p TC |- lvalue : %
 
@@ -26351,11 +26357,11 @@ relation CallableType_ok: p TC |- callableTargetIR' `< (typeArgumentIR)*{typeArg
 
                   1. Result in: % % |- % `< % `> `( % `) : (actionTypeIR as callableTypeIR) `< '#' [] `> `( '#' (id_default)*{id_default <- id_default*} '#' (id_optional)*{id_optional <- id_optional*} `)
 
-              1. Else Dangling#7893
+              1. Else Dangling#7896
 
-          1. Else Dangling#7891
+          1. Else Dangling#7894
 
-      1. Else Dangling#7889
+      1. Else Dangling#7892
 
       2. (Let (callResolution<callableTypeDefIR>)?{callResolution<callableTypeDefIR> <- callResolution<callableTypeDefIR>?} be $find_callableDef_overloaded_t(p, TC, prefixedNameIR, (argumentIR)*{argumentIR <- argumentIR*}))
 
@@ -26375,11 +26381,11 @@ relation CallableType_ok: p TC |- callableTargetIR' `< (typeArgumentIR)*{typeArg
 
                       1. Result in: % % |- % `< % `> `( % `) : (functionTypeIR as callableTypeIR) `< '#' (typeId_impl)*{typeId_impl <- typeId_impl*} `> `( '#' (id_default)*{id_default <- id_default*} '#' (id_optional)*{id_optional <- id_optional*} `)
 
-                  1. Else Dangling#7902
+                  1. Else Dangling#7905
 
-            1. Else Dangling#7899
+            1. Else Dangling#7902
 
-        1. Else Dangling#7897
+        1. Else Dangling#7900
 
   2. Case (% matches pattern `% . %`)
 
@@ -26399,9 +26405,9 @@ relation CallableType_ok: p TC |- callableTargetIR' `< (typeArgumentIR)*{typeArg
 
                   1. Result in: % % |- % `< % `> `( % `) : (methodTypeIR as callableTypeIR) `< '#' [] `> `( '#' [] '#' [] `)
 
-              1. Else Dangling#7910
+              1. Else Dangling#7913
 
-          1. Else Dangling#7908
+          1. Else Dangling#7911
 
           2. Case analysis on nameIR
 
@@ -26417,7 +26423,7 @@ relation CallableType_ok: p TC |- callableTargetIR' `< (typeArgumentIR)*{typeArg
 
                       1. Result in: % % |- % `< % `> `( % `) : (methodTypeIR as callableTypeIR) `< '#' [] `> `( '#' [] '#' [] `)
 
-                  1. Else Dangling#7916
+                  1. Else Dangling#7919
 
             2. Case (% = "setValid")
 
@@ -26431,7 +26437,7 @@ relation CallableType_ok: p TC |- callableTargetIR' `< (typeArgumentIR)*{typeArg
 
                       1. Result in: % % |- % `< % `> `( % `) : (methodTypeIR as callableTypeIR) `< '#' [] `> `( '#' [] '#' [] `)
 
-                  1. Else Dangling#7921
+                  1. Else Dangling#7924
 
             3. Case (% = "setInvalid")
 
@@ -26445,13 +26451,13 @@ relation CallableType_ok: p TC |- callableTargetIR' `< (typeArgumentIR)*{typeArg
 
                       1. Result in: % % |- % `< % `> `( % `) : (methodTypeIR as callableTypeIR) `< '#' [] `> `( '#' [] '#' [] `)
 
-                  1. Else Dangling#7926
+                  1. Else Dangling#7929
 
-          2. Else Dangling#7913
+          2. Else Dangling#7916
 
-        1. Else Dangling#7907
+        1. Else Dangling#7910
 
-      1. Else Dangling#7906
+      1. Else Dangling#7909
 
       2. Case analysis on nameIR
 
@@ -26471,11 +26477,11 @@ relation CallableType_ok: p TC |- callableTargetIR' `< (typeArgumentIR)*{typeArg
 
                       1. Result in: % % |- % `< % `> `( % `) : (methodTypeIR as callableTypeIR) `< '#' [] `> `( '#' [] '#' [] `)
 
-                  1. Else Dangling#7934
+                  1. Else Dangling#7937
 
-            1. Else Dangling#7931
+            1. Else Dangling#7934
 
-          1. Else Dangling#7930
+          1. Else Dangling#7933
 
         2. Case (% = "pop_front")
 
@@ -26493,11 +26499,11 @@ relation CallableType_ok: p TC |- callableTargetIR' `< (typeArgumentIR)*{typeArg
 
                       1. Result in: % % |- % `< % `> `( % `) : (methodTypeIR as callableTypeIR) `< '#' [] `> `( '#' [] '#' [] `)
 
-                  1. Else Dangling#7941
+                  1. Else Dangling#7944
 
-            1. Else Dangling#7938
+            1. Else Dangling#7941
 
-          1. Else Dangling#7937
+          1. Else Dangling#7940
 
         3. Case (% = "isValid")
 
@@ -26515,13 +26521,13 @@ relation CallableType_ok: p TC |- callableTargetIR' `< (typeArgumentIR)*{typeArg
 
                       1. Result in: % % |- % `< % `> `( % `) : (methodTypeIR as callableTypeIR) `< '#' [] `> `( '#' [] '#' [] `)
 
-                  1. Else Dangling#7948
+                  1. Else Dangling#7951
 
-            1. Else Dangling#7945
+            1. Else Dangling#7948
 
-          1. Else Dangling#7944
+          1. Else Dangling#7947
 
-      2. Else Dangling#7929
+      2. Else Dangling#7932
 
       3. (Let typeIR_base be $type_of_typedExpressionIR(typedExpressionIR_base))
 
@@ -26547,11 +26553,11 @@ relation CallableType_ok: p TC |- callableTargetIR' `< (typeArgumentIR)*{typeArg
 
                             1. Result in: % % |- % `< % `> `( % `) : (externMethodTypeIR as callableTypeIR) `< '#' (typeId_impl)*{typeId_impl <- typeId_impl*} `> `( '#' (id_default)*{id_default <- id_default*} '#' (id_optional)*{id_optional <- id_optional*} `)
 
-                        1. Else Dangling#7960
+                        1. Else Dangling#7963
 
-                  1. Else Dangling#7957
+                  1. Else Dangling#7960
 
-          1. Else Dangling#7953
+          1. Else Dangling#7956
 
       4. If ((nameIR = "apply")), then
 
@@ -26583,7 +26589,7 @@ relation CallableType_ok: p TC |- callableTargetIR' `< (typeArgumentIR)*{typeArg
 
                                   1. Result in: % % |- % `< % `> `( % `) : (parserApplyMethodTypeIR as callableTypeIR) `< '#' [] `> `( '#' (id_default)*{id_default <- id_default*} '#' (id_optional)*{id_optional <- id_optional*} `)
 
-                              1. Else Dangling#7974
+                              1. Else Dangling#7977
 
                 2. Case (% has type controlObjectTypeIR)
 
@@ -26605,9 +26611,9 @@ relation CallableType_ok: p TC |- callableTargetIR' `< (typeArgumentIR)*{typeArg
 
                                   1. Result in: % % |- % `< % `> `( % `) : (controlApplyMethodTypeIR as callableTypeIR) `< '#' [] `> `( '#' (id_default)*{id_default <- id_default*} '#' (id_optional)*{id_optional <- id_optional*} `)
 
-                              1. Else Dangling#7983
+                              1. Else Dangling#7986
 
-              1. Else Dangling#7967
+              1. Else Dangling#7970
 
           2. If (((argumentIR)*{argumentIR <- argumentIR*} matches pattern [])), then
 
@@ -26623,13 +26629,13 @@ relation CallableType_ok: p TC |- callableTargetIR' `< (typeArgumentIR)*{typeArg
 
                       1. Result in: % % |- % `< % `> `( % `) : (tableApplyMethodTypeIR as callableTypeIR) `< '#' [] `> `( '#' [] '#' [] `)
 
-                1. Else Dangling#7989
+                1. Else Dangling#7992
 
-          2. Else Dangling#7986
+          2. Else Dangling#7989
 
-        1. Else Dangling#7964
+        1. Else Dangling#7967
 
-      4. Else Dangling#7963
+      4. Else Dangling#7966
 
   3. Case (% matches pattern `(%)`)
 
@@ -26639,7 +26645,7 @@ relation CallableType_ok: p TC |- callableTargetIR' `< (typeArgumentIR)*{typeArg
 
         1. Result in: % % |- % `< % `> `( % `) : callableTypeIR `< '#' (typeId_inserted)*{typeId_inserted <- typeId_inserted*} `> `( '#' (id_default)*{id_default <- id_default*} '#' (id_optional)*{id_optional <- id_optional*} `)
 
-1. Else Dangling#7887
+1. Else Dangling#7890
 
 relation Call_ok: p TC |- callableTypeIR `< (typeArgumentIR)*{typeArgumentIR <- typeArgumentIR*} '#' (typeId)*{typeId <- typeId*} `> `( (argumentIR)*{argumentIR <- argumentIR*} '#' (id_default)*{id_default <- id_default*} '#' (id_optional)*{id_optional <- id_optional*} `) : % `< % `> `( % `)
 
@@ -26663,11 +26669,11 @@ relation Call_ok: p TC |- callableTypeIR `< (typeArgumentIR)*{typeArgumentIR <- 
 
                   1. Result in: % % |- % `< % '#' % `> `( % '#' % '#' % `) : ((VOID) as typeIR) `< [] `> `( (argumentIR_cast)*{argumentIR_cast <- argumentIR_cast*} `)
 
-              1. Else Dangling#8002
+              1. Else Dangling#8005
 
-        1. Else Dangling#7999
+        1. Else Dangling#8002
 
-      1. Else Dangling#7998
+      1. Else Dangling#8001
 
   2. Case (% has type definedFunctionTypeIR)
 
@@ -26697,9 +26703,9 @@ relation Call_ok: p TC |- callableTypeIR `< (typeArgumentIR)*{typeArgumentIR <- 
 
                             1. Result in: % % |- % `< % '#' % `> `( % '#' % '#' % `) : typeIR_ret_inferred `< (typeArgumentIR_inferred)*{typeArgumentIR_inferred <- typeArgumentIR_inferred*} `> `( (argumentIR_cast)*{argumentIR_cast <- argumentIR_cast*} `)
 
-                        1. Else Dangling#8015
+                        1. Else Dangling#8018
 
-                      1. Else Dangling#8014
+                      1. Else Dangling#8017
 
   3. Case (% has type externFunctionTypeIR)
 
@@ -26729,9 +26735,9 @@ relation Call_ok: p TC |- callableTypeIR `< (typeArgumentIR)*{typeArgumentIR <- 
 
                             1. Result in: % % |- % `< % '#' % `> `( % '#' % '#' % `) : typeIR_ret_inferred `< (typeArgumentIR_inferred)*{typeArgumentIR_inferred <- typeArgumentIR_inferred*} `> `( (argumentIR_cast)*{argumentIR_cast <- argumentIR_cast*} `)
 
-                        1. Else Dangling#8028
+                        1. Else Dangling#8031
 
-                      1. Else Dangling#8027
+                      1. Else Dangling#8030
 
   4. Case (% has type builtinMethodTypeIR)
 
@@ -26747,7 +26753,7 @@ relation Call_ok: p TC |- callableTypeIR `< (typeArgumentIR)*{typeArgumentIR <- 
 
               1. Result in: % % |- % `< % '#' % `> `( % '#' % '#' % `) : typeIR_ret `< (typeArgumentIR)*{typeArgumentIR <- typeArgumentIR*} `> `( (argumentIR_cast)*{argumentIR_cast <- argumentIR_cast*} `)
 
-      1. Else Dangling#8032
+      1. Else Dangling#8035
 
   5. Case (% has type externMethodTypeIR)
 
@@ -26781,9 +26787,9 @@ relation Call_ok: p TC |- callableTypeIR `< (typeArgumentIR)*{typeArgumentIR <- 
 
                                 1. Result in: % % |- % `< % '#' % `> `( % '#' % '#' % `) : typeIR_ret_inferred `< (typeArgumentIR_inferred)*{typeArgumentIR_inferred <- typeArgumentIR_inferred*} `> `( (argumentIR_cast)*{argumentIR_cast <- argumentIR_cast*} `)
 
-                            1. Else Dangling#8048
+                            1. Else Dangling#8051
 
-                          1. Else Dangling#8047
+                          1. Else Dangling#8050
 
         2. Case (% matches pattern `EXTERN_METHOD ABSTRACT % (%) : %`)
 
@@ -26811,9 +26817,9 @@ relation Call_ok: p TC |- callableTypeIR `< (typeArgumentIR)*{typeArgumentIR <- 
 
                                 1. Result in: % % |- % `< % '#' % `> `( % '#' % '#' % `) : typeIR_ret_inferred `< (typeArgumentIR_inferred)*{typeArgumentIR_inferred <- typeArgumentIR_inferred*} `> `( (argumentIR_cast)*{argumentIR_cast <- argumentIR_cast*} `)
 
-                            1. Else Dangling#8060
+                            1. Else Dangling#8063
 
-                          1. Else Dangling#8059
+                          1. Else Dangling#8062
 
   6. Case (% has type parserApplyMethodTypeIR)
 
@@ -26833,11 +26839,11 @@ relation Call_ok: p TC |- callableTypeIR `< (typeArgumentIR)*{typeArgumentIR <- 
 
                   1. Result in: % % |- % `< % '#' % `> `( % '#' % '#' % `) : ((VOID) as typeIR) `< [] `> `( (argumentIR_cast)*{argumentIR_cast <- argumentIR_cast*} `)
 
-              1. Else Dangling#8068
+              1. Else Dangling#8071
 
-        1. Else Dangling#8065
+        1. Else Dangling#8068
 
-      1. Else Dangling#8064
+      1. Else Dangling#8067
 
   7. Case (% has type controlApplyMethodTypeIR)
 
@@ -26857,11 +26863,11 @@ relation Call_ok: p TC |- callableTypeIR `< (typeArgumentIR)*{typeArgumentIR <- 
 
                   1. Result in: % % |- % `< % '#' % `> `( % '#' % '#' % `) : ((VOID) as typeIR) `< [] `> `( (argumentIR_cast)*{argumentIR_cast <- argumentIR_cast*} `)
 
-              1. Else Dangling#8076
+              1. Else Dangling#8079
 
-        1. Else Dangling#8073
+        1. Else Dangling#8076
 
-      1. Else Dangling#8072
+      1. Else Dangling#8075
 
   8. Case (% has type tableApplyMethodTypeIR)
 
@@ -26883,17 +26889,17 @@ relation Call_ok: p TC |- callableTypeIR `< (typeArgumentIR)*{typeArgumentIR <- 
 
                     1. Result in: % % |- % `< % '#' % `> `( % '#' % '#' % `) : (tableMetadataStructTypeIR as typeIR) `< [] `> `( [] `)
 
-                  1. Else Dangling#8086
+                  1. Else Dangling#8089
 
-              1. Else Dangling#8084
+              1. Else Dangling#8087
 
-            1. Else Dangling#8083
+            1. Else Dangling#8086
 
-          1. Else Dangling#8082
+          1. Else Dangling#8085
 
-        1. Else Dangling#8081
+        1. Else Dangling#8084
 
-      1. Else Dangling#8080
+      1. Else Dangling#8083
 
 relation ConstructorType_ok: p TC |- (prefixedNameIR `< (typeArgumentIR')*{typeArgumentIR' <- typeArgumentIR'*} `>) `( (argumentIR)*{argumentIR <- argumentIR*} `) : % `< '#' % `> `( '#' % '#' % `)
 
@@ -26909,9 +26915,9 @@ relation ConstructorType_ok: p TC |- (prefixedNameIR `< (typeArgumentIR')*{typeA
 
           1. Result in: % % |- % `( % `) : constructorTypeIR `< '#' (typeId_impl)*{typeId_impl <- typeId_impl*} `> `( '#' (id_default)*{id_default <- id_default*} '#' (id_optional)*{id_optional <- id_optional*} `)
 
-    1. Else Dangling#8090
+    1. Else Dangling#8093
 
-1. Else Dangling#8088
+1. Else Dangling#8091
 
 2. (Let (typeDefIR')?{typeDefIR' <- typeDefIR'?} be $find_typeDef_t(p, TC, prefixedNameIR))
 
@@ -26931,11 +26937,11 @@ relation ConstructorType_ok: p TC |- (prefixedNameIR `< (typeArgumentIR')*{typeA
 
                 1. Result in: % % |- % `( % `) : constructorTypeIR `< '#' (typeId_impl)*{typeId_impl <- typeId_impl*} `> `( '#' (id_default)*{id_default <- id_default*} '#' (id_optional)*{id_optional <- id_optional*} `)
 
-          1. Else Dangling#8099
+          1. Else Dangling#8102
 
-      1. Else Dangling#8097
+      1. Else Dangling#8100
 
-  1. Else Dangling#8095
+  1. Else Dangling#8098
 
 3. If (((typeArgumentIR')*{typeArgumentIR' <- typeArgumentIR'*} matches pattern [])), then
 
@@ -26961,13 +26967,13 @@ relation ConstructorType_ok: p TC |- (prefixedNameIR `< (typeArgumentIR')*{typeA
 
                       1. Result in: % % |- % `( % `) : constructorTypeIR `< '#' (typeId_impl)*{typeId_impl <- typeId_impl*} `> `( '#' (id_default)*{id_default <- id_default*} '#' (id_optional)*{id_optional <- id_optional*} `)
 
-                1. Else Dangling#8111
+                1. Else Dangling#8114
 
-        1. Else Dangling#8107
+        1. Else Dangling#8110
 
-    1. Else Dangling#8105
+    1. Else Dangling#8108
 
-3. Else Dangling#8103
+3. Else Dangling#8106
 
 syntax instctxt = 
    | NAMED (from instctxt) 
@@ -27005,7 +27011,7 @@ relation Inst_ok: p TC instctxt |- constructorTypeIR `< (typeArgumentIR)*{typeAr
 
                             1. Result in: % % % |- % `< % '#' % `> `( % '#' % '#' % `) : typeIR_object_inferred `< (typeArgumentIR_inferred)*{typeArgumentIR_inferred <- typeArgumentIR_inferred*} `> `( (argumentIR_cast)*{argumentIR_cast <- argumentIR_cast*} `)
 
-                        1. Else Dangling#8126
+                        1. Else Dangling#8129
 
                       2. Case false
 
@@ -27013,9 +27019,9 @@ relation Inst_ok: p TC instctxt |- constructorTypeIR `< (typeArgumentIR)*{typeAr
 
                           1. Result in: % % % |- % `< % '#' % `> `( % '#' % '#' % `) : typeIR_object_inferred `< (typeArgumentIR_inferred)*{typeArgumentIR_inferred <- typeArgumentIR_inferred*} `> `( (argumentIR_cast)*{argumentIR_cast <- argumentIR_cast*} `)
 
-                1. Else Dangling#8123
+                1. Else Dangling#8126
 
-              1. Else Dangling#8122
+              1. Else Dangling#8125
 
 def $reduce_serenum(typedExpressionIR)
 
@@ -27701,7 +27707,7 @@ def $result_concat(typeIR, typeIR')
 
           1. Return ((STRING) as typeIR)
 
-      1. Else Dangling#8376
+      1. Else Dangling#8379
 
   2. Case (% has type fixedIntTypeIR)
 
@@ -27721,7 +27727,7 @@ def $result_concat(typeIR, typeIR')
 
             1. Return ((INT `< (w_a + w_b) `>) as typeIR)
 
-      1. Else Dangling#8380
+      1. Else Dangling#8383
 
   3. Case (% has type fixedBitTypeIR)
 
@@ -27741,7 +27747,7 @@ def $result_concat(typeIR, typeIR')
 
             1. Return ((BIT `< (w_a + w_b) `>) as typeIR)
 
-      1. Else Dangling#8386
+      1. Else Dangling#8389
 
   4. Case (% has type typedefTypeIR)
 
@@ -27749,7 +27755,7 @@ def $result_concat(typeIR, typeIR')
 
       1. Return $result_concat(typeIR_l, typeIR')
 
-1. Else Dangling#8374
+1. Else Dangling#8377
 
 2. If ((typeIR' has type typedefTypeIR)), then
 
@@ -27759,9 +27765,9 @@ def $result_concat(typeIR, typeIR')
 
       1. Return $result_concat(typeIR, typeIR_r)
 
-    1. Else Dangling#8395
+    1. Else Dangling#8398
 
-2. Else Dangling#8393
+2. Else Dangling#8396
 
 tbl def $compat_logical(typeIR'', typeIR''')
 =
@@ -28091,7 +28097,7 @@ relation ForUpdateStmt_ok: TC |- forUpdateStatement : %
 
             1. Result in: % |- % : (callableTargetIR `< (typeArgumentIR)*{typeArgumentIR <- typeArgumentIR*} `> `( (argumentIR)*{argumentIR <- argumentIR*} `))
 
-        1. Else Dangling#8502
+        1. Else Dangling#8505
 
   2. Case (% matches pattern `% <%> (%)`)
 
@@ -28105,7 +28111,7 @@ relation ForUpdateStmt_ok: TC |- forUpdateStatement : %
 
             1. Result in: % |- % : (callableTargetIR `< (typeArgumentIR)*{typeArgumentIR <- typeArgumentIR*} `> `( (argumentIR)*{argumentIR <- argumentIR*} `))
 
-        1. Else Dangling#8507
+        1. Else Dangling#8510
 
   3. Case (% matches pattern `% % %`)
 
@@ -28121,9 +28127,9 @@ relation ForUpdateStmt_ok: TC |- forUpdateStatement : %
 
               1. Result in: % |- % : (typedLvalueIR assignop typedExpressionIR)
 
-            1. Else Dangling#8514
+            1. Else Dangling#8517
 
-        1. Else Dangling#8512
+        1. Else Dangling#8515
 
 relation ForUpdateStmtList_ok: TC |- forUpdateStatementList : %
 
@@ -28159,11 +28165,11 @@ relation ForInitStmt_ok: TC |- forInitStatement : % %
 
                       1. Result in: % |- % : TC_1 (annotationList typeIR nameIR ?())
 
-                1. Else Dangling#8525
+                1. Else Dangling#8528
 
-              1. Else Dangling#8524
+              1. Else Dangling#8527
 
-            1. Else Dangling#8523
+            1. Else Dangling#8526
 
         2. Case (% has type initializer)
 
@@ -28191,13 +28197,13 @@ relation ForInitStmt_ok: TC |- forInitStatement : % %
 
                                 1. Result in: % |- % : TC_1 (annotationList typeIR nameIR ?(('=' typedExpressionIR_init_cast)))
 
-                        1. Else Dangling#8536
+                        1. Else Dangling#8539
 
-                  1. Else Dangling#8533
+                  1. Else Dangling#8536
 
-                1. Else Dangling#8532
+                1. Else Dangling#8535
 
-              1. Else Dangling#8531
+              1. Else Dangling#8534
 
   2. Case (% has type forUpdateStatement)
 
@@ -28257,7 +28263,7 @@ relation ForCollectionExpr_ok: TC typeIR_var |- forCollectionExpression : %
 
                     1. Result in: % % |- % : (typedExpressionIR as forCollectionExpressionIR)
 
-                  1. Else Dangling#8560
+                  1. Else Dangling#8563
 
               2. Case (% has type arrayTypeIR)
 
@@ -28267,7 +28273,7 @@ relation ForCollectionExpr_ok: TC typeIR_var |- forCollectionExpression : %
 
                     1. Result in: % % |- % : (typedExpressionIR as forCollectionExpressionIR)
 
-                  1. Else Dangling#8563
+                  1. Else Dangling#8566
 
               3. Case (% has type headerStackTypeIR)
 
@@ -28277,9 +28283,9 @@ relation ForCollectionExpr_ok: TC typeIR_var |- forCollectionExpression : %
 
                     1. Result in: % % |- % : (typedExpressionIR as forCollectionExpressionIR)
 
-                  1. Else Dangling#8566
+                  1. Else Dangling#8569
 
-            1. Else Dangling#8558
+            1. Else Dangling#8561
 
   2. Case (% matches pattern `% .. %`)
 
@@ -28309,11 +28315,11 @@ relation ForCollectionExpr_ok: TC typeIR_var |- forCollectionExpression : %
 
                             1. Result in: % % |- % : (typedExpressionIR_l_casted '..' typedExpressionIR_r_casted)
 
-                          1. Else Dangling#8579
+                          1. Else Dangling#8582
 
-                  1. Else Dangling#8575
+                  1. Else Dangling#8578
 
-            1. Else Dangling#8572
+            1. Else Dangling#8575
 
 tbl def $compat_range(typeIR'', typeIR''')
 =
@@ -28434,15 +28440,15 @@ relation SwitchLabel_table_ok: TC typeId_table |- switchLabel : %
 
                               1. Result in: % % |- % : (typedExpressionIR_label as switchLabelIR)
 
-                          1. Else Dangling#8622
+                          1. Else Dangling#8625
 
-                      1. Else Dangling#8620
+                      1. Else Dangling#8623
 
-                  1. Else Dangling#8618
+                  1. Else Dangling#8621
 
-        1. Else Dangling#8613
+        1. Else Dangling#8616
 
-1. Else Dangling#8609
+1. Else Dangling#8612
 
 relation SwitchCase_table_ok: TC_0 typeId_table |- switchCase : % %
 
@@ -28532,9 +28538,9 @@ relation SwitchLabel_general_ok: TC typeIR |- switchLabel : %
 
                     1. Result in: % % |- % : (typedExpressionIR_label_cast as switchLabelIR)
 
-                  1. Else Dangling#8656
+                  1. Else Dangling#8659
 
-            1. Else Dangling#8653
+            1. Else Dangling#8656
 
 relation SwitchCase_general_ok: TC_0 typeIR_switch |- switchCase : % %
 
@@ -28639,7 +28645,7 @@ relation Switch_general_ok: TC_0 |- SWITCH `( typedExpressionIR_switch `) `{ swi
 
       1. Result in: % |- SWITCH `( % `) `{ % `} : TC_1 (switchCaseIR)*{switchCaseIR <- switchCaseIR*}
 
-  1. Else Dangling#8691
+  1. Else Dangling#8694
 
 relation BlockElementStmts_ok: TC |- (blockElementStatement)*{blockElementStatement <- blockElementStatement*} : % %
 
@@ -28689,7 +28695,7 @@ relation InstDecl_non_objectInitializer_ok: p TC_0 |- annotationList prefixedTyp
 
                           1. Result in: % % |- % % `< % `> `( % `) % ';' : TC_1 instantiationIR
 
-                1. Else Dangling#8708
+                1. Else Dangling#8711
 
 relation ObjectDecl_ok: p TC_0 typeFrame externMethodTypeDefEnv |- objectDeclaration : % % %
 
@@ -28713,7 +28719,7 @@ relation ObjectDecl_ok: p TC_0 typeFrame externMethodTypeDefEnv |- objectDeclara
 
                   1. Result in: % % % % |- % : typeFrame_init externMethodTypeDefEnv (instantiationIR as objectDeclarationIR)
 
-            1. Else Dangling#8719
+            1. Else Dangling#8722
 
   2. Case (% has type functionDeclaration)
 
@@ -28753,11 +28759,11 @@ relation ObjectDecl_ok: p TC_0 typeFrame externMethodTypeDefEnv |- objectDeclara
 
                                       1. Result in: % % % % |- % : typeFrame externMethodTypeDefEnv_init (functionDeclarationIR as objectDeclarationIR)
 
-                                1. Else Dangling#8737
+                                1. Else Dangling#8740
 
-                        1. Else Dangling#8733
+                        1. Else Dangling#8736
 
-                1. Else Dangling#8729
+                1. Else Dangling#8732
 
 relation ObjectDecls_ok: p TC typeFrame externMethodTypeDefEnv |- (objectDeclaration)*{objectDeclaration <- objectDeclaration*} : % % %
 
@@ -28791,7 +28797,7 @@ def $subst_externMethodTypeDefEnv(externMethodTypeDefEnv_extern, set<pair<callab
 
   1. Return externMethodTypeDefEnv_extern
 
-1. Else Dangling#8750
+1. Else Dangling#8753
 
 2. (Let (`{ (pair<callableId, externMethodTypeDefIR>)*{pair<callableId, externMethodTypeDefIR> <- pair<callableId, externMethodTypeDefIR>*} `}) be set<pair<callableId, externMethodTypeDefIR>>)
 
@@ -28819,13 +28825,13 @@ def $subst_externMethodTypeDefEnv(externMethodTypeDefEnv_extern, set<pair<callab
 
                         1. Return $subst_externMethodTypeDefEnv(externMethodTypeDefEnv_extern_subst, (`{ ((callableId_init_t ':' externMethodTypeDefIR_init_t))*{callableId_init_t <- callableId_init_t*, externMethodTypeDefIR_init_t <- externMethodTypeDefIR_init_t*} `}))
 
-                    1. Else Dangling#8762
+                    1. Else Dangling#8765
 
-              1. Else Dangling#8759
+              1. Else Dangling#8762
 
-          1. Else Dangling#8757
+          1. Else Dangling#8760
 
-  1. Else Dangling#8753
+  1. Else Dangling#8756
 
 relation InstDecl_objectInitializer_ok: p TC_0 |- annotationList prefixedTypeName `< typeArgumentList `> `( argumentList `) name '=' `{ objectDeclarationList `} ';' : % %
 
@@ -28871,9 +28877,9 @@ relation InstDecl_objectInitializer_ok: p TC_0 |- annotationList prefixedTypeNam
 
                                         1. Result in: % % |- % % `< % `> `( % `) % '=' `{ % `} ';' : TC_2 instantiationIR
 
-                              1. Else Dangling#8780
+                              1. Else Dangling#8783
 
-                  1. Else Dangling#8774
+                  1. Else Dangling#8777
 
 def $split_externConstructorOrMethodPrototypeList(externConstructorOrMethodPrototypeList)
 
@@ -28893,9 +28899,9 @@ def $split_externConstructorOrMethodPrototypeList(externConstructorOrMethodProto
 
               1. Return ((externConstructorPrototype)*{externConstructorPrototype <- externConstructorPrototype*}, (externMethodPrototype)*{externMethodPrototype <- externMethodPrototype*})
 
-          1. Else Dangling#8791
+          1. Else Dangling#8794
 
-    1. Else Dangling#8788
+    1. Else Dangling#8791
 
 def $constructorTypeDef_of_externConstructorPrototypeIR(typeParameterListIR_expl, typeIR, (_annotationList nameIR `< ',' typeParameterListIR_impl `> `( (parameterIR)*{parameterIR <- parameterIR*} `) ';'))
 
@@ -28925,9 +28931,9 @@ relation Enum_serializable_field_ok: TC_0 nameIR_enum typeIR |- (name '=' expres
 
                   1. Result in: % % % |- % : TC_1 (nameIR '=' value)
 
-        1. Else Dangling#8800
+        1. Else Dangling#8803
 
-    1. Else Dangling#8798
+    1. Else Dangling#8801
 
 relation Enum_serializable_fields_ok: TC nameIR_enum typeIR |- (namedExpression)*{namedExpression <- namedExpression*} : % %
 
@@ -28991,7 +28997,7 @@ relation SelectCase_keyset_simple_ok: TC typeIR_key |- simpleKeysetExpression : 
 
                           1. Result in: % % |- % : (typedExpressionIR_cast as simpleKeysetExpressionIR)
 
-                    1. Else Dangling#8825
+                    1. Else Dangling#8828
 
               2. Case false
 
@@ -29003,7 +29009,7 @@ relation SelectCase_keyset_simple_ok: TC typeIR_key |- simpleKeysetExpression : 
 
                       1. Result in: % % |- % : (typedExpressionIR_cast as simpleKeysetExpressionIR)
 
-                1. Else Dangling#8829
+                1. Else Dangling#8832
 
   2. Case (% matches pattern `% &&& %`)
 
@@ -29041,13 +29047,13 @@ relation SelectCase_keyset_simple_ok: TC typeIR_key |- simpleKeysetExpression : 
 
                                     1. Result in: % % |- % : (typedExpressionIR_l_casted '&&&' typedExpressionIR_r_casted)
 
-                                1. Else Dangling#8847
+                                1. Else Dangling#8850
 
-                          1. Else Dangling#8844
+                          1. Else Dangling#8847
 
-                  1. Else Dangling#8840
+                  1. Else Dangling#8843
 
-            1. Else Dangling#8837
+            1. Else Dangling#8840
 
   3. Case (% matches pattern `% .. %`)
 
@@ -29087,15 +29093,15 @@ relation SelectCase_keyset_simple_ok: TC typeIR_key |- simpleKeysetExpression : 
 
                                       1. Result in: % % |- % : (typedExpressionIR_l_casted '..' typedExpressionIR_r_casted)
 
-                                  1. Else Dangling#8865
+                                  1. Else Dangling#8868
 
-                            1. Else Dangling#8862
+                            1. Else Dangling#8865
 
-                        1. Else Dangling#8860
+                        1. Else Dangling#8863
 
-                  1. Else Dangling#8857
+                  1. Else Dangling#8860
 
-            1. Else Dangling#8854
+            1. Else Dangling#8857
 
   4. Case (% matches pattern `DEFAULT`)
 
@@ -29180,7 +29186,7 @@ relation SelectCase_keyset_ok: TC (typeIR)*{typeIR <- typeIR*} |- keysetExpressi
 
             1. Result in: % % |- % : (simpleKeysetExpressionIR as keysetExpressionIR)
 
-      1. Else Dangling#8894
+      1. Else Dangling#8897
 
       2. If ((keysetExpression has type simpleKeysetExpression)), then
 
@@ -29204,9 +29210,9 @@ relation SelectCase_keyset_ok: TC (typeIR)*{typeIR <- typeIR*} |- keysetExpressi
 
                   1. Result in: % % |- % : (simpleKeysetExpressionIR as keysetExpressionIR)
 
-          1. Else Dangling#8900
+          1. Else Dangling#8903
 
-      2. Else Dangling#8898
+      2. Else Dangling#8901
 
       3. Case analysis on keysetExpression
 
@@ -29222,7 +29228,7 @@ relation SelectCase_keyset_ok: TC (typeIR)*{typeIR <- typeIR*} |- keysetExpressi
 
             1. Result in: % % |- % : (simpleKeysetExpressionIR as keysetExpressionIR)
 
-      3. Else Dangling#8907
+      3. Else Dangling#8910
 
   2. Case (% matches pattern [])
 
@@ -29230,9 +29236,9 @@ relation SelectCase_keyset_ok: TC (typeIR)*{typeIR <- typeIR*} |- keysetExpressi
 
       1. Result in: % % |- % : ((DEFAULT) as keysetExpressionIR)
 
-    1. Else Dangling#8912
+    1. Else Dangling#8915
 
-1. Else Dangling#8892
+1. Else Dangling#8895
 
 2. Case analysis on keysetExpression
 
@@ -29248,7 +29254,7 @@ relation SelectCase_keyset_ok: TC (typeIR)*{typeIR <- typeIR*} |- keysetExpressi
 
             1. Result in: % % |- % : (simpleKeysetExpressionIR as keysetExpressionIR)
 
-      1. Else Dangling#8916
+      1. Else Dangling#8919
 
   2. Case (% has type tupleKeysetExpression)
 
@@ -29288,9 +29294,9 @@ relation SelectCase_keyset_ok: TC (typeIR)*{typeIR <- typeIR*} |- keysetExpressi
 
                 1. Result in: % % |- % : ((`( [simpleKeysetExpressionIR] `)) as keysetExpressionIR)
 
-          1. Else Dangling#8923
+          1. Else Dangling#8926
 
-      1. Else Dangling#8921
+      1. Else Dangling#8924
 
       2. Case analysis on tupleKeysetExpression
 
@@ -29302,7 +29308,7 @@ relation SelectCase_keyset_ok: TC (typeIR)*{typeIR <- typeIR*} |- keysetExpressi
 
               1. Result in: % % |- % : ((`( [simpleKeysetExpressionIR] `)) as keysetExpressionIR)
 
-          1. Else Dangling#8935
+          1. Else Dangling#8938
 
         2. Case (% matches pattern `(_)`)
 
@@ -29312,7 +29318,7 @@ relation SelectCase_keyset_ok: TC (typeIR)*{typeIR <- typeIR*} |- keysetExpressi
 
               1. Result in: % % |- % : ((`( [simpleKeysetExpressionIR] `)) as keysetExpressionIR)
 
-          1. Else Dangling#8938
+          1. Else Dangling#8941
 
         3. Case (% matches pattern `(% , %)`)
 
@@ -29328,11 +29334,11 @@ relation SelectCase_keyset_ok: TC (typeIR)*{typeIR <- typeIR*} |- keysetExpressi
 
                     1. Result in: % % |- % : ((`( (simpleKeysetExpressionIR)*{simpleKeysetExpressionIR <- simpleKeysetExpressionIR*} `)) as keysetExpressionIR)
 
-                1. Else Dangling#8944
+                1. Else Dangling#8947
 
-      2. Else Dangling#8934
+      2. Else Dangling#8937
 
-2. Else Dangling#8914
+2. Else Dangling#8917
 
 3. Case analysis on keysetExpression
 
@@ -29344,7 +29350,7 @@ relation SelectCase_keyset_ok: TC (typeIR)*{typeIR <- typeIR*} |- keysetExpressi
 
         1. Result in: % % |- % : (simpleKeysetExpressionIR as keysetExpressionIR)
 
-    1. Else Dangling#8948
+    1. Else Dangling#8951
 
   2. Case (% = (('_') as keysetExpression))
 
@@ -29354,9 +29360,9 @@ relation SelectCase_keyset_ok: TC (typeIR)*{typeIR <- typeIR*} |- keysetExpressi
 
         1. Result in: % % |- % : (simpleKeysetExpressionIR as keysetExpressionIR)
 
-    1. Else Dangling#8951
+    1. Else Dangling#8954
 
-3. Else Dangling#8947
+3. Else Dangling#8950
 
 relation SelectCase_ok: TC (nameIR_state)*{nameIR_state <- nameIR_state*} (typeIR_key)*{typeIR_key <- typeIR_key*} |- (keysetExpression ':' name ';') : %
 
@@ -29368,7 +29374,7 @@ relation SelectCase_ok: TC (nameIR_state)*{nameIR_state <- nameIR_state*} (typeI
 
       1. Result in: % % % |- % : (keysetExpressionIR ':' nameIR ';')
 
-    1. Else Dangling#8956
+    1. Else Dangling#8959
 
 relation ParserBlockElementStmts_ok: TC |- (parserBlockElementStatement)*{parserBlockElementStatement <- parserBlockElementStatement*} : % %
 
@@ -29610,9 +29616,9 @@ relation TableEntry_keyset_simple_ok: TC TBLC |- (typeIR_key ':' t) '@' simpleKe
 
                             1. Result in: % % |- % '@' % : (LPM n) (typedExpressionIR_set as simpleKeysetExpressionIR)
 
-                      1. Else Dangling#9038
+                      1. Else Dangling#9041
 
-            1. Else Dangling#9033
+            1. Else Dangling#9036
 
         2. Case (% =/= "lpm")
 
@@ -29644,13 +29650,13 @@ relation TableEntry_keyset_simple_ok: TC TBLC |- (typeIR_key ':' t) '@' simpleKe
 
                                     1. Result in: % % |- % '@' % : (NON_LPM) (typedExpressionIR_set as simpleKeysetExpressionIR)
 
-                              1. Else Dangling#9051
+                              1. Else Dangling#9054
 
-                      1. Else Dangling#9047
+                      1. Else Dangling#9050
 
-                  1. Else Dangling#9045
+                  1. Else Dangling#9048
 
-              1. Else Dangling#9043
+              1. Else Dangling#9046
 
             2. Case false
 
@@ -29668,7 +29674,7 @@ relation TableEntry_keyset_simple_ok: TC TBLC |- (typeIR_key ':' t) '@' simpleKe
 
                           1. Result in: % % |- % '@' % : (NON_LPM) (typedExpressionIR_set as simpleKeysetExpressionIR)
 
-                    1. Else Dangling#9058
+                    1. Else Dangling#9061
 
   2. Case (% matches pattern `% &&& %`)
 
@@ -29726,19 +29732,19 @@ relation TableEntry_keyset_simple_ok: TC TBLC |- (typeIR_key ':' t) '@' simpleKe
 
                                                         1. Result in: % % |- % '@' % : (LPM n_prefix) (typedExpressionIR_l_reduced '&&&' typedExpressionIR_r_reduced)
 
-                                                  1. Else Dangling#9084
+                                                  1. Else Dangling#9087
 
-                                            1. Else Dangling#9081
+                                            1. Else Dangling#9084
 
-                                        1. Else Dangling#9079
+                                        1. Else Dangling#9082
 
-                                  1. Else Dangling#9076
+                                  1. Else Dangling#9079
 
-                            1. Else Dangling#9073
+                            1. Else Dangling#9076
 
-                      1. Else Dangling#9070
+                      1. Else Dangling#9073
 
-            1. Else Dangling#9065
+            1. Else Dangling#9068
 
         2. Case (% = "ternary")
 
@@ -29766,13 +29772,13 @@ relation TableEntry_keyset_simple_ok: TC TBLC |- (typeIR_key ':' t) '@' simpleKe
 
                                 1. Result in: % % |- % '@' % : (NON_LPM) (typedExpressionIR_l_reduced '&&&' typedExpressionIR_r_reduced)
 
-                            1. Else Dangling#9097
+                            1. Else Dangling#9100
 
-                      1. Else Dangling#9094
+                      1. Else Dangling#9097
 
-                1. Else Dangling#9091
+                1. Else Dangling#9094
 
-      1. Else Dangling#9063
+      1. Else Dangling#9066
 
   3. Case (% matches pattern `DEFAULT`)
 
@@ -29788,7 +29794,7 @@ relation TableEntry_keyset_simple_ok: TC TBLC |- (typeIR_key ':' t) '@' simpleKe
 
               1. Result in: % % |- % '@' % : (LPM n) (DEFAULT)
 
-          1. Else Dangling#9102
+          1. Else Dangling#9105
 
       2. Case (% =/= "lpm")
 
@@ -29796,7 +29802,7 @@ relation TableEntry_keyset_simple_ok: TC TBLC |- (typeIR_key ':' t) '@' simpleKe
 
           1. Result in: % % |- % '@' % : (NON_LPM) (DEFAULT)
 
-        1. Else Dangling#9105
+        1. Else Dangling#9108
 
   4. Case (% matches pattern `_`)
 
@@ -29810,7 +29816,7 @@ relation TableEntry_keyset_simple_ok: TC TBLC |- (typeIR_key ':' t) '@' simpleKe
 
             1. Result in: % % |- % '@' % : (LPM 0) ('_')
 
-          1. Else Dangling#9109
+          1. Else Dangling#9112
 
       2. Case (% =/= "lpm")
 
@@ -29818,9 +29824,9 @@ relation TableEntry_keyset_simple_ok: TC TBLC |- (typeIR_key ':' t) '@' simpleKe
 
           1. Result in: % % |- % '@' % : (NON_LPM) ('_')
 
-        1. Else Dangling#9111
+        1. Else Dangling#9114
 
-1. Else Dangling#9029
+1. Else Dangling#9032
 
 2. If ((t = "range")), then
 
@@ -29852,15 +29858,15 @@ relation TableEntry_keyset_simple_ok: TC TBLC |- (typeIR_key ':' t) '@' simpleKe
 
                             1. Result in: % % |- % '@' % : (NON_LPM) (typedExpressionIR_l_reduced '..' typedExpressionIR_r_reduced)
 
-                        1. Else Dangling#9125
+                        1. Else Dangling#9128
 
-                  1. Else Dangling#9122
+                  1. Else Dangling#9125
 
-            1. Else Dangling#9119
+            1. Else Dangling#9122
 
-  1. Else Dangling#9114
+  1. Else Dangling#9117
 
-2. Else Dangling#9113
+2. Else Dangling#9116
 
 def $is_singleton_list_expression(expression)
 
@@ -29888,7 +29894,7 @@ relation TableEntry_keysets_simple_ok: TC TBLC TBLS |- (matchKey)*{matchKey <- m
 
       1. Result in: % % % |- % '@' % : TBLS []
 
-    1. Else Dangling#9135
+    1. Else Dangling#9138
 
   2. Case (% matches pattern _ :: _)
 
@@ -29906,7 +29912,7 @@ relation TableEntry_keysets_simple_ok: TC TBLC TBLS |- (matchKey)*{matchKey <- m
 
                 1. Result in: % % % |- % '@' % : TBLS_3 simpleKeysetExpressionIR_h :: (simpleKeysetExpressionIR_t)*{simpleKeysetExpressionIR_t <- simpleKeysetExpressionIR_t*}
 
-      1. Else Dangling#9138
+      1. Else Dangling#9141
 
 def $is_tableKeysProperty(tableProperty)
 
@@ -30076,7 +30082,7 @@ def $infer((typeId)*{typeId <- typeId*}, (parameterIR)*{parameterIR <- parameter
 
                             1. Return inference_resolved
 
-                  1. Else Dangling#9192
+                  1. Else Dangling#9195
 
 def $infer_pair(constraint, parameterIR, argumentIR)
 
@@ -30144,7 +30150,7 @@ def $gen_constraint(constraint, (typeIR_param)*{typeIR_param <- typeIR_param*}, 
 
     1. Return $merge_constraints(constraint, (constraint_pair)*{constraint_pair <- constraint_pair*})
 
-1. Else Dangling#9219
+1. Else Dangling#9222
 
 def $gen_constraint_pair(constraint, typeIR, typeIR_arg')
 
@@ -30338,7 +30344,7 @@ def $merge_constraint(constraint_pre, constraint_post)
 
       1. Return $merge_constraint'(constraint_pre, constraint_post, (typeId_pre)*{typeId_pre <- typeId_pre*}, (`{ [] `}))
 
-    1. Else Dangling#9299
+    1. Else Dangling#9302
 
 def $merge_constraint'(constraint_pre, constraint_post, (typeId)*{typeId <- typeId*}, constraint)
 
@@ -30360,7 +30366,7 @@ def $merge_constraint'(constraint_pre, constraint_post, (typeId)*{typeId <- type
 
             1. Return $merge_constraint'(constraint_pre, constraint_post, (typeId_t)*{typeId_t <- typeId_t*}, constraint_updated)
 
-        1. Else Dangling#9305
+        1. Else Dangling#9308
 
         2. (Let (infer')?{infer' <- infer'?} be $find_map<typeId, infer>(constraint_post, typeId_h))
 
@@ -30376,11 +30382,11 @@ def $merge_constraint'(constraint_pre, constraint_post, (typeId)*{typeId <- type
 
                     1. Return $merge_constraint'(constraint_pre, constraint_post, (typeId_t)*{typeId_t <- typeId_t*}, constraint_updated)
 
-              1. Else Dangling#9311
+              1. Else Dangling#9314
 
-          1. Else Dangling#9309
+          1. Else Dangling#9312
 
-      1. Else Dangling#9304
+      1. Else Dangling#9307
 
       2. (Let (infer')?{infer' <- infer'?} be $find_map<typeId, infer>(constraint_pre, typeId_h))
 
@@ -30398,7 +30404,7 @@ def $merge_constraint'(constraint_pre, constraint_post, (typeId)*{typeId <- type
 
                     1. Return $merge_constraint'(constraint_pre, constraint_post, (typeId_t)*{typeId_t <- typeId_t*}, constraint_updated)
 
-                1. Else Dangling#9320
+                1. Else Dangling#9323
 
                 2. (Let (infer''')?{infer''' <- infer'''?} be $find_map<typeId, infer>(constraint_post, typeId_h))
 
@@ -30424,15 +30430,15 @@ def $merge_constraint'(constraint_pre, constraint_post, (typeId)*{typeId <- type
 
                                 1. Return $merge_constraint'(constraint_pre, constraint_post, (typeId_t)*{typeId_t <- typeId_t*}, constraint_updated)
 
-                            1. Else Dangling#9331
+                            1. Else Dangling#9334
 
-                      1. Else Dangling#9326
+                      1. Else Dangling#9329
 
-                  1. Else Dangling#9324
+                  1. Else Dangling#9327
 
-            1. Else Dangling#9318
+            1. Else Dangling#9321
 
-        1. Else Dangling#9316
+        1. Else Dangling#9319
 
 def $merge_constraints(constraint_pre, (constraint)*{constraint <- constraint*})
 
@@ -30458,7 +30464,7 @@ def $resolve_constraint(strictness, set<pair<typeId, infer>>)
 
   1. Return (`{ [] `})
 
-1. Else Dangling#9340
+1. Else Dangling#9343
 
 2. (Let (`{ (pair<typeId, infer>)*{pair<typeId, infer> <- pair<typeId, infer>*} `}) be set<pair<typeId, infer>>)
 
@@ -30480,9 +30486,9 @@ def $resolve_constraint(strictness, set<pair<typeId, infer>>)
 
                   1. Return (`{ (typeId_h ':' typeIR_h) :: ((typeId_t ':' typeIR_t))*{typeIR_t <- typeIR_t*, typeId_t <- typeId_t*} `})
 
-                1. Else Dangling#9349
+                1. Else Dangling#9352
 
-              1. Else Dangling#9348
+              1. Else Dangling#9351
 
         2. Case (% matches pattern `UNKNOWN`)
 
@@ -30496,13 +30502,13 @@ def $resolve_constraint(strictness, set<pair<typeId, infer>>)
 
                   1. Return (`{ (typeId_h ':' ((BOOL) as typeIR)) :: ((typeId_t ':' typeIR_t))*{typeIR_t <- typeIR_t*, typeId_t <- typeId_t*} `})
 
-                1. Else Dangling#9354
+                1. Else Dangling#9357
 
-              1. Else Dangling#9353
+              1. Else Dangling#9356
 
-          1. Else Dangling#9351
+          1. Else Dangling#9354
 
-  1. Else Dangling#9343
+  1. Else Dangling#9346
 
 def $resolve_type_alias(typeIR)
 
@@ -30526,7 +30532,7 @@ def $resolve_type_alias(typeIR)
 
       1. Return (nameIR_alias, (typeIR_arg)*{typeIR_arg <- typeIR_arg*})
 
-1. Else Dangling#9356
+1. Else Dangling#9359
 
 def $instantiable_extern(p, TC, instctxt)
 
@@ -30646,7 +30652,7 @@ def $instantiable(p, TC, instctxt, typeIR)
 
       1. Return $instantiable_table(p, TC, instctxt)
 
-  1. Else Dangling#9390
+  1. Else Dangling#9393
 
 def $callable_action(p, TC)
 
@@ -30946,7 +30952,7 @@ def $parameterListIR_of_externMethodDef(externMethodDef)
 
     1. Return parameterListIR
 
-1. Else Dangling#9466
+1. Else Dangling#9469
 
 def $parameterListIR_of_parserApplyMethodDef((PARSER_APPLY `( parameterListIR `) `{ _parserLocalDeclarationListIR ';' _stateEnv `}))
 
@@ -31172,7 +31178,7 @@ def $find_store(store, objectId)
 
       1. Return object
 
-  1. Else Dangling#9490
+  1. Else Dangling#9493
 
 syntax globalInstLayer = {CONSTRUCTOR constructorDefEnv, TYPE typeDefEnv, CALLABLE callableDefEnv, FRAME frame}
 
@@ -31210,7 +31216,7 @@ def $exit_i(IC)
 
       1. Return IC[LOCAL.FRAMES = (frame_t)*{frame_t <- frame_t*}]
 
-  1. Else Dangling#9500
+  1. Else Dangling#9503
 
 def $enter_path_i(IC, id)
 
@@ -31250,7 +31256,7 @@ def $add_var_i(p, IC, id, value)
 
         1. Return IC[GLOBAL.FRAME = frame]
 
-    1. Else Dangling#9512
+    1. Else Dangling#9515
 
   2. Case (% matches pattern `BLOCK`)
 
@@ -31260,7 +31266,7 @@ def $add_var_i(p, IC, id, value)
 
         1. Return IC[BLOCK.FRAME = frame]
 
-    1. Else Dangling#9515
+    1. Else Dangling#9518
 
   3. Case (% matches pattern `LOCAL`)
 
@@ -31276,9 +31282,9 @@ def $add_var_i(p, IC, id, value)
 
               1. Return IC[LOCAL.FRAMES = frame_h' :: (frame_t)*{frame_t <- frame_t*}]
 
-          1. Else Dangling#9521
+          1. Else Dangling#9524
 
-      1. Else Dangling#9519
+      1. Else Dangling#9522
 
 def $add_vars_i(p, IC, (id)*{id <- id*}, (value)*{value <- value*})
 
@@ -31290,7 +31296,7 @@ def $add_vars_i(p, IC, (id)*{id <- id*}, (value)*{value <- value*})
 
       1. Return IC
 
-    1. Else Dangling#9525
+    1. Else Dangling#9528
 
   2. Case (% matches pattern _ :: _)
 
@@ -31306,7 +31312,7 @@ def $add_vars_i(p, IC, (id)*{id <- id*}, (value)*{value <- value*})
 
               1. Return IC''
 
-      1. Else Dangling#9528
+      1. Else Dangling#9531
 
 def $add_typeDef_i(p, IC, typeId, typeDefIR)
 
@@ -31316,7 +31322,7 @@ def $add_typeDef_i(p, IC, typeId, typeDefIR)
 
     1. Return IC[GLOBAL.TYPE = typeDefEnv]
 
-1. Else Dangling#9533
+1. Else Dangling#9536
 
 def $add_parserState_i(IC, nameIR, parserStateIR)
 
@@ -31326,7 +31332,7 @@ def $add_parserState_i(IC, nameIR, parserStateIR)
 
     1. Return IC[BLOCK.STATE = stateEnv]
 
-1. Else Dangling#9536
+1. Else Dangling#9539
 
 def $add_type_i(p, IC, typeId, typeIR)
 
@@ -31344,7 +31350,7 @@ def $add_type_i(p, IC, typeId, typeIR)
 
       1. Return IC[LOCAL.TYPE = theta]
 
-1. Else Dangling#9539
+1. Else Dangling#9542
 
 def $add_types_i(p, IC, (typeId)*{typeId <- typeId*}, (typeIR)*{typeIR <- typeIR*})
 
@@ -31356,7 +31362,7 @@ def $add_types_i(p, IC, (typeId)*{typeId <- typeId*}, (typeIR)*{typeIR <- typeIR
 
       1. Return IC
 
-    1. Else Dangling#9545
+    1. Else Dangling#9548
 
   2. Case (% matches pattern _ :: _)
 
@@ -31370,7 +31376,7 @@ def $add_types_i(p, IC, (typeId)*{typeId <- typeId*}, (typeIR)*{typeIR <- typeIR
 
             1. Return $add_types_i(p, IC', (typeId_t)*{typeId_t <- typeId_t*}, (typeIR_t)*{typeIR_t <- typeIR_t*})
 
-      1. Else Dangling#9548
+      1. Else Dangling#9551
 
 def $add_callableDef_overload_i(p, IC, callableId, callableDef)
 
@@ -31384,7 +31390,7 @@ def $add_callableDef_overload_i(p, IC, callableId, callableDef)
 
         1. Return IC[GLOBAL.CALLABLE = callableDefEnv]
 
-    1. Else Dangling#9553
+    1. Else Dangling#9556
 
   2. Case (% matches pattern `BLOCK`)
 
@@ -31394,9 +31400,9 @@ def $add_callableDef_overload_i(p, IC, callableId, callableDef)
 
         1. Return IC[BLOCK.CALLABLE = callableDefEnv]
 
-    1. Else Dangling#9556
+    1. Else Dangling#9559
 
-1. Else Dangling#9552
+1. Else Dangling#9555
 
 def $add_callableDef_non_overload_i(p, IC, callableId, callableDef)
 
@@ -31414,7 +31420,7 @@ def $add_callableDef_non_overload_i(p, IC, callableId, callableDef)
 
             1. Return IC[GLOBAL.CALLABLE = callableDefEnv]
 
-        1. Else Dangling#9562
+        1. Else Dangling#9565
 
   2. Case (% matches pattern `BLOCK`)
 
@@ -31428,9 +31434,9 @@ def $add_callableDef_non_overload_i(p, IC, callableId, callableDef)
 
             1. Return IC[BLOCK.CALLABLE = callableDefEnv]
 
-        1. Else Dangling#9567
+        1. Else Dangling#9570
 
-1. Else Dangling#9559
+1. Else Dangling#9562
 
 def $find_callableDef_non_overload_i(p, IC, prefixedNameIR)
 
@@ -31442,7 +31448,7 @@ def $find_callableDef_non_overload_i(p, IC, prefixedNameIR)
 
       1. Return ?()
 
-    1. Else Dangling#9572
+    1. Else Dangling#9575
 
     2. (Let ((callableId, callableDef))?{(callableId, callableDef) <- (callableId, callableDef)?} be $find_non_overloaded<callableDef>(IC.GLOBAL.CALLABLE, nameIR))
 
@@ -31452,9 +31458,9 @@ def $find_callableDef_non_overload_i(p, IC, prefixedNameIR)
 
           1. Return ?(((GLOBAL), callableId, callableDef))
 
-      1. Else Dangling#9575
+      1. Else Dangling#9578
 
-1. Else Dangling#9570
+1. Else Dangling#9573
 
 2. Case analysis on p
 
@@ -31466,7 +31472,7 @@ def $find_callableDef_non_overload_i(p, IC, prefixedNameIR)
 
         1. Return $find_callableDef_non_overload_i((GLOBAL), IC, ('.' nameIR))
 
-    1. Else Dangling#9579
+    1. Else Dangling#9582
 
   2. Case (% matches pattern `BLOCK`)
 
@@ -31482,15 +31488,15 @@ def $find_callableDef_non_overload_i(p, IC, prefixedNameIR)
 
               1. Return ?(((BLOCK), callableId, callableDef))
 
-          1. Else Dangling#9585
+          1. Else Dangling#9588
 
         2. If (($find_non_overloaded<callableDef>(IC.BLOCK.CALLABLE, nameIR) matches pattern ())), then
 
           1. Return $find_callableDef_non_overload_i((GLOBAL), IC, (_BARE nameIR))
 
-        2. Else Dangling#9588
+        2. Else Dangling#9591
 
-    1. Else Dangling#9582
+    1. Else Dangling#9585
 
   3. Case (% matches pattern `LOCAL`)
 
@@ -31500,7 +31506,7 @@ def $find_callableDef_non_overload_i(p, IC, prefixedNameIR)
 
         1. Return $find_callableDef_non_overload_i((BLOCK), IC, (_BARE nameIR))
 
-    1. Else Dangling#9590
+    1. Else Dangling#9593
 
 def $add_constructorDef_i(IC, callableId, constructorDef)
 
@@ -31518,7 +31524,7 @@ def $add_constructorDefs_i(IC, (callableId)*{callableId <- callableId*}, (constr
 
       1. Return IC
 
-    1. Else Dangling#9596
+    1. Else Dangling#9599
 
   2. Case (% matches pattern _ :: _)
 
@@ -31534,7 +31540,7 @@ def $add_constructorDefs_i(IC, (callableId)*{callableId <- callableId*}, (constr
 
               1. Return IC''
 
-      1. Else Dangling#9599
+      1. Else Dangling#9602
 
 def $find_var_i(prefixedNameIR, p, IC)
 
@@ -31552,7 +31558,7 @@ def $find_var_i(prefixedNameIR, p, IC)
 
             1. Return value
 
-        1. Else Dangling#9607
+        1. Else Dangling#9610
 
   2. Case (% matches pattern `_BARE %`)
 
@@ -31570,7 +31576,7 @@ def $find_var_i(prefixedNameIR, p, IC)
 
                 1. Return value
 
-            1. Else Dangling#9613
+            1. Else Dangling#9616
 
         2. Case (% matches pattern `BLOCK`)
 
@@ -31582,13 +31588,13 @@ def $find_var_i(prefixedNameIR, p, IC)
 
                 1. Return value
 
-            1. Else Dangling#9617
+            1. Else Dangling#9620
 
           2. If (($find_map<id, value>(IC.BLOCK.FRAME, id) matches pattern ())), then
 
             1. Return $find_var_i((_BARE id), (GLOBAL), IC)
 
-          2. Else Dangling#9620
+          2. Else Dangling#9623
 
         3. Case (% matches pattern `LOCAL`)
 
@@ -31600,13 +31606,13 @@ def $find_var_i(prefixedNameIR, p, IC)
 
                 1. Return value
 
-            1. Else Dangling#9623
+            1. Else Dangling#9626
 
           2. If (($find_maps<id, value>(IC.LOCAL.FRAMES, id) matches pattern ())), then
 
             1. Return $find_var_i((_BARE id), (BLOCK), IC)
 
-          2. Else Dangling#9626
+          2. Else Dangling#9629
 
 def $find_typeDef_i(_p, IC, prefixedNameIR)
 
@@ -31730,7 +31736,7 @@ relation Expr_inst: p IC STO |- (expressionIR '#' expressionNoteIR) : % %
 
             1. Result in: % % % |- % : STO_2 $bin_op(binop, value_l, value_r)
 
-      1. Else Dangling#9667
+      1. Else Dangling#9670
 
       2. Case analysis on binop
 
@@ -31750,7 +31756,7 @@ relation Expr_inst: p IC STO |- (expressionIR '#' expressionNoteIR) : % %
 
                   1. Result in: % % % |- % : STO_2 value_r
 
-            1. Else Dangling#9673
+            1. Else Dangling#9676
 
         2. Case (% matches pattern `||`)
 
@@ -31768,9 +31774,9 @@ relation Expr_inst: p IC STO |- (expressionIR '#' expressionNoteIR) : % %
 
                   1. Result in: % % % |- % : STO_2 value_r
 
-            1. Else Dangling#9678
+            1. Else Dangling#9681
 
-      2. Else Dangling#9671
+      2. Else Dangling#9674
 
   8. Case (% has type ternaryExpressionIR)
 
@@ -31792,7 +31798,7 @@ relation Expr_inst: p IC STO |- (expressionIR '#' expressionNoteIR) : % %
 
               1. Result in: % % % |- % : STO_2 value_false
 
-        1. Else Dangling#9684
+        1. Else Dangling#9687
 
   9. Case (% has type castExpressionIR)
 
@@ -31848,7 +31854,7 @@ relation Expr_inst: p IC STO |- (expressionIR '#' expressionNoteIR) : % %
 
                 1. Result in: % % % |- % : STO_1 ((RECORD `{ ((value nameIR ';'))*{nameIR <- nameIR*, value <- value*} `}) as value)
 
-              1. Else Dangling#9707
+              1. Else Dangling#9710
 
         2. Case (% matches pattern `RECORD {% , ...}`)
 
@@ -31860,7 +31866,7 @@ relation Expr_inst: p IC STO |- (expressionIR '#' expressionNoteIR) : % %
 
                 1. Result in: % % % |- % : STO_1 ((RECORD `{ ((value nameIR ';'))*{nameIR <- nameIR*, value <- value*} ',' '...' `}) as value)
 
-              1. Else Dangling#9711
+              1. Else Dangling#9714
 
   13. Case (% has type errorAccessExpressionIR)
 
@@ -31908,11 +31914,11 @@ relation Expr_inst: p IC STO |- (expressionIR '#' expressionNoteIR) : % %
 
                               1. Result in: % % % |- % : STO ((typeId '.' nameIR '.' value) as value)
 
-                          1. Else Dangling#9728
+                          1. Else Dangling#9731
 
-                  1. Else Dangling#9723
+                  1. Else Dangling#9726
 
-              1. Else Dangling#9721
+              1. Else Dangling#9724
 
         2. Case (% has type typedExpressionIR)
 
@@ -31930,9 +31936,9 @@ relation Expr_inst: p IC STO |- (expressionIR '#' expressionNoteIR) : % %
 
                       1. Result in: % % % |- % : STO ((32 W (n_size as int)) as value)
 
-                    1. Else Dangling#9736
+                    1. Else Dangling#9739
 
-                1. Else Dangling#9734
+                1. Else Dangling#9737
 
             2. (Expr_inst: p IC STO |- typedExpressionIR_base : STO_1 value')
 
@@ -31952,7 +31958,7 @@ relation Expr_inst: p IC STO |- (expressionIR '#' expressionNoteIR) : % %
 
                             1. Result in: % % % |- % : STO_1 value
 
-                        1. Else Dangling#9743
+                        1. Else Dangling#9746
 
                 2. Case (% has type headerValue)
 
@@ -31968,7 +31974,7 @@ relation Expr_inst: p IC STO |- (expressionIR '#' expressionNoteIR) : % %
 
                             1. Result in: % % % |- % : STO_1 value
 
-                        1. Else Dangling#9749
+                        1. Else Dangling#9752
 
                 3. Case (% has type headerUnionValue)
 
@@ -31984,9 +31990,9 @@ relation Expr_inst: p IC STO |- (expressionIR '#' expressionNoteIR) : % %
 
                             1. Result in: % % % |- % : STO_1 value
 
-                        1. Else Dangling#9755
+                        1. Else Dangling#9758
 
-              1. Else Dangling#9739
+              1. Else Dangling#9742
 
   15. Case (% has type indexAccessExpressionIR)
 
@@ -32020,11 +32026,11 @@ relation Expr_inst: p IC STO |- (expressionIR '#' expressionNoteIR) : % %
 
                                 1. Result in: % % % |- % : STO_2 value
 
-                            1. Else Dangling#9769
+                            1. Else Dangling#9772
 
-                          1. Else Dangling#9768
+                          1. Else Dangling#9771
 
-                      1. Else Dangling#9766
+                      1. Else Dangling#9769
 
                 2. Case (% has type arrayValue)
 
@@ -32044,11 +32050,11 @@ relation Expr_inst: p IC STO |- (expressionIR '#' expressionNoteIR) : % %
 
                                 1. Result in: % % % |- % : STO_2 value
 
-                            1. Else Dangling#9777
+                            1. Else Dangling#9780
 
-                          1. Else Dangling#9776
+                          1. Else Dangling#9779
 
-                      1. Else Dangling#9774
+                      1. Else Dangling#9777
 
                 3. Case (% has type headerStackValue)
 
@@ -32068,15 +32074,15 @@ relation Expr_inst: p IC STO |- (expressionIR '#' expressionNoteIR) : % %
 
                                 1. Result in: % % % |- % : STO_2 value
 
-                            1. Else Dangling#9785
+                            1. Else Dangling#9788
 
-                          1. Else Dangling#9784
+                          1. Else Dangling#9787
 
-                      1. Else Dangling#9782
+                      1. Else Dangling#9785
 
-              1. Else Dangling#9763
+              1. Else Dangling#9766
 
-          1. Else Dangling#9761
+          1. Else Dangling#9764
 
   16. Case (% has type sliceAccessExpressionIR)
 
@@ -32140,7 +32146,7 @@ relation Expr_inst: p IC STO |- (expressionIR '#' expressionNoteIR) : % %
 
                       1. Result in: % % % |- % : STO $sizeof(typeIR_base, nameIR)
 
-                    1. Else Dangling#9810
+                    1. Else Dangling#9813
 
               2. Case (% matches pattern `TYPE % . %`)
 
@@ -32162,7 +32168,7 @@ relation Expr_inst: p IC STO |- (expressionIR '#' expressionNoteIR) : % %
 
                                 1. Result in: % % % |- % : STO $sizeof(typeIR_base, nameIR)
 
-                              1. Else Dangling#9818
+                              1. Else Dangling#9821
 
                           2. Case false
 
@@ -32174,11 +32180,11 @@ relation Expr_inst: p IC STO |- (expressionIR '#' expressionNoteIR) : % %
 
                                   1. Result in: % % % |- % : STO $sizeof(typeIR_base, nameIR)
 
-                                1. Else Dangling#9822
+                                1. Else Dangling#9825
 
-                            1. Else Dangling#9820
+                            1. Else Dangling#9823
 
-                    1. Else Dangling#9814
+                    1. Else Dangling#9817
 
               3. Case (% matches pattern `(%)`)
 
@@ -32188,7 +32194,7 @@ relation Expr_inst: p IC STO |- (expressionIR '#' expressionNoteIR) : % %
 
                     1. Result in: % % % |- % : STO_1 value
 
-            1. Else Dangling#9807
+            1. Else Dangling#9810
 
   18. Case (% has type parenthesizedExpressionIR)
 
@@ -32236,7 +32242,7 @@ relation Argument_inst: p IC STO_0 |- argumentIR : % %
 
         1. Result in: % % % |- % : STO_1 value
 
-1. Else Dangling#9836
+1. Else Dangling#9839
 
 relation DirectApplicationStmt_inst: p IC STO_0 |- (constructorTargetIR '.' APPLY `( argumentListIR `) ';') : % % %
 
@@ -32360,7 +32366,7 @@ relation Stmt_inst: p IC STO |- statementIR' : % % %
 
                   1. Result in: % % % |- % : IC STO_1 (forStatementIR as statementIR)
 
-            1. Else Dangling#9887
+            1. Else Dangling#9890
 
         3. Case (% matches pattern `% FOR (% ; % ; %) %`)
 
@@ -32392,7 +32398,7 @@ relation Stmt_inst: p IC STO |- statementIR' : % % %
 
         1. Result in: % % % |- % : IC STO_1 ((SWITCH `( typedExpressionIR `) `{ switchCaseListIR_inst `}) as statementIR)
 
-1. Else Dangling#9858
+1. Else Dangling#9861
 
 2. If ((p matches pattern `LOCAL`)), then
 
@@ -32416,9 +32422,9 @@ relation Stmt_inst: p IC STO |- statementIR' : % % %
 
               1. Result in: % % % |- % : IC_3 STO_1 ((annotationList `{ blockElementStatementListIR_inst `}) as statementIR)
 
-  1. Else Dangling#9903
+  1. Else Dangling#9906
 
-2. Else Dangling#9902
+2. Else Dangling#9905
 
 relation BlockElementStmt_inst: IC STO |- blockElementStatementIR : % % %
 
@@ -32532,7 +32538,7 @@ relation ParserStmt_inst: IC_0 STO_0 |- parserStatementIR : % % %
 
             1. Result in: % % |- % : IC_1 STO_1 (emptyStatementIR_inst as parserStatementIR)
 
-        1. Else Dangling#9948
+        1. Else Dangling#9951
 
   2. Case (% has type assignmentStatementIR)
 
@@ -32546,7 +32552,7 @@ relation ParserStmt_inst: IC_0 STO_0 |- parserStatementIR : % % %
 
             1. Result in: % % |- % : IC_1 STO_1 (assignmentStatementIR_inst as parserStatementIR)
 
-        1. Else Dangling#9953
+        1. Else Dangling#9956
 
   3. Case (% has type callStatementIR)
 
@@ -32560,7 +32566,7 @@ relation ParserStmt_inst: IC_0 STO_0 |- parserStatementIR : % % %
 
             1. Result in: % % |- % : IC_1 STO_1 (callStatementIR_inst as parserStatementIR)
 
-        1. Else Dangling#9958
+        1. Else Dangling#9961
 
   4. Case (% has type directApplicationStatementIR)
 
@@ -32744,9 +32750,9 @@ relation ParserLocalDecl_inst: IC_0 STO |- parserLocalDeclarationIR : % % %
 
                               1. Result in: % % |- % : IC_0 STO_2 (constantDeclarationIR as parserLocalDeclarationIR)
 
-              1. Else Dangling#10021
+              1. Else Dangling#10024
 
-        1. Else Dangling#10018
+        1. Else Dangling#10021
 
 relation ParserLocalDecls_inst: IC STO |- (parserLocalDeclarationIR)*{parserLocalDeclarationIR <- parserLocalDeclarationIR*} : % % %
 
@@ -32810,7 +32816,7 @@ relation TableAction_inst: IC STO |- (annotationList tableActionReferenceIR '#' 
 
                               1. Result in: % % |- % : STO tableActionIR
 
-                1. Else Dangling#10044
+                1. Else Dangling#10047
 
               2. If (($name_annotation(annotationList_actionDef) matches pattern [])), then
 
@@ -32822,11 +32828,11 @@ relation TableAction_inst: IC STO |- (annotationList tableActionReferenceIR '#' 
 
                       1. Result in: % % |- % : STO tableActionIR
 
-              2. Else Dangling#10055
+              2. Else Dangling#10058
 
-        1. Else Dangling#10040
+        1. Else Dangling#10043
 
-    1. Else Dangling#10038
+    1. Else Dangling#10041
 
 relation TableActions_inst: IC STO |- (tableActionIR)*{tableActionIR <- tableActionIR*} : % %
 
@@ -32990,7 +32996,7 @@ relation ControlLocalDecl_inst: IC_0 STO |- controlLocalDeclarationIR : % % %
 
                                   1. Result in: % % |- % : IC_1 STO_2 ?((constantDeclarationIR as controlLocalDeclarationIR))
 
-                            1. Else Dangling#10117
+                            1. Else Dangling#10120
 
                             2. (Let (nameIR')*{nameIR' <- nameIR'*} be $name_annotation(annotationList))
 
@@ -33008,9 +33014,9 @@ relation ControlLocalDecl_inst: IC_0 STO |- controlLocalDeclarationIR : % % %
 
                                           1. Result in: % % |- % : IC_1 STO_3 ?((constantDeclarationIR as controlLocalDeclarationIR))
 
-                              1. Else Dangling#10122
+                              1. Else Dangling#10125
 
-                1. Else Dangling#10111
+                1. Else Dangling#10114
 
 relation ControlLocalDecls_inst: IC STO |- (controlLocalDeclarationIR)*{controlLocalDeclarationIR <- controlLocalDeclarationIR*} : % % %
 
@@ -33084,7 +33090,7 @@ relation InstDecl_inst: p IC_0 STO_0 |- (annotationList typeIR constructorTarget
 
                                 1. Result in: % % % |- % : IC_1 STO_3 constantDeclarationIR
 
-        1. Else Dangling#10145
+        1. Else Dangling#10148
 
     2. (Let nameIR' be $name_annotation_default(annotationList, nameIR))
 
@@ -33104,7 +33110,7 @@ relation InstDecl_inst: p IC_0 STO_0 |- (annotationList typeIR constructorTarget
 
                     1. Result in: % % % |- % : IC_1 STO_2 constantDeclarationIR
 
-          1. Else Dangling#10161
+          1. Else Dangling#10164
 
 relation FuncDecl_inst: p IC_0 |- (annotationList (typeIR nameIR `< typeParameterListIR_expl ',' typeParameterListIR_impl `> `( parameterListIR `)) blockStatementIR) : %
 
@@ -33412,11 +33418,11 @@ relation Decl_inst: IC_0 STO |- declarationIR : % %
 
                                             1. Result in: % % |- % : IC_2 STO
 
-                                    1. Else Dangling#10288
+                                    1. Else Dangling#10291
 
-                            1. Else Dangling#10281
+                            1. Else Dangling#10284
 
-                      1. Else Dangling#10278
+                      1. Else Dangling#10281
 
         2. Case (% matches pattern `% TYPE % % ;`)
 
@@ -33516,7 +33522,7 @@ relation Copy_in_inst: STO p_caller IC_caller (argumentIR)*{argumentIR <- argume
 
       1. Result in: % % % % '@' % % % ~> STO IC
 
-    1. Else Dangling#10329
+    1. Else Dangling#10332
 
   2. Case (% matches pattern _ :: _)
 
@@ -33532,7 +33538,7 @@ relation Copy_in_inst: STO p_caller IC_caller (argumentIR)*{argumentIR <- argume
 
               1. Result in: % % % % '@' % % % ~> STO_2 IC_callee_2
 
-      1. Else Dangling#10332
+      1. Else Dangling#10335
 
 relation Copy_in_arg_inst_default: STO p_caller IC_caller '@' p_callee IC_callee_0 parameterIR ~> % %
 
@@ -33564,7 +33570,7 @@ relation Copy_in_arg_inst_default: STO p_caller IC_caller '@' p_callee IC_callee
 
               1. Result in: % % % '@' % % % ~> STO IC_callee_1
 
-  1. Else Dangling#10338
+  1. Else Dangling#10341
 
 relation Copy_in_inst_default: STO p_caller IC_caller '@' p_callee IC (parameterIR)*{parameterIR <- parameterIR*} ~> % %
 
@@ -33596,9 +33602,9 @@ relation Constructor_inst: p IC |- prefixedNameIR `< (typeArgumentIR')*{typeArgu
 
         1. Result in: % % |- % `< % `> `( % `) : constructorDef `< (typeArgumentIR')*{typeArgumentIR' <- typeArgumentIR'*} `> `( '#' (id_default)*{id_default <- id_default*} '#' (id_optional)*{id_optional <- id_optional*} `)
 
-    1. Else Dangling#10357
+    1. Else Dangling#10360
 
-1. Else Dangling#10355
+1. Else Dangling#10358
 
 2. (Let (typeDefIR')?{typeDefIR' <- typeDefIR'?} be $find_typeDef_i(p, IC, prefixedNameIR))
 
@@ -33616,11 +33622,11 @@ relation Constructor_inst: p IC |- prefixedNameIR `< (typeArgumentIR')*{typeArgu
 
               1. Result in: % % |- % `< % `> `( % `) : constructorDef `< (typeArgumentIR')*{typeArgumentIR' <- typeArgumentIR'*} `> `( '#' (id_default)*{id_default <- id_default*} '#' (id_optional)*{id_optional <- id_optional*} `)
 
-          1. Else Dangling#10365
+          1. Else Dangling#10368
 
-      1. Else Dangling#10363
+      1. Else Dangling#10366
 
-  1. Else Dangling#10361
+  1. Else Dangling#10364
 
 3. If (((typeArgumentIR')*{typeArgumentIR' <- typeArgumentIR'*} matches pattern [])), then
 
@@ -33644,13 +33650,13 @@ relation Constructor_inst: p IC |- prefixedNameIR `< (typeArgumentIR')*{typeArgu
 
                     1. Result in: % % |- % `< % `> `( % `) : constructorDef `< (typeArgumentIR)*{typeArgumentIR <- typeArgumentIR*} `> `( '#' (id_default)*{id_default <- id_default*} '#' (id_optional)*{id_optional <- id_optional*} `)
 
-                1. Else Dangling#10376
+                1. Else Dangling#10379
 
-        1. Else Dangling#10372
+        1. Else Dangling#10375
 
-    1. Else Dangling#10370
+    1. Else Dangling#10373
 
-3. Else Dangling#10368
+3. Else Dangling#10371
 
 relation Constructor_call: p IC STO_0 |- constructorDef `< (typeArgumentIR)*{typeArgumentIR <- typeArgumentIR*} `> `( (argumentIR)*{argumentIR <- argumentIR*} '#' (id_default)*{id_default <- id_default*} '#' (id_optional)*{id_optional <- id_optional*} `) : % %
 
@@ -33714,15 +33720,15 @@ relation Constructor_call: p IC STO_0 |- constructorDef `< (typeArgumentIR)*{typ
 
                                                           1. Result in: % % % |- % `< % `> `( % '#' % '#' % `) : STO_2 object_extern
 
-                                            1. Else Dangling#10400
+                                            1. Else Dangling#10403
 
-                                      1. Else Dangling#10397
+                                      1. Else Dangling#10400
 
-                                    1. Else Dangling#10396
+                                    1. Else Dangling#10399
 
-                              1. Else Dangling#10393
+                              1. Else Dangling#10396
 
-            1. Else Dangling#10384
+            1. Else Dangling#10387
 
   2. Case (% has type parserObjectConstructorDef)
 
@@ -33760,7 +33766,7 @@ relation Constructor_call: p IC STO_0 |- constructorDef `< (typeArgumentIR)*{typ
 
                                     1. Result in: % % % |- % `< % `> `( % '#' % '#' % `) : STO_4 object_parser
 
-            1. Else Dangling#10412
+            1. Else Dangling#10415
 
   3. Case (% has type controlObjectConstructorDef)
 
@@ -33802,9 +33808,9 @@ relation Constructor_call: p IC STO_0 |- constructorDef `< (typeArgumentIR)*{typ
 
                                         1. Result in: % % % |- % `< % `> `( % '#' % '#' % `) : STO_4 object_control
 
-                                  1. Else Dangling#10440
+                                  1. Else Dangling#10443
 
-            1. Else Dangling#10429
+            1. Else Dangling#10432
 
   4. Case (% has type packageObjectConstructorDef)
 
@@ -33836,7 +33842,7 @@ relation Constructor_call: p IC STO_0 |- constructorDef `< (typeArgumentIR)*{typ
 
                               1. Result in: % % % |- % `< % `> `( % '#' % '#' % `) : STO_2 object_package
 
-            1. Else Dangling#10448
+            1. Else Dangling#10451
 
 relation SwitchCase_inst: p IC STO |- switchCaseIR : % %
 
@@ -33854,7 +33860,7 @@ relation SwitchCase_inst: p IC STO |- switchCaseIR : % %
 
             1. Result in: % % % |- % : STO_1 (switchLabelIR ':' blockStatementIR_inst)
 
-        1. Else Dangling#10461
+        1. Else Dangling#10464
 
   2. Case (% matches pattern `% :`)
 
@@ -33890,7 +33896,7 @@ def $merge_externMethodDefEnvs(externMethodDefEnv, set<pair<callableId, callable
 
   1. Return externMethodDefEnv
 
-1. Else Dangling#10473
+1. Else Dangling#10476
 
 2. (Let (`{ (pair<callableId, callableDef>)*{pair<callableId, callableDef> <- pair<callableId, callableDef>*} `}) be set<pair<callableId, callableDef>>)
 
@@ -33908,9 +33914,9 @@ def $merge_externMethodDefEnvs(externMethodDefEnv, set<pair<callableId, callable
 
               1. Return $merge_externMethodDefEnvs(externMethodDefEnv_post, (`{ ((callableId_t ':' callableDef_t))*{callableDef_t <- callableDef_t*, callableId_t <- callableId_t*} `}))
 
-      1. Else Dangling#10478
+      1. Else Dangling#10481
 
-  1. Else Dangling#10476
+  1. Else Dangling#10479
 
 relation ObjectDecl_inst: IC_0 STO |- objectDeclarationIR : % %
 
@@ -34014,15 +34020,15 @@ def $init_table((tablePropertyIR)*{tablePropertyIR <- tablePropertyIR*})
 
                                 1. Return TBL
 
-                          1. Else Dangling#10518
+                          1. Else Dangling#10521
 
-                  1. Else Dangling#10514
+                  1. Else Dangling#10517
 
-              1. Else Dangling#10512
+              1. Else Dangling#10515
 
-        1. Else Dangling#10509
+        1. Else Dangling#10512
 
-    1. Else Dangling#10507
+    1. Else Dangling#10510
 
 def $init_tableKeys((tablePropertyIR)*{tablePropertyIR <- tablePropertyIR*})
 
@@ -34038,15 +34044,15 @@ def $init_tableKeys((tablePropertyIR)*{tablePropertyIR <- tablePropertyIR*})
 
           1. Return tableKeysPropertyIR
 
-      1. Else Dangling#10525
+      1. Else Dangling#10528
 
-  1. Else Dangling#10523
+  1. Else Dangling#10526
 
 2. If (($filter_<tablePropertyIR>((tablePropertyIR)*{tablePropertyIR <- tablePropertyIR*}, ((tablePropertyIR has type tableKeysPropertyIR))*{tablePropertyIR <- tablePropertyIR*}) matches pattern [])), then
 
   1. Return (KEY '=' `{ [] `})
 
-2. Else Dangling#10528
+2. Else Dangling#10531
 
 def $init_tableEntries((tablePropertyIR)*{tablePropertyIR <- tablePropertyIR*})
 
@@ -34062,15 +34068,15 @@ def $init_tableEntries((tablePropertyIR)*{tablePropertyIR <- tablePropertyIR*})
 
           1. Return tableEntriesPropertyIR
 
-      1. Else Dangling#10533
+      1. Else Dangling#10536
 
-  1. Else Dangling#10531
+  1. Else Dangling#10534
 
 2. If (($filter_<tablePropertyIR>((tablePropertyIR)*{tablePropertyIR <- tablePropertyIR*}, ((tablePropertyIR has type tableEntriesPropertyIR))*{tablePropertyIR <- tablePropertyIR*}) matches pattern [])), then
 
   1. Return ((_EMPTY) ?() ENTRIES '=' `{ [] `})
 
-2. Else Dangling#10536
+2. Else Dangling#10539
 
 syntax globalEvalLayer = globalInstLayer
 
@@ -34096,7 +34102,7 @@ def $exit_e(EC)
 
       1. Return EC[LOCAL.FRAMES = (frame_t)*{frame_t <- frame_t*}]
 
-  1. Else Dangling#10540
+  1. Else Dangling#10543
 
 def $inherit_e(p, EC)
 
@@ -34170,7 +34176,7 @@ def $add_var_e(p, EC, prefixedNameIR, value)
 
           1. Return EC[BLOCK.FRAME = frame]
 
-    1. Else Dangling#10562
+    1. Else Dangling#10565
 
   3. Case (% matches pattern `LOCAL`)
 
@@ -34188,9 +34194,9 @@ def $add_var_e(p, EC, prefixedNameIR, value)
 
                 1. Return EC[LOCAL.FRAMES = frame_h' :: (frame_t)*{frame_t <- frame_t*}]
 
-          1. Else Dangling#10569
+          1. Else Dangling#10572
 
-    1. Else Dangling#10566
+    1. Else Dangling#10569
 
 def $add_vars_e(p, EC, (prefixedNameIR)*{prefixedNameIR <- prefixedNameIR*}, (value)*{value <- value*})
 
@@ -34202,7 +34208,7 @@ def $add_vars_e(p, EC, (prefixedNameIR)*{prefixedNameIR <- prefixedNameIR*}, (va
 
       1. Return EC
 
-    1. Else Dangling#10574
+    1. Else Dangling#10577
 
   2. Case (% matches pattern _ :: _)
 
@@ -34218,7 +34224,7 @@ def $add_vars_e(p, EC, (prefixedNameIR)*{prefixedNameIR <- prefixedNameIR*}, (va
 
               1. Return EC''
 
-      1. Else Dangling#10577
+      1. Else Dangling#10580
 
 def $update_var_e(p, EC, prefixedNameIR, value)
 
@@ -34230,7 +34236,7 @@ def $update_var_e(p, EC, prefixedNameIR, value)
 
       1. Return EC[GLOBAL.FRAME = frame]
 
-1. Else Dangling#10582
+1. Else Dangling#10585
 
 2. Case analysis on p
 
@@ -34248,9 +34254,9 @@ def $update_var_e(p, EC, prefixedNameIR, value)
 
               1. Return EC[GLOBAL.FRAME = frame']
 
-          1. Else Dangling#10590
+          1. Else Dangling#10593
 
-    1. Else Dangling#10587
+    1. Else Dangling#10590
 
   2. Case (% matches pattern `BLOCK`)
 
@@ -34272,7 +34278,7 @@ def $update_var_e(p, EC, prefixedNameIR, value)
 
               1. Return $update_var_e((GLOBAL), EC, (_BARE id), value)
 
-    1. Else Dangling#10593
+    1. Else Dangling#10596
 
   3. Case (% matches pattern `LOCAL`)
 
@@ -34284,7 +34290,7 @@ def $update_var_e(p, EC, prefixedNameIR, value)
 
           1. Return $update_var_e((BLOCK), EC, (_BARE id), value)
 
-        1. Else Dangling#10602
+        1. Else Dangling#10605
 
         2. (Let (frame)*{frame <- frame*} be EC.LOCAL.FRAMES)
 
@@ -34308,9 +34314,9 @@ def $update_var_e(p, EC, prefixedNameIR, value)
 
                       1. Return EC_pop'[LOCAL.FRAMES = frame_h :: EC_pop'.LOCAL.FRAMES]
 
-          1. Else Dangling#10605
+          1. Else Dangling#10608
 
-    1. Else Dangling#10600
+    1. Else Dangling#10603
 
 def $find_var_e(prefixedNameIR, p, EC)
 
@@ -34328,7 +34334,7 @@ def $find_var_e(prefixedNameIR, p, EC)
 
             1. Return value
 
-        1. Else Dangling#10616
+        1. Else Dangling#10619
 
   2. Case (% matches pattern `_BARE %`)
 
@@ -34346,7 +34352,7 @@ def $find_var_e(prefixedNameIR, p, EC)
 
                 1. Return value
 
-            1. Else Dangling#10622
+            1. Else Dangling#10625
 
         2. Case (% matches pattern `BLOCK`)
 
@@ -34358,13 +34364,13 @@ def $find_var_e(prefixedNameIR, p, EC)
 
                 1. Return value
 
-            1. Else Dangling#10626
+            1. Else Dangling#10629
 
           2. If (($find_map<id, value>(EC.BLOCK.FRAME, id) matches pattern ())), then
 
             1. Return $find_var_e((_BARE id), (GLOBAL), EC)
 
-          2. Else Dangling#10629
+          2. Else Dangling#10632
 
         3. Case (% matches pattern `LOCAL`)
 
@@ -34376,13 +34382,13 @@ def $find_var_e(prefixedNameIR, p, EC)
 
                 1. Return value
 
-            1. Else Dangling#10632
+            1. Else Dangling#10635
 
           2. If (($find_maps<id, value>(EC.LOCAL.FRAMES, id) matches pattern ())), then
 
             1. Return $find_var_e((_BARE id), (BLOCK), EC)
 
-          2. Else Dangling#10635
+          2. Else Dangling#10638
 
 def $find_typeDef_e(_p, EC, prefixedNameIR)
 
@@ -34418,15 +34424,15 @@ def $find_type_e(p, EC, nameIR)
 
           1. Return ?(typeIR)
 
-      1. Else Dangling#10645
+      1. Else Dangling#10648
 
     2. If (($find_map<typeId, typeIR>(EC.LOCAL.TYPE, nameIR) matches pattern ())), then
 
       1. Return $find_type_e((BLOCK), EC, nameIR)
 
-    2. Else Dangling#10648
+    2. Else Dangling#10651
 
-1. Else Dangling#10642
+1. Else Dangling#10645
 
 def $find_callableDef_overloaded_e(p, EC, prefixedNameIR, (argumentIR)*{argumentIR <- argumentIR*})
 
@@ -34450,13 +34456,13 @@ def $find_callableDef_overloaded_e(p, EC, prefixedNameIR, (argumentIR)*{argument
 
                   1. Return ?((callableId ':' ((GLOBAL), callableDef) '#' (id_default)*{id_default <- id_default*} '#' (id_optional)*{id_optional <- id_optional*}))
 
-              1. Else Dangling#10655
+              1. Else Dangling#10658
 
             2. If (($find_overloaded<callableDef>(EC.GLOBAL.CALLABLE, callTargetKey, $parameterListIR_of_callableDef) matches pattern ())), then
 
               1. Return ?()
 
-            2. Else Dangling#10658
+            2. Else Dangling#10661
 
       2. Case (% matches pattern `. %`)
 
@@ -34472,13 +34478,13 @@ def $find_callableDef_overloaded_e(p, EC, prefixedNameIR, (argumentIR)*{argument
 
                   1. Return ?((callableId ':' ((GLOBAL), callableDef) '#' (id_default)*{id_default <- id_default*} '#' (id_optional)*{id_optional <- id_optional*}))
 
-              1. Else Dangling#10663
+              1. Else Dangling#10666
 
             2. If (($find_overloaded<callableDef>(EC.GLOBAL.CALLABLE, callTargetKey, $parameterListIR_of_callableDef) matches pattern ())), then
 
               1. Return ?()
 
-            2. Else Dangling#10666
+            2. Else Dangling#10669
 
   2. Case (% matches pattern `BLOCK`)
 
@@ -34496,15 +34502,15 @@ def $find_callableDef_overloaded_e(p, EC, prefixedNameIR, (argumentIR)*{argument
 
                 1. Return ?((callableId ':' ((BLOCK), callableDef) '#' (id_default)*{id_default <- id_default*} '#' (id_optional)*{id_optional <- id_optional*}))
 
-            1. Else Dangling#10672
+            1. Else Dangling#10675
 
           2. If (($find_overloaded<callableDef>(EC.BLOCK.CALLABLE, callTargetKey, $parameterListIR_of_callableDef) matches pattern ())), then
 
             1. Return $find_callableDef_overloaded_e((GLOBAL), EC, (_BARE nameIR), (argumentIR)*{argumentIR <- argumentIR*})
 
-          2. Else Dangling#10675
+          2. Else Dangling#10678
 
-    1. Else Dangling#10668
+    1. Else Dangling#10671
 
   3. Case (% matches pattern `LOCAL`)
 
@@ -34514,7 +34520,7 @@ def $find_callableDef_overloaded_e(p, EC, prefixedNameIR, (argumentIR)*{argument
 
         1. Return $find_callableDef_overloaded_e((BLOCK), EC, (_BARE nameIR), (argumentIR)*{argumentIR <- argumentIR*})
 
-    1. Else Dangling#10677
+    1. Else Dangling#10680
 
 def $find_constructorDef_e(EC, prefixedNameIR, (argumentIR)*{argumentIR <- argumentIR*})
 
@@ -34648,7 +34654,7 @@ def $update_object_qualified_e(ARCH_0, objectId, object)
 
     1. Return ARCH_1
 
-1. Else Dangling#10721
+1. Else Dangling#10724
 
 def $update_object_unqualified_e(ARCH_0, id, object)
 
@@ -34670,9 +34676,9 @@ def $update_object_unqualified_e(ARCH_0, id, object)
 
                 1. Return ARCH_1
 
-          1. Else Dangling#10729
+          1. Else Dangling#10732
 
-      1. Else Dangling#10727
+      1. Else Dangling#10730
 
 def $update_objectState_e(ARCH_0, objectId, objectState)
 
@@ -34826,9 +34832,9 @@ relation Expr_eval: p EC ARCH |- (expressionIR '#' _expressionNoteIR) : % % %
 
                       1. Result in: % % % |- % : EC_1 ARCH_1 expressionResult
 
-                1. Else Dangling#10776
+                1. Else Dangling#10779
 
-      1. Else Dangling#10770
+      1. Else Dangling#10773
 
       2. Case analysis on binop
 
@@ -34842,7 +34848,7 @@ relation Expr_eval: p EC ARCH |- (expressionIR '#' _expressionNoteIR) : % % %
 
                 1. Result in: % % % |- % : EC_1 ARCH_1 (abortResult as expressionResult)
 
-            1. Else Dangling#10782
+            1. Else Dangling#10785
 
             2. Case analysis on expressionResult'
 
@@ -34858,7 +34864,7 @@ relation Expr_eval: p EC ARCH |- (expressionIR '#' _expressionNoteIR) : % % %
 
                   1. Result in: % % % |- % : EC_2 ARCH_2 expressionResult_r
 
-            2. Else Dangling#10785
+            2. Else Dangling#10788
 
         2. Case (% matches pattern `||`)
 
@@ -34870,7 +34876,7 @@ relation Expr_eval: p EC ARCH |- (expressionIR '#' _expressionNoteIR) : % % %
 
                 1. Result in: % % % |- % : EC_1 ARCH_1 (abortResult as expressionResult)
 
-            1. Else Dangling#10791
+            1. Else Dangling#10794
 
             2. Case analysis on expressionResult'
 
@@ -34886,9 +34892,9 @@ relation Expr_eval: p EC ARCH |- (expressionIR '#' _expressionNoteIR) : % % %
 
                   1. Result in: % % % |- % : EC_2 ARCH_2 expressionResult_r
 
-            2. Else Dangling#10794
+            2. Else Dangling#10797
 
-      2. Else Dangling#10780
+      2. Else Dangling#10783
 
   8. Case (% has type ternaryExpressionIR)
 
@@ -34902,7 +34908,7 @@ relation Expr_eval: p EC ARCH |- (expressionIR '#' _expressionNoteIR) : % % %
 
             1. Result in: % % % |- % : EC_1 ARCH_1 (abortResult as expressionResult)
 
-        1. Else Dangling#10801
+        1. Else Dangling#10804
 
         2. Case analysis on expressionResult
 
@@ -34918,7 +34924,7 @@ relation Expr_eval: p EC ARCH |- (expressionIR '#' _expressionNoteIR) : % % %
 
               1. Result in: % % % |- % : EC_2 ARCH_2 expressionResult_false
 
-        2. Else Dangling#10804
+        2. Else Dangling#10807
 
   9. Case (% has type castExpressionIR)
 
@@ -35030,7 +35036,7 @@ relation Expr_eval: p EC ARCH |- (expressionIR '#' _expressionNoteIR) : % % %
 
                         1. Result in: % % % |- % : EC_1 ARCH_1 expressionResult
 
-                    1. Else Dangling#10846
+                    1. Else Dangling#10849
 
         2. Case (% matches pattern `RECORD {% , ...}`)
 
@@ -35056,7 +35062,7 @@ relation Expr_eval: p EC ARCH |- (expressionIR '#' _expressionNoteIR) : % % %
 
                         1. Result in: % % % |- % : EC_1 ARCH_1 expressionResult
 
-                    1. Else Dangling#10855
+                    1. Else Dangling#10858
 
   13. Case (% has type errorAccessExpressionIR)
 
@@ -35110,11 +35116,11 @@ relation Expr_eval: p EC ARCH |- (expressionIR '#' _expressionNoteIR) : % % %
 
                                 1. Result in: % % % |- % : EC ARCH expressionResult
 
-                          1. Else Dangling#10875
+                          1. Else Dangling#10878
 
-                  1. Else Dangling#10869
+                  1. Else Dangling#10872
 
-              1. Else Dangling#10867
+              1. Else Dangling#10870
 
         2. Case (% has type typedExpressionIR)
 
@@ -35182,9 +35188,9 @@ relation Expr_eval: p EC ARCH |- (expressionIR '#' _expressionNoteIR) : % % %
 
                                                     1. Result in: % % % |- % : EC_1 ARCH_1 expressionResult
 
-                                              1. Else Dangling#10900
+                                              1. Else Dangling#10903
 
-                                          1. Else Dangling#10898
+                                          1. Else Dangling#10901
 
                               3. Case (% = "lastIndex")
 
@@ -35200,9 +35206,9 @@ relation Expr_eval: p EC ARCH |- (expressionIR '#' _expressionNoteIR) : % % %
 
                                           1. Result in: % % % |- % : EC_1 ARCH_1 expressionResult
 
-                                  1. Else Dangling#10905
+                                  1. Else Dangling#10908
 
-                            1. Else Dangling#10888
+                            1. Else Dangling#10891
 
                       2. Case (% has type structValue)
 
@@ -35220,7 +35226,7 @@ relation Expr_eval: p EC ARCH |- (expressionIR '#' _expressionNoteIR) : % % %
 
                                     1. Result in: % % % |- % : EC_1 ARCH_1 expressionResult
 
-                              1. Else Dangling#10913
+                              1. Else Dangling#10916
 
                       3. Case (% has type headerValue)
 
@@ -35238,7 +35244,7 @@ relation Expr_eval: p EC ARCH |- (expressionIR '#' _expressionNoteIR) : % % %
 
                                     1. Result in: % % % |- % : EC_1 ARCH_1 expressionResult
 
-                              1. Else Dangling#10920
+                              1. Else Dangling#10923
 
                       4. Case (% has type headerUnionValue)
 
@@ -35256,9 +35262,9 @@ relation Expr_eval: p EC ARCH |- (expressionIR '#' _expressionNoteIR) : % % %
 
                                     1. Result in: % % % |- % : EC_1 ARCH_1 expressionResult
 
-                              1. Else Dangling#10927
+                              1. Else Dangling#10930
 
-                    1. Else Dangling#10885
+                    1. Else Dangling#10888
 
             2. (Expr_eval: p EC ARCH |- typedExpressionIR_base : EC_1 ARCH_1 expressionResult')
 
@@ -35292,11 +35298,11 @@ relation Expr_eval: p EC ARCH |- (expressionIR '#' _expressionNoteIR) : % % %
 
                               1. Result in: % % % |- % : EC_1 ARCH_1 expressionResult
 
-                        1. Else Dangling#10937
+                        1. Else Dangling#10940
 
-                  1. Else Dangling#10934
+                  1. Else Dangling#10937
 
-              1. Else Dangling#10932
+              1. Else Dangling#10935
 
   15. Case (% has type indexAccessExpressionIR)
 
@@ -35344,11 +35350,11 @@ relation Expr_eval: p EC ARCH |- (expressionIR '#' _expressionNoteIR) : % % %
 
                                         1. Result in: % % % |- % : EC_1 ARCH_1 expressionResult
 
-                                    1. Else Dangling#10960
+                                    1. Else Dangling#10963
 
-                                1. Else Dangling#10958
+                                1. Else Dangling#10961
 
-                        1. Else Dangling#10954
+                        1. Else Dangling#10957
 
                     2. Case (% has type arrayValue)
 
@@ -35378,11 +35384,11 @@ relation Expr_eval: p EC ARCH |- (expressionIR '#' _expressionNoteIR) : % % %
 
                                               1. Result in: % % % |- % : EC_1 ARCH_1 expressionResult
 
-                                          1. Else Dangling#10973
+                                          1. Else Dangling#10976
 
-                                      1. Else Dangling#10971
+                                      1. Else Dangling#10974
 
-                        1. Else Dangling#10964
+                        1. Else Dangling#10967
 
                     3. Case (% has type headerStackValue)
 
@@ -35412,15 +35418,15 @@ relation Expr_eval: p EC ARCH |- (expressionIR '#' _expressionNoteIR) : % % %
 
                                               1. Result in: % % % |- % : EC_1 ARCH_1 expressionResult
 
-                                          1. Else Dangling#10986
+                                          1. Else Dangling#10989
 
-                                      1. Else Dangling#10984
+                                      1. Else Dangling#10987
 
-                        1. Else Dangling#10977
+                        1. Else Dangling#10980
 
-                  1. Else Dangling#10952
+                  1. Else Dangling#10955
 
-              1. Else Dangling#10950
+              1. Else Dangling#10953
 
   16. Case (% has type sliceAccessExpressionIR)
 
@@ -35434,7 +35440,7 @@ relation Expr_eval: p EC ARCH |- (expressionIR '#' _expressionNoteIR) : % % %
 
             1. Result in: % % % |- % : EC_1 ARCH_1 (abortResult as expressionResult)
 
-        1. Else Dangling#10991
+        1. Else Dangling#10994
 
       2. Case analysis on sliceop
 
@@ -35454,9 +35460,9 @@ relation Expr_eval: p EC ARCH |- (expressionIR '#' _expressionNoteIR) : % % %
 
                       1. Result in: % % % |- % : EC_1 ARCH_1 expressionResult
 
-                1. Else Dangling#10998
+                1. Else Dangling#11001
 
-            1. Else Dangling#10996
+            1. Else Dangling#10999
 
         2. Case (% matches pattern `+:`)
 
@@ -35474,9 +35480,9 @@ relation Expr_eval: p EC ARCH |- (expressionIR '#' _expressionNoteIR) : % % %
 
                       1. Result in: % % % |- % : EC_1 ARCH_1 expressionResult
 
-                1. Else Dangling#11005
+                1. Else Dangling#11008
 
-            1. Else Dangling#11003
+            1. Else Dangling#11006
 
   17. Case (% has type callExpressionIR)
 
@@ -35520,9 +35526,9 @@ relation Expr_eval: p EC ARCH |- (expressionIR '#' _expressionNoteIR) : % % %
 
                               1. Result in: % % % |- % : EC_2 ARCH_2 ((_CONT value) as expressionResult)
 
-                          1. Else Dangling#11022
+                          1. Else Dangling#11025
 
-      1. Else Dangling#11010
+      1. Else Dangling#11013
 
   18. Case (% has type parenthesizedExpressionIR)
 
@@ -35612,7 +35618,7 @@ relation Argument_eval: p EC_0 ARCH_0 |- argumentIR : % % %
 
         1. Result in: % % % |- % : EC_1 ARCH_1 expressionResult
 
-1. Else Dangling#11045
+1. Else Dangling#11048
 
 syntax storageReferenceResult = 
    | _CONT storageReference? (from continueResult<storageReference?>) 
@@ -35637,7 +35643,7 @@ relation Argument_eval_lvalue: p EC ARCH |- argumentIR : % % %
 
               1. Result in: % % % |- % : EC_1 ARCH_1 storageReferenceResult
 
-        1. Else Dangling#11055
+        1. Else Dangling#11058
 
   2. Case (% matches pattern `% = %`)
 
@@ -35653,7 +35659,7 @@ relation Argument_eval_lvalue: p EC ARCH |- argumentIR : % % %
 
               1. Result in: % % % |- % : EC_1 ARCH_1 storageReferenceResult
 
-        1. Else Dangling#11061
+        1. Else Dangling#11064
 
   3. Case (% matches pattern `% = _`)
 
@@ -35715,9 +35721,9 @@ relation Lvalue_eval: p EC ARCH |- (lvalueIR '#' _lvalueNoteIR) : % % %
 
                                     1. Result in: % % % |- % : EC_1 ARCH_1 (rejectTransitionResult as storageReferenceResult)
 
-                                1. Else Dangling#11084
+                                1. Else Dangling#11087
 
-                            1. Else Dangling#11082
+                            1. Else Dangling#11085
 
                             2. (Let n_size be |(value_element)*{value_element <- value_element*}|)
 
@@ -35729,9 +35735,9 @@ relation Lvalue_eval: p EC ARCH |- (lvalueIR '#' _lvalueNoteIR) : % % %
 
                                     1. Result in: % % % |- % : EC_1 ARCH_1 storageReferenceResult
 
-                                1. Else Dangling#11089
+                                1. Else Dangling#11092
 
-                              1. Else Dangling#11088
+                              1. Else Dangling#11091
 
                             3. If ((nameIR = "last")), then
 
@@ -35743,9 +35749,9 @@ relation Lvalue_eval: p EC ARCH |- (lvalueIR '#' _lvalueNoteIR) : % % %
 
                                     1. Result in: % % % |- % : EC_1 ARCH_1 (rejectTransitionResult as storageReferenceResult)
 
-                                1. Else Dangling#11094
+                                1. Else Dangling#11097
 
-                            3. Else Dangling#11092
+                            3. Else Dangling#11095
 
                             4. (Let n_size be |(value_element)*{value_element <- value_element*}|)
 
@@ -35757,9 +35763,9 @@ relation Lvalue_eval: p EC ARCH |- (lvalueIR '#' _lvalueNoteIR) : % % %
 
                                     1. Result in: % % % |- % : EC_1 ARCH_1 storageReferenceResult
 
-                                1. Else Dangling#11099
+                                1. Else Dangling#11102
 
-                              1. Else Dangling#11098
+                              1. Else Dangling#11101
 
                       2. Case false
 
@@ -35767,7 +35773,7 @@ relation Lvalue_eval: p EC ARCH |- (lvalueIR '#' _lvalueNoteIR) : % % %
 
                           1. Result in: % % % |- % : EC_1 ARCH_1 storageReferenceResult
 
-              1. Else Dangling#11076
+              1. Else Dangling#11079
 
   3. Case (% matches pattern `% [%]`)
 
@@ -35813,9 +35819,9 @@ relation Lvalue_eval: p EC ARCH |- (lvalueIR '#' _lvalueNoteIR) : % % %
 
                                 1. Result in: % % % |- % : EC_2 ARCH_2 storageReferenceResult
 
-                          1. Else Dangling#11117
+                          1. Else Dangling#11120
 
-              1. Else Dangling#11110
+              1. Else Dangling#11113
 
   4. Case (% matches pattern `% [% % %]`)
 
@@ -35861,9 +35867,9 @@ relation Lvalue_eval: p EC ARCH |- (lvalueIR '#' _lvalueNoteIR) : % % %
 
                                 1. Result in: % % % |- % : EC_1 ARCH_1 storageReferenceResult
 
-                          1. Else Dangling#11134
+                          1. Else Dangling#11137
 
-              1. Else Dangling#11127
+              1. Else Dangling#11130
 
   5. Case (% matches pattern `(%)`)
 
@@ -35915,11 +35921,11 @@ relation Lvalue_read: p EC ARCH |- storageReference' : %
 
                               1. Result in: % % % |- % : value
 
-                          1. Else Dangling#11155
+                          1. Else Dangling#11158
 
-                    1. Else Dangling#11152
+                    1. Else Dangling#11155
 
-                1. Else Dangling#11150
+                1. Else Dangling#11153
 
           2. Case (% has type headerStackValue)
 
@@ -35941,9 +35947,9 @@ relation Lvalue_read: p EC ARCH |- storageReference' : %
 
                             1. Result in: % % % |- % : value
 
-                        1. Else Dangling#11163
+                        1. Else Dangling#11166
 
-                      1. Else Dangling#11162
+                      1. Else Dangling#11165
 
                   2. Case (% = "last")
 
@@ -35963,13 +35969,13 @@ relation Lvalue_read: p EC ARCH |- storageReference' : %
 
                                   1. Result in: % % % |- % : value
 
-                              1. Else Dangling#11171
+                              1. Else Dangling#11174
 
-                          1. Else Dangling#11169
+                          1. Else Dangling#11172
 
-                      1. Else Dangling#11167
+                      1. Else Dangling#11170
 
-                1. Else Dangling#11160
+                1. Else Dangling#11163
 
           3. Case (% has type structValue)
 
@@ -35985,7 +35991,7 @@ relation Lvalue_read: p EC ARCH |- storageReference' : %
 
                       1. Result in: % % % |- % : value
 
-                  1. Else Dangling#11177
+                  1. Else Dangling#11180
 
           4. Case (% has type headerValue)
 
@@ -36001,7 +36007,7 @@ relation Lvalue_read: p EC ARCH |- storageReference' : %
 
                       1. Result in: % % % |- % : value
 
-                  1. Else Dangling#11183
+                  1. Else Dangling#11186
 
           5. Case (% has type headerUnionValue)
 
@@ -36017,9 +36023,9 @@ relation Lvalue_read: p EC ARCH |- storageReference' : %
 
                       1. Result in: % % % |- % : value
 
-                  1. Else Dangling#11189
+                  1. Else Dangling#11192
 
-        1. Else Dangling#11147
+        1. Else Dangling#11150
 
   3. Case (% matches pattern `% [%]`)
 
@@ -36059,9 +36065,9 @@ relation Lvalue_read: p EC ARCH |- storageReference' : %
 
                                       1. Result in: % % % |- % : value
 
-                                  1. Else Dangling#11205
+                                  1. Else Dangling#11208
 
-                              1. Else Dangling#11203
+                              1. Else Dangling#11206
 
                             2. Case false
 
@@ -36077,9 +36083,9 @@ relation Lvalue_read: p EC ARCH |- storageReference' : %
 
                                         1. Result in: % % % |- % : value
 
-                                  1. Else Dangling#11210
+                                  1. Else Dangling#11213
 
-                              1. Else Dangling#11208
+                              1. Else Dangling#11211
 
               2. Case (% has type headerStackValue)
 
@@ -36107,9 +36113,9 @@ relation Lvalue_read: p EC ARCH |- storageReference' : %
 
                                       1. Result in: % % % |- % : value
 
-                                  1. Else Dangling#11222
+                                  1. Else Dangling#11225
 
-                              1. Else Dangling#11220
+                              1. Else Dangling#11223
 
                             2. Case false
 
@@ -36125,13 +36131,13 @@ relation Lvalue_read: p EC ARCH |- storageReference' : %
 
                                         1. Result in: % % % |- % : value
 
-                                  1. Else Dangling#11227
+                                  1. Else Dangling#11230
 
-                              1. Else Dangling#11225
+                              1. Else Dangling#11228
 
-            1. Else Dangling#11196
+            1. Else Dangling#11199
 
-      1. Else Dangling#11193
+      1. Else Dangling#11196
 
   4. Case (% matches pattern `% [% % %]`)
 
@@ -36209,9 +36215,9 @@ relation Lvalue_write: p EC_0 ARCH |- storageReference' := value : %
 
                                 1. Result in: % % % |- % := % : EC_1
 
-                      1. Else Dangling#11254
+                      1. Else Dangling#11257
 
-                1. Else Dangling#11248
+                1. Else Dangling#11251
 
           2. Case (% has type structValue)
 
@@ -36287,13 +36293,13 @@ relation Lvalue_write: p EC_0 ARCH |- storageReference' := value : %
 
                                               1. Result in: % % % |- % := % : EC_1
 
-                              1. Else Dangling#11281
+                              1. Else Dangling#11284
 
-                        1. Else Dangling#11278
+                        1. Else Dangling#11281
 
-                    1. Else Dangling#11276
+                    1. Else Dangling#11279
 
-        1. Else Dangling#11245
+        1. Else Dangling#11248
 
   3. Case (% matches pattern `% [%]`)
 
@@ -36335,7 +36341,7 @@ relation Lvalue_write: p EC_0 ARCH |- storageReference' := value : %
 
                                         1. Result in: % % % |- % := % : EC_1
 
-                              1. Else Dangling#11303
+                              1. Else Dangling#11306
 
                             2. Case false
 
@@ -36369,15 +36375,15 @@ relation Lvalue_write: p EC_0 ARCH |- storageReference' := value : %
 
                                         1. Result in: % % % |- % := % : EC_1
 
-                              1. Else Dangling#11316
+                              1. Else Dangling#11319
 
                             2. Case false
 
                               1. Result in: % % % |- % := % : EC_0
 
-            1. Else Dangling#11296
+            1. Else Dangling#11299
 
-      1. Else Dangling#11293
+      1. Else Dangling#11296
 
   4. Case (% matches pattern `% [% % %]`)
 
@@ -36512,9 +36518,9 @@ relation Stmt_eval: p EC ARCH |- statementIR' : % % %
 
                                           1. Result in: % % % |- % : EC_3 ARCH_2 ((_EMPTY) as statementResult)
 
-                                  1. Else Dangling#11359
+                                  1. Else Dangling#11362
 
-              1. Else Dangling#11342
+              1. Else Dangling#11345
 
   3. Case (% has type callStatementIR)
 
@@ -36584,7 +36590,7 @@ relation Stmt_eval: p EC ARCH |- statementIR' : % % %
 
                   1. Result in: % % % |- % : EC_cond ARCH_cond (abortResult as statementResult)
 
-              1. Else Dangling#11386
+              1. Else Dangling#11389
 
               2. Case analysis on expressionResult
 
@@ -36598,7 +36604,7 @@ relation Stmt_eval: p EC ARCH |- statementIR' : % % %
 
                   1. Result in: % % % |- % : EC_cond ARCH_cond ((_EMPTY) as statementResult)
 
-              2. Else Dangling#11389
+              2. Else Dangling#11392
 
         2. Case (% matches pattern `IF (%) % ELSE %`)
 
@@ -36612,7 +36618,7 @@ relation Stmt_eval: p EC ARCH |- statementIR' : % % %
 
                   1. Result in: % % % |- % : EC_cond ARCH_cond (abortResult as statementResult)
 
-              1. Else Dangling#11395
+              1. Else Dangling#11398
 
               2. Case analysis on expressionResult
 
@@ -36628,9 +36634,9 @@ relation Stmt_eval: p EC ARCH |- statementIR' : % % %
 
                     1. Result in: % % % |- % : EC_else ARCH_else statementResult
 
-              2. Else Dangling#11398
+              2. Else Dangling#11401
 
-1. Else Dangling#11333
+1. Else Dangling#11336
 
 2. If ((p matches pattern `LOCAL`)), then
 
@@ -36742,7 +36748,7 @@ relation Stmt_eval: p EC ARCH |- statementIR' : % % %
 
                             1. Result in: % % % |- % : EC_4 ARCH_2 statementResult
 
-                  1. Else Dangling#11437
+                  1. Else Dangling#11440
 
     3. Case (% has type breakStatement)
 
@@ -36790,9 +36796,9 @@ relation Stmt_eval: p EC ARCH |- statementIR' : % % %
 
                       1. Result in: % % % |- % : EC_2 ARCH_2 statementResult
 
-  1. Else Dangling#11404
+  1. Else Dangling#11407
 
-2. Else Dangling#11403
+2. Else Dangling#11406
 
 relation BlockElementStmt_eval: EC_0 ARCH |- blockElementStatementIR : % % %
 
@@ -36840,7 +36846,7 @@ relation BlockElementStmtList_eval: EC ARCH |- (blockElementStatementIR)*{blockE
 
           1. Result in: % % |- % : EC_1 ARCH_1 statementResult
 
-        1. Else Dangling#11475
+        1. Else Dangling#11478
 
         2. If ((statementResult has type continueEmptyResult)), then
 
@@ -36850,7 +36856,7 @@ relation BlockElementStmtList_eval: EC ARCH |- (blockElementStatementIR)*{blockE
 
               1. Result in: % % |- % : EC_2 ARCH_2 statementResult'
 
-        2. Else Dangling#11477
+        2. Else Dangling#11480
 
 relation Block_eval: EC_0 ARCH_0 |- (annotationList `{ blockElementStatementListIR `}) : % % %
 
@@ -36878,7 +36884,7 @@ relation ParserStmt_eval: EC_0 ARCH_0 |- parserStatementIR : % % %
 
             1. Result in: % % |- % : EC_1 ARCH_1 ((_EMPTY) as parserStatementResult)
 
-        1. Else Dangling#11486
+        1. Else Dangling#11489
 
   2. Case (% has type assignmentStatementIR)
 
@@ -36900,7 +36906,7 @@ relation ParserStmt_eval: EC_0 ARCH_0 |- parserStatementIR : % % %
 
               1. Result in: % % |- % : EC_1 ARCH_1 ((_EMPTY) as parserStatementResult)
 
-        1. Else Dangling#11491
+        1. Else Dangling#11494
 
   3. Case (% has type callStatementIR)
 
@@ -36922,7 +36928,7 @@ relation ParserStmt_eval: EC_0 ARCH_0 |- parserStatementIR : % % %
 
               1. Result in: % % |- % : EC_1 ARCH_1 ((_EMPTY) as parserStatementResult)
 
-        1. Else Dangling#11498
+        1. Else Dangling#11501
 
   4. Case (% has type parserBlockStatementIR)
 
@@ -36954,7 +36960,7 @@ relation ParserStmt_eval: EC_0 ARCH_0 |- parserStatementIR : % % %
 
                   1. Result in: % % |- % : EC_cond ARCH_cond (rejectTransitionResult as parserStatementResult)
 
-              1. Else Dangling#11512
+              1. Else Dangling#11515
 
               2. Case analysis on expressionResult
 
@@ -36968,7 +36974,7 @@ relation ParserStmt_eval: EC_0 ARCH_0 |- parserStatementIR : % % %
 
                   1. Result in: % % |- % : EC_cond ARCH_cond ((_EMPTY) as parserStatementResult)
 
-              2. Else Dangling#11515
+              2. Else Dangling#11518
 
         2. Case (% matches pattern `IF (%) % ELSE %`)
 
@@ -36982,7 +36988,7 @@ relation ParserStmt_eval: EC_0 ARCH_0 |- parserStatementIR : % % %
 
                   1. Result in: % % |- % : EC_cond ARCH_cond (rejectTransitionResult as parserStatementResult)
 
-              1. Else Dangling#11521
+              1. Else Dangling#11524
 
               2. Case analysis on expressionResult
 
@@ -36998,9 +37004,9 @@ relation ParserStmt_eval: EC_0 ARCH_0 |- parserStatementIR : % % %
 
                     1. Result in: % % |- % : EC_else ARCH_else parserStatementResult
 
-              2. Else Dangling#11524
+              2. Else Dangling#11527
 
-1. Else Dangling#11483
+1. Else Dangling#11486
 
 relation ParserBlockElementStmt_eval: EC_0 ARCH |- parserBlockElementStatementIR : % % %
 
@@ -37034,7 +37040,7 @@ relation ParserBlockElementStmt_eval: EC_0 ARCH |- parserBlockElementStatementIR
 
               1. Result in: % % |- % : EC_1 ARCH_1 ((_EMPTY) as parserStatementResult)
 
-        1. Else Dangling#11535
+        1. Else Dangling#11538
 
   3. Case (% has type parserStatementIR)
 
@@ -37062,7 +37068,7 @@ relation ParserBlockElementStmtList_eval: EC ARCH |- (parserBlockElementStatemen
 
           1. Result in: % % |- % : EC_1 ARCH_1 parserStatementResult
 
-        1. Else Dangling#11547
+        1. Else Dangling#11550
 
         2. If ((parserStatementResult has type continueEmptyResult)), then
 
@@ -37072,7 +37078,7 @@ relation ParserBlockElementStmtList_eval: EC ARCH |- (parserBlockElementStatemen
 
               1. Result in: % % |- % : EC_2 ARCH_2 parserStatementResult'
 
-        2. Else Dangling#11549
+        2. Else Dangling#11552
 
 relation ParserBlock_eval: EC_0 ARCH_0 |- (annotationList `{ parserBlockElementStatementListIR `}) : % % %
 
@@ -37133,7 +37139,7 @@ relation ParserSelect_eval: EC_0 ARCH_0 |- selectExpressionIR : % % %
 
                           1. Result in: % % |- % : EC_3 ARCH_3 transitionResult
 
-    1. Else Dangling#11557
+    1. Else Dangling#11560
 
 relation ParserTransition_eval: EC ARCH |- (TRANSITION stateExpressionIR) : % % %
 
@@ -37155,13 +37161,13 @@ relation ParserTransition_eval: EC ARCH |- (TRANSITION stateExpressionIR) : % % 
 
             1. Result in: % % |- % : EC ARCH ((REJECT errorValue) as transitionResult)
 
-      1. Else Dangling#11574
+      1. Else Dangling#11577
 
       2. If (((nameIR =/= "accept") /\ (nameIR =/= "reject"))), then
 
         1. Result in: % % |- % : EC ARCH ((STATE nameIR) as transitionResult)
 
-      2. Else Dangling#11578
+      2. Else Dangling#11581
 
   2. Case (% has type selectExpressionIR)
 
@@ -37231,7 +37237,7 @@ relation ParserState_trans: EC_0 ARCH_0 |- TRANSITION nameIR : % % %
 
                 1. Result in: % % |- TRANSITION % : EC_2 ARCH_2 transitionResult
 
-  1. Else Dangling#11595
+  1. Else Dangling#11598
 
 syntax parserDeclarationResult = parserStatementResult
 
@@ -37267,9 +37273,9 @@ relation ParserLocalDecl_eval: EC_0 ARCH |- parserLocalDeclarationIR : % % %
 
               1. Result in: % % |- % : EC_1 ARCH_1 ((_EMPTY) as parserStatementResult)
 
-        1. Else Dangling#11612
+        1. Else Dangling#11615
 
-1. Else Dangling#11606
+1. Else Dangling#11609
 
 relation ParserLocalDecls_eval: EC ARCH |- (parserLocalDeclarationIR)*{parserLocalDeclarationIR <- parserLocalDeclarationIR*} : % % %
 
@@ -37363,7 +37369,7 @@ relation Table_eval: EC_0 ARCH_0 |- typeId TBL : % % %
 
                                       1. Result in: % % |- % % : EC_3 ARCH_3 ((RETURN ?((tableMetadataStructValue as value))) as tableResult)
 
-                        1. Else Dangling#11640
+                        1. Else Dangling#11643
 
 syntax controlBodyResult = 
    | EXIT (from exitResult) 
@@ -37387,13 +37393,13 @@ relation ControlBody_eval: EC_0 ARCH_0 |- controlBodyIR : % % %
 
         1. Result in: % % |- % : EC_1 ARCH_1 ((EXIT) as controlBodyResult)
 
-  1. Else Dangling#11650
+  1. Else Dangling#11653
 
   2. If ((statementResult = ((RETURN ?()) as statementResult))), then
 
     1. Result in: % % |- % : EC_1 ARCH_1 ((RETURN ?()) as controlBodyResult)
 
-  2. Else Dangling#11655
+  2. Else Dangling#11658
 
 syntax controlLocalDeclarationResult = 
    | _EMPTY (from continueEmptyResult) 
@@ -37431,9 +37437,9 @@ relation ControlLocalDecl_eval: EC_0 ARCH |- controlLocalDeclarationIR : % % %
 
               1. Result in: % % |- % : EC_1 ARCH_1 ((_EMPTY) as controlLocalDeclarationResult)
 
-        1. Else Dangling#11663
+        1. Else Dangling#11666
 
-1. Else Dangling#11657
+1. Else Dangling#11660
 
 relation ControlLocalDecls_eval: EC ARCH |- (controlLocalDeclarationIR)*{controlLocalDeclarationIR <- controlLocalDeclarationIR*} : % % %
 
@@ -37541,7 +37547,7 @@ relation Callee_eval: p EC ARCH |- callableTargetIR' `< '_' `> `( argumentListIR
 
                     1. Result in: % % % |- % `< '_' `> `( % `) : EC ARCH ((_CONT (actionCallee as callee)) as calleeResult)
 
-            1. Else Dangling#11698
+            1. Else Dangling#11701
 
           2. (Let ?((_callableId ':' (_p, callableDef) '#' (id_default)*{id_default <- id_default*} '#' (id_optional)*{id_optional <- id_optional*})) be (callResolution<(cursor, callableDef)>)?{callResolution<(cursor, callableDef)> <- callResolution<(cursor, callableDef)>?})
 
@@ -37567,9 +37573,9 @@ relation Callee_eval: p EC ARCH |- callableTargetIR' `< '_' `> `( argumentListIR
 
                       1. Result in: % % % |- % `< '_' `> `( % `) : EC ARCH ((_CONT (definedFunctionCallee as callee)) as calleeResult)
 
-            1. Else Dangling#11704
+            1. Else Dangling#11707
 
-        1. Else Dangling#11696
+        1. Else Dangling#11699
 
   2. Case (% matches pattern `% . %`)
 
@@ -37593,9 +37599,9 @@ relation Callee_eval: p EC ARCH |- callableTargetIR' `< '_' `> `( argumentListIR
 
                       1. Result in: % % % |- % `< '_' `> `( % `) : EC_1 ARCH_1 (abortResult as calleeResult)
 
-                  1. Else Dangling#11719
+                  1. Else Dangling#11722
 
-            1. Else Dangling#11716
+            1. Else Dangling#11719
 
           2. If ((argumentListIR matches pattern [ _/1 ])), then
 
@@ -37619,13 +37625,13 @@ relation Callee_eval: p EC ARCH |- callableTargetIR' `< '_' `> `( argumentListIR
 
                               1. Result in: % % % |- % `< '_' `> `( % `) : EC_1 ARCH_1 ((_CONT (builtinPushFrontMethodCallee as callee)) as calleeResult)
 
-                        1. Else Dangling#11729
+                        1. Else Dangling#11732
 
-                    1. Else Dangling#11727
+                    1. Else Dangling#11730
 
-              1. Else Dangling#11724
+              1. Else Dangling#11727
 
-          2. Else Dangling#11722
+          2. Else Dangling#11725
 
         2. Case (% = "pop_front")
 
@@ -37643,9 +37649,9 @@ relation Callee_eval: p EC ARCH |- callableTargetIR' `< '_' `> `( argumentListIR
 
                       1. Result in: % % % |- % `< '_' `> `( % `) : EC_1 ARCH_1 (abortResult as calleeResult)
 
-                  1. Else Dangling#11737
+                  1. Else Dangling#11740
 
-            1. Else Dangling#11734
+            1. Else Dangling#11737
 
           2. If ((argumentListIR matches pattern [ _/1 ])), then
 
@@ -37669,13 +37675,13 @@ relation Callee_eval: p EC ARCH |- callableTargetIR' `< '_' `> `( argumentListIR
 
                               1. Result in: % % % |- % `< '_' `> `( % `) : EC_1 ARCH_1 ((_CONT (builtinPopFrontMethodCallee as callee)) as calleeResult)
 
-                        1. Else Dangling#11747
+                        1. Else Dangling#11750
 
-                    1. Else Dangling#11745
+                    1. Else Dangling#11748
 
-              1. Else Dangling#11742
+              1. Else Dangling#11745
 
-          2. Else Dangling#11740
+          2. Else Dangling#11743
 
         3. Case (% = "isValid")
 
@@ -37693,9 +37699,9 @@ relation Callee_eval: p EC ARCH |- callableTargetIR' `< '_' `> `( argumentListIR
 
                       1. Result in: % % % |- % `< '_' `> `( % `) : EC_1 ARCH_1 (abortResult as calleeResult)
 
-                  1. Else Dangling#11755
+                  1. Else Dangling#11758
 
-            1. Else Dangling#11752
+            1. Else Dangling#11755
 
           2. If ((argumentListIR matches pattern [])), then
 
@@ -37719,13 +37725,13 @@ relation Callee_eval: p EC ARCH |- callableTargetIR' `< '_' `> `( argumentListIR
 
                               1. Result in: % % % |- % `< '_' `> `( % `) : EC_1 ARCH_1 ((_CONT (builtinIsValidMethodCallee as callee)) as calleeResult)
 
-                        1. Else Dangling#11765
+                        1. Else Dangling#11768
 
-                    1. Else Dangling#11763
+                    1. Else Dangling#11766
 
-              1. Else Dangling#11760
+              1. Else Dangling#11763
 
-          2. Else Dangling#11758
+          2. Else Dangling#11761
 
         4. Case (% = "setValid")
 
@@ -37743,9 +37749,9 @@ relation Callee_eval: p EC ARCH |- callableTargetIR' `< '_' `> `( argumentListIR
 
                       1. Result in: % % % |- % `< '_' `> `( % `) : EC_1 ARCH_1 (abortResult as calleeResult)
 
-                  1. Else Dangling#11773
+                  1. Else Dangling#11776
 
-            1. Else Dangling#11770
+            1. Else Dangling#11773
 
           2. If ((argumentListIR matches pattern [])), then
 
@@ -37769,13 +37775,13 @@ relation Callee_eval: p EC ARCH |- callableTargetIR' `< '_' `> `( argumentListIR
 
                               1. Result in: % % % |- % `< '_' `> `( % `) : EC_1 ARCH_1 ((_CONT (builtinSetValidMethodCallee as callee)) as calleeResult)
 
-                        1. Else Dangling#11783
+                        1. Else Dangling#11786
 
-                    1. Else Dangling#11781
+                    1. Else Dangling#11784
 
-              1. Else Dangling#11778
+              1. Else Dangling#11781
 
-          2. Else Dangling#11776
+          2. Else Dangling#11779
 
         5. Case (% = "setInvalid")
 
@@ -37793,9 +37799,9 @@ relation Callee_eval: p EC ARCH |- callableTargetIR' `< '_' `> `( argumentListIR
 
                       1. Result in: % % % |- % `< '_' `> `( % `) : EC_1 ARCH_1 (abortResult as calleeResult)
 
-                  1. Else Dangling#11791
+                  1. Else Dangling#11794
 
-            1. Else Dangling#11788
+            1. Else Dangling#11791
 
           2. If ((argumentListIR matches pattern [])), then
 
@@ -37819,17 +37825,17 @@ relation Callee_eval: p EC ARCH |- callableTargetIR' `< '_' `> `( argumentListIR
 
                               1. Result in: % % % |- % `< '_' `> `( % `) : EC_1 ARCH_1 ((_CONT (builtinSetInvalidMethodCallee as callee)) as calleeResult)
 
-                        1. Else Dangling#11801
+                        1. Else Dangling#11804
 
-                    1. Else Dangling#11799
+                    1. Else Dangling#11802
 
-              1. Else Dangling#11796
+              1. Else Dangling#11799
 
-          2. Else Dangling#11794
+          2. Else Dangling#11797
 
-      1. Else Dangling#11714
+      1. Else Dangling#11717
 
-1. Else Dangling#11693
+1. Else Dangling#11696
 
 2. (Let (argumentIR)*{argumentIR <- argumentIR*} be argumentListIR)
 
@@ -37847,11 +37853,11 @@ relation Callee_eval: p EC ARCH |- callableTargetIR' `< '_' `> `( argumentListIR
 
               1. Result in: % % % |- % `< '_' `> `( % `) : EC ARCH ((_CONT (builtinSizeMethodCallee as callee)) as calleeResult)
 
-        1. Else Dangling#11809
+        1. Else Dangling#11812
 
-      1. Else Dangling#11808
+      1. Else Dangling#11811
 
-  1. Else Dangling#11806
+  1. Else Dangling#11809
 
 3. If ((callableTargetIR' matches pattern `% . %`)), then
 
@@ -37915,21 +37921,21 @@ relation Callee_eval: p EC ARCH |- callableTargetIR' `< '_' `> `( argumentListIR
 
                                                       1. Result in: % % % |- % `< '_' `> `( % `) : EC_1 ARCH_1 ((_CONT (externMethodCallee as callee)) as calleeResult)
 
-                                                  1. Else Dangling#11839
+                                                  1. Else Dangling#11842
 
-                                              1. Else Dangling#11837
+                                              1. Else Dangling#11840
 
-                                          1. Else Dangling#11835
+                                          1. Else Dangling#11838
 
-                                  1. Else Dangling#11831
+                                  1. Else Dangling#11834
 
-                              1. Else Dangling#11829
+                              1. Else Dangling#11832
 
-                        1. Else Dangling#11826
+                        1. Else Dangling#11829
 
-                  1. Else Dangling#11823
+                  1. Else Dangling#11826
 
-      1. Else Dangling#11816
+      1. Else Dangling#11819
 
     2. If ((nameIR = "apply")), then
 
@@ -37985,7 +37991,7 @@ relation Callee_eval: p EC ARCH |- callableTargetIR' `< '_' `> `( argumentListIR
 
                                                         1. Result in: % % % |- % `< '_' `> `( % `) : EC_1 ARCH_1 ((_CONT (parserApplyMethodCallee as callee)) as calleeResult)
 
-                                                  1. Else Dangling#11863
+                                                  1. Else Dangling#11866
 
                                       2. Case (% has type controlObject)
 
@@ -38007,23 +38013,23 @@ relation Callee_eval: p EC ARCH |- callableTargetIR' `< '_' `> `( argumentListIR
 
                                                         1. Result in: % % % |- % `< '_' `> `( % `) : EC_1 ARCH_1 ((_CONT (controlApplyMethodCallee as callee)) as calleeResult)
 
-                                                  1. Else Dangling#11872
+                                                  1. Else Dangling#11875
 
-                                    1. Else Dangling#11857
+                                    1. Else Dangling#11860
 
-                                1. Else Dangling#11855
+                                1. Else Dangling#11858
 
-                          1. Else Dangling#11852
+                          1. Else Dangling#11855
 
-                    1. Else Dangling#11849
+                    1. Else Dangling#11852
 
-              1. Else Dangling#11847
+              1. Else Dangling#11850
 
-        1. Else Dangling#11844
+        1. Else Dangling#11847
 
-    2. Else Dangling#11842
+    2. Else Dangling#11845
 
-3. Else Dangling#11813
+3. Else Dangling#11816
 
 4. (Let (argumentIR)*{argumentIR <- argumentIR*} be argumentListIR)
 
@@ -38079,21 +38085,21 @@ relation Callee_eval: p EC ARCH |- callableTargetIR' `< '_' `> `( argumentListIR
 
                                               1. Result in: % % % |- % `< '_' `> `( % `) : EC_1 ARCH_1 ((_CONT (tableApplyMethodCallee as callee)) as calleeResult)
 
-                                        1. Else Dangling#11897
+                                        1. Else Dangling#11900
 
-                                    1. Else Dangling#11895
+                                    1. Else Dangling#11898
 
-                              1. Else Dangling#11892
+                              1. Else Dangling#11895
 
-                        1. Else Dangling#11889
+                        1. Else Dangling#11892
 
-            1. Else Dangling#11882
+            1. Else Dangling#11885
 
-        1. Else Dangling#11880
+        1. Else Dangling#11883
 
-      1. Else Dangling#11879
+      1. Else Dangling#11882
 
-  1. Else Dangling#11877
+  1. Else Dangling#11880
 
 5. If ((callableTargetIR' matches pattern `(%)`)), then
 
@@ -38103,7 +38109,7 @@ relation Callee_eval: p EC ARCH |- callableTargetIR' `< '_' `> `( argumentListIR
 
       1. Result in: % % % |- % `< '_' `> `( % `) : EC_1 ARCH_1 calleeResult
 
-5. Else Dangling#11901
+5. Else Dangling#11904
 
 syntax copyInArgumentResult = 
    | _CONT storageReference? (from continueResult<storageReference?>) 
@@ -38132,7 +38138,7 @@ relation Copy_in_arg: ARCH_0 |- p_caller EC_caller_0 (_annotationList direction 
 
             1. Result in: % |- % % % '@' % % % ~> ARCH_1 EC_caller_1 EC_callee_1 '#' ((_CONT ?()) as copyInArgumentResult)
 
-1. Else Dangling#11905
+1. Else Dangling#11908
 
 2. Case analysis on direction
 
@@ -38162,7 +38168,7 @@ relation Copy_in_arg: ARCH_0 |- p_caller EC_caller_0 (_annotationList direction 
 
                     1. Result in: % |- % % % '@' % % % ~> ARCH_1 EC_caller_1 EC_callee_1 '#' ((_CONT ?(storageReference)) as copyInArgumentResult)
 
-            1. Else Dangling#11919
+            1. Else Dangling#11922
 
   2. Case (% matches pattern `OUT`)
 
@@ -38188,7 +38194,7 @@ relation Copy_in_arg: ARCH_0 |- p_caller EC_caller_0 (_annotationList direction 
 
                   1. Result in: % |- % % % '@' % % % ~> ARCH_1 EC_caller_1 EC_callee_1 '#' ((_CONT (storageReference)?{storageReference <- storageReference?}) as copyInArgumentResult)
 
-2. Else Dangling#11913
+2. Else Dangling#11916
 
 syntax copyInResult = 
    | _CONT storageReference?* (from continueResult<storageReference?*>) 
@@ -38207,7 +38213,7 @@ relation Copy_in: p_shared ARCH |- p_caller EC (parameterIR)*{parameterIR <- par
 
         1. Result in: % % |- % % % '@' % % % ~> ARCH EC EC_callee_1 '#' ((_CONT []) as copyInResult)
 
-    1. Else Dangling#11934
+    1. Else Dangling#11937
 
   2. Case (% matches pattern _ :: _)
 
@@ -38249,7 +38255,7 @@ relation Copy_in: p_shared ARCH |- p_caller EC (parameterIR)*{parameterIR <- par
 
                             1. Result in: % % |- % % % '@' % % % ~> ARCH_2 EC_caller_2 EC_callee_2 '#' ((_CONT ((storageReference)?{storageReference <- storageReference?})*{storageReference? <- storageReference?*}) as copyInResult)
 
-      1. Else Dangling#11938
+      1. Else Dangling#11941
 
 relation Copy_in_default: (parameterIR)*{parameterIR <- parameterIR*} '@' p_callee EC_callee_0 ~> %
 
@@ -38267,9 +38273,9 @@ relation Copy_in_default: (parameterIR)*{parameterIR <- parameterIR*} '@' p_call
 
             1. Result in: % '@' % % ~> EC_callee_1
 
-      1. Else Dangling#11955
+      1. Else Dangling#11958
 
-  1. Else Dangling#11953
+  1. Else Dangling#11956
 
 relation Copy_out_argument: ARCH |- p_caller EC_caller_0 (_annotationList direction typeIR nameIR _parameterInitializerOptIR) '@' p_callee EC_callee (storageReference')?{storageReference' <- storageReference'?} ~> %
 
@@ -38281,13 +38287,13 @@ relation Copy_out_argument: ARCH |- p_caller EC_caller_0 (_annotationList direct
 
       1. Result in: % |- % % % '@' % % % ~> EC_caller_0
 
-    1. Else Dangling#11960
+    1. Else Dangling#11963
 
     2. If (((direction = (OUT)) \/ (direction = (INOUT)))), then
 
       1. Result in: % |- % % % '@' % % % ~> EC_caller_0
 
-    2. Else Dangling#11962
+    2. Else Dangling#11965
 
   2. Case (% matches pattern (_))
 
@@ -38301,7 +38307,7 @@ relation Copy_out_argument: ARCH |- p_caller EC_caller_0 (_annotationList direct
 
             1. Result in: % |- % % % '@' % % % ~> EC_caller_1
 
-      1. Else Dangling#11965
+      1. Else Dangling#11968
 
 relation Copy_out: p_shared ARCH |- p_caller EC_caller_0 parameterListIR '@' p_callee EC_callee ((storageReference)?{storageReference <- storageReference?})*{storageReference? <- storageReference?*} ~> %
 
@@ -38355,7 +38361,7 @@ relation Call_eval: p EC_0 ARCH_0 |- callee '@' `< typeArgumentListIR `> `( argu
 
                                   1. Result in: % % % |- % '@' `< % `> `( % `) : EC_2 ARCH_2 ((EXIT) as callResult)
 
-                            1. Else Dangling#11986
+                            1. Else Dangling#11989
 
                             2. If ((actionResult = ((RETURN ?()) as actionResult))), then
 
@@ -38363,11 +38369,11 @@ relation Call_eval: p EC_0 ARCH_0 |- callee '@' `< typeArgumentListIR `> `( argu
 
                                 1. Result in: % % % |- % '@' `< % `> `( % `) : EC_2 ARCH_2 ((RETURN ?()) as callResult)
 
-                            2. Else Dangling#11990
+                            2. Else Dangling#11993
 
-                  1. Else Dangling#11980
+                  1. Else Dangling#11983
 
-        1. Else Dangling#11975
+        1. Else Dangling#11978
 
     2. Case (% has type definedFunctionCallee)
 
@@ -38407,9 +38413,9 @@ relation Call_eval: p EC_0 ARCH_0 |- callee '@' `< typeArgumentListIR `> `( argu
 
                                   1. Result in: % % % |- % '@' `< % `> `( % `) : EC_2 ARCH_2 (definedFunctionResult as callResult)
 
-            1. Else Dangling#11996
+            1. Else Dangling#11999
 
-  1. Else Dangling#11973
+  1. Else Dangling#11976
 
   2. (Let (argumentIR)*{argumentIR <- argumentIR*} be argumentListIR)
 
@@ -38463,9 +38469,9 @@ relation Call_eval: p EC_0 ARCH_0 |- callee '@' `< typeArgumentListIR `> `( argu
 
                                         1. Result in: % % % |- % '@' `< % `> `( % `) : EC_2 ARCH_2 callResult
 
-            1. Else Dangling#12014
+            1. Else Dangling#12017
 
-    1. Else Dangling#12010
+    1. Else Dangling#12013
 
   3. Case analysis on callee
 
@@ -38497,7 +38503,7 @@ relation Call_eval: p EC_0 ARCH_0 |- callee '@' `< typeArgumentListIR `> `( argu
 
                               1. Result in: % % % |- % '@' `< % `> `( % `) : EC_1 ARCH_1 (abortResult as callResult)
 
-                          1. Else Dangling#12042
+                          1. Else Dangling#12045
 
                         2. (Let n_size be |(value_element)*{value_element <- value_element*}|)
 
@@ -38541,9 +38547,9 @@ relation Call_eval: p EC_0 ARCH_0 |- callee '@' `< typeArgumentListIR `> `( argu
 
                                                                 1. Result in: % % % |- % '@' `< % `> `( % `) : EC_2 ARCH_1 ((RETURN ?()) as callResult)
 
-                                                  1. Else Dangling#12058
+                                                  1. Else Dangling#12061
 
-                                          1. Else Dangling#12054
+                                          1. Else Dangling#12057
 
                                           2. If ((n_count >= n_size)), then
 
@@ -38557,19 +38563,19 @@ relation Call_eval: p EC_0 ARCH_0 |- callee '@' `< typeArgumentListIR `> `( argu
 
                                                     1. Result in: % % % |- % '@' `< % `> `( % `) : EC_2 ARCH_1 ((RETURN ?()) as callResult)
 
-                                          2. Else Dangling#12066
+                                          2. Else Dangling#12069
 
-                                      1. Else Dangling#12052
+                                      1. Else Dangling#12055
 
-                                1. Else Dangling#12049
+                                1. Else Dangling#12052
 
-                            1. Else Dangling#12047
+                            1. Else Dangling#12050
 
-                  1. Else Dangling#12038
+                  1. Else Dangling#12041
 
-          1. Else Dangling#12034
+          1. Else Dangling#12037
 
-        1. Else Dangling#12033
+        1. Else Dangling#12036
 
     2. Case (% has type builtinPopFrontMethodCallee)
 
@@ -38599,7 +38605,7 @@ relation Call_eval: p EC_0 ARCH_0 |- callee '@' `< typeArgumentListIR `> `( argu
 
                               1. Result in: % % % |- % '@' `< % `> `( % `) : EC_1 ARCH_1 (abortResult as callResult)
 
-                          1. Else Dangling#12082
+                          1. Else Dangling#12085
 
                         2. (Let n_size be |(value_element)*{value_element <- value_element*}|)
 
@@ -38641,9 +38647,9 @@ relation Call_eval: p EC_0 ARCH_0 |- callee '@' `< typeArgumentListIR `> `( argu
 
                                                               1. Result in: % % % |- % '@' `< % `> `( % `) : EC_2 ARCH_1 ((RETURN ?()) as callResult)
 
-                                              1. Else Dangling#12096
+                                              1. Else Dangling#12099
 
-                                          1. Else Dangling#12094
+                                          1. Else Dangling#12097
 
                                           2. If ((n_count >= n_size)), then
 
@@ -38661,23 +38667,23 @@ relation Call_eval: p EC_0 ARCH_0 |- callee '@' `< typeArgumentListIR `> `( argu
 
                                                         1. Result in: % % % |- % '@' `< % `> `( % `) : EC_2 ARCH_1 ((RETURN ?()) as callResult)
 
-                                                1. Else Dangling#12108
+                                                1. Else Dangling#12111
 
-                                          2. Else Dangling#12105
+                                          2. Else Dangling#12108
 
-                                      1. Else Dangling#12092
+                                      1. Else Dangling#12095
 
-                                1. Else Dangling#12089
+                                1. Else Dangling#12092
 
-                            1. Else Dangling#12087
+                            1. Else Dangling#12090
 
-                  1. Else Dangling#12078
+                  1. Else Dangling#12081
 
-          1. Else Dangling#12074
+          1. Else Dangling#12077
 
-        1. Else Dangling#12073
+        1. Else Dangling#12076
 
-  3. Else Dangling#12031
+  3. Else Dangling#12034
 
   4. (Let (argumentIR)*{argumentIR <- argumentIR*} be argumentListIR)
 
@@ -38723,11 +38729,11 @@ relation Call_eval: p EC_0 ARCH_0 |- callee '@' `< typeArgumentListIR `> `( argu
 
                                   1. Result in: % % % |- % '@' `< % `> `( % `) : EC_0 ARCH_0 (returnResult as callResult)
 
-                  1. Else Dangling#12120
+                  1. Else Dangling#12123
 
-            1. Else Dangling#12117
+            1. Else Dangling#12120
 
-          1. Else Dangling#12116
+          1. Else Dangling#12119
 
       2. Case (% has type builtinSetValidMethodCallee)
 
@@ -38755,11 +38761,11 @@ relation Call_eval: p EC_0 ARCH_0 |- callee '@' `< typeArgumentListIR `> `( argu
 
                               1. Result in: % % % |- % '@' `< % `> `( % `) : EC_1 ARCH_0 (returnResult as callResult)
 
-                  1. Else Dangling#12137
+                  1. Else Dangling#12140
 
-            1. Else Dangling#12134
+            1. Else Dangling#12137
 
-          1. Else Dangling#12133
+          1. Else Dangling#12136
 
       3. Case (% has type builtinSetInvalidMethodCallee)
 
@@ -38787,11 +38793,11 @@ relation Call_eval: p EC_0 ARCH_0 |- callee '@' `< typeArgumentListIR `> `( argu
 
                               1. Result in: % % % |- % '@' `< % `> `( % `) : EC_1 ARCH_0 (returnResult as callResult)
 
-                  1. Else Dangling#12149
+                  1. Else Dangling#12152
 
-            1. Else Dangling#12146
+            1. Else Dangling#12149
 
-          1. Else Dangling#12145
+          1. Else Dangling#12148
 
       4. Case (% has type builtinSizeMethodCallee)
 
@@ -38807,9 +38813,9 @@ relation Call_eval: p EC_0 ARCH_0 |- callee '@' `< typeArgumentListIR `> `( argu
 
                   1. Result in: % % % |- % '@' `< % `> `( % `) : EC_0 ARCH_0 (returnResult as callResult)
 
-            1. Else Dangling#12158
+            1. Else Dangling#12161
 
-          1. Else Dangling#12157
+          1. Else Dangling#12160
 
       5. Case (% has type externMethodCallee)
 
@@ -38859,7 +38865,7 @@ relation Call_eval: p EC_0 ARCH_0 |- callee '@' `< typeArgumentListIR `> `( argu
 
                                               1. Result in: % % % |- % '@' `< % `> `( % `) : EC_2 ARCH_2 (definedFunctionResult as callResult)
 
-                        1. Else Dangling#12169
+                        1. Else Dangling#12172
 
               2. Case (% matches pattern ())
 
@@ -38911,9 +38917,9 @@ relation Call_eval: p EC_0 ARCH_0 |- callee '@' `< typeArgumentListIR `> `( argu
 
                                                   1. Result in: % % % |- % '@' `< % `> `( % `) : EC_2 ARCH_2 callResult
 
-                      1. Else Dangling#12185
+                      1. Else Dangling#12188
 
-    1. Else Dangling#12114
+    1. Else Dangling#12117
 
 2. Case analysis on callee
 
@@ -38981,9 +38987,9 @@ relation Call_eval: p EC_0 ARCH_0 |- callee '@' `< typeArgumentListIR `> `( argu
 
                                           1. Result in: % % % |- % '@' `< % `> `( % `) : EC_2 ARCH_3 ((RETURN ?()) as callResult)
 
-                                  1. Else Dangling#12221
+                                  1. Else Dangling#12224
 
-                  1. Else Dangling#12210
+                  1. Else Dangling#12213
 
   2. Case (% has type controlApplyMethodCallee)
 
@@ -39043,7 +39049,7 @@ relation Call_eval: p EC_0 ARCH_0 |- callee '@' `< typeArgumentListIR `> `( argu
 
                                             1. Result in: % % % |- % '@' `< % `> `( % `) : EC_2 ARCH_3 ((EXIT) as callResult)
 
-                                      1. Else Dangling#12248
+                                      1. Else Dangling#12251
 
                                       2. If ((controlBodyResult = ((RETURN ?()) as controlBodyResult))), then
 
@@ -39051,9 +39057,9 @@ relation Call_eval: p EC_0 ARCH_0 |- callee '@' `< typeArgumentListIR `> `( argu
 
                                           1. Result in: % % % |- % '@' `< % `> `( % `) : EC_2 ARCH_3 ((RETURN ?()) as callResult)
 
-                                      2. Else Dangling#12252
+                                      2. Else Dangling#12255
 
-                    1. Else Dangling#12236
+                    1. Else Dangling#12239
 
   3. Case (% has type tableApplyMethodCallee)
 
@@ -39091,9 +39097,9 @@ relation Call_eval: p EC_0 ARCH_0 |- callee '@' `< typeArgumentListIR `> `( argu
 
                             1. Result in: % % % |- % '@' `< % `> `( % `) : EC_1 ARCH_1 (returnResult as callResult)
 
-              1. Else Dangling#12260
+              1. Else Dangling#12263
 
-2. Else Dangling#12202
+2. Else Dangling#12205
 
 extern relation ExternFunctionCall_eval: EC ARCH |- nameIR `( (nameIR')*{nameIR' <- nameIR'*} `) : % % %
 
@@ -39109,7 +39115,7 @@ def $match_keysets((setValue')*{setValue' <- setValue'*}, (value)*{value <- valu
 
       1. Return true
 
-    1. Else Dangling#12271
+    1. Else Dangling#12274
 
   2. Case (% matches pattern [ _/1 ])
 
@@ -39123,9 +39129,9 @@ def $match_keysets((setValue')*{setValue' <- setValue'*}, (value)*{value <- valu
 
             1. Return $match_keyset(setValue, value_key)
 
-          1. Else Dangling#12276
+          1. Else Dangling#12279
 
-      1. Else Dangling#12274
+      1. Else Dangling#12277
 
   3. Case (% matches pattern _ :: _)
 
@@ -39149,19 +39155,19 @@ def $match_keysets((setValue')*{setValue' <- setValue'*}, (value)*{value <- valu
 
                   1. Return false
 
-            1. Else Dangling#12282
+            1. Else Dangling#12285
 
-          1. Else Dangling#12281
+          1. Else Dangling#12284
 
-      1. Else Dangling#12279
+      1. Else Dangling#12282
 
-1. Else Dangling#12270
+1. Else Dangling#12273
 
 2. If (((setValue')*{setValue' <- setValue'*} = [(SET `{ '...' `})])), then
 
   1. Return true
 
-2. Else Dangling#12286
+2. Else Dangling#12289
 
 def $match_keyset(setValue, value_key)
 
@@ -39248,11 +39254,11 @@ relation Eval_keyset_simple: EC_0 ARCH_0 |- simpleKeysetExpressionIR : % % %
 
                                 1. Result in: % % |- % : EC_1 ARCH_1 ((_CONT setValue) as simpleKeysetExpressionResult)
 
-                          1. Else Dangling#12312
+                          1. Else Dangling#12315
 
-                      1. Else Dangling#12310
+                      1. Else Dangling#12313
 
-              1. Else Dangling#12305
+              1. Else Dangling#12308
 
   2. Case (% matches pattern `% &&& %`)
 
@@ -39326,7 +39332,7 @@ relation Eval_keyset_simple: EC_0 ARCH_0 |- simpleKeysetExpressionIR : % % %
 
                         1. Result in: % % |- % : EC_2 ARCH_2 ((_CONT setValue) as simpleKeysetExpressionResult)
 
-1. Else Dangling#12298
+1. Else Dangling#12301
 
 2. If (((simpleKeysetExpressionIR = (DEFAULT)) \/ (simpleKeysetExpressionIR = ('_')))), then
 
@@ -39334,7 +39340,7 @@ relation Eval_keyset_simple: EC_0 ARCH_0 |- simpleKeysetExpressionIR : % % %
 
     1. Result in: % % |- % : EC_0 ARCH_0 ((_CONT setValue) as simpleKeysetExpressionResult)
 
-2. Else Dangling#12342
+2. Else Dangling#12345
 
 relation Eval_keysets_simple: EC ARCH |- (simpleKeysetExpressionIR)*{simpleKeysetExpressionIR <- simpleKeysetExpressionIR*} : % % %
 
@@ -39430,7 +39436,7 @@ relation ForUpdateStmts_eval: EC ARCH |- (forUpdateStatementIR)*{forUpdateStatem
 
                 1. Result in: % % |- % : EC_2 ARCH_2 statementResult
 
-        1. Else Dangling#12371
+        1. Else Dangling#12374
 
 relation ForInitStmt_eval: EC_0 ARCH |- forInitStatementIR : % % %
 
@@ -39450,7 +39456,7 @@ relation ForInitStmt_eval: EC_0 ARCH |- forInitStatementIR : % % %
 
               1. Result in: % % |- % : EC_1 ARCH ((_EMPTY) as statementResult)
 
-      1. Else Dangling#12379
+      1. Else Dangling#12382
 
     2. (Let (annotationList typeIR nameIR initializerOptIR) be forInitStatementIR)
 
@@ -39476,7 +39482,7 @@ relation ForInitStmt_eval: EC_0 ARCH |- forInitStatementIR : % % %
 
                     1. Result in: % % |- % : EC_2 ARCH_1 ((_EMPTY) as statementResult)
 
-      1. Else Dangling#12385
+      1. Else Dangling#12388
 
   2. Case (% has type forUpdateStatementIR)
 
@@ -39516,7 +39522,7 @@ relation ForInitStmts_eval: EC ARCH |- (forInitStatementIR)*{forInitStatementIR 
 
                 1. Result in: % % |- % : EC_2 ARCH_2 statementResult
 
-        1. Else Dangling#12401
+        1. Else Dangling#12404
 
 relation ForThreeClauseStmt_eval: EC_0 ARCH_0 |- typedExpressionIR statementIR forUpdateStatementListIR : % % %
 
@@ -39528,7 +39534,7 @@ relation ForThreeClauseStmt_eval: EC_0 ARCH_0 |- typedExpressionIR statementIR f
 
       1. Result in: % % |- % % % : EC_1 ARCH_1 (abortResult as statementResult)
 
-  1. Else Dangling#12408
+  1. Else Dangling#12411
 
   2. Case analysis on expressionResult
 
@@ -39560,7 +39566,7 @@ relation ForThreeClauseStmt_eval: EC_0 ARCH_0 |- typedExpressionIR statementIR f
 
               1. Result in: % % |- % % % : EC_2 ARCH_2 ((_EMPTY) as statementResult)
 
-        1. Else Dangling#12414
+        1. Else Dangling#12417
 
         2. If (((statementResult' = ((_EMPTY) as statementResult)) \/ (statementResult' = ((CONTINUE) as statementResult)))), then
 
@@ -39582,11 +39588,11 @@ relation ForThreeClauseStmt_eval: EC_0 ARCH_0 |- typedExpressionIR statementIR f
 
                     1. Result in: % % |- % % % : EC_4 ARCH_4 statementResult
 
-            1. Else Dangling#12423
+            1. Else Dangling#12426
 
-        2. Else Dangling#12421
+        2. Else Dangling#12424
 
-  2. Else Dangling#12411
+  2. Else Dangling#12414
 
 relation ForCollectionExpr_eval: EC_0 ARCH_0 |- forCollectionExpressionIR : % % %
 
@@ -39636,7 +39642,7 @@ relation ForCollectionExpr_eval: EC_0 ARCH_0 |- forCollectionExpressionIR : % % 
 
                       1. Result in: % % |- % : EC_1 ARCH_1 ((_CONT (value)*{value <- value*}) as expressionListResult)
 
-              1. Else Dangling#12436
+              1. Else Dangling#12439
 
   2. Case (% matches pattern `% .. %`)
 
@@ -39690,21 +39696,21 @@ def $values_of_setValue((SET `< typeIR `>), setValue)
 
           1. Return value_l :: $values_of_setValue((SET `< typeIR `>), (SET `{ value_l_inc '..' value_r `}))
 
-    1. Else Dangling#12462
+    1. Else Dangling#12465
 
     2. If ($bin_eq(value_l, value_r)), then
 
       1. Return [value_l]
 
-    2. Else Dangling#12466
+    2. Else Dangling#12469
 
     3. If ($bin_gt(value_l, value_r)), then
 
       1. Return []
 
-    3. Else Dangling#12468
+    3. Else Dangling#12471
 
-1. Else Dangling#12460
+1. Else Dangling#12463
 
 relation ForInStmt_eval: EC ARCH |- nameIR (value)*{value <- value*} statementIR : % % %
 
@@ -39742,7 +39748,7 @@ relation ForInStmt_eval: EC ARCH |- nameIR (value)*{value <- value*} statementIR
 
                 1. Result in: % % |- % % % : EC_2 ARCH_1 ((_EMPTY) as statementResult)
 
-          1. Else Dangling#12475
+          1. Else Dangling#12478
 
           2. If (((statementResult' = ((_EMPTY) as statementResult)) \/ (statementResult' = ((CONTINUE) as statementResult)))), then
 
@@ -39750,7 +39756,7 @@ relation ForInStmt_eval: EC ARCH |- nameIR (value)*{value <- value*} statementIR
 
               1. Result in: % % |- % % % : EC_3 ARCH_2 statementResult
 
-          2. Else Dangling#12482
+          2. Else Dangling#12485
 
 relation Switch_table_eval: EC_0 ARCH_0 |- SWITCH `( id_enum `) `{ (switchCaseIR)*{switchCaseIR <- switchCaseIR*} `} : % % %
 
@@ -39848,15 +39854,15 @@ relation SwitchCases_table_eval: id |- (switchCaseIR)*{switchCaseIR <- switchCas
 
                           1. Result in: % |- % : ?(blockStatementIR)
 
-                      1. Else Dangling#12515
+                      1. Else Dangling#12518
 
-                  1. Else Dangling#12513
+                  1. Else Dangling#12516
 
                 2. If (($filter_<switchCaseIR>((switchCaseIR_t)*{switchCaseIR_t <- switchCaseIR_t*}, ($is_non_fallthrough_switchCaseIR(switchCaseIR_t))*{switchCaseIR_t <- switchCaseIR_t*}) matches pattern [])), then
 
                   1. Result in: % |- % : ?()
 
-                2. Else Dangling#12518
+                2. Else Dangling#12521
 
               2. Case false
 
@@ -39912,7 +39918,7 @@ relation SwitchLabel_general_eval: p EC_0 ARCH_0 |- switchLabelIR : % % %
 
           1. Result in: % % % |- % : EC_1 ARCH_1 expressionResult
 
-1. Else Dangling#12531
+1. Else Dangling#12534
 
 def $match_switchLabelIR_general(value, value')
 
@@ -39964,7 +39970,7 @@ relation SwitchCases_general_eval: p EC_0 ARCH_0 value |- (switchCaseIR)*{switch
 
                           1. Result in: % % % % |- % : EC_2 ARCH_2 (blockStatementIR)?{blockStatementIR <- blockStatementIR?}
 
-                1. Else Dangling#12548
+                1. Else Dangling#12551
 
           2. Case (% matches pattern `% :`)
 
@@ -39992,15 +39998,15 @@ relation SwitchCases_general_eval: p EC_0 ARCH_0 value |- (switchCaseIR)*{switch
 
                                   1. Result in: % % % % |- % : EC_1 ARCH_1 ?(blockStatementIR)
 
-                              1. Else Dangling#12562
+                              1. Else Dangling#12565
 
-                          1. Else Dangling#12560
+                          1. Else Dangling#12563
 
                         2. If (($filter_<switchCaseIR>((switchCaseIR_t)*{switchCaseIR_t <- switchCaseIR_t*}, ($is_non_fallthrough_switchCaseIR(switchCaseIR_t))*{switchCaseIR_t <- switchCaseIR_t*}) matches pattern [])), then
 
                           1. Result in: % % % % |- % : EC_1 ARCH_1 ?()
 
-                        2. Else Dangling#12565
+                        2. Else Dangling#12568
 
                       2. Case false
 
@@ -40008,9 +40014,9 @@ relation SwitchCases_general_eval: p EC_0 ARCH_0 value |- (switchCaseIR)*{switch
 
                           1. Result in: % % % % |- % : EC_2 ARCH_2 (blockStatementIR)?{blockStatementIR <- blockStatementIR?}
 
-                1. Else Dangling#12556
+                1. Else Dangling#12559
 
-1. Else Dangling#12541
+1. Else Dangling#12544
 
 syntax selectCaseMatchResult = 
    | _CONT nameIR? (from continueResult<nameIR?>) 
@@ -40042,7 +40048,7 @@ relation SelectCase_match: EC_0 ARCH_0 (value_key)*{value_key <- value_key*} |- 
 
             1. Result in: % % % |- % : EC_1 ARCH_1 ((_CONT ?(nameIR)) as selectCaseMatchResult)
 
-  1. Else Dangling#12570
+  1. Else Dangling#12573
 
 relation SelectCases_match: EC ARCH (value_key)*{value_key <- value_key*} |- (selectCaseIR)*{selectCaseIR <- selectCaseIR*} : % % %
 
@@ -40076,7 +40082,7 @@ relation SelectCases_match: EC ARCH (value_key)*{value_key <- value_key*} |- (se
 
                   1. Result in: % % % |- % : EC_1 ARCH_1 ((_CONT ?(nameIR_state)) as selectCaseMatchResult)
 
-              1. Else Dangling#12585
+              1. Else Dangling#12588
 
         2. If ((selectCaseMatchResult' = ((_CONT ?()) as selectCaseMatchResult))), then
 
@@ -40084,7 +40090,7 @@ relation SelectCases_match: EC ARCH (value_key)*{value_key <- value_key*} |- (se
 
             1. Result in: % % % |- % : EC_2 ARCH_2 selectCaseMatchResult
 
-        2. Else Dangling#12588
+        2. Else Dangling#12591
 
 syntax tableKeyValue = 
    | value ':' nameIR (from tableKeyValue) 
@@ -40113,7 +40119,7 @@ relation TableKey_eval: EC_0 ARCH_0 |- (typedExpressionIR '#' _nameIR ':' nameIR
 
           1. Result in: % % |- % : EC_1 ARCH_1 ((_CONT tableKeyValue) as tableKeyResult)
 
-  1. Else Dangling#12592
+  1. Else Dangling#12595
 
 syntax tableKeysResult = 
    | _CONT tableKeyValue* (from continueResult<tableKeyValue*>) 
@@ -40183,7 +40189,7 @@ def $get_tableEntryPriority((tableEntryPriorityIR)?{tableEntryPriorityIR <- tabl
 
             1. Return ?(n)
 
-        1. Else Dangling#12617
+        1. Else Dangling#12620
 
 syntax tableMatch = 
    | nat? ':' tableActionReferenceIR (from tableMatch) 
@@ -40226,7 +40232,7 @@ relation TableMatch_eval: EC_0 ARCH_0 |- (tableKeyValue)*{tableKeyValue <- table
 
                     1. Result in: % % |- % '@' % : EC_1 ARCH_1 ((_CONT ?(tableMatch)) as tableMatchResult)
 
-      1. Else Dangling#12623
+      1. Else Dangling#12626
 
 syntax tableMatchesResult = 
    | _CONT tableMatch* (from continueResult<tableMatch*>) 
@@ -40296,17 +40302,17 @@ def $largest_priority_wins(TBL)
 
                 1. Return b
 
-            1. Else Dangling#12653
+            1. Else Dangling#12656
 
-        1. Else Dangling#12651
+        1. Else Dangling#12654
 
-    1. Else Dangling#12649
+    1. Else Dangling#12652
 
   2. If (($filter_<tableCustomPropertyIR>((tableCustomPropertyIR)*{tableCustomPropertyIR <- tableCustomPropertyIR*}, ($is_largest_priority_wins(tableCustomPropertyIR))*{tableCustomPropertyIR <- tableCustomPropertyIR*}) matches pattern [])), then
 
     1. Return true
 
-  2. Else Dangling#12656
+  2. Else Dangling#12659
 
 def $is_largest_priority_wins(tableCustomPropertyIR)
 
@@ -40340,7 +40346,7 @@ def $select_action(TBL, (tableMatch')*{tableMatch' <- tableMatch'*})
 
         1. Return tableActionReferenceIR
 
-1. Else Dangling#12663
+1. Else Dangling#12666
 
 2. If ((|(tableMatch')*{tableMatch' <- tableMatch'*}| > 1)), then
 
@@ -40364,7 +40370,7 @@ def $select_action(TBL, (tableMatch')*{tableMatch' <- tableMatch'*})
 
                     1. Return tableActionReferenceIR_h
 
-                1. Else Dangling#12676
+                1. Else Dangling#12679
 
             2. Case false
 
@@ -40374,11 +40380,11 @@ def $select_action(TBL, (tableMatch')*{tableMatch' <- tableMatch'*})
 
                   1. Return tableActionReferenceIR_h
 
-              1. Else Dangling#12679
+              1. Else Dangling#12682
 
-    1. Else Dangling#12671
+    1. Else Dangling#12674
 
-2. Else Dangling#12669
+2. Else Dangling#12672
 
 relation Copy_out_inner: ARCH |- p_caller EC (parameterIR)*{parameterIR <- parameterIR*} '@' p_callee EC_callee ((storageReference)?{storageReference <- storageReference?})*{storageReference? <- storageReference?*} ~> %
 
@@ -40390,7 +40396,7 @@ relation Copy_out_inner: ARCH |- p_caller EC (parameterIR)*{parameterIR <- param
 
       1. Result in: % |- % % % '@' % % % ~> EC
 
-    1. Else Dangling#12683
+    1. Else Dangling#12686
 
   2. Case (% matches pattern _ :: _)
 
@@ -40408,7 +40414,7 @@ relation Copy_out_inner: ARCH |- p_caller EC (parameterIR)*{parameterIR <- param
 
                 1. Result in: % |- % % % '@' % % % ~> EC_caller_2
 
-        1. Else Dangling#12687
+        1. Else Dangling#12690
 
 syntax actionResult = 
    | EXIT (from exitResult) 
@@ -40432,13 +40438,13 @@ relation ActionBody_eval: EC_0 ARCH_0 |- blockStatementIR : % % %
 
         1. Result in: % % |- % : EC_1 ARCH_1 ((EXIT) as actionResult)
 
-  1. Else Dangling#12693
+  1. Else Dangling#12696
 
   2. If ((statementResult = ((RETURN ?()) as statementResult))), then
 
     1. Result in: % % |- % : EC_1 ARCH_1 ((RETURN ?()) as actionResult)
 
-  2. Else Dangling#12698
+  2. Else Dangling#12701
 
 syntax definedFunctionResult = 
    | EXIT (from exitResult) 
@@ -40468,7 +40474,7 @@ relation DefinedFunctionBody_eval: EC_0 ARCH_0 |- blockStatementIR : % % %
 
         1. Result in: % % |- % : EC_1 ARCH_1 (returnResult as definedFunctionResult)
 
-  1. Else Dangling#12701
+  1. Else Dangling#12704
 
 relation Var_init: EC_0 |- typeIR nameIR : %
 
@@ -40502,11 +40508,11 @@ relation Extern_init: EC ARCH_0 |- nameIR_extern nameIR : %
 
                     1. Result in: % % |- % % : ARCH_2
 
-        1. Else Dangling#12715
+        1. Else Dangling#12718
 
-      1. Else Dangling#12714
+      1. Else Dangling#12717
 
-    1. Else Dangling#12713
+    1. Else Dangling#12716
 
 relation Program_init: |- p4program : % %
 
@@ -40646,9 +40652,9 @@ def $reverse_bytes_of_hex(t)
 
           1. Return "0x" ++ $reverse_bytes_of_hex'(t[2 : n_len_bytes])
 
-      1. Else Dangling#12781
+      1. Else Dangling#12784
 
-1. Else Dangling#12778
+1. Else Dangling#12781
 
 def $reverse_bytes_of_hex'(t)
 
@@ -40656,7 +40662,7 @@ def $reverse_bytes_of_hex'(t)
 
   1. Return t
 
-1. Else Dangling#12784
+1. Else Dangling#12787
 
 2. (Let n_len be |t|)
 
@@ -40676,9 +40682,9 @@ def $reverse_bytes_of_hex'(t)
 
                 1. Return t_bytes_rev ++ t_byte
 
-        1. Else Dangling#12790
+        1. Else Dangling#12793
 
-  1. Else Dangling#12787
+  1. Else Dangling#12790
 
 syntax tableEntryPriorityInterface = int?
 
@@ -40730,7 +40736,7 @@ def $tableObject_create_entry_priority(tableEntryPriorityInterface)
 
     1. Return ?()
 
-  1. Else Dangling#12804
+  1. Else Dangling#12807
 
 2. If ((tableEntryPriorityInterface matches pattern (_))), then
 
@@ -40742,9 +40748,9 @@ def $tableObject_create_entry_priority(tableEntryPriorityInterface)
 
         1. Return ?((PRIORITY '=' (D (n_priority as int)) ':'))
 
-    1. Else Dangling#12808
+    1. Else Dangling#12811
 
-2. Else Dangling#12806
+2. Else Dangling#12809
 
 def $needs_priority_tableKeysPropertyIR((KEY '=' `{ (tableKeyIR)*{tableKeyIR <- tableKeyIR*} `}))
 
@@ -40786,11 +40792,11 @@ def $tableObject_create_entry_key(EC, (nameIR_key, t, typeIR), (tableKeyInterfac
 
                               1. Return simpleKeysetExpressionIR
 
-                      1. Else Dangling#12823
+                      1. Else Dangling#12826
 
-            1. Else Dangling#12818
+            1. Else Dangling#12821
 
-      1. Else Dangling#12815
+      1. Else Dangling#12818
 
   2. Case (% = "ternary")
 
@@ -40834,9 +40840,9 @@ def $tableObject_create_entry_key(EC, (nameIR_key, t, typeIR), (tableKeyInterfac
 
                                           1. Return simpleKeysetExpressionIR
 
-                                    1. Else Dangling#12843
+                                    1. Else Dangling#12846
 
-                        1. Else Dangling#12837
+                        1. Else Dangling#12840
 
             2. Case (% matches pattern `_BIN %`)
 
@@ -40870,13 +40876,13 @@ def $tableObject_create_entry_key(EC, (nameIR_key, t, typeIR), (tableKeyInterfac
 
                                           1. Return simpleKeysetExpressionIR
 
-                                    1. Else Dangling#12858
+                                    1. Else Dangling#12861
 
-                        1. Else Dangling#12852
+                        1. Else Dangling#12855
 
-          1. Else Dangling#12831
+          1. Else Dangling#12834
 
-      1. Else Dangling#12829
+      1. Else Dangling#12832
 
   3. Case (% = "lpm")
 
@@ -40924,11 +40930,11 @@ def $tableObject_create_entry_key(EC, (nameIR_key, t, typeIR), (tableKeyInterfac
 
                                               1. Return simpleKeysetExpressionIR
 
-                                        1. Else Dangling#12879
+                                        1. Else Dangling#12882
 
-                            1. Else Dangling#12873
+                            1. Else Dangling#12876
 
-                  1. Else Dangling#12868
+                  1. Else Dangling#12871
 
             2. Case (% matches pattern `_BIN %`)
 
@@ -40966,11 +40972,11 @@ def $tableObject_create_entry_key(EC, (nameIR_key, t, typeIR), (tableKeyInterfac
 
                                               1. Return simpleKeysetExpressionIR
 
-                                        1. Else Dangling#12896
+                                        1. Else Dangling#12899
 
-                            1. Else Dangling#12890
+                            1. Else Dangling#12893
 
-                  1. Else Dangling#12885
+                  1. Else Dangling#12888
 
             3. Case (% matches pattern `% _SLASH %`)
 
@@ -41012,17 +41018,17 @@ def $tableObject_create_entry_key(EC, (nameIR_key, t, typeIR), (tableKeyInterfac
 
                                                   1. Return simpleKeysetExpressionIR
 
-                                            1. Else Dangling#12915
+                                            1. Else Dangling#12918
 
-                                    1. Else Dangling#12911
+                                    1. Else Dangling#12914
 
-                          1. Else Dangling#12906
+                          1. Else Dangling#12909
 
-                      1. Else Dangling#12904
+                      1. Else Dangling#12907
 
-          1. Else Dangling#12865
+          1. Else Dangling#12868
 
-      1. Else Dangling#12863
+      1. Else Dangling#12866
 
   4. Case (% = "optional")
 
@@ -41066,15 +41072,15 @@ def $tableObject_create_entry_key(EC, (nameIR_key, t, typeIR), (tableKeyInterfac
 
                                           1. Return simpleKeysetExpressionIR
 
-                                    1. Else Dangling#12935
+                                    1. Else Dangling#12938
 
-                        1. Else Dangling#12929
+                        1. Else Dangling#12932
 
-              1. Else Dangling#12924
+              1. Else Dangling#12927
 
-          1. Else Dangling#12922
+          1. Else Dangling#12925
 
-      1. Else Dangling#12920
+      1. Else Dangling#12923
 
   5. Case (% = "selector")
 
@@ -41090,9 +41096,9 @@ def $tableObject_create_entry_key(EC, (nameIR_key, t, typeIR), (tableKeyInterfac
 
               1. Return simpleKeysetExpressionIR
 
-        1. Else Dangling#12941
+        1. Else Dangling#12944
 
-1. Else Dangling#12813
+1. Else Dangling#12816
 
 def $tableObject_create_entry_keys(EC, ((nameIR, nameIR, typeIR))*{(nameIR, nameIR, typeIR) <- (nameIR, nameIR, typeIR)*}, tableKeysetInterface)
 
@@ -41100,7 +41106,7 @@ def $tableObject_create_entry_keys(EC, ((nameIR, nameIR, typeIR))*{(nameIR, name
 
   1. Return []
 
-1. Else Dangling#12945
+1. Else Dangling#12948
 
 2. (Let (tableKeyInterface)*{tableKeyInterface <- tableKeyInterface*} be tableKeysetInterface)
 
@@ -41112,7 +41118,7 @@ def $tableObject_create_entry_keys(EC, ((nameIR, nameIR, typeIR))*{(nameIR, name
 
         1. Return simpleKeysetExpressionIR_h :: $tableObject_create_entry_keys(EC, ((nameIR_key_t, nameIR_matchKind_t, typeIR_t))*{nameIR_key_t <- nameIR_key_t*, nameIR_matchKind_t <- nameIR_matchKind_t*, typeIR_t <- typeIR_t*}, (tableKeyInterface)*{tableKeyInterface <- tableKeyInterface*})
 
-  1. Else Dangling#12948
+  1. Else Dangling#12951
 
 def $interface_of_tableKeyIR((typedExpressionIR '#' nameIR_key ':' nameIR_matchKind annotationList ';'))
 
@@ -41142,7 +41148,7 @@ def $tableObject_create_entry_keyset(EC, (KEY '=' `{ (tableKeyIR)*{tableKeyIR <-
 
           1. Return ((`( (simpleKeysetExpressionIR)*{simpleKeysetExpressionIR <- simpleKeysetExpressionIR*} `)) as keysetExpressionIR)
 
-      1. Else Dangling#12960
+      1. Else Dangling#12963
 
 def $alias_to_original_lookup_map((parameterIR)*{parameterIR <- parameterIR*})
 
@@ -41166,9 +41172,9 @@ def $alias_to_original_lookup_map((parameterIR)*{parameterIR <- parameterIR*})
 
                   1. Return $extend_map<nameIR, nameIR>((`{ ((nameIR_alias ':' nameIR_original))*{nameIR_alias <- nameIR_alias*, nameIR_original <- nameIR_original*} `}), (`{ ((id ':' id))*{id <- id*} `}))
 
-                1. Else Dangling#12971
+                1. Else Dangling#12974
 
-            1. Else Dangling#12969
+            1. Else Dangling#12972
 
 def $align_tableActionArgumentInterfaces((parameterIR)*{parameterIR <- parameterIR*}, ((nameIR_arg, i_arg))*{i_arg <- i_arg*, nameIR_arg <- nameIR_arg*})
 
@@ -41188,9 +41194,9 @@ def $align_tableActionArgumentInterfaces((parameterIR)*{parameterIR <- parameter
 
               1. Return (i_aligned)*{i_aligned <- i_aligned*}
 
-          1. Else Dangling#12978
+          1. Else Dangling#12981
 
-    1. Else Dangling#12975
+    1. Else Dangling#12978
 
 def $align_tableActionArgumentInterfaces'((`{ ((id_arg ':' i_arg))*{i_arg <- i_arg*, id_arg <- id_arg*} `}), (_annotationList _direction _typeIR nameIR_param _parameterInitializerOptIR))
 
@@ -41202,13 +41208,13 @@ def $align_tableActionArgumentInterfaces'((`{ ((id_arg ':' i_arg))*{i_arg <- i_a
 
       1. Return i
 
-  1. Else Dangling#12982
+  1. Else Dangling#12985
 
 2. If (($find_map<id, int>((`{ ((id_arg ':' i_arg))*{i_arg <- i_arg*, id_arg <- id_arg*} `}), nameIR_param) matches pattern ())), then
 
   1. Return (0 as int)
 
-2. Else Dangling#12985
+2. Else Dangling#12988
 
 def $find_tableActionIR_qualified((tableActionIR)*{tableActionIR <- tableActionIR*}, nameIR)
 
@@ -41230,7 +41236,7 @@ def $find_tableActionIR_qualified((tableActionIR)*{tableActionIR <- tableActionI
 
             1. Return $find_tableActionIR_qualified((tableActionIR_t)*{tableActionIR_t <- tableActionIR_t*}, nameIR)
 
-          1. Else Dangling#12992
+          1. Else Dangling#12995
 
           2. If ((?(nameIR) = controlPlaneNameIR)), then
 
@@ -41238,7 +41244,7 @@ def $find_tableActionIR_qualified((tableActionIR)*{tableActionIR <- tableActionI
 
               1. Return ?((nameIR_action, tableActionIR_h))
 
-          2. Else Dangling#12994
+          2. Else Dangling#12997
 
 def $find_tableActionIR_unqualified((tableActionIR)*{tableActionIR <- tableActionIR*}, nameIR)
 
@@ -41250,7 +41256,7 @@ def $find_tableActionIR_unqualified((tableActionIR)*{tableActionIR <- tableActio
 
       1. Return $find_tableActionIR_unqualified'((tableActionIR)*{tableActionIR <- tableActionIR*}, nameIR_action)
 
-  1. Else Dangling#12998
+  1. Else Dangling#13001
 
 def $find_tableActionIR_unqualified'((tableActionIR)*{tableActionIR <- tableActionIR*}, nameIR)
 
@@ -41284,7 +41290,7 @@ def $find_tableActionIR_unqualified'((tableActionIR)*{tableActionIR <- tableActi
 
                         1. Return $find_tableActionIR_unqualified'((tableActionIR_t)*{tableActionIR_t <- tableActionIR_t*}, nameIR)
 
-                      1. Else Dangling#13012
+                      1. Else Dangling#13015
 
                       2. If ((nameIR = nameIR_unqualified)), then
 
@@ -41292,11 +41298,11 @@ def $find_tableActionIR_unqualified'((tableActionIR)*{tableActionIR <- tableActi
 
                           1. Return ?((nameIR_action, tableActionIR_h))
 
-                      2. Else Dangling#13014
+                      2. Else Dangling#13017
 
-                  1. Else Dangling#13010
+                  1. Else Dangling#13013
 
-          1. Else Dangling#13006
+          1. Else Dangling#13009
 
 def $tableObject_create_entry_action(EC, (ACTIONS '=' `{ (tableActionIR)*{tableActionIR <- tableActionIR*} `}), (nameIR_action_update, (tableActionArgumentInterface_update)*{tableActionArgumentInterface_update <- tableActionArgumentInterface_update*}))
 
@@ -41326,11 +41332,11 @@ def $tableObject_create_entry_action(EC, (ACTIONS '=' `{ (tableActionIR)*{tableA
 
                         1. Return ((_BARE nameIR_found) controlPlaneNameIR `( (argumentIR)*{argumentIR <- argumentIR*} `))
 
-                  1. Else Dangling#13026
+                  1. Else Dangling#13029
 
-              1. Else Dangling#13024
+              1. Else Dangling#13027
 
-  1. Else Dangling#13018
+  1. Else Dangling#13021
 
 2. If (($find_tableActionIR_qualified((tableActionIR)*{tableActionIR <- tableActionIR*}, nameIR_action_update) matches pattern ())), then
 
@@ -41360,13 +41366,13 @@ def $tableObject_create_entry_action(EC, (ACTIONS '=' `{ (tableActionIR)*{tableA
 
                           1. Return ((_BARE nameIR_found) controlPlaneNameIR `( (argumentIR)*{argumentIR <- argumentIR*} `))
 
-                    1. Else Dangling#13040
+                    1. Else Dangling#13043
 
-                1. Else Dangling#13038
+                1. Else Dangling#13041
 
-    1. Else Dangling#13032
+    1. Else Dangling#13035
 
-2. Else Dangling#13030
+2. Else Dangling#13033
 
 def $tableObject_add_entry(EC, (TABLE typeId `{ frame TBL `}), tableEntryPriorityInterface, tableKeysetInterface, tableActionInterface)
 
@@ -41406,7 +41412,7 @@ def $tableObject_add_default_action(EC, (TABLE typeId `{ frame TBL `}), tableAct
 
           1. Return (TABLE typeId `{ frame TBL_updated `})
 
-  1. Else Dangling#13055
+  1. Else Dangling#13058
 
 relation V1Model_init: |- p4program : % %
 
@@ -41440,9 +41446,9 @@ relation V1Model_init_packet_in: EC_0 ARCH_0 |- objectState_packet_in : % %
 
                     1. Result in: % % |- % : EC_1 ARCH_2
 
-          1. Else Dangling#13068
+          1. Else Dangling#13071
 
-      1. Else Dangling#13066
+      1. Else Dangling#13069
 
 relation V1Model_init_packet_out: EC_0 ARCH_0 |- objectState_packet_out : % %
 
@@ -41468,9 +41474,9 @@ relation V1Model_init_packet_out: EC_0 ARCH_0 |- objectState_packet_out : % %
 
                     1. Result in: % % |- % : EC_1 ARCH_2
 
-          1. Else Dangling#13079
+          1. Else Dangling#13082
 
-      1. Else Dangling#13077
+      1. Else Dangling#13080
 
 relation V1Model_init_globals: EC_0 ARCH |- i_port : %
 
@@ -41518,15 +41524,15 @@ relation V1Model_init_globals: EC_0 ARCH |- i_port : %
 
                                           1. Result in: % % |- % : EC_4
 
-                            1. Else Dangling#13099
+                            1. Else Dangling#13102
 
-                  1. Else Dangling#13094
+                  1. Else Dangling#13097
 
-            1. Else Dangling#13091
+            1. Else Dangling#13094
 
-      1. Else Dangling#13088
+      1. Else Dangling#13091
 
-  1. Else Dangling#13086
+  1. Else Dangling#13089
 
 def $V1Model_setup_packet_in_argument(EC)
 
@@ -41542,7 +41548,7 @@ def $V1Model_setup_packet_in_argument(EC)
 
           1. Return argumentIR_packet_in
 
-  1. Else Dangling#13108
+  1. Else Dangling#13111
 
 def $V1Model_setup_packet_out_argument(EC)
 
@@ -41558,7 +41564,7 @@ def $V1Model_setup_packet_out_argument(EC)
 
           1. Return argumentIR_packet_out
 
-  1. Else Dangling#13114
+  1. Else Dangling#13117
 
 def $V1Model_setup_hdr_argument(ARCH)
 
@@ -41582,11 +41588,11 @@ def $V1Model_setup_hdr_argument(ARCH)
 
                   1. Return argumentIR_hdr
 
-            1. Else Dangling#13125
+            1. Else Dangling#13128
 
-      1. Else Dangling#13122
+      1. Else Dangling#13125
 
-  1. Else Dangling#13120
+  1. Else Dangling#13123
 
 def $V1Model_setup_meta_argument(ARCH)
 
@@ -41610,11 +41616,11 @@ def $V1Model_setup_meta_argument(ARCH)
 
                   1. Return argumentIR_meta
 
-            1. Else Dangling#13135
+            1. Else Dangling#13138
 
-      1. Else Dangling#13132
+      1. Else Dangling#13135
 
-  1. Else Dangling#13130
+  1. Else Dangling#13133
 
 def $V1Model_setup_standard_metadata_argument(EC)
 
@@ -41630,7 +41636,7 @@ def $V1Model_setup_standard_metadata_argument(EC)
 
           1. Return argumentIR_standard_metadata
 
-  1. Else Dangling#13140
+  1. Else Dangling#13143
 
 def $V1Model_setup_main_callee(EC, ARCH)
 
@@ -41668,15 +41674,15 @@ def $V1Model_setup_main_callee(EC, ARCH)
 
                                 1. Return typedExpressionIR_main
 
-                        1. Else Dangling#13157
+                        1. Else Dangling#13160
 
-                  1. Else Dangling#13154
+                  1. Else Dangling#13157
 
-            1. Else Dangling#13151
+            1. Else Dangling#13154
 
-        1. Else Dangling#13149
+        1. Else Dangling#13152
 
-  1. Else Dangling#13146
+  1. Else Dangling#13149
 
 def $V1Model_setup_parser_callee(EC, ARCH, typedExpressionIR_main)
 
@@ -41714,15 +41720,15 @@ def $V1Model_setup_parser_callee(EC, ARCH, typedExpressionIR_main)
 
                                 1. Return typedExpressionIR_parser
 
-                        1. Else Dangling#13174
+                        1. Else Dangling#13177
 
-                  1. Else Dangling#13171
+                  1. Else Dangling#13174
 
-            1. Else Dangling#13168
+            1. Else Dangling#13171
 
-        1. Else Dangling#13166
+        1. Else Dangling#13169
 
-  1. Else Dangling#13163
+  1. Else Dangling#13166
 
 def $V1Model_setup_verify_callee(EC, ARCH, typedExpressionIR_main)
 
@@ -41760,15 +41766,15 @@ def $V1Model_setup_verify_callee(EC, ARCH, typedExpressionIR_main)
 
                                 1. Return typedExpressionIR_verify
 
-                        1. Else Dangling#13191
+                        1. Else Dangling#13194
 
-                  1. Else Dangling#13188
+                  1. Else Dangling#13191
 
-            1. Else Dangling#13185
+            1. Else Dangling#13188
 
-        1. Else Dangling#13183
+        1. Else Dangling#13186
 
-  1. Else Dangling#13180
+  1. Else Dangling#13183
 
 def $V1Model_setup_ingress_callee(EC, ARCH, typedExpressionIR_main)
 
@@ -41806,15 +41812,15 @@ def $V1Model_setup_ingress_callee(EC, ARCH, typedExpressionIR_main)
 
                                 1. Return typedExpressionIR_ingress
 
-                        1. Else Dangling#13208
+                        1. Else Dangling#13211
 
-                  1. Else Dangling#13205
+                  1. Else Dangling#13208
 
-            1. Else Dangling#13202
+            1. Else Dangling#13205
 
-        1. Else Dangling#13200
+        1. Else Dangling#13203
 
-  1. Else Dangling#13197
+  1. Else Dangling#13200
 
 def $V1Model_setup_egress_callee(EC, ARCH, typedExpressionIR_main)
 
@@ -41852,15 +41858,15 @@ def $V1Model_setup_egress_callee(EC, ARCH, typedExpressionIR_main)
 
                                 1. Return typedExpressionIR_egress
 
-                        1. Else Dangling#13225
+                        1. Else Dangling#13228
 
-                  1. Else Dangling#13222
+                  1. Else Dangling#13225
 
-            1. Else Dangling#13219
+            1. Else Dangling#13222
 
-        1. Else Dangling#13217
+        1. Else Dangling#13220
 
-  1. Else Dangling#13214
+  1. Else Dangling#13217
 
 def $V1Model_setup_check_callee(EC, ARCH, typedExpressionIR_main)
 
@@ -41898,15 +41904,15 @@ def $V1Model_setup_check_callee(EC, ARCH, typedExpressionIR_main)
 
                                 1. Return typedExpressionIR_check
 
-                        1. Else Dangling#13242
+                        1. Else Dangling#13245
 
-                  1. Else Dangling#13239
+                  1. Else Dangling#13242
 
-            1. Else Dangling#13236
+            1. Else Dangling#13239
 
-        1. Else Dangling#13234
+        1. Else Dangling#13237
 
-  1. Else Dangling#13231
+  1. Else Dangling#13234
 
 def $V1Model_setup_deparse_callee(EC, ARCH, typedExpressionIR_main)
 
@@ -41938,13 +41944,13 @@ def $V1Model_setup_deparse_callee(EC, ARCH, typedExpressionIR_main)
 
                           1. Return typedExpressionIR_deparse
 
-                  1. Else Dangling#13256
+                  1. Else Dangling#13259
 
-            1. Else Dangling#13253
+            1. Else Dangling#13256
 
-        1. Else Dangling#13251
+        1. Else Dangling#13254
 
-  1. Else Dangling#13248
+  1. Else Dangling#13251
 
 relation V1Model_parser: EC_0 ARCH_0 |- % % %
 
@@ -41980,7 +41986,7 @@ relation V1Model_parser: EC_0 ARCH_0 |- % % %
 
                         1. Result in: % % |- EC_1 ARCH_1 (rejectTransitionResult as transitionResult)
 
-                  1. Else Dangling#13270
+                  1. Else Dangling#13273
 
 relation V1Model_verify: EC_0 ARCH_0 |- % % %
 
@@ -42012,7 +42018,7 @@ relation V1Model_verify: EC_0 ARCH_0 |- % % %
 
                     1. Result in: % % |- EC_1 ARCH_1 ((EXIT) as callResult)
 
-              1. Else Dangling#13282
+              1. Else Dangling#13285
 
 relation V1Model_ingress: EC_0 ARCH_0 |- % % %
 
@@ -42046,7 +42052,7 @@ relation V1Model_ingress: EC_0 ARCH_0 |- % % %
 
                       1. Result in: % % |- EC_1 ARCH_1 ((RETURN ?()) as callResult)
 
-                1. Else Dangling#13295
+                1. Else Dangling#13298
 
 relation V1Model_egress: EC_0 ARCH_0 |- % % %
 
@@ -42080,7 +42086,7 @@ relation V1Model_egress: EC_0 ARCH_0 |- % % %
 
                       1. Result in: % % |- EC_1 ARCH_1 ((EXIT) as callResult)
 
-                1. Else Dangling#13308
+                1. Else Dangling#13311
 
 relation V1Model_check: EC_0 ARCH_0 |- % % %
 
@@ -42112,7 +42118,7 @@ relation V1Model_check: EC_0 ARCH_0 |- % % %
 
                     1. Result in: % % |- EC_1 ARCH_1 ((EXIT) as callResult)
 
-              1. Else Dangling#13320
+              1. Else Dangling#13323
 
 relation V1Model_deparse: EC_0 ARCH_0 |- % % %
 
@@ -42144,7 +42150,7 @@ relation V1Model_deparse: EC_0 ARCH_0 |- % % %
 
                     1. Result in: % % |- EC_1 ARCH_1 ((EXIT) as callResult)
 
-              1. Else Dangling#13332
+              1. Else Dangling#13335
 
 def $field_list_annotation_index(annotationList)
 
@@ -42266,13 +42272,13 @@ def $V1Model_meta_fields_of_index(ARCH, integerLiteral_index)
 
                       1. Return (nameIR_field)*{nameIR_field <- nameIR_field*}
 
-                1. Else Dangling#13381
+                1. Else Dangling#13384
 
-            1. Else Dangling#13379
+            1. Else Dangling#13382
 
-      1. Else Dangling#13376
+      1. Else Dangling#13379
 
-  1. Else Dangling#13374
+  1. Else Dangling#13377
 
 relation V1Model_copy_meta_fields: EC_capture EC_0 ARCH |- (nameIR)*{nameIR <- nameIR*} : %
 
@@ -42322,11 +42328,11 @@ relation V1Model_setup_preserved_meta_fields: EC_0 ARCH |- integerLiteral_index 
 
                       1. Result in: % % |- % : EC_2
 
-            1. Else Dangling#13399
+            1. Else Dangling#13402
 
-      1. Else Dangling#13396
+      1. Else Dangling#13399
 
-  1. Else Dangling#13394
+  1. Else Dangling#13397
 
 relation EBPF_init: |- p4program : % %
 
@@ -42360,9 +42366,9 @@ relation EBPF_init_packet_in: EC_0 ARCH_0 |- objectState_packet_in : % %
 
                     1. Result in: % % |- % : EC_1 ARCH_2
 
-          1. Else Dangling#13413
+          1. Else Dangling#13416
 
-      1. Else Dangling#13411
+      1. Else Dangling#13414
 
 relation EBPF_init_globals: EC_0 ARCH |- %
 
@@ -42388,11 +42394,11 @@ relation EBPF_init_globals: EC_0 ARCH |- %
 
                     1. Result in: % % |- EC_2
 
-            1. Else Dangling#13425
+            1. Else Dangling#13428
 
-      1. Else Dangling#13422
+      1. Else Dangling#13425
 
-  1. Else Dangling#13420
+  1. Else Dangling#13423
 
 def $eBPF_setup_packet_in_argument(EC)
 
@@ -42408,7 +42414,7 @@ def $eBPF_setup_packet_in_argument(EC)
 
           1. Return argumentIR_packet_in
 
-  1. Else Dangling#13431
+  1. Else Dangling#13434
 
 def $eBPF_setup_headers_argument(ARCH)
 
@@ -42432,11 +42438,11 @@ def $eBPF_setup_headers_argument(ARCH)
 
                   1. Return argumentIR_headers
 
-            1. Else Dangling#13442
+            1. Else Dangling#13445
 
-      1. Else Dangling#13439
+      1. Else Dangling#13442
 
-  1. Else Dangling#13437
+  1. Else Dangling#13440
 
 def $eBPF_setup_main_callee(EC, ARCH)
 
@@ -42468,13 +42474,13 @@ def $eBPF_setup_main_callee(EC, ARCH)
 
                           1. Return typedExpressionIR_main
 
-                  1. Else Dangling#13455
+                  1. Else Dangling#13458
 
-            1. Else Dangling#13452
+            1. Else Dangling#13455
 
-        1. Else Dangling#13450
+        1. Else Dangling#13453
 
-  1. Else Dangling#13447
+  1. Else Dangling#13450
 
 def $eBPF_setup_parse_callee(EC, ARCH, typedExpressionIR_main)
 
@@ -42506,13 +42512,13 @@ def $eBPF_setup_parse_callee(EC, ARCH, typedExpressionIR_main)
 
                           1. Return typedExpressionIR_parse
 
-                  1. Else Dangling#13469
+                  1. Else Dangling#13472
 
-            1. Else Dangling#13466
+            1. Else Dangling#13469
 
-        1. Else Dangling#13464
+        1. Else Dangling#13467
 
-  1. Else Dangling#13461
+  1. Else Dangling#13464
 
 def $eBPF_setup_filter_callee(EC, ARCH, typedExpressionIR_main)
 
@@ -42544,13 +42550,13 @@ def $eBPF_setup_filter_callee(EC, ARCH, typedExpressionIR_main)
 
                           1. Return typedExpressionIR_filter
 
-                  1. Else Dangling#13483
+                  1. Else Dangling#13486
 
-            1. Else Dangling#13480
+            1. Else Dangling#13483
 
-        1. Else Dangling#13478
+        1. Else Dangling#13481
 
-  1. Else Dangling#13475
+  1. Else Dangling#13478
 
 relation EBPF_parse: EC_0 ARCH_0 |- % % %
 
@@ -42582,7 +42588,7 @@ relation EBPF_parse: EC_0 ARCH_0 |- % % %
 
                     1. Result in: % % |- EC_1 ARCH_1 (rejectTransitionResult as transitionResult)
 
-              1. Else Dangling#13495
+              1. Else Dangling#13498
 
 relation EBPF_filter: EC_0 ARCH_0 |- % % %
 
@@ -42614,7 +42620,7 @@ relation EBPF_filter: EC_0 ARCH_0 |- % % %
 
                     1. Result in: % % |- EC_1 ARCH_1 ((EXIT) as callResult)
 
-              1. Else Dangling#13507
+              1. Else Dangling#13510
 
 relation PSA_init: |- p4program : % %
 
@@ -42646,11 +42652,11 @@ def $PSA_setup_normal_meta_argument(ARCH)
 
                   1. Return argumentIR_normal_meta
 
-            1. Else Dangling#13521
+            1. Else Dangling#13524
 
-      1. Else Dangling#13518
+      1. Else Dangling#13521
 
-  1. Else Dangling#13516
+  1. Else Dangling#13519
 
 def $PSA_setup_clone_i2e_meta_argument(ARCH)
 
@@ -42674,11 +42680,11 @@ def $PSA_setup_clone_i2e_meta_argument(ARCH)
 
                   1. Return argumentIR_clone_i2e_meta
 
-            1. Else Dangling#13531
+            1. Else Dangling#13534
 
-      1. Else Dangling#13528
+      1. Else Dangling#13531
 
-  1. Else Dangling#13526
+  1. Else Dangling#13529
 
 def $PSA_setup_clone_e2e_meta_argument(ARCH)
 
@@ -42702,11 +42708,11 @@ def $PSA_setup_clone_e2e_meta_argument(ARCH)
 
                   1. Return argumentIR_clone_e2e_meta
 
-            1. Else Dangling#13541
+            1. Else Dangling#13544
 
-      1. Else Dangling#13538
+      1. Else Dangling#13541
 
-  1. Else Dangling#13536
+  1. Else Dangling#13539
 
 def $PSA_setup_resubmit_meta_argument(ARCH)
 
@@ -42730,11 +42736,11 @@ def $PSA_setup_resubmit_meta_argument(ARCH)
 
                   1. Return argumentIR_resubmit_meta
 
-            1. Else Dangling#13551
+            1. Else Dangling#13554
 
-      1. Else Dangling#13548
+      1. Else Dangling#13551
 
-  1. Else Dangling#13546
+  1. Else Dangling#13549
 
 def $PSA_setup_recirculate_meta_argument(ARCH)
 
@@ -42758,11 +42764,11 @@ def $PSA_setup_recirculate_meta_argument(ARCH)
 
                   1. Return argumentIR_recirculate_meta
 
-            1. Else Dangling#13561
+            1. Else Dangling#13564
 
-      1. Else Dangling#13558
+      1. Else Dangling#13561
 
-  1. Else Dangling#13556
+  1. Else Dangling#13559
 
 def $PSA_setup_main_callee(EC, ARCH)
 
@@ -42844,29 +42850,29 @@ def $PSA_setup_main_callee(EC, ARCH)
 
                                                                             1. Return typedExpressionIR_main
 
-                                                                  1. Else Dangling#13598
+                                                                  1. Else Dangling#13601
 
-                                                            1. Else Dangling#13595
+                                                            1. Else Dangling#13598
 
-                                                      1. Else Dangling#13592
+                                                      1. Else Dangling#13595
 
-                                                1. Else Dangling#13589
+                                                1. Else Dangling#13592
 
-                                          1. Else Dangling#13586
+                                          1. Else Dangling#13589
 
-                                    1. Else Dangling#13583
+                                    1. Else Dangling#13586
 
-                              1. Else Dangling#13580
+                              1. Else Dangling#13583
 
-                        1. Else Dangling#13577
+                        1. Else Dangling#13580
 
-                  1. Else Dangling#13574
+                  1. Else Dangling#13577
 
-            1. Else Dangling#13571
+            1. Else Dangling#13574
 
-        1. Else Dangling#13569
+        1. Else Dangling#13572
 
-  1. Else Dangling#13566
+  1. Else Dangling#13569
 
 relation PSA_ingress_init_packet_in: EC_0 ARCH_0 |- objectState_packet_in : % %
 
@@ -42892,9 +42898,9 @@ relation PSA_ingress_init_packet_in: EC_0 ARCH_0 |- objectState_packet_in : % %
 
                     1. Result in: % % |- % : EC_1 ARCH_2
 
-          1. Else Dangling#13609
+          1. Else Dangling#13612
 
-      1. Else Dangling#13607
+      1. Else Dangling#13610
 
 relation PSA_ingress_init_packet_out: EC_0 ARCH_0 |- objectState_packet_out : % %
 
@@ -42920,9 +42926,9 @@ relation PSA_ingress_init_packet_out: EC_0 ARCH_0 |- objectState_packet_out : % 
 
                     1. Result in: % % |- % : EC_1 ARCH_2
 
-          1. Else Dangling#13620
+          1. Else Dangling#13623
 
-      1. Else Dangling#13618
+      1. Else Dangling#13621
 
 relation PSA_ingress_init_parser_input_metadata: EC_0 ARCH |- i_port t_path : %
 
@@ -43100,27 +43106,27 @@ relation PSA_ingress_init_globals: EC_0 ARCH |- i_port : %
 
                                                                                           1. Result in: % % |- % : EC_10
 
-                                                                              1. Else Dangling#13702
+                                                                              1. Else Dangling#13705
 
-                                                                        1. Else Dangling#13699
+                                                                        1. Else Dangling#13702
 
-                                                                  1. Else Dangling#13696
+                                                                  1. Else Dangling#13699
 
-                                                            1. Else Dangling#13693
+                                                            1. Else Dangling#13696
 
-                                                1. Else Dangling#13687
+                                                1. Else Dangling#13690
 
-                                      1. Else Dangling#13682
+                                      1. Else Dangling#13685
 
-                            1. Else Dangling#13677
+                            1. Else Dangling#13680
 
-                  1. Else Dangling#13672
+                  1. Else Dangling#13675
 
-            1. Else Dangling#13669
+            1. Else Dangling#13672
 
-      1. Else Dangling#13666
+      1. Else Dangling#13669
 
-  1. Else Dangling#13664
+  1. Else Dangling#13667
 
 def $PSA_setup_ingress_packet_in_argument(EC)
 
@@ -43136,7 +43142,7 @@ def $PSA_setup_ingress_packet_in_argument(EC)
 
           1. Return argumentIR_packet_in
 
-  1. Else Dangling#13710
+  1. Else Dangling#13713
 
 def $PSA_setup_ingress_packet_out_argument(EC)
 
@@ -43152,7 +43158,7 @@ def $PSA_setup_ingress_packet_out_argument(EC)
 
           1. Return argumentIR_packet_out
 
-  1. Else Dangling#13716
+  1. Else Dangling#13719
 
 def $PSA_setup_ingress_hdr_argument(ARCH)
 
@@ -43176,11 +43182,11 @@ def $PSA_setup_ingress_hdr_argument(ARCH)
 
                   1. Return argumentIR_hdr
 
-            1. Else Dangling#13727
+            1. Else Dangling#13730
 
-      1. Else Dangling#13724
+      1. Else Dangling#13727
 
-  1. Else Dangling#13722
+  1. Else Dangling#13725
 
 def $PSA_setup_ingress_user_meta_argument(ARCH)
 
@@ -43204,11 +43210,11 @@ def $PSA_setup_ingress_user_meta_argument(ARCH)
 
                   1. Return argumentIR_user_meta
 
-            1. Else Dangling#13737
+            1. Else Dangling#13740
 
-      1. Else Dangling#13734
+      1. Else Dangling#13737
 
-  1. Else Dangling#13732
+  1. Else Dangling#13735
 
 def $PSA_setup_ingress_parser_input_metadata_argument(EC)
 
@@ -43224,7 +43230,7 @@ def $PSA_setup_ingress_parser_input_metadata_argument(EC)
 
           1. Return argumentIR_parser_input_metadata
 
-  1. Else Dangling#13742
+  1. Else Dangling#13745
 
 def $PSA_setup_ingress_input_metadata_argument(EC)
 
@@ -43240,7 +43246,7 @@ def $PSA_setup_ingress_input_metadata_argument(EC)
 
           1. Return argumentIR_input_metadata
 
-  1. Else Dangling#13748
+  1. Else Dangling#13751
 
 def $PSA_setup_ingress_output_metadata_argument(EC)
 
@@ -43256,7 +43262,7 @@ def $PSA_setup_ingress_output_metadata_argument(EC)
 
           1. Return argumentIR_output_metadata
 
-  1. Else Dangling#13754
+  1. Else Dangling#13757
 
 def $PSA_setup_ingress_pipeline_callee(EC, ARCH, typedExpressionIR_main)
 
@@ -43320,23 +43326,23 @@ def $PSA_setup_ingress_pipeline_callee(EC, ARCH, typedExpressionIR_main)
 
                                                           1. Return typedExpressionIR_ingress_pipeline
 
-                                                1. Else Dangling#13783
+                                                1. Else Dangling#13786
 
-                                          1. Else Dangling#13780
+                                          1. Else Dangling#13783
 
-                                    1. Else Dangling#13777
+                                    1. Else Dangling#13780
 
-                              1. Else Dangling#13774
+                              1. Else Dangling#13777
 
-                        1. Else Dangling#13771
+                        1. Else Dangling#13774
 
-                  1. Else Dangling#13768
+                  1. Else Dangling#13771
 
-            1. Else Dangling#13765
+            1. Else Dangling#13768
 
-        1. Else Dangling#13763
+        1. Else Dangling#13766
 
-  1. Else Dangling#13760
+  1. Else Dangling#13763
 
 def $PSA_setup_ingress_parser_callee(EC, ARCH, typedExpressionIR_ingress_pipeline)
 
@@ -43388,19 +43394,19 @@ def $PSA_setup_ingress_parser_callee(EC, ARCH, typedExpressionIR_ingress_pipelin
 
                                               1. Return typedExpressionIR_ingress_parser
 
-                                    1. Else Dangling#13807
+                                    1. Else Dangling#13810
 
-                              1. Else Dangling#13804
+                              1. Else Dangling#13807
 
-                        1. Else Dangling#13801
+                        1. Else Dangling#13804
 
-                  1. Else Dangling#13798
+                  1. Else Dangling#13801
 
-            1. Else Dangling#13795
+            1. Else Dangling#13798
 
-        1. Else Dangling#13793
+        1. Else Dangling#13796
 
-  1. Else Dangling#13790
+  1. Else Dangling#13793
 
 def $PSA_setup_ingress_callee(EC, ARCH, typedExpressionIR_ingress_pipeline)
 
@@ -43440,15 +43446,15 @@ def $PSA_setup_ingress_callee(EC, ARCH, typedExpressionIR_ingress_pipeline)
 
                                   1. Return typedExpressionIR_ingress
 
-                        1. Else Dangling#13825
+                        1. Else Dangling#13828
 
-                  1. Else Dangling#13822
+                  1. Else Dangling#13825
 
-            1. Else Dangling#13819
+            1. Else Dangling#13822
 
-        1. Else Dangling#13817
+        1. Else Dangling#13820
 
-  1. Else Dangling#13814
+  1. Else Dangling#13817
 
 def $PSA_setup_ingress_deparser_callee(EC, ARCH, typedExpressionIR_ingress_pipeline)
 
@@ -43506,21 +43512,21 @@ def $PSA_setup_ingress_deparser_callee(EC, ARCH, typedExpressionIR_ingress_pipel
 
                                                     1. Return typedExpressionIR_ingress_deparser
 
-                                          1. Else Dangling#13852
+                                          1. Else Dangling#13855
 
-                                    1. Else Dangling#13849
+                                    1. Else Dangling#13852
 
-                              1. Else Dangling#13846
+                              1. Else Dangling#13849
 
-                        1. Else Dangling#13843
+                        1. Else Dangling#13846
 
-                  1. Else Dangling#13840
+                  1. Else Dangling#13843
 
-            1. Else Dangling#13837
+            1. Else Dangling#13840
 
-        1. Else Dangling#13835
+        1. Else Dangling#13838
 
-  1. Else Dangling#13832
+  1. Else Dangling#13835
 
 relation PSA_ingress_parser: EC_0 ARCH_0 |- % % %
 
@@ -43562,7 +43568,7 @@ relation PSA_ingress_parser: EC_0 ARCH_0 |- % % %
 
                               1. Result in: % % |- EC_1 ARCH_1 (rejectTransitionResult as transitionResult)
 
-                        1. Else Dangling#13870
+                        1. Else Dangling#13873
 
 relation PSA_ingress: EC_0 ARCH_0 |- % % %
 
@@ -43600,7 +43606,7 @@ relation PSA_ingress: EC_0 ARCH_0 |- % % %
 
                           1. Result in: % % |- EC_1 ARCH_1 ((RETURN ?()) as callResult)
 
-                    1. Else Dangling#13885
+                    1. Else Dangling#13888
 
 relation PSA_ingress_deparser: EC_0 ARCH_0 |- % % %
 
@@ -43644,7 +43650,7 @@ relation PSA_ingress_deparser: EC_0 ARCH_0 |- % % %
 
                                 1. Result in: % % |- EC_1 ARCH_1 ((EXIT) as callResult)
 
-                          1. Else Dangling#13903
+                          1. Else Dangling#13906
 
 relation PSA_egress_init_packet_in: EC_0 ARCH_0 |- objectState_packet_in : % %
 
@@ -43670,9 +43676,9 @@ relation PSA_egress_init_packet_in: EC_0 ARCH_0 |- objectState_packet_in : % %
 
                     1. Result in: % % |- % : EC_1 ARCH_2
 
-          1. Else Dangling#13913
+          1. Else Dangling#13916
 
-      1. Else Dangling#13911
+      1. Else Dangling#13914
 
 relation PSA_egress_init_packet_out: EC_0 ARCH_0 |- objectState_packet_out : % %
 
@@ -43698,9 +43704,9 @@ relation PSA_egress_init_packet_out: EC_0 ARCH_0 |- objectState_packet_out : % %
 
                     1. Result in: % % |- % : EC_1 ARCH_2
 
-          1. Else Dangling#13924
+          1. Else Dangling#13927
 
-      1. Else Dangling#13922
+      1. Else Dangling#13925
 
 relation PSA_egress_init_parser_input_metadata: EC_0 ARCH |- i_port t_path : %
 
@@ -43880,25 +43886,25 @@ relation PSA_egress_init_globals: EC_0 ARCH |- i_port : %
 
                                                                                       1. Result in: % % |- % : EC_8
 
-                                                                                1. Else Dangling#14009
+                                                                                1. Else Dangling#14012
 
-                                                                      1. Else Dangling#14004
+                                                                      1. Else Dangling#14007
 
-                                                          1. Else Dangling#13998
+                                                          1. Else Dangling#14001
 
-                                                1. Else Dangling#13993
+                                                1. Else Dangling#13996
 
-                                      1. Else Dangling#13988
+                                      1. Else Dangling#13991
 
-                            1. Else Dangling#13983
+                            1. Else Dangling#13986
 
-                  1. Else Dangling#13978
+                  1. Else Dangling#13981
 
-            1. Else Dangling#13975
+            1. Else Dangling#13978
 
-      1. Else Dangling#13972
+      1. Else Dangling#13975
 
-  1. Else Dangling#13970
+  1. Else Dangling#13973
 
 def $PSA_setup_egress_packet_in_argument(EC)
 
@@ -43914,7 +43920,7 @@ def $PSA_setup_egress_packet_in_argument(EC)
 
           1. Return argumentIR_packet_in
 
-  1. Else Dangling#14014
+  1. Else Dangling#14017
 
 def $PSA_setup_egress_packet_out_argument(EC)
 
@@ -43930,7 +43936,7 @@ def $PSA_setup_egress_packet_out_argument(EC)
 
           1. Return argumentIR_packet_out
 
-  1. Else Dangling#14020
+  1. Else Dangling#14023
 
 def $PSA_setup_egress_hdr_argument(ARCH)
 
@@ -43954,11 +43960,11 @@ def $PSA_setup_egress_hdr_argument(ARCH)
 
                   1. Return argumentIR_hdr
 
-            1. Else Dangling#14031
+            1. Else Dangling#14034
 
-      1. Else Dangling#14028
+      1. Else Dangling#14031
 
-  1. Else Dangling#14026
+  1. Else Dangling#14029
 
 def $PSA_setup_egress_user_meta_argument(ARCH)
 
@@ -43982,11 +43988,11 @@ def $PSA_setup_egress_user_meta_argument(ARCH)
 
                   1. Return argumentIR_user_meta
 
-            1. Else Dangling#14041
+            1. Else Dangling#14044
 
-      1. Else Dangling#14038
+      1. Else Dangling#14041
 
-  1. Else Dangling#14036
+  1. Else Dangling#14039
 
 def $PSA_setup_egress_parser_input_metadata_argument(EC)
 
@@ -44002,7 +44008,7 @@ def $PSA_setup_egress_parser_input_metadata_argument(EC)
 
           1. Return argumentIR_parser_input_metadata
 
-  1. Else Dangling#14046
+  1. Else Dangling#14049
 
 def $PSA_setup_egress_input_metadata_argument(EC)
 
@@ -44018,7 +44024,7 @@ def $PSA_setup_egress_input_metadata_argument(EC)
 
           1. Return argumentIR_input_metadata
 
-  1. Else Dangling#14052
+  1. Else Dangling#14055
 
 def $PSA_setup_egress_output_metadata_argument(EC)
 
@@ -44034,7 +44040,7 @@ def $PSA_setup_egress_output_metadata_argument(EC)
 
           1. Return argumentIR_output_metadata
 
-  1. Else Dangling#14058
+  1. Else Dangling#14061
 
 def $PSA_setup_egress_deparser_input_metadata_argument(EC)
 
@@ -44050,7 +44056,7 @@ def $PSA_setup_egress_deparser_input_metadata_argument(EC)
 
           1. Return argumentIR_deparser_input_metadata
 
-  1. Else Dangling#14064
+  1. Else Dangling#14067
 
 def $PSA_setup_egress_pipeline_callee(EC, ARCH, typedExpressionIR_main)
 
@@ -44114,23 +44120,23 @@ def $PSA_setup_egress_pipeline_callee(EC, ARCH, typedExpressionIR_main)
 
                                                           1. Return typedExpressionIR_egress_pipeline
 
-                                                1. Else Dangling#14093
+                                                1. Else Dangling#14096
 
-                                          1. Else Dangling#14090
+                                          1. Else Dangling#14093
 
-                                    1. Else Dangling#14087
+                                    1. Else Dangling#14090
 
-                              1. Else Dangling#14084
+                              1. Else Dangling#14087
 
-                        1. Else Dangling#14081
+                        1. Else Dangling#14084
 
-                  1. Else Dangling#14078
+                  1. Else Dangling#14081
 
-            1. Else Dangling#14075
+            1. Else Dangling#14078
 
-        1. Else Dangling#14073
+        1. Else Dangling#14076
 
-  1. Else Dangling#14070
+  1. Else Dangling#14073
 
 def $PSA_setup_egress_parser_callee(EC, ARCH, typedExpressionIR_egress_pipeline)
 
@@ -44188,21 +44194,21 @@ def $PSA_setup_egress_parser_callee(EC, ARCH, typedExpressionIR_egress_pipeline)
 
                                                     1. Return typedExpressionIR_egress_parser
 
-                                          1. Else Dangling#14120
+                                          1. Else Dangling#14123
 
-                                    1. Else Dangling#14117
+                                    1. Else Dangling#14120
 
-                              1. Else Dangling#14114
+                              1. Else Dangling#14117
 
-                        1. Else Dangling#14111
+                        1. Else Dangling#14114
 
-                  1. Else Dangling#14108
+                  1. Else Dangling#14111
 
-            1. Else Dangling#14105
+            1. Else Dangling#14108
 
-        1. Else Dangling#14103
+        1. Else Dangling#14106
 
-  1. Else Dangling#14100
+  1. Else Dangling#14103
 
 def $PSA_setup_egress_callee(EC, ARCH, typedExpressionIR_egress_pipeline)
 
@@ -44242,15 +44248,15 @@ def $PSA_setup_egress_callee(EC, ARCH, typedExpressionIR_egress_pipeline)
 
                                   1. Return typedExpressionIR_egress
 
-                        1. Else Dangling#14138
+                        1. Else Dangling#14141
 
-                  1. Else Dangling#14135
+                  1. Else Dangling#14138
 
-            1. Else Dangling#14132
+            1. Else Dangling#14135
 
-        1. Else Dangling#14130
+        1. Else Dangling#14133
 
-  1. Else Dangling#14127
+  1. Else Dangling#14130
 
 def $PSA_setup_egress_deparser_callee(EC, ARCH, typedExpressionIR_egress_pipeline)
 
@@ -44302,19 +44308,19 @@ def $PSA_setup_egress_deparser_callee(EC, ARCH, typedExpressionIR_egress_pipelin
 
                                               1. Return typedExpressionIR_egress_deparser
 
-                                    1. Else Dangling#14162
+                                    1. Else Dangling#14165
 
-                              1. Else Dangling#14159
+                              1. Else Dangling#14162
 
-                        1. Else Dangling#14156
+                        1. Else Dangling#14159
 
-                  1. Else Dangling#14153
+                  1. Else Dangling#14156
 
-            1. Else Dangling#14150
+            1. Else Dangling#14153
 
-        1. Else Dangling#14148
+        1. Else Dangling#14151
 
-  1. Else Dangling#14145
+  1. Else Dangling#14148
 
 relation PSA_egress_parser: EC_0 ARCH_0 |- % % %
 
@@ -44358,7 +44364,7 @@ relation PSA_egress_parser: EC_0 ARCH_0 |- % % %
 
                                 1. Result in: % % |- EC_1 ARCH_1 (rejectTransitionResult as transitionResult)
 
-                          1. Else Dangling#14181
+                          1. Else Dangling#14184
 
 relation PSA_egress: EC_0 ARCH_0 |- % % %
 
@@ -44396,7 +44402,7 @@ relation PSA_egress: EC_0 ARCH_0 |- % % %
 
                           1. Result in: % % |- EC_1 ARCH_1 ((RETURN ?()) as callResult)
 
-                    1. Else Dangling#14196
+                    1. Else Dangling#14199
 
 relation PSA_egress_deparser: EC_0 ARCH_0 |- % % %
 
@@ -44440,4 +44446,4 @@ relation PSA_egress_deparser: EC_0 ARCH_0 |- % % %
 
                                 1. Result in: % % |- EC_1 ARCH_1 ((EXIT) as callResult)
 
-                          1. Else Dangling#14214
+                          1. Else Dangling#14217

--- a/p4spec/test/parse/parser_neg.expected
+++ b/p4spec/test/parse/parser_neg.expected
@@ -1,4 +1,4 @@
-Running parser tests on 564 files
+Running parser tests on 577 files
 
 
 >>> Running parser test on ../../../p4c/testdata/p4_16_errors/accept_e.p4
@@ -18,7 +18,7 @@ Parser roundtrip success: ../../../p4c/testdata/p4_16_errors/action-bind3.p4
 
 >>> Running parser test on ../../../p4c/testdata/p4_16_errors/action-named-default-bmv2.p4
 Error parsing file: ../../../p4c/testdata/p4_16_errors/action-named-default-bmv2.p4
-../../../p4c/testdata/p4_16_errors/action-named-default-bmv2.p4:56.12-56.19: syntax error
+../../../p4c/testdata/p4_16_errors/action-named-default-bmv2.p4:47.12-47.19: syntax error
 
 >>> Running parser test on ../../../p4c/testdata/p4_16_errors/actions-with-duplicate-control-plane-names1.p4
 Parser roundtrip success: ../../../p4c/testdata/p4_16_errors/actions-with-duplicate-control-plane-names1.p4
@@ -111,7 +111,7 @@ Parser roundtrip success: ../../../p4c/testdata/p4_16_errors/constructor_e.p4
 
 >>> Running parser test on ../../../p4c/testdata/p4_16_errors/control-inline.p4
 Error parsing file: ../../../p4c/testdata/p4_16_errors/control-inline.p4
-../../../p4c/testdata/p4_16_errors/control-inline.p4:34.11-34.12: syntax error
+../../../p4c/testdata/p4_16_errors/control-inline.p4:25.11-25.12: syntax error
 
 >>> Running parser test on ../../../p4c/testdata/p4_16_errors/control-verify.p4
 Parser roundtrip success: ../../../p4c/testdata/p4_16_errors/control-verify.p4
@@ -807,7 +807,7 @@ Parser roundtrip success: ../../../p4c/testdata/p4_16_errors/issue1059.p4
 
 >>> Running parser test on ../../../p4c/testdata/p4_16_errors/issue1202.p4
 Error parsing file: ../../../p4c/testdata/p4_16_errors/issue1202.p4
-../../../p4c/testdata/p4_16_errors/issue1202.p4:1.19-1.22: syntax error
+../../../p4c/testdata/p4_16_errors/issue1202.p4:7.19-7.22: syntax error
 
 >>> Running parser test on ../../../p4c/testdata/p4_16_errors/issue122.p4
 Parser roundtrip success: ../../../p4c/testdata/p4_16_errors/issue122.p4
@@ -990,13 +990,10 @@ Parser roundtrip success: ../../../p4c/testdata/p4_16_errors/issue3197-e.p4
 
 >>> Running parser test on ../../../p4c/testdata/p4_16_errors/issue3210.p4
 Error parsing file: ../../../p4c/testdata/p4_16_errors/issue3210.p4
-../../../p4c/testdata/p4_16_errors/issue3210.p4:9.6-9.7: syntax error
+../../../p4c/testdata/p4_16_errors/issue3210.p4:15.6-15.7: syntax error
 
 >>> Running parser test on ../../../p4c/testdata/p4_16_errors/issue3221.p4
 Parser roundtrip success: ../../../p4c/testdata/p4_16_errors/issue3221.p4
-
->>> Running parser test on ../../../p4c/testdata/p4_16_errors/issue3233.p4
-Parser roundtrip success: ../../../p4c/testdata/p4_16_errors/issue3233.p4
 
 >>> Running parser test on ../../../p4c/testdata/p4_16_errors/issue3246.p4
 Parser roundtrip success: ../../../p4c/testdata/p4_16_errors/issue3246.p4
@@ -1006,11 +1003,11 @@ Parser roundtrip success: ../../../p4c/testdata/p4_16_errors/issue3264.p4
 
 >>> Running parser test on ../../../p4c/testdata/p4_16_errors/issue3271-1.p4
 Error parsing file: ../../../p4c/testdata/p4_16_errors/issue3271-1.p4
-../../../p4c/testdata/p4_16_errors/issue3271-1.p4:23.8-23.9: syntax error
+../../../p4c/testdata/p4_16_errors/issue3271-1.p4:29.8-29.9: syntax error
 
 >>> Running parser test on ../../../p4c/testdata/p4_16_errors/issue3271.p4
 Error parsing file: ../../../p4c/testdata/p4_16_errors/issue3271.p4
-../../../p4c/testdata/p4_16_errors/issue3271.p4:3.8-3.9: syntax error
+../../../p4c/testdata/p4_16_errors/issue3271.p4:9.8-9.9: syntax error
 
 >>> Running parser test on ../../../p4c/testdata/p4_16_errors/issue3273.p4
 Parser roundtrip success: ../../../p4c/testdata/p4_16_errors/issue3273.p4
@@ -1020,7 +1017,7 @@ Parser roundtrip success: ../../../p4c/testdata/p4_16_errors/issue3282.p4
 
 >>> Running parser test on ../../../p4c/testdata/p4_16_errors/issue3285.p4
 Error parsing file: ../../../p4c/testdata/p4_16_errors/issue3285.p4
-../../../p4c/testdata/p4_16_errors/issue3285.p4:1.15-1.18: lexer error: signed integers must have width at least 2
+../../../p4c/testdata/p4_16_errors/issue3285.p4:7.15-7.18: lexer error: signed integers must have width at least 2
 
 >>> Running parser test on ../../../p4c/testdata/p4_16_errors/issue3291.p4
 Parser roundtrip success: ../../../p4c/testdata/p4_16_errors/issue3291.p4
@@ -1193,11 +1190,48 @@ Parser roundtrip success: ../../../p4c/testdata/p4_16_errors/issue477.p4
 >>> Running parser test on ../../../p4c/testdata/p4_16_errors/issue478.p4
 Parser roundtrip success: ../../../p4c/testdata/p4_16_errors/issue478.p4
 
+>>> Running parser test on ../../../p4c/testdata/p4_16_errors/issue5085.p4
+Parser roundtrip success: ../../../p4c/testdata/p4_16_errors/issue5085.p4
+
+>>> Running parser test on ../../../p4c/testdata/p4_16_errors/issue5094-meta-bmv2.p4
+Parser roundtrip success: ../../../p4c/testdata/p4_16_errors/issue5094-meta-bmv2.p4
+
+>>> Running parser test on ../../../p4c/testdata/p4_16_errors/issue5094-string-bmv2.p4
+Parser roundtrip success: ../../../p4c/testdata/p4_16_errors/issue5094-string-bmv2.p4
+
+>>> Running parser test on ../../../p4c/testdata/p4_16_errors/issue5094-type-bmv2.p4
+Parser roundtrip success: ../../../p4c/testdata/p4_16_errors/issue5094-type-bmv2.p4
+
 >>> Running parser test on ../../../p4c/testdata/p4_16_errors/issue5254_dup_switch_case_label_error.p4
 Parser roundtrip success: ../../../p4c/testdata/p4_16_errors/issue5254_dup_switch_case_label_error.p4
 
+>>> Running parser test on ../../../p4c/testdata/p4_16_errors/issue5268.p4
+Parser roundtrip success: ../../../p4c/testdata/p4_16_errors/issue5268.p4
+
+>>> Running parser test on ../../../p4c/testdata/p4_16_errors/issue5296_invalid_version.p4
+Parser roundtrip success: ../../../p4c/testdata/p4_16_errors/issue5296_invalid_version.p4
+
+>>> Running parser test on ../../../p4c/testdata/p4_16_errors/issue5296_unknown_version.p4
+Parser roundtrip success: ../../../p4c/testdata/p4_16_errors/issue5296_unknown_version.p4
+
 >>> Running parser test on ../../../p4c/testdata/p4_16_errors/issue532.p4
 Parser roundtrip success: ../../../p4c/testdata/p4_16_errors/issue532.p4
+
+>>> Running parser test on ../../../p4c/testdata/p4_16_errors/issue5437_action.p4
+Parser roundtrip success: ../../../p4c/testdata/p4_16_errors/issue5437_action.p4
+
+>>> Running parser test on ../../../p4c/testdata/p4_16_errors/issue5437_instantiation.p4
+Parser roundtrip success: ../../../p4c/testdata/p4_16_errors/issue5437_instantiation.p4
+
+>>> Running parser test on ../../../p4c/testdata/p4_16_errors/issue5437_table.p4
+Error parsing file: ../../../p4c/testdata/p4_16_errors/issue5437_table.p4
+../../../p4c/testdata/p4_16_errors/issue5437_table.p4:10.19-10.20: syntax error
+
+>>> Running parser test on ../../../p4c/testdata/p4_16_errors/issue5441.p4
+Parser roundtrip success: ../../../p4c/testdata/p4_16_errors/issue5441.p4
+
+>>> Running parser test on ../../../p4c/testdata/p4_16_errors/issue5443.p4
+Parser roundtrip success: ../../../p4c/testdata/p4_16_errors/issue5443.p4
 
 >>> Running parser test on ../../../p4c/testdata/p4_16_errors/issue561-1.p4
 Parser roundtrip success: ../../../p4c/testdata/p4_16_errors/issue561-1.p4
@@ -1255,7 +1289,10 @@ Parser roundtrip success: ../../../p4c/testdata/p4_16_errors/loop2-err.p4
 
 >>> Running parser test on ../../../p4c/testdata/p4_16_errors/loop3-err.p4
 Error parsing file: ../../../p4c/testdata/p4_16_errors/loop3-err.p4
-../../../p4c/testdata/p4_16_errors/loop3-err.p4:51.16-51.18: syntax error
+../../../p4c/testdata/p4_16_errors/loop3-err.p4:42.16-42.18: syntax error
+
+>>> Running parser test on ../../../p4c/testdata/p4_16_errors/loop4-err.p4
+Parser roundtrip success: ../../../p4c/testdata/p4_16_errors/loop4-err.p4
 
 >>> Running parser test on ../../../p4c/testdata/p4_16_errors/lvalue-assign-to-unsupported-type.p4
 Parser roundtrip success: ../../../p4c/testdata/p4_16_errors/lvalue-assign-to-unsupported-type.p4
@@ -1490,11 +1527,11 @@ Parser roundtrip success: ../../../p4c/testdata/p4_16_errors/structure-valued-ex
 
 >>> Running parser test on ../../../p4c/testdata/p4_16_errors/structure-valued-expr-errs-2.p4
 Error parsing file: ../../../p4c/testdata/p4_16_errors/structure-valued-expr-errs-2.p4
-../../../p4c/testdata/p4_16_errors/structure-valued-expr-errs-2.p4:106.28-106.29: syntax error
+../../../p4c/testdata/p4_16_errors/structure-valued-expr-errs-2.p4:97.28-97.29: syntax error
 
 >>> Running parser test on ../../../p4c/testdata/p4_16_errors/structured-annotation-e.p4
 Error parsing file: ../../../p4c/testdata/p4_16_errors/structured-annotation-e.p4
-../../../p4c/testdata/p4_16_errors/structured-annotation-e.p4:1.23-1.24: syntax error
+../../../p4c/testdata/p4_16_errors/structured-annotation-e.p4:7.23-7.24: syntax error
 
 >>> Running parser test on ../../../p4c/testdata/p4_16_errors/structured-annotation-e1.p4
 Parser roundtrip success: ../../../p4c/testdata/p4_16_errors/structured-annotation-e1.p4
@@ -1543,7 +1580,7 @@ Parser roundtrip success: ../../../p4c/testdata/p4_16_errors/table-entries-optio
 
 >>> Running parser test on ../../../p4c/testdata/p4_16_errors/table-entries-outside-table.p4
 Error parsing file: ../../../p4c/testdata/p4_16_errors/table-entries-outside-table.p4
-../../../p4c/testdata/p4_16_errors/table-entries-outside-table.p4:68.11-68.18: syntax error
+../../../p4c/testdata/p4_16_errors/table-entries-outside-table.p4:59.11-59.18: syntax error
 
 >>> Running parser test on ../../../p4c/testdata/p4_16_errors/table-entries-range.p4
 Parser roundtrip success: ../../../p4c/testdata/p4_16_errors/table-entries-range.p4
@@ -1601,7 +1638,7 @@ Parser roundtrip success: ../../../p4c/testdata/p4_16_errors/template_e.p4
 
 >>> Running parser test on ../../../p4c/testdata/p4_16_errors/tuple-left.p4
 Error parsing file: ../../../p4c/testdata/p4_16_errors/tuple-left.p4
-../../../p4c/testdata/p4_16_errors/tuple-left.p4:21.12-21.13: syntax error
+../../../p4c/testdata/p4_16_errors/tuple-left.p4:12.12-12.13: syntax error
 
 >>> Running parser test on ../../../p4c/testdata/p4_16_errors/tuple-newtype.p4
 Parser roundtrip success: ../../../p4c/testdata/p4_16_errors/tuple-newtype.p4
@@ -1699,6 +1736,9 @@ Error parsing file: ../../../p4c/testdata/p4_16_errors/underscore3_e.p4
 Error parsing file: ../../../p4c/testdata/p4_16_errors/underscore_e.p4
 ../../../p4c/testdata/p4_16_errors/underscore_e.p4:16.13-16.14: syntax error
 
+>>> Running parser test on ../../../p4c/testdata/p4_16_errors/unknown-struct1.p4
+Parser roundtrip success: ../../../p4c/testdata/p4_16_errors/unknown-struct1.p4
+
 >>> Running parser test on ../../../p4c/testdata/p4_16_errors/virtual1.p4
 Parser roundtrip success: ../../../p4c/testdata/p4_16_errors/virtual1.p4
 
@@ -1726,6 +1766,6 @@ Parser roundtrip success: ../../../p4c/testdata/p4_16_errors/width_e.p4
 >>> Running parser test on ../../../p4c/testdata/p4_16_errors/wrong-cast.p4
 Parser roundtrip success: ../../../p4c/testdata/p4_16_errors/wrong-cast.p4
 
-Running parser: [EXCLUDE] 0/564 (0.00%) [PASS] 531/564 (94.15%) [FAIL] 33/564 (5.85%) [PATCH] 0/564 (0.00%)
+Running parser: [EXCLUDE] 0/577 (0.00%) [PASS] 543/577 (94.11%) [FAIL] 34/577 (5.89%) [PATCH] 0/577 (0.00%)
 
 Running parser: [PATCH]: [EXCLUDE] 0/0 (0.00%) [PASS] 0/0 (0.00%) [FAIL] 0/0 (0.00%)

--- a/p4spec/test/parse/parser_neg.expected
+++ b/p4spec/test/parse/parser_neg.expected
@@ -1,4 +1,4 @@
-Running parser tests on 577 files
+Running parser tests on 584 files
 
 
 >>> Running parser test on ../../../p4c/testdata/p4_16_errors/accept_e.p4
@@ -97,11 +97,11 @@ Parser roundtrip success: ../../../p4c/testdata/p4_16_errors/constructor-with-du
 
 >>> Running parser test on ../../../p4c/testdata/p4_16_errors/constructor1_e.p4
 Error parsing file: ../../../p4c/testdata/p4_16_errors/constructor1_e.p4
-../../../p4c/testdata/p4_16_errors/constructor1_e.p4:18.9-18.10: syntax error
+../../../p4c/testdata/p4_16_errors/constructor1_e.p4:9.9-9.10: syntax error
 
 >>> Running parser test on ../../../p4c/testdata/p4_16_errors/constructor2_e.p4
 Error parsing file: ../../../p4c/testdata/p4_16_errors/constructor2_e.p4
-../../../p4c/testdata/p4_16_errors/constructor2_e.p4:18.6-18.7: syntax error
+../../../p4c/testdata/p4_16_errors/constructor2_e.p4:9.6-9.7: syntax error
 
 >>> Running parser test on ../../../p4c/testdata/p4_16_errors/constructor3_e.p4
 Parser roundtrip success: ../../../p4c/testdata/p4_16_errors/constructor3_e.p4
@@ -602,7 +602,7 @@ Parser roundtrip success: ../../../p4c/testdata/p4_16_errors/expr-unary-minus-on
 
 >>> Running parser test on ../../../p4c/testdata/p4_16_errors/expression_e.p4
 Error parsing file: ../../../p4c/testdata/p4_16_errors/expression_e.p4
-../../../p4c/testdata/p4_16_errors/expression_e.p4:21.20-21.21: syntax error
+../../../p4c/testdata/p4_16_errors/expression_e.p4:12.20-12.21: syntax error
 
 >>> Running parser test on ../../../p4c/testdata/p4_16_errors/extern-abstract-method-parameter-type-illformed.p4
 Parser roundtrip success: ../../../p4c/testdata/p4_16_errors/extern-abstract-method-parameter-type-illformed.p4
@@ -673,6 +673,15 @@ Parser roundtrip success: ../../../p4c/testdata/p4_16_errors/functors2_e.p4
 >>> Running parser test on ../../../p4c/testdata/p4_16_errors/functors3_e.p4
 Parser roundtrip success: ../../../p4c/testdata/p4_16_errors/functors3_e.p4
 
+>>> Running parser test on ../../../p4c/testdata/p4_16_errors/generic-extern-inference-abstract_e.p4
+Parser roundtrip success: ../../../p4c/testdata/p4_16_errors/generic-extern-inference-abstract_e.p4
+
+>>> Running parser test on ../../../p4c/testdata/p4_16_errors/generic-extern-inference-typedef_e.p4
+Parser roundtrip success: ../../../p4c/testdata/p4_16_errors/generic-extern-inference-typedef_e.p4
+
+>>> Running parser test on ../../../p4c/testdata/p4_16_errors/generic-extern-inference_e.p4
+Parser roundtrip success: ../../../p4c/testdata/p4_16_errors/generic-extern-inference_e.p4
+
 >>> Running parser test on ../../../p4c/testdata/p4_16_errors/generic-struct-self-nested.p4
 Parser roundtrip success: ../../../p4c/testdata/p4_16_errors/generic-struct-self-nested.p4
 
@@ -681,11 +690,11 @@ Parser roundtrip success: ../../../p4c/testdata/p4_16_errors/generic1_e.p4
 
 >>> Running parser test on ../../../p4c/testdata/p4_16_errors/globalVar_e.p4
 Error parsing file: ../../../p4c/testdata/p4_16_errors/globalVar_e.p4
-../../../p4c/testdata/p4_16_errors/globalVar_e.p4:16.6-16.7: syntax error
+../../../p4c/testdata/p4_16_errors/globalVar_e.p4:7.6-7.7: syntax error
 
 >>> Running parser test on ../../../p4c/testdata/p4_16_errors/header1_e.p4
 Error parsing file: ../../../p4c/testdata/p4_16_errors/header1_e.p4
-../../../p4c/testdata/p4_16_errors/header1_e.p4:18.5-18.6: syntax error
+../../../p4c/testdata/p4_16_errors/header1_e.p4:9.5-9.6: syntax error
 
 >>> Running parser test on ../../../p4c/testdata/p4_16_errors/header2_e.p4
 Parser roundtrip success: ../../../p4c/testdata/p4_16_errors/header2_e.p4
@@ -1019,6 +1028,9 @@ Parser roundtrip success: ../../../p4c/testdata/p4_16_errors/issue3282.p4
 Error parsing file: ../../../p4c/testdata/p4_16_errors/issue3285.p4
 ../../../p4c/testdata/p4_16_errors/issue3285.p4:7.15-7.18: lexer error: signed integers must have width at least 2
 
+>>> Running parser test on ../../../p4c/testdata/p4_16_errors/issue3291-1.p4
+Parser roundtrip success: ../../../p4c/testdata/p4_16_errors/issue3291-1.p4
+
 >>> Running parser test on ../../../p4c/testdata/p4_16_errors/issue3291.p4
 Parser roundtrip success: ../../../p4c/testdata/p4_16_errors/issue3291.p4
 
@@ -1202,6 +1214,9 @@ Parser roundtrip success: ../../../p4c/testdata/p4_16_errors/issue5094-string-bm
 >>> Running parser test on ../../../p4c/testdata/p4_16_errors/issue5094-type-bmv2.p4
 Parser roundtrip success: ../../../p4c/testdata/p4_16_errors/issue5094-type-bmv2.p4
 
+>>> Running parser test on ../../../p4c/testdata/p4_16_errors/issue5253.p4
+Parser roundtrip success: ../../../p4c/testdata/p4_16_errors/issue5253.p4
+
 >>> Running parser test on ../../../p4c/testdata/p4_16_errors/issue5254_dup_switch_case_label_error.p4
 Parser roundtrip success: ../../../p4c/testdata/p4_16_errors/issue5254_dup_switch_case_label_error.p4
 
@@ -1235,6 +1250,9 @@ Parser roundtrip success: ../../../p4c/testdata/p4_16_errors/issue5443.p4
 
 >>> Running parser test on ../../../p4c/testdata/p4_16_errors/issue561-1.p4
 Parser roundtrip success: ../../../p4c/testdata/p4_16_errors/issue561-1.p4
+
+>>> Running parser test on ../../../p4c/testdata/p4_16_errors/issue5703_header_union_stack.p4
+Parser roundtrip success: ../../../p4c/testdata/p4_16_errors/issue5703_header_union_stack.p4
 
 >>> Running parser test on ../../../p4c/testdata/p4_16_errors/issue584.p4
 Parser roundtrip success: ../../../p4c/testdata/p4_16_errors/issue584.p4
@@ -1389,7 +1407,7 @@ Parser roundtrip success: ../../../p4c/testdata/p4_16_errors/not_bound.p4
 
 >>> Running parser test on ../../../p4c/testdata/p4_16_errors/p_e.p4
 Error parsing file: ../../../p4c/testdata/p4_16_errors/p_e.p4
-../../../p4c/testdata/p4_16_errors/p_e.p4:18.1: syntax error
+../../../p4c/testdata/p4_16_errors/p_e.p4:9.1: syntax error
 
 >>> Running parser test on ../../../p4c/testdata/p4_16_errors/package.p4
 Parser roundtrip success: ../../../p4c/testdata/p4_16_errors/package.p4
@@ -1450,7 +1468,7 @@ Parser roundtrip success: ../../../p4c/testdata/p4_16_errors/shift-int-non-const
 
 >>> Running parser test on ../../../p4c/testdata/p4_16_errors/shift_e.p4
 Error parsing file: ../../../p4c/testdata/p4_16_errors/shift_e.p4
-../../../p4c/testdata/p4_16_errors/shift_e.p4:20.25-20.26: syntax error
+../../../p4c/testdata/p4_16_errors/shift_e.p4:11.25-11.26: syntax error
 
 >>> Running parser test on ../../../p4c/testdata/p4_16_errors/signed.p4
 Parser roundtrip success: ../../../p4c/testdata/p4_16_errors/signed.p4
@@ -1541,6 +1559,9 @@ Parser roundtrip success: ../../../p4c/testdata/p4_16_errors/structured-annotati
 
 >>> Running parser test on ../../../p4c/testdata/p4_16_errors/structured-annotation-e3.p4
 Parser roundtrip success: ../../../p4c/testdata/p4_16_errors/structured-annotation-e3.p4
+
+>>> Running parser test on ../../../p4c/testdata/p4_16_errors/switch_string.p4
+Parser roundtrip success: ../../../p4c/testdata/p4_16_errors/switch_string.p4
 
 >>> Running parser test on ../../../p4c/testdata/p4_16_errors/table-action-duplicate-actions.p4
 Parser roundtrip success: ../../../p4c/testdata/p4_16_errors/table-action-duplicate-actions.p4
@@ -1722,19 +1743,19 @@ Parser roundtrip success: ../../../p4c/testdata/p4_16_errors/typedef-and-type-de
 
 >>> Running parser test on ../../../p4c/testdata/p4_16_errors/underscore1_e.p4
 Error parsing file: ../../../p4c/testdata/p4_16_errors/underscore1_e.p4
-../../../p4c/testdata/p4_16_errors/underscore1_e.p4:17.9-17.10: syntax error
+../../../p4c/testdata/p4_16_errors/underscore1_e.p4:8.9-8.10: syntax error
 
 >>> Running parser test on ../../../p4c/testdata/p4_16_errors/underscore2_e.p4
 Error parsing file: ../../../p4c/testdata/p4_16_errors/underscore2_e.p4
-../../../p4c/testdata/p4_16_errors/underscore2_e.p4:19.13-19.14: syntax error
+../../../p4c/testdata/p4_16_errors/underscore2_e.p4:10.13-10.14: syntax error
 
 >>> Running parser test on ../../../p4c/testdata/p4_16_errors/underscore3_e.p4
 Error parsing file: ../../../p4c/testdata/p4_16_errors/underscore3_e.p4
-../../../p4c/testdata/p4_16_errors/underscore3_e.p4:16.11-16.12: syntax error
+../../../p4c/testdata/p4_16_errors/underscore3_e.p4:7.11-7.12: syntax error
 
 >>> Running parser test on ../../../p4c/testdata/p4_16_errors/underscore_e.p4
 Error parsing file: ../../../p4c/testdata/p4_16_errors/underscore_e.p4
-../../../p4c/testdata/p4_16_errors/underscore_e.p4:16.13-16.14: syntax error
+../../../p4c/testdata/p4_16_errors/underscore_e.p4:7.13-7.14: syntax error
 
 >>> Running parser test on ../../../p4c/testdata/p4_16_errors/unknown-struct1.p4
 Parser roundtrip success: ../../../p4c/testdata/p4_16_errors/unknown-struct1.p4
@@ -1766,6 +1787,6 @@ Parser roundtrip success: ../../../p4c/testdata/p4_16_errors/width_e.p4
 >>> Running parser test on ../../../p4c/testdata/p4_16_errors/wrong-cast.p4
 Parser roundtrip success: ../../../p4c/testdata/p4_16_errors/wrong-cast.p4
 
-Running parser: [EXCLUDE] 0/577 (0.00%) [PASS] 543/577 (94.11%) [FAIL] 34/577 (5.89%) [PATCH] 0/577 (0.00%)
+Running parser: [EXCLUDE] 0/584 (0.00%) [PASS] 550/584 (94.18%) [FAIL] 34/584 (5.82%) [PATCH] 0/584 (0.00%)
 
 Running parser: [PATCH]: [EXCLUDE] 0/0 (0.00%) [PASS] 0/0 (0.00%) [FAIL] 0/0 (0.00%)

--- a/p4spec/test/parse/parser_pos.expected
+++ b/p4spec/test/parse/parser_pos.expected
@@ -1,4 +1,4 @@
-Running parser tests on 1336 files
+Running parser tests on 1339 files
 
 
 >>> Running parser test on ../../../p4c/testdata/p4_16_samples/action-bind.p4
@@ -929,6 +929,10 @@ Parser roundtrip success: ../../../p4c/testdata/p4_16_samples/gauntlet_variable_
 
 >>> Running parser test on ../../../p4c/testdata/p4_16_samples/gauntlet_various_ops-bmv2.p4
 Parser roundtrip success: ../../../p4c/testdata/p4_16_samples/gauntlet_various_ops-bmv2.p4
+
+>>> Running parser test on ../../../p4c/testdata/p4_16_samples/generic-extern-inference.p4
+Error parsing file: ../../../p4c/testdata/p4_16_samples/generic-extern-inference.p4
+../../../p4c/testdata/p4_16_samples/generic-extern-inference.p4:35.43-35.44: syntax error
 
 >>> Running parser test on ../../../p4c/testdata/p4_16_samples/generic-struct-tuple.p4
 Parser roundtrip success: ../../../p4c/testdata/p4_16_samples/generic-struct-tuple.p4
@@ -1971,9 +1975,6 @@ Parser roundtrip success: ../../../p4c/testdata/p4_16_samples/issue3288.p4
 >>> Running parser test on ../../../p4c/testdata/p4_16_samples/issue3289.p4
 Parser roundtrip success: ../../../p4c/testdata/p4_16_samples/issue3289.p4
 
->>> Running parser test on ../../../p4c/testdata/p4_16_samples/issue3291-1.p4
-Parser roundtrip success: ../../../p4c/testdata/p4_16_samples/issue3291-1.p4
-
 >>> Running parser test on ../../../p4c/testdata/p4_16_samples/issue3292.p4
 Parser roundtrip success: ../../../p4c/testdata/p4_16_samples/issue3292.p4
 
@@ -2259,6 +2260,9 @@ Parser roundtrip success: ../../../p4c/testdata/p4_16_samples/issue5237-folding-
 >>> Running parser test on ../../../p4c/testdata/p4_16_samples/issue5237-folding-unused-minsizeinbits.p4
 Parser roundtrip success: ../../../p4c/testdata/p4_16_samples/issue5237-folding-unused-minsizeinbits.p4
 
+>>> Running parser test on ../../../p4c/testdata/p4_16_samples/issue5253_legal_overloads.p4
+Parser roundtrip success: ../../../p4c/testdata/p4_16_samples/issue5253_legal_overloads.p4
+
 >>> Running parser test on ../../../p4c/testdata/p4_16_samples/issue529.p4
 Parser roundtrip success: ../../../p4c/testdata/p4_16_samples/issue529.p4
 
@@ -2318,6 +2322,9 @@ Parser roundtrip success: ../../../p4c/testdata/p4_16_samples/issue562-bmv2.p4
 
 >>> Running parser test on ../../../p4c/testdata/p4_16_samples/issue5653.p4
 Parser roundtrip success: ../../../p4c/testdata/p4_16_samples/issue5653.p4
+
+>>> Running parser test on ../../../p4c/testdata/p4_16_samples/issue5706_header_union_stack.p4
+Parser roundtrip success: ../../../p4c/testdata/p4_16_samples/issue5706_header_union_stack.p4
 
 >>> Running parser test on ../../../p4c/testdata/p4_16_samples/issue584-1-bmv2.p4
 Parser roundtrip success: ../../../p4c/testdata/p4_16_samples/issue584-1-bmv2.p4
@@ -3814,6 +3821,9 @@ Parser roundtrip success: ../../../p4c/testdata/p4_16_samples/switch-expression.
 >>> Running parser test on ../../../p4c/testdata/p4_16_samples/switch_ebpf.p4
 Parser roundtrip success: ../../../p4c/testdata/p4_16_samples/switch_ebpf.p4
 
+>>> Running parser test on ../../../p4c/testdata/p4_16_samples/switch_p4_16.p4
+Parser roundtrip success: ../../../p4c/testdata/p4_16_samples/switch_p4_16.p4
+
 >>> Running parser test on ../../../p4c/testdata/p4_16_samples/synth-action.p4
 Parser roundtrip success: ../../../p4c/testdata/p4_16_samples/synth-action.p4
 
@@ -4057,6 +4067,6 @@ Parser roundtrip success: ../../../testdata/custom/for-loop-exit.p4
 >>> Running parser test on ../../../testdata/custom/for-update-exit.p4
 Parser roundtrip success: ../../../testdata/custom/for-update-exit.p4
 
-Running parser: [EXCLUDE] 0/1336 (0.00%) [PASS] 1324/1336 (99.10%) [FAIL] 12/1336 (0.90%) [PATCH] 0/1336 (0.00%)
+Running parser: [EXCLUDE] 0/1339 (0.00%) [PASS] 1326/1339 (99.03%) [FAIL] 13/1339 (0.97%) [PATCH] 0/1339 (0.00%)
 
 Running parser: [PATCH]: [EXCLUDE] 0/0 (0.00%) [PASS] 0/0 (0.00%) [FAIL] 0/0 (0.00%)

--- a/p4spec/test/parse/parser_pos.expected
+++ b/p4spec/test/parse/parser_pos.expected
@@ -1,4 +1,4 @@
-Running parser tests on 1312 files
+Running parser tests on 1336 files
 
 
 >>> Running parser test on ../../../p4c/testdata/p4_16_samples/action-bind.p4
@@ -129,7 +129,7 @@ Parser roundtrip success: ../../../p4c/testdata/p4_16_samples/array1.p4
 
 >>> Running parser test on ../../../p4c/testdata/p4_16_samples/array2.p4
 Error parsing file: ../../../p4c/testdata/p4_16_samples/array2.p4
-../../../p4c/testdata/p4_16_samples/array2.p4:9.15-9.16: syntax error
+../../../p4c/testdata/p4_16_samples/array2.p4:15.15-15.16: syntax error
 
 >>> Running parser test on ../../../p4c/testdata/p4_16_samples/array3.p4
 Parser roundtrip success: ../../../p4c/testdata/p4_16_samples/array3.p4
@@ -160,6 +160,10 @@ Parser roundtrip success: ../../../p4c/testdata/p4_16_samples/bit0-bmv2.p4
 
 >>> Running parser test on ../../../p4c/testdata/p4_16_samples/bitExtract.p4
 Parser roundtrip success: ../../../p4c/testdata/p4_16_samples/bitExtract.p4
+
+>>> Running parser test on ../../../p4c/testdata/p4_16_samples/bitexpr1.p4
+Error parsing file: ../../../p4c/testdata/p4_16_samples/bitexpr1.p4
+../../../p4c/testdata/p4_16_samples/bitexpr1.p4:7.13-7.14: syntax error
 
 >>> Running parser test on ../../../p4c/testdata/p4_16_samples/bitwise-and.p4
 Parser roundtrip success: ../../../p4c/testdata/p4_16_samples/bitwise-and.p4
@@ -202,6 +206,10 @@ Parser roundtrip success: ../../../p4c/testdata/p4_16_samples/cast.p4
 
 >>> Running parser test on ../../../p4c/testdata/p4_16_samples/cast_noop.p4
 Parser roundtrip success: ../../../p4c/testdata/p4_16_samples/cast_noop.p4
+
+>>> Running parser test on ../../../p4c/testdata/p4_16_samples/cfoldBitTypedefs.p4
+Error parsing file: ../../../p4c/testdata/p4_16_samples/cfoldBitTypedefs.p4
+../../../p4c/testdata/p4_16_samples/cfoldBitTypedefs.p4:5.13-5.15: syntax error
 
 >>> Running parser test on ../../../p4c/testdata/p4_16_samples/chain.p4
 Parser roundtrip success: ../../../p4c/testdata/p4_16_samples/chain.p4
@@ -410,6 +418,9 @@ Parser roundtrip success: ../../../p4c/testdata/p4_16_samples/ebpf_headers.p4
 >>> Running parser test on ../../../p4c/testdata/p4_16_samples/elimActRun1.p4
 Parser roundtrip success: ../../../p4c/testdata/p4_16_samples/elimActRun1.p4
 
+>>> Running parser test on ../../../p4c/testdata/p4_16_samples/elimActRun2.p4
+Parser roundtrip success: ../../../p4c/testdata/p4_16_samples/elimActRun2.p4
+
 >>> Running parser test on ../../../p4c/testdata/p4_16_samples/empty-bmv2.p4
 Parser roundtrip success: ../../../p4c/testdata/p4_16_samples/empty-bmv2.p4
 
@@ -487,7 +498,7 @@ Parser roundtrip success: ../../../p4c/testdata/p4_16_samples/extern3.p4
 
 >>> Running parser test on ../../../p4c/testdata/p4_16_samples/externArray1.p4
 Error parsing file: ../../../p4c/testdata/p4_16_samples/externArray1.p4
-../../../p4c/testdata/p4_16_samples/externArray1.p4:30.31-30.32: syntax error
+../../../p4c/testdata/p4_16_samples/externArray1.p4:36.31-36.32: syntax error
 
 >>> Running parser test on ../../../p4c/testdata/p4_16_samples/extract_for_header_union.p4
 Parser roundtrip success: ../../../p4c/testdata/p4_16_samples/extract_for_header_union.p4
@@ -513,6 +524,9 @@ Parser roundtrip success: ../../../p4c/testdata/p4_16_samples/flowlet_switching-
 >>> Running parser test on ../../../p4c/testdata/p4_16_samples/fold_match.p4
 Parser roundtrip success: ../../../p4c/testdata/p4_16_samples/fold_match.p4
 
+>>> Running parser test on ../../../p4c/testdata/p4_16_samples/forloop-bmv2.p4
+Parser roundtrip success: ../../../p4c/testdata/p4_16_samples/forloop-bmv2.p4
+
 >>> Running parser test on ../../../p4c/testdata/p4_16_samples/forloop1.p4
 Parser roundtrip success: ../../../p4c/testdata/p4_16_samples/forloop1.p4
 
@@ -521,6 +535,9 @@ Parser roundtrip success: ../../../p4c/testdata/p4_16_samples/forloop10.p4
 
 >>> Running parser test on ../../../p4c/testdata/p4_16_samples/forloop11.p4
 Parser roundtrip success: ../../../p4c/testdata/p4_16_samples/forloop11.p4
+
+>>> Running parser test on ../../../p4c/testdata/p4_16_samples/forloop12.p4
+Parser roundtrip success: ../../../p4c/testdata/p4_16_samples/forloop12.p4
 
 >>> Running parser test on ../../../p4c/testdata/p4_16_samples/forloop2.p4
 Parser roundtrip success: ../../../p4c/testdata/p4_16_samples/forloop2.p4
@@ -967,11 +984,17 @@ Parser roundtrip success: ../../../p4c/testdata/p4_16_samples/header-bmv2.p4
 >>> Running parser test on ../../../p4c/testdata/p4_16_samples/header-bool-bmv2.p4
 Parser roundtrip success: ../../../p4c/testdata/p4_16_samples/header-bool-bmv2.p4
 
+>>> Running parser test on ../../../p4c/testdata/p4_16_samples/header-stack-cast-init.p4
+Parser roundtrip success: ../../../p4c/testdata/p4_16_samples/header-stack-cast-init.p4
+
 >>> Running parser test on ../../../p4c/testdata/p4_16_samples/header-stack-ops-bmv2.p4
 Parser roundtrip success: ../../../p4c/testdata/p4_16_samples/header-stack-ops-bmv2.p4
 
 >>> Running parser test on ../../../p4c/testdata/p4_16_samples/header.p4
 Parser roundtrip success: ../../../p4c/testdata/p4_16_samples/header.p4
+
+>>> Running parser test on ../../../p4c/testdata/p4_16_samples/header_union_is_valid_in_parser.p4
+Parser roundtrip success: ../../../p4c/testdata/p4_16_samples/header_union_is_valid_in_parser.p4
 
 >>> Running parser test on ../../../p4c/testdata/p4_16_samples/highorder.p4
 Parser roundtrip success: ../../../p4c/testdata/p4_16_samples/highorder.p4
@@ -1008,6 +1031,12 @@ Parser roundtrip success: ../../../p4c/testdata/p4_16_samples/inline-control.p4
 
 >>> Running parser test on ../../../p4c/testdata/p4_16_samples/inline-control1.p4
 Parser roundtrip success: ../../../p4c/testdata/p4_16_samples/inline-control1.p4
+
+>>> Running parser test on ../../../p4c/testdata/p4_16_samples/inline-function-to-array-index-chained.p4
+Parser roundtrip success: ../../../p4c/testdata/p4_16_samples/inline-function-to-array-index-chained.p4
+
+>>> Running parser test on ../../../p4c/testdata/p4_16_samples/inline-function-to-array-index.p4
+Parser roundtrip success: ../../../p4c/testdata/p4_16_samples/inline-function-to-array-index.p4
 
 >>> Running parser test on ../../../p4c/testdata/p4_16_samples/inline-function.p4
 Parser roundtrip success: ../../../p4c/testdata/p4_16_samples/inline-function.p4
@@ -1077,6 +1106,9 @@ Parser roundtrip success: ../../../p4c/testdata/p4_16_samples/invalid-header.p4
 
 >>> Running parser test on ../../../p4c/testdata/p4_16_samples/invalid-union.p4
 Parser roundtrip success: ../../../p4c/testdata/p4_16_samples/invalid-union.p4
+
+>>> Running parser test on ../../../p4c/testdata/p4_16_samples/invalid_header_default_action_arg.p4
+Parser roundtrip success: ../../../p4c/testdata/p4_16_samples/invalid_header_default_action_arg.p4
 
 >>> Running parser test on ../../../p4c/testdata/p4_16_samples/inverted-range.p4
 Parser roundtrip success: ../../../p4c/testdata/p4_16_samples/inverted-range.p4
@@ -1909,6 +1941,9 @@ Parser roundtrip success: ../../../p4c/testdata/p4_16_samples/issue3225.p4
 >>> Running parser test on ../../../p4c/testdata/p4_16_samples/issue323.p4
 Parser roundtrip success: ../../../p4c/testdata/p4_16_samples/issue323.p4
 
+>>> Running parser test on ../../../p4c/testdata/p4_16_samples/issue3233.p4
+Parser roundtrip success: ../../../p4c/testdata/p4_16_samples/issue3233.p4
+
 >>> Running parser test on ../../../p4c/testdata/p4_16_samples/issue3238.p4
 Parser roundtrip success: ../../../p4c/testdata/p4_16_samples/issue3238.p4
 
@@ -2200,6 +2235,12 @@ Parser roundtrip success: ../../../p4c/testdata/p4_16_samples/issue496.p4
 >>> Running parser test on ../../../p4c/testdata/p4_16_samples/issue5035.p4
 Parser roundtrip success: ../../../p4c/testdata/p4_16_samples/issue5035.p4
 
+>>> Running parser test on ../../../p4c/testdata/p4_16_samples/issue5085.p4
+Parser roundtrip success: ../../../p4c/testdata/p4_16_samples/issue5085.p4
+
+>>> Running parser test on ../../../p4c/testdata/p4_16_samples/issue5094-typedef-bmv2.p4
+Parser roundtrip success: ../../../p4c/testdata/p4_16_samples/issue5094-typedef-bmv2.p4
+
 >>> Running parser test on ../../../p4c/testdata/p4_16_samples/issue510-bmv2.p4
 Parser roundtrip success: ../../../p4c/testdata/p4_16_samples/issue510-bmv2.p4
 
@@ -2239,6 +2280,12 @@ Parser roundtrip success: ../../../p4c/testdata/p4_16_samples/issue5335_default_
 >>> Running parser test on ../../../p4c/testdata/p4_16_samples/issue5335_default_initialized_non_header_stack_nested.p4
 Parser roundtrip success: ../../../p4c/testdata/p4_16_samples/issue5335_default_initialized_non_header_stack_nested.p4
 
+>>> Running parser test on ../../../p4c/testdata/p4_16_samples/issue5439.p4
+Parser roundtrip success: ../../../p4c/testdata/p4_16_samples/issue5439.p4
+
+>>> Running parser test on ../../../p4c/testdata/p4_16_samples/issue5499.p4
+Parser roundtrip success: ../../../p4c/testdata/p4_16_samples/issue5499.p4
+
 >>> Running parser test on ../../../p4c/testdata/p4_16_samples/issue561-1-bmv2.p4
 Parser roundtrip success: ../../../p4c/testdata/p4_16_samples/issue561-1-bmv2.p4
 
@@ -2268,6 +2315,9 @@ Parser roundtrip success: ../../../p4c/testdata/p4_16_samples/issue561.p4
 
 >>> Running parser test on ../../../p4c/testdata/p4_16_samples/issue562-bmv2.p4
 Parser roundtrip success: ../../../p4c/testdata/p4_16_samples/issue562-bmv2.p4
+
+>>> Running parser test on ../../../p4c/testdata/p4_16_samples/issue5653.p4
+Parser roundtrip success: ../../../p4c/testdata/p4_16_samples/issue5653.p4
 
 >>> Running parser test on ../../../p4c/testdata/p4_16_samples/issue584-1-bmv2.p4
 Parser roundtrip success: ../../../p4c/testdata/p4_16_samples/issue584-1-bmv2.p4
@@ -2586,6 +2636,12 @@ Parser roundtrip success: ../../../p4c/testdata/p4_16_samples/next-def-use.p4
 
 >>> Running parser test on ../../../p4c/testdata/p4_16_samples/noMatch.p4
 Parser roundtrip success: ../../../p4c/testdata/p4_16_samples/noMatch.p4
+
+>>> Running parser test on ../../../p4c/testdata/p4_16_samples/noWarn-unknown-diagnostic.p4
+Parser roundtrip success: ../../../p4c/testdata/p4_16_samples/noWarn-unknown-diagnostic.p4
+
+>>> Running parser test on ../../../p4c/testdata/p4_16_samples/non_header_array_access_in_parser.p4
+Parser roundtrip success: ../../../p4c/testdata/p4_16_samples/non_header_array_access_in_parser.p4
 
 >>> Running parser test on ../../../p4c/testdata/p4_16_samples/nonstandard_table_names-bmv2.p4
 Error parsing string: ../../../p4c/testdata/p4_16_samples/nonstandard_table_names-bmv2.p4
@@ -3550,6 +3606,12 @@ Parser roundtrip success: ../../../p4c/testdata/p4_16_samples/simple-actions_ubp
 >>> Running parser test on ../../../p4c/testdata/p4_16_samples/simple-firewall_ubpf.p4
 Parser roundtrip success: ../../../p4c/testdata/p4_16_samples/simple-firewall_ubpf.p4
 
+>>> Running parser test on ../../../p4c/testdata/p4_16_samples/simplify-select-cases1.p4
+Parser roundtrip success: ../../../p4c/testdata/p4_16_samples/simplify-select-cases1.p4
+
+>>> Running parser test on ../../../p4c/testdata/p4_16_samples/simplify-select-cases2.p4
+Parser roundtrip success: ../../../p4c/testdata/p4_16_samples/simplify-select-cases2.p4
+
 >>> Running parser test on ../../../p4c/testdata/p4_16_samples/simplify.p4
 Parser roundtrip success: ../../../p4c/testdata/p4_16_samples/simplify.p4
 
@@ -3559,11 +3621,20 @@ Parser roundtrip success: ../../../p4c/testdata/p4_16_samples/simplify_method_ca
 >>> Running parser test on ../../../p4c/testdata/p4_16_samples/simplify_slice.p4
 Parser roundtrip success: ../../../p4c/testdata/p4_16_samples/simplify_slice.p4
 
+>>> Running parser test on ../../../p4c/testdata/p4_16_samples/singleton_range_select.p4
+Parser roundtrip success: ../../../p4c/testdata/p4_16_samples/singleton_range_select.p4
+
 >>> Running parser test on ../../../p4c/testdata/p4_16_samples/slice-def-use.p4
 Parser roundtrip success: ../../../p4c/testdata/p4_16_samples/slice-def-use.p4
 
 >>> Running parser test on ../../../p4c/testdata/p4_16_samples/slice-def-use1.p4
 Parser roundtrip success: ../../../p4c/testdata/p4_16_samples/slice-def-use1.p4
+
+>>> Running parser test on ../../../p4c/testdata/p4_16_samples/slice-def-use2.p4
+Parser roundtrip success: ../../../p4c/testdata/p4_16_samples/slice-def-use2.p4
+
+>>> Running parser test on ../../../p4c/testdata/p4_16_samples/slice1.p4
+Parser roundtrip success: ../../../p4c/testdata/p4_16_samples/slice1.p4
 
 >>> Running parser test on ../../../p4c/testdata/p4_16_samples/spec-ex01.p4
 Parser roundtrip success: ../../../p4c/testdata/p4_16_samples/spec-ex01.p4
@@ -3696,6 +3767,9 @@ Parser roundtrip success: ../../../p4c/testdata/p4_16_samples/strength5.p4
 
 >>> Running parser test on ../../../p4c/testdata/p4_16_samples/strength6.p4
 Parser roundtrip success: ../../../p4c/testdata/p4_16_samples/strength6.p4
+
+>>> Running parser test on ../../../p4c/testdata/p4_16_samples/strength7.p4
+Parser roundtrip success: ../../../p4c/testdata/p4_16_samples/strength7.p4
 
 >>> Running parser test on ../../../p4c/testdata/p4_16_samples/string.p4
 Parser roundtrip success: ../../../p4c/testdata/p4_16_samples/string.p4
@@ -3983,6 +4057,6 @@ Parser roundtrip success: ../../../testdata/custom/for-loop-exit.p4
 >>> Running parser test on ../../../testdata/custom/for-update-exit.p4
 Parser roundtrip success: ../../../testdata/custom/for-update-exit.p4
 
-Running parser: [EXCLUDE] 0/1312 (0.00%) [PASS] 1302/1312 (99.24%) [FAIL] 10/1312 (0.76%) [PATCH] 0/1312 (0.00%)
+Running parser: [EXCLUDE] 0/1336 (0.00%) [PASS] 1324/1336 (99.10%) [FAIL] 12/1336 (0.90%) [PATCH] 0/1336 (0.00%)
 
 Running parser: [PATCH]: [EXCLUDE] 0/0 (0.00%) [PASS] 0/0 (0.00%) [FAIL] 0/0 (0.00%)

--- a/p4spec/test/run/run_neg_al.expected
+++ b/p4spec/test/run/run_neg_al.expected
@@ -1,4 +1,4 @@
-Running interpreter test (Program_ok) on 577 files
+Running interpreter test (Program_ok) on 584 files
 
 
 >>> Running interpreter test (Program_ok) on ../../../p4c/testdata/p4_16_errors/accept_e.p4
@@ -664,6 +664,15 @@ Error on run: ../../../p4c/testdata/p4_16_errors/functors2_e.p4
 >>> Running interpreter test (Program_ok) on ../../../p4c/testdata/p4_16_errors/functors3_e.p4
 Error on run: ../../../p4c/testdata/p4_16_errors/functors3_e.p4
 
+>>> Running interpreter test (Program_ok) on ../../../p4c/testdata/p4_16_errors/generic-extern-inference-abstract_e.p4
+Error on run: ../../../p4c/testdata/p4_16_errors/generic-extern-inference-abstract_e.p4
+
+>>> Running interpreter test (Program_ok) on ../../../p4c/testdata/p4_16_errors/generic-extern-inference-typedef_e.p4
+Error on run: ../../../p4c/testdata/p4_16_errors/generic-extern-inference-typedef_e.p4
+
+>>> Running interpreter test (Program_ok) on ../../../p4c/testdata/p4_16_errors/generic-extern-inference_e.p4
+Error on run: ../../../p4c/testdata/p4_16_errors/generic-extern-inference_e.p4
+
 >>> Running interpreter test (Program_ok) on ../../../p4c/testdata/p4_16_errors/generic-struct-self-nested.p4
 Error on run: ../../../p4c/testdata/p4_16_errors/generic-struct-self-nested.p4
 
@@ -1000,6 +1009,9 @@ Error on run: ../../../p4c/testdata/p4_16_errors/issue3282.p4
 >>> Running interpreter test (Program_ok) on ../../../p4c/testdata/p4_16_errors/issue3285.p4
 Error on run: ../../../p4c/testdata/p4_16_errors/issue3285.p4
 
+>>> Running interpreter test (Program_ok) on ../../../p4c/testdata/p4_16_errors/issue3291-1.p4
+Error on run: ../../../p4c/testdata/p4_16_errors/issue3291-1.p4
+
 >>> Running interpreter test (Program_ok) on ../../../p4c/testdata/p4_16_errors/issue3291.p4
 Excluding file: ../../../p4c/testdata/p4_16_errors/issue3291.p4
 
@@ -1183,6 +1195,9 @@ Error on run: ../../../p4c/testdata/p4_16_errors/issue5094-string-bmv2.p4
 >>> Running interpreter test (Program_ok) on ../../../p4c/testdata/p4_16_errors/issue5094-type-bmv2.p4
 Error on run: ../../../p4c/testdata/p4_16_errors/issue5094-type-bmv2.p4
 
+>>> Running interpreter test (Program_ok) on ../../../p4c/testdata/p4_16_errors/issue5253.p4
+Error on run: ../../../p4c/testdata/p4_16_errors/issue5253.p4
+
 >>> Running interpreter test (Program_ok) on ../../../p4c/testdata/p4_16_errors/issue5254_dup_switch_case_label_error.p4
 Error on run: ../../../p4c/testdata/p4_16_errors/issue5254_dup_switch_case_label_error.p4
 
@@ -1215,6 +1230,9 @@ Error on run: ../../../p4c/testdata/p4_16_errors/issue5443.p4
 
 >>> Running interpreter test (Program_ok) on ../../../p4c/testdata/p4_16_errors/issue561-1.p4
 Error on run: ../../../p4c/testdata/p4_16_errors/issue561-1.p4
+
+>>> Running interpreter test (Program_ok) on ../../../p4c/testdata/p4_16_errors/issue5703_header_union_stack.p4
+Excluding file: ../../../p4c/testdata/p4_16_errors/issue5703_header_union_stack.p4
 
 >>> Running interpreter test (Program_ok) on ../../../p4c/testdata/p4_16_errors/issue584.p4
 Error on run: ../../../p4c/testdata/p4_16_errors/issue584.p4
@@ -1516,6 +1534,9 @@ Excluding file: ../../../p4c/testdata/p4_16_errors/structured-annotation-e2.p4
 >>> Running interpreter test (Program_ok) on ../../../p4c/testdata/p4_16_errors/structured-annotation-e3.p4
 Excluding file: ../../../p4c/testdata/p4_16_errors/structured-annotation-e3.p4
 
+>>> Running interpreter test (Program_ok) on ../../../p4c/testdata/p4_16_errors/switch_string.p4
+Error on run: ../../../p4c/testdata/p4_16_errors/switch_string.p4
+
 >>> Running interpreter test (Program_ok) on ../../../p4c/testdata/p4_16_errors/table-action-duplicate-actions.p4
 Error on run: ../../../p4c/testdata/p4_16_errors/table-action-duplicate-actions.p4
 
@@ -1732,6 +1753,6 @@ Error on run: ../../../p4c/testdata/p4_16_errors/width_e.p4
 >>> Running interpreter test (Program_ok) on ../../../p4c/testdata/p4_16_errors/wrong-cast.p4
 Error on run: ../../../p4c/testdata/p4_16_errors/wrong-cast.p4
 
-Running interpreter test (Program_ok): [EXCLUDE] 48/577 (8.32%) [PASS] 0/577 (0.00%) [FAIL] 529/577 (91.68%) [PATCH] 0/577 (0.00%)
+Running interpreter test (Program_ok): [EXCLUDE] 49/584 (8.39%) [PASS] 0/584 (0.00%) [FAIL] 535/584 (91.61%) [PATCH] 0/584 (0.00%)
 
 Running interpreter test (Program_ok): [PATCH]: [EXCLUDE] 0/0 (0.00%) [PASS] 0/0 (0.00%) [FAIL] 0/0 (0.00%)

--- a/p4spec/test/run/run_neg_al.expected
+++ b/p4spec/test/run/run_neg_al.expected
@@ -1,4 +1,4 @@
-Running interpreter test (Program_ok) on 564 files
+Running interpreter test (Program_ok) on 577 files
 
 
 >>> Running interpreter test (Program_ok) on ../../../p4c/testdata/p4_16_errors/accept_e.p4
@@ -979,9 +979,6 @@ Error on run: ../../../p4c/testdata/p4_16_errors/issue3210.p4
 >>> Running interpreter test (Program_ok) on ../../../p4c/testdata/p4_16_errors/issue3221.p4
 Error on run: ../../../p4c/testdata/p4_16_errors/issue3221.p4
 
->>> Running interpreter test (Program_ok) on ../../../p4c/testdata/p4_16_errors/issue3233.p4
-Excluding file: ../../../p4c/testdata/p4_16_errors/issue3233.p4
-
 >>> Running interpreter test (Program_ok) on ../../../p4c/testdata/p4_16_errors/issue3246.p4
 Error on run: ../../../p4c/testdata/p4_16_errors/issue3246.p4
 
@@ -1174,11 +1171,47 @@ Excluding file: ../../../p4c/testdata/p4_16_errors/issue477.p4
 >>> Running interpreter test (Program_ok) on ../../../p4c/testdata/p4_16_errors/issue478.p4
 Excluding file: ../../../p4c/testdata/p4_16_errors/issue478.p4
 
+>>> Running interpreter test (Program_ok) on ../../../p4c/testdata/p4_16_errors/issue5085.p4
+Error on run: ../../../p4c/testdata/p4_16_errors/issue5085.p4
+
+>>> Running interpreter test (Program_ok) on ../../../p4c/testdata/p4_16_errors/issue5094-meta-bmv2.p4
+Error on run: ../../../p4c/testdata/p4_16_errors/issue5094-meta-bmv2.p4
+
+>>> Running interpreter test (Program_ok) on ../../../p4c/testdata/p4_16_errors/issue5094-string-bmv2.p4
+Error on run: ../../../p4c/testdata/p4_16_errors/issue5094-string-bmv2.p4
+
+>>> Running interpreter test (Program_ok) on ../../../p4c/testdata/p4_16_errors/issue5094-type-bmv2.p4
+Error on run: ../../../p4c/testdata/p4_16_errors/issue5094-type-bmv2.p4
+
 >>> Running interpreter test (Program_ok) on ../../../p4c/testdata/p4_16_errors/issue5254_dup_switch_case_label_error.p4
 Error on run: ../../../p4c/testdata/p4_16_errors/issue5254_dup_switch_case_label_error.p4
 
+>>> Running interpreter test (Program_ok) on ../../../p4c/testdata/p4_16_errors/issue5268.p4
+Error on run: ../../../p4c/testdata/p4_16_errors/issue5268.p4
+
+>>> Running interpreter test (Program_ok) on ../../../p4c/testdata/p4_16_errors/issue5296_invalid_version.p4
+Excluding file: ../../../p4c/testdata/p4_16_errors/issue5296_invalid_version.p4
+
+>>> Running interpreter test (Program_ok) on ../../../p4c/testdata/p4_16_errors/issue5296_unknown_version.p4
+Excluding file: ../../../p4c/testdata/p4_16_errors/issue5296_unknown_version.p4
+
 >>> Running interpreter test (Program_ok) on ../../../p4c/testdata/p4_16_errors/issue532.p4
 Excluding file: ../../../p4c/testdata/p4_16_errors/issue532.p4
+
+>>> Running interpreter test (Program_ok) on ../../../p4c/testdata/p4_16_errors/issue5437_action.p4
+Error on run: ../../../p4c/testdata/p4_16_errors/issue5437_action.p4
+
+>>> Running interpreter test (Program_ok) on ../../../p4c/testdata/p4_16_errors/issue5437_instantiation.p4
+Error on run: ../../../p4c/testdata/p4_16_errors/issue5437_instantiation.p4
+
+>>> Running interpreter test (Program_ok) on ../../../p4c/testdata/p4_16_errors/issue5437_table.p4
+Error on run: ../../../p4c/testdata/p4_16_errors/issue5437_table.p4
+
+>>> Running interpreter test (Program_ok) on ../../../p4c/testdata/p4_16_errors/issue5441.p4
+Error on run: ../../../p4c/testdata/p4_16_errors/issue5441.p4
+
+>>> Running interpreter test (Program_ok) on ../../../p4c/testdata/p4_16_errors/issue5443.p4
+Error on run: ../../../p4c/testdata/p4_16_errors/issue5443.p4
 
 >>> Running interpreter test (Program_ok) on ../../../p4c/testdata/p4_16_errors/issue561-1.p4
 Error on run: ../../../p4c/testdata/p4_16_errors/issue561-1.p4
@@ -1236,6 +1269,9 @@ Error on run: ../../../p4c/testdata/p4_16_errors/loop2-err.p4
 
 >>> Running interpreter test (Program_ok) on ../../../p4c/testdata/p4_16_errors/loop3-err.p4
 Error on run: ../../../p4c/testdata/p4_16_errors/loop3-err.p4
+
+>>> Running interpreter test (Program_ok) on ../../../p4c/testdata/p4_16_errors/loop4-err.p4
+Error on run: ../../../p4c/testdata/p4_16_errors/loop4-err.p4
 
 >>> Running interpreter test (Program_ok) on ../../../p4c/testdata/p4_16_errors/lvalue-assign-to-unsupported-type.p4
 Error on run: ../../../p4c/testdata/p4_16_errors/lvalue-assign-to-unsupported-type.p4
@@ -1666,6 +1702,9 @@ Error on run: ../../../p4c/testdata/p4_16_errors/underscore3_e.p4
 >>> Running interpreter test (Program_ok) on ../../../p4c/testdata/p4_16_errors/underscore_e.p4
 Error on run: ../../../p4c/testdata/p4_16_errors/underscore_e.p4
 
+>>> Running interpreter test (Program_ok) on ../../../p4c/testdata/p4_16_errors/unknown-struct1.p4
+Error on run: ../../../p4c/testdata/p4_16_errors/unknown-struct1.p4
+
 >>> Running interpreter test (Program_ok) on ../../../p4c/testdata/p4_16_errors/virtual1.p4
 Error on run: ../../../p4c/testdata/p4_16_errors/virtual1.p4
 
@@ -1693,6 +1732,6 @@ Error on run: ../../../p4c/testdata/p4_16_errors/width_e.p4
 >>> Running interpreter test (Program_ok) on ../../../p4c/testdata/p4_16_errors/wrong-cast.p4
 Error on run: ../../../p4c/testdata/p4_16_errors/wrong-cast.p4
 
-Running interpreter test (Program_ok): [EXCLUDE] 47/564 (8.33%) [PASS] 0/564 (0.00%) [FAIL] 517/564 (91.67%) [PATCH] 0/564 (0.00%)
+Running interpreter test (Program_ok): [EXCLUDE] 48/577 (8.32%) [PASS] 0/577 (0.00%) [FAIL] 529/577 (91.68%) [PATCH] 0/577 (0.00%)
 
 Running interpreter test (Program_ok): [PATCH]: [EXCLUDE] 0/0 (0.00%) [PASS] 0/0 (0.00%) [FAIL] 0/0 (0.00%)

--- a/p4spec/test/run/run_neg_sl.expected
+++ b/p4spec/test/run/run_neg_sl.expected
@@ -1,4 +1,4 @@
-Running interpreter test (Program_ok) on 577 files
+Running interpreter test (Program_ok) on 584 files
 
 
 >>> Running interpreter test (Program_ok) on ../../../p4c/testdata/p4_16_errors/accept_e.p4
@@ -664,6 +664,15 @@ Error on run: ../../../p4c/testdata/p4_16_errors/functors2_e.p4
 >>> Running interpreter test (Program_ok) on ../../../p4c/testdata/p4_16_errors/functors3_e.p4
 Error on run: ../../../p4c/testdata/p4_16_errors/functors3_e.p4
 
+>>> Running interpreter test (Program_ok) on ../../../p4c/testdata/p4_16_errors/generic-extern-inference-abstract_e.p4
+Error on run: ../../../p4c/testdata/p4_16_errors/generic-extern-inference-abstract_e.p4
+
+>>> Running interpreter test (Program_ok) on ../../../p4c/testdata/p4_16_errors/generic-extern-inference-typedef_e.p4
+Error on run: ../../../p4c/testdata/p4_16_errors/generic-extern-inference-typedef_e.p4
+
+>>> Running interpreter test (Program_ok) on ../../../p4c/testdata/p4_16_errors/generic-extern-inference_e.p4
+Error on run: ../../../p4c/testdata/p4_16_errors/generic-extern-inference_e.p4
+
 >>> Running interpreter test (Program_ok) on ../../../p4c/testdata/p4_16_errors/generic-struct-self-nested.p4
 Error on run: ../../../p4c/testdata/p4_16_errors/generic-struct-self-nested.p4
 
@@ -1000,6 +1009,9 @@ Error on run: ../../../p4c/testdata/p4_16_errors/issue3282.p4
 >>> Running interpreter test (Program_ok) on ../../../p4c/testdata/p4_16_errors/issue3285.p4
 Error on run: ../../../p4c/testdata/p4_16_errors/issue3285.p4
 
+>>> Running interpreter test (Program_ok) on ../../../p4c/testdata/p4_16_errors/issue3291-1.p4
+Error on run: ../../../p4c/testdata/p4_16_errors/issue3291-1.p4
+
 >>> Running interpreter test (Program_ok) on ../../../p4c/testdata/p4_16_errors/issue3291.p4
 Excluding file: ../../../p4c/testdata/p4_16_errors/issue3291.p4
 
@@ -1183,6 +1195,9 @@ Error on run: ../../../p4c/testdata/p4_16_errors/issue5094-string-bmv2.p4
 >>> Running interpreter test (Program_ok) on ../../../p4c/testdata/p4_16_errors/issue5094-type-bmv2.p4
 Error on run: ../../../p4c/testdata/p4_16_errors/issue5094-type-bmv2.p4
 
+>>> Running interpreter test (Program_ok) on ../../../p4c/testdata/p4_16_errors/issue5253.p4
+Error on run: ../../../p4c/testdata/p4_16_errors/issue5253.p4
+
 >>> Running interpreter test (Program_ok) on ../../../p4c/testdata/p4_16_errors/issue5254_dup_switch_case_label_error.p4
 Error on run: ../../../p4c/testdata/p4_16_errors/issue5254_dup_switch_case_label_error.p4
 
@@ -1215,6 +1230,9 @@ Error on run: ../../../p4c/testdata/p4_16_errors/issue5443.p4
 
 >>> Running interpreter test (Program_ok) on ../../../p4c/testdata/p4_16_errors/issue561-1.p4
 Error on run: ../../../p4c/testdata/p4_16_errors/issue561-1.p4
+
+>>> Running interpreter test (Program_ok) on ../../../p4c/testdata/p4_16_errors/issue5703_header_union_stack.p4
+Excluding file: ../../../p4c/testdata/p4_16_errors/issue5703_header_union_stack.p4
 
 >>> Running interpreter test (Program_ok) on ../../../p4c/testdata/p4_16_errors/issue584.p4
 Error on run: ../../../p4c/testdata/p4_16_errors/issue584.p4
@@ -1516,6 +1534,9 @@ Excluding file: ../../../p4c/testdata/p4_16_errors/structured-annotation-e2.p4
 >>> Running interpreter test (Program_ok) on ../../../p4c/testdata/p4_16_errors/structured-annotation-e3.p4
 Excluding file: ../../../p4c/testdata/p4_16_errors/structured-annotation-e3.p4
 
+>>> Running interpreter test (Program_ok) on ../../../p4c/testdata/p4_16_errors/switch_string.p4
+Error on run: ../../../p4c/testdata/p4_16_errors/switch_string.p4
+
 >>> Running interpreter test (Program_ok) on ../../../p4c/testdata/p4_16_errors/table-action-duplicate-actions.p4
 Error on run: ../../../p4c/testdata/p4_16_errors/table-action-duplicate-actions.p4
 
@@ -1732,6 +1753,6 @@ Error on run: ../../../p4c/testdata/p4_16_errors/width_e.p4
 >>> Running interpreter test (Program_ok) on ../../../p4c/testdata/p4_16_errors/wrong-cast.p4
 Error on run: ../../../p4c/testdata/p4_16_errors/wrong-cast.p4
 
-Running interpreter test (Program_ok): [EXCLUDE] 48/577 (8.32%) [PASS] 0/577 (0.00%) [FAIL] 529/577 (91.68%) [PATCH] 0/577 (0.00%)
+Running interpreter test (Program_ok): [EXCLUDE] 49/584 (8.39%) [PASS] 0/584 (0.00%) [FAIL] 535/584 (91.61%) [PATCH] 0/584 (0.00%)
 
 Running interpreter test (Program_ok): [PATCH]: [EXCLUDE] 0/0 (0.00%) [PASS] 0/0 (0.00%) [FAIL] 0/0 (0.00%)

--- a/p4spec/test/run/run_neg_sl.expected
+++ b/p4spec/test/run/run_neg_sl.expected
@@ -1,4 +1,4 @@
-Running interpreter test (Program_ok) on 564 files
+Running interpreter test (Program_ok) on 577 files
 
 
 >>> Running interpreter test (Program_ok) on ../../../p4c/testdata/p4_16_errors/accept_e.p4
@@ -979,9 +979,6 @@ Error on run: ../../../p4c/testdata/p4_16_errors/issue3210.p4
 >>> Running interpreter test (Program_ok) on ../../../p4c/testdata/p4_16_errors/issue3221.p4
 Error on run: ../../../p4c/testdata/p4_16_errors/issue3221.p4
 
->>> Running interpreter test (Program_ok) on ../../../p4c/testdata/p4_16_errors/issue3233.p4
-Excluding file: ../../../p4c/testdata/p4_16_errors/issue3233.p4
-
 >>> Running interpreter test (Program_ok) on ../../../p4c/testdata/p4_16_errors/issue3246.p4
 Error on run: ../../../p4c/testdata/p4_16_errors/issue3246.p4
 
@@ -1174,11 +1171,47 @@ Excluding file: ../../../p4c/testdata/p4_16_errors/issue477.p4
 >>> Running interpreter test (Program_ok) on ../../../p4c/testdata/p4_16_errors/issue478.p4
 Excluding file: ../../../p4c/testdata/p4_16_errors/issue478.p4
 
+>>> Running interpreter test (Program_ok) on ../../../p4c/testdata/p4_16_errors/issue5085.p4
+Error on run: ../../../p4c/testdata/p4_16_errors/issue5085.p4
+
+>>> Running interpreter test (Program_ok) on ../../../p4c/testdata/p4_16_errors/issue5094-meta-bmv2.p4
+Error on run: ../../../p4c/testdata/p4_16_errors/issue5094-meta-bmv2.p4
+
+>>> Running interpreter test (Program_ok) on ../../../p4c/testdata/p4_16_errors/issue5094-string-bmv2.p4
+Error on run: ../../../p4c/testdata/p4_16_errors/issue5094-string-bmv2.p4
+
+>>> Running interpreter test (Program_ok) on ../../../p4c/testdata/p4_16_errors/issue5094-type-bmv2.p4
+Error on run: ../../../p4c/testdata/p4_16_errors/issue5094-type-bmv2.p4
+
 >>> Running interpreter test (Program_ok) on ../../../p4c/testdata/p4_16_errors/issue5254_dup_switch_case_label_error.p4
 Error on run: ../../../p4c/testdata/p4_16_errors/issue5254_dup_switch_case_label_error.p4
 
+>>> Running interpreter test (Program_ok) on ../../../p4c/testdata/p4_16_errors/issue5268.p4
+Error on run: ../../../p4c/testdata/p4_16_errors/issue5268.p4
+
+>>> Running interpreter test (Program_ok) on ../../../p4c/testdata/p4_16_errors/issue5296_invalid_version.p4
+Excluding file: ../../../p4c/testdata/p4_16_errors/issue5296_invalid_version.p4
+
+>>> Running interpreter test (Program_ok) on ../../../p4c/testdata/p4_16_errors/issue5296_unknown_version.p4
+Excluding file: ../../../p4c/testdata/p4_16_errors/issue5296_unknown_version.p4
+
 >>> Running interpreter test (Program_ok) on ../../../p4c/testdata/p4_16_errors/issue532.p4
 Excluding file: ../../../p4c/testdata/p4_16_errors/issue532.p4
+
+>>> Running interpreter test (Program_ok) on ../../../p4c/testdata/p4_16_errors/issue5437_action.p4
+Error on run: ../../../p4c/testdata/p4_16_errors/issue5437_action.p4
+
+>>> Running interpreter test (Program_ok) on ../../../p4c/testdata/p4_16_errors/issue5437_instantiation.p4
+Error on run: ../../../p4c/testdata/p4_16_errors/issue5437_instantiation.p4
+
+>>> Running interpreter test (Program_ok) on ../../../p4c/testdata/p4_16_errors/issue5437_table.p4
+Error on run: ../../../p4c/testdata/p4_16_errors/issue5437_table.p4
+
+>>> Running interpreter test (Program_ok) on ../../../p4c/testdata/p4_16_errors/issue5441.p4
+Error on run: ../../../p4c/testdata/p4_16_errors/issue5441.p4
+
+>>> Running interpreter test (Program_ok) on ../../../p4c/testdata/p4_16_errors/issue5443.p4
+Error on run: ../../../p4c/testdata/p4_16_errors/issue5443.p4
 
 >>> Running interpreter test (Program_ok) on ../../../p4c/testdata/p4_16_errors/issue561-1.p4
 Error on run: ../../../p4c/testdata/p4_16_errors/issue561-1.p4
@@ -1236,6 +1269,9 @@ Error on run: ../../../p4c/testdata/p4_16_errors/loop2-err.p4
 
 >>> Running interpreter test (Program_ok) on ../../../p4c/testdata/p4_16_errors/loop3-err.p4
 Error on run: ../../../p4c/testdata/p4_16_errors/loop3-err.p4
+
+>>> Running interpreter test (Program_ok) on ../../../p4c/testdata/p4_16_errors/loop4-err.p4
+Error on run: ../../../p4c/testdata/p4_16_errors/loop4-err.p4
 
 >>> Running interpreter test (Program_ok) on ../../../p4c/testdata/p4_16_errors/lvalue-assign-to-unsupported-type.p4
 Error on run: ../../../p4c/testdata/p4_16_errors/lvalue-assign-to-unsupported-type.p4
@@ -1666,6 +1702,9 @@ Error on run: ../../../p4c/testdata/p4_16_errors/underscore3_e.p4
 >>> Running interpreter test (Program_ok) on ../../../p4c/testdata/p4_16_errors/underscore_e.p4
 Error on run: ../../../p4c/testdata/p4_16_errors/underscore_e.p4
 
+>>> Running interpreter test (Program_ok) on ../../../p4c/testdata/p4_16_errors/unknown-struct1.p4
+Error on run: ../../../p4c/testdata/p4_16_errors/unknown-struct1.p4
+
 >>> Running interpreter test (Program_ok) on ../../../p4c/testdata/p4_16_errors/virtual1.p4
 Error on run: ../../../p4c/testdata/p4_16_errors/virtual1.p4
 
@@ -1693,6 +1732,6 @@ Error on run: ../../../p4c/testdata/p4_16_errors/width_e.p4
 >>> Running interpreter test (Program_ok) on ../../../p4c/testdata/p4_16_errors/wrong-cast.p4
 Error on run: ../../../p4c/testdata/p4_16_errors/wrong-cast.p4
 
-Running interpreter test (Program_ok): [EXCLUDE] 47/564 (8.33%) [PASS] 0/564 (0.00%) [FAIL] 517/564 (91.67%) [PATCH] 0/564 (0.00%)
+Running interpreter test (Program_ok): [EXCLUDE] 48/577 (8.32%) [PASS] 0/577 (0.00%) [FAIL] 529/577 (91.68%) [PATCH] 0/577 (0.00%)
 
 Running interpreter test (Program_ok): [PATCH]: [EXCLUDE] 0/0 (0.00%) [PASS] 0/0 (0.00%) [FAIL] 0/0 (0.00%)

--- a/p4spec/test/run/run_pos_al.expected
+++ b/p4spec/test/run/run_pos_al.expected
@@ -1,4 +1,4 @@
-Running interpreter test (Program_inst) on 1307 files
+Running interpreter test (Program_inst) on 1331 files
 
 
 >>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/action-bind.p4
@@ -160,6 +160,9 @@ Run success: ../../../p4c/testdata/p4_16_samples/bit0-bmv2.p4
 >>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/bitExtract.p4
 Run success: ../../../p4c/testdata/p4_16_samples/bitExtract.p4
 
+>>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/bitexpr1.p4
+Excluding file: ../../../p4c/testdata/p4_16_samples/bitexpr1.p4
+
 >>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/bitwise-and.p4
 Run success: ../../../p4c/testdata/p4_16_samples/bitwise-and.p4
 
@@ -201,6 +204,9 @@ Run success: ../../../p4c/testdata/p4_16_samples/cast.p4
 
 >>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/cast_noop.p4
 Run success: ../../../p4c/testdata/p4_16_samples/cast_noop.p4
+
+>>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/cfoldBitTypedefs.p4
+Excluding file: ../../../p4c/testdata/p4_16_samples/cfoldBitTypedefs.p4
 
 >>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/chain.p4
 Run success: ../../../p4c/testdata/p4_16_samples/chain.p4
@@ -409,6 +415,9 @@ Run success: ../../../p4c/testdata/p4_16_samples/ebpf_headers.p4
 >>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/elimActRun1.p4
 Run success: ../../../p4c/testdata/p4_16_samples/elimActRun1.p4
 
+>>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/elimActRun2.p4
+Run success: ../../../p4c/testdata/p4_16_samples/elimActRun2.p4
+
 >>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/empty-bmv2.p4
 Run success: ../../../p4c/testdata/p4_16_samples/empty-bmv2.p4
 
@@ -511,6 +520,9 @@ Run success: ../../../p4c/testdata/p4_16_samples/flowlet_switching-bmv2.p4
 >>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/fold_match.p4
 Run success: ../../../p4c/testdata/p4_16_samples/fold_match.p4
 
+>>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/forloop-bmv2.p4
+Run success: ../../../p4c/testdata/p4_16_samples/forloop-bmv2.p4
+
 >>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/forloop1.p4
 Run success: ../../../p4c/testdata/p4_16_samples/forloop1.p4
 
@@ -519,6 +531,9 @@ Run success: ../../../p4c/testdata/p4_16_samples/forloop10.p4
 
 >>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/forloop11.p4
 Run success: ../../../p4c/testdata/p4_16_samples/forloop11.p4
+
+>>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/forloop12.p4
+Run success: ../../../p4c/testdata/p4_16_samples/forloop12.p4
 
 >>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/forloop2.p4
 Run success: ../../../p4c/testdata/p4_16_samples/forloop2.p4
@@ -928,11 +943,17 @@ Run success: ../../../p4c/testdata/p4_16_samples/header-bmv2.p4
 >>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/header-bool-bmv2.p4
 Run success: ../../../p4c/testdata/p4_16_samples/header-bool-bmv2.p4
 
+>>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/header-stack-cast-init.p4
+Run success: ../../../p4c/testdata/p4_16_samples/header-stack-cast-init.p4
+
 >>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/header-stack-ops-bmv2.p4
 Run success: ../../../p4c/testdata/p4_16_samples/header-stack-ops-bmv2.p4
 
 >>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/header.p4
 Run success: ../../../p4c/testdata/p4_16_samples/header.p4
+
+>>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/header_union_is_valid_in_parser.p4
+Run success: ../../../p4c/testdata/p4_16_samples/header_union_is_valid_in_parser.p4
 
 >>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/highorder.p4
 Run success: ../../../p4c/testdata/p4_16_samples/highorder.p4
@@ -969,6 +990,12 @@ Run success: ../../../p4c/testdata/p4_16_samples/inline-control.p4
 
 >>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/inline-control1.p4
 Run success: ../../../p4c/testdata/p4_16_samples/inline-control1.p4
+
+>>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/inline-function-to-array-index-chained.p4
+Run success: ../../../p4c/testdata/p4_16_samples/inline-function-to-array-index-chained.p4
+
+>>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/inline-function-to-array-index.p4
+Run success: ../../../p4c/testdata/p4_16_samples/inline-function-to-array-index.p4
 
 >>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/inline-function.p4
 Run success: ../../../p4c/testdata/p4_16_samples/inline-function.p4
@@ -1038,6 +1065,9 @@ Run success: ../../../p4c/testdata/p4_16_samples/invalid-header.p4
 
 >>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/invalid-union.p4
 Run success: ../../../p4c/testdata/p4_16_samples/invalid-union.p4
+
+>>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/invalid_header_default_action_arg.p4
+Run success: ../../../p4c/testdata/p4_16_samples/invalid_header_default_action_arg.p4
 
 >>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/inverted-range.p4
 Run success: ../../../p4c/testdata/p4_16_samples/inverted-range.p4
@@ -1870,6 +1900,9 @@ Run success: ../../../p4c/testdata/p4_16_samples/issue3225.p4
 >>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/issue323.p4
 Run success: ../../../p4c/testdata/p4_16_samples/issue323.p4
 
+>>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/issue3233.p4
+Run success: ../../../p4c/testdata/p4_16_samples/issue3233.p4
+
 >>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/issue3238.p4
 Excluding file: ../../../p4c/testdata/p4_16_samples/issue3238.p4
 
@@ -2161,6 +2194,12 @@ Run success: ../../../p4c/testdata/p4_16_samples/issue496.p4
 >>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/issue5035.p4
 Run success: ../../../p4c/testdata/p4_16_samples/issue5035.p4
 
+>>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/issue5085.p4
+Run success: ../../../p4c/testdata/p4_16_samples/issue5085.p4
+
+>>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/issue5094-typedef-bmv2.p4
+Run success: ../../../p4c/testdata/p4_16_samples/issue5094-typedef-bmv2.p4
+
 >>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/issue510-bmv2.p4
 Run success: ../../../p4c/testdata/p4_16_samples/issue510-bmv2.p4
 
@@ -2200,6 +2239,12 @@ Run success: ../../../p4c/testdata/p4_16_samples/issue5335_default_initialized_n
 >>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/issue5335_default_initialized_non_header_stack_nested.p4
 Run success: ../../../p4c/testdata/p4_16_samples/issue5335_default_initialized_non_header_stack_nested.p4
 
+>>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/issue5439.p4
+Run success: ../../../p4c/testdata/p4_16_samples/issue5439.p4
+
+>>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/issue5499.p4
+Run success: ../../../p4c/testdata/p4_16_samples/issue5499.p4
+
 >>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/issue561-1-bmv2.p4
 Run success: ../../../p4c/testdata/p4_16_samples/issue561-1-bmv2.p4
 
@@ -2229,6 +2274,9 @@ Run success: ../../../p4c/testdata/p4_16_samples/issue561.p4
 
 >>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/issue562-bmv2.p4
 Run success: ../../../p4c/testdata/p4_16_samples/issue562-bmv2.p4
+
+>>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/issue5653.p4
+Run success: ../../../p4c/testdata/p4_16_samples/issue5653.p4
 
 >>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/issue584-1-bmv2.p4
 Run success: ../../../p4c/testdata/p4_16_samples/issue584-1-bmv2.p4
@@ -2547,6 +2595,12 @@ Run success: ../../../p4c/testdata/p4_16_samples/next-def-use.p4
 
 >>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/noMatch.p4
 Run success: ../../../p4c/testdata/p4_16_samples/noMatch.p4
+
+>>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/noWarn-unknown-diagnostic.p4
+Run success: ../../../p4c/testdata/p4_16_samples/noWarn-unknown-diagnostic.p4
+
+>>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/non_header_array_access_in_parser.p4
+Run success: ../../../p4c/testdata/p4_16_samples/non_header_array_access_in_parser.p4
 
 >>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/nonstandard_table_names-bmv2.p4
 Run success: ../../../p4c/testdata/p4_16_samples/nonstandard_table_names-bmv2.p4
@@ -3505,6 +3559,12 @@ Run success: ../../../p4c/testdata/p4_16_samples/simple-actions_ubpf.p4
 >>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/simple-firewall_ubpf.p4
 Run success: ../../../p4c/testdata/p4_16_samples/simple-firewall_ubpf.p4
 
+>>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/simplify-select-cases1.p4
+Run success: ../../../p4c/testdata/p4_16_samples/simplify-select-cases1.p4
+
+>>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/simplify-select-cases2.p4
+Run success: ../../../p4c/testdata/p4_16_samples/simplify-select-cases2.p4
+
 >>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/simplify.p4
 Run success: ../../../p4c/testdata/p4_16_samples/simplify.p4
 
@@ -3514,11 +3574,20 @@ Run success: ../../../p4c/testdata/p4_16_samples/simplify_method_calls.p4
 >>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/simplify_slice.p4
 Run success: ../../../p4c/testdata/p4_16_samples/simplify_slice.p4
 
+>>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/singleton_range_select.p4
+Run success: ../../../p4c/testdata/p4_16_samples/singleton_range_select.p4
+
 >>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/slice-def-use.p4
 Run success: ../../../p4c/testdata/p4_16_samples/slice-def-use.p4
 
 >>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/slice-def-use1.p4
 Run success: ../../../p4c/testdata/p4_16_samples/slice-def-use1.p4
+
+>>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/slice-def-use2.p4
+Run success: ../../../p4c/testdata/p4_16_samples/slice-def-use2.p4
+
+>>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/slice1.p4
+Run success: ../../../p4c/testdata/p4_16_samples/slice1.p4
 
 >>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/spec-ex01.p4
 Run success: ../../../p4c/testdata/p4_16_samples/spec-ex01.p4
@@ -3651,6 +3720,9 @@ Run success: ../../../p4c/testdata/p4_16_samples/strength5.p4
 
 >>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/strength6.p4
 Run success: ../../../p4c/testdata/p4_16_samples/strength6.p4
+
+>>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/strength7.p4
+Run success: ../../../p4c/testdata/p4_16_samples/strength7.p4
 
 >>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/string.p4
 Run success: ../../../p4c/testdata/p4_16_samples/string.p4
@@ -3922,6 +3994,6 @@ Run success: ../../../p4c/testdata/p4_16_samples/xdp_vlan_push_pop_ebpf-kernel.p
 >>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/xor_test.p4
 Run success: ../../../p4c/testdata/p4_16_samples/xor_test.p4
 
-Running interpreter test (Program_inst): [EXCLUDE] 65/1307 (4.97%) [PASS] 1242/1307 (95.03%) [FAIL] 0/1307 (0.00%) [PATCH] 0/1307 (0.00%)
+Running interpreter test (Program_inst): [EXCLUDE] 67/1331 (5.03%) [PASS] 1264/1331 (94.97%) [FAIL] 0/1331 (0.00%) [PATCH] 0/1331 (0.00%)
 
 Running interpreter test (Program_inst): [PATCH]: [EXCLUDE] 0/0 (0.00%) [PASS] 0/0 (0.00%) [FAIL] 0/0 (0.00%)

--- a/p4spec/test/run/run_pos_al.expected
+++ b/p4spec/test/run/run_pos_al.expected
@@ -1,4 +1,4 @@
-Running interpreter test (Program_inst) on 1331 files
+Running interpreter test (Program_inst) on 1334 files
 
 
 >>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/action-bind.p4
@@ -888,6 +888,9 @@ Run success: ../../../p4c/testdata/p4_16_samples/gauntlet_variable_shadowing-bmv
 
 >>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/gauntlet_various_ops-bmv2.p4
 Excluding file: ../../../p4c/testdata/p4_16_samples/gauntlet_various_ops-bmv2.p4
+
+>>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/generic-extern-inference.p4
+Excluding file: ../../../p4c/testdata/p4_16_samples/generic-extern-inference.p4
 
 >>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/generic-struct-tuple.p4
 Run success: ../../../p4c/testdata/p4_16_samples/generic-struct-tuple.p4
@@ -1930,9 +1933,6 @@ Run success: ../../../p4c/testdata/p4_16_samples/issue3288.p4
 >>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/issue3289.p4
 Run success: ../../../p4c/testdata/p4_16_samples/issue3289.p4
 
->>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/issue3291-1.p4
-Excluding file: ../../../p4c/testdata/p4_16_samples/issue3291-1.p4
-
 >>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/issue3292.p4
 Run success: ../../../p4c/testdata/p4_16_samples/issue3292.p4
 
@@ -2218,6 +2218,9 @@ Run success: ../../../p4c/testdata/p4_16_samples/issue5237-folding-unused-const.
 >>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/issue5237-folding-unused-minsizeinbits.p4
 Run success: ../../../p4c/testdata/p4_16_samples/issue5237-folding-unused-minsizeinbits.p4
 
+>>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/issue5253_legal_overloads.p4
+Run success: ../../../p4c/testdata/p4_16_samples/issue5253_legal_overloads.p4
+
 >>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/issue529.p4
 Run success: ../../../p4c/testdata/p4_16_samples/issue529.p4
 
@@ -2277,6 +2280,9 @@ Run success: ../../../p4c/testdata/p4_16_samples/issue562-bmv2.p4
 
 >>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/issue5653.p4
 Run success: ../../../p4c/testdata/p4_16_samples/issue5653.p4
+
+>>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/issue5706_header_union_stack.p4
+Run success: ../../../p4c/testdata/p4_16_samples/issue5706_header_union_stack.p4
 
 >>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/issue584-1-bmv2.p4
 Run success: ../../../p4c/testdata/p4_16_samples/issue584-1-bmv2.p4
@@ -3766,6 +3772,9 @@ Run success: ../../../p4c/testdata/p4_16_samples/switch-expression.p4
 >>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/switch_ebpf.p4
 Run success: ../../../p4c/testdata/p4_16_samples/switch_ebpf.p4
 
+>>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/switch_p4_16.p4
+Run success: ../../../p4c/testdata/p4_16_samples/switch_p4_16.p4
+
 >>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/synth-action.p4
 Run success: ../../../p4c/testdata/p4_16_samples/synth-action.p4
 
@@ -3994,6 +4003,6 @@ Run success: ../../../p4c/testdata/p4_16_samples/xdp_vlan_push_pop_ebpf-kernel.p
 >>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/xor_test.p4
 Run success: ../../../p4c/testdata/p4_16_samples/xor_test.p4
 
-Running interpreter test (Program_inst): [EXCLUDE] 67/1331 (5.03%) [PASS] 1264/1331 (94.97%) [FAIL] 0/1331 (0.00%) [PATCH] 0/1331 (0.00%)
+Running interpreter test (Program_inst): [EXCLUDE] 67/1334 (5.02%) [PASS] 1267/1334 (94.98%) [FAIL] 0/1334 (0.00%) [PATCH] 0/1334 (0.00%)
 
 Running interpreter test (Program_inst): [PATCH]: [EXCLUDE] 0/0 (0.00%) [PASS] 0/0 (0.00%) [FAIL] 0/0 (0.00%)

--- a/p4spec/test/run/run_pos_sl.expected
+++ b/p4spec/test/run/run_pos_sl.expected
@@ -1,4 +1,4 @@
-Running interpreter test (Program_inst) on 1307 files
+Running interpreter test (Program_inst) on 1331 files
 
 
 >>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/action-bind.p4
@@ -160,6 +160,9 @@ Run success: ../../../p4c/testdata/p4_16_samples/bit0-bmv2.p4
 >>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/bitExtract.p4
 Run success: ../../../p4c/testdata/p4_16_samples/bitExtract.p4
 
+>>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/bitexpr1.p4
+Excluding file: ../../../p4c/testdata/p4_16_samples/bitexpr1.p4
+
 >>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/bitwise-and.p4
 Run success: ../../../p4c/testdata/p4_16_samples/bitwise-and.p4
 
@@ -201,6 +204,9 @@ Run success: ../../../p4c/testdata/p4_16_samples/cast.p4
 
 >>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/cast_noop.p4
 Run success: ../../../p4c/testdata/p4_16_samples/cast_noop.p4
+
+>>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/cfoldBitTypedefs.p4
+Excluding file: ../../../p4c/testdata/p4_16_samples/cfoldBitTypedefs.p4
 
 >>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/chain.p4
 Run success: ../../../p4c/testdata/p4_16_samples/chain.p4
@@ -409,6 +415,9 @@ Run success: ../../../p4c/testdata/p4_16_samples/ebpf_headers.p4
 >>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/elimActRun1.p4
 Run success: ../../../p4c/testdata/p4_16_samples/elimActRun1.p4
 
+>>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/elimActRun2.p4
+Run success: ../../../p4c/testdata/p4_16_samples/elimActRun2.p4
+
 >>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/empty-bmv2.p4
 Run success: ../../../p4c/testdata/p4_16_samples/empty-bmv2.p4
 
@@ -511,6 +520,9 @@ Run success: ../../../p4c/testdata/p4_16_samples/flowlet_switching-bmv2.p4
 >>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/fold_match.p4
 Run success: ../../../p4c/testdata/p4_16_samples/fold_match.p4
 
+>>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/forloop-bmv2.p4
+Run success: ../../../p4c/testdata/p4_16_samples/forloop-bmv2.p4
+
 >>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/forloop1.p4
 Run success: ../../../p4c/testdata/p4_16_samples/forloop1.p4
 
@@ -519,6 +531,9 @@ Run success: ../../../p4c/testdata/p4_16_samples/forloop10.p4
 
 >>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/forloop11.p4
 Run success: ../../../p4c/testdata/p4_16_samples/forloop11.p4
+
+>>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/forloop12.p4
+Run success: ../../../p4c/testdata/p4_16_samples/forloop12.p4
 
 >>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/forloop2.p4
 Run success: ../../../p4c/testdata/p4_16_samples/forloop2.p4
@@ -928,11 +943,17 @@ Run success: ../../../p4c/testdata/p4_16_samples/header-bmv2.p4
 >>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/header-bool-bmv2.p4
 Run success: ../../../p4c/testdata/p4_16_samples/header-bool-bmv2.p4
 
+>>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/header-stack-cast-init.p4
+Run success: ../../../p4c/testdata/p4_16_samples/header-stack-cast-init.p4
+
 >>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/header-stack-ops-bmv2.p4
 Run success: ../../../p4c/testdata/p4_16_samples/header-stack-ops-bmv2.p4
 
 >>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/header.p4
 Run success: ../../../p4c/testdata/p4_16_samples/header.p4
+
+>>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/header_union_is_valid_in_parser.p4
+Run success: ../../../p4c/testdata/p4_16_samples/header_union_is_valid_in_parser.p4
 
 >>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/highorder.p4
 Run success: ../../../p4c/testdata/p4_16_samples/highorder.p4
@@ -969,6 +990,12 @@ Run success: ../../../p4c/testdata/p4_16_samples/inline-control.p4
 
 >>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/inline-control1.p4
 Run success: ../../../p4c/testdata/p4_16_samples/inline-control1.p4
+
+>>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/inline-function-to-array-index-chained.p4
+Run success: ../../../p4c/testdata/p4_16_samples/inline-function-to-array-index-chained.p4
+
+>>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/inline-function-to-array-index.p4
+Run success: ../../../p4c/testdata/p4_16_samples/inline-function-to-array-index.p4
 
 >>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/inline-function.p4
 Run success: ../../../p4c/testdata/p4_16_samples/inline-function.p4
@@ -1038,6 +1065,9 @@ Run success: ../../../p4c/testdata/p4_16_samples/invalid-header.p4
 
 >>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/invalid-union.p4
 Run success: ../../../p4c/testdata/p4_16_samples/invalid-union.p4
+
+>>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/invalid_header_default_action_arg.p4
+Run success: ../../../p4c/testdata/p4_16_samples/invalid_header_default_action_arg.p4
 
 >>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/inverted-range.p4
 Run success: ../../../p4c/testdata/p4_16_samples/inverted-range.p4
@@ -1870,6 +1900,9 @@ Run success: ../../../p4c/testdata/p4_16_samples/issue3225.p4
 >>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/issue323.p4
 Run success: ../../../p4c/testdata/p4_16_samples/issue323.p4
 
+>>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/issue3233.p4
+Run success: ../../../p4c/testdata/p4_16_samples/issue3233.p4
+
 >>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/issue3238.p4
 Excluding file: ../../../p4c/testdata/p4_16_samples/issue3238.p4
 
@@ -2161,6 +2194,12 @@ Run success: ../../../p4c/testdata/p4_16_samples/issue496.p4
 >>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/issue5035.p4
 Run success: ../../../p4c/testdata/p4_16_samples/issue5035.p4
 
+>>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/issue5085.p4
+Run success: ../../../p4c/testdata/p4_16_samples/issue5085.p4
+
+>>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/issue5094-typedef-bmv2.p4
+Run success: ../../../p4c/testdata/p4_16_samples/issue5094-typedef-bmv2.p4
+
 >>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/issue510-bmv2.p4
 Run success: ../../../p4c/testdata/p4_16_samples/issue510-bmv2.p4
 
@@ -2200,6 +2239,12 @@ Run success: ../../../p4c/testdata/p4_16_samples/issue5335_default_initialized_n
 >>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/issue5335_default_initialized_non_header_stack_nested.p4
 Run success: ../../../p4c/testdata/p4_16_samples/issue5335_default_initialized_non_header_stack_nested.p4
 
+>>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/issue5439.p4
+Run success: ../../../p4c/testdata/p4_16_samples/issue5439.p4
+
+>>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/issue5499.p4
+Run success: ../../../p4c/testdata/p4_16_samples/issue5499.p4
+
 >>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/issue561-1-bmv2.p4
 Run success: ../../../p4c/testdata/p4_16_samples/issue561-1-bmv2.p4
 
@@ -2229,6 +2274,9 @@ Run success: ../../../p4c/testdata/p4_16_samples/issue561.p4
 
 >>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/issue562-bmv2.p4
 Run success: ../../../p4c/testdata/p4_16_samples/issue562-bmv2.p4
+
+>>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/issue5653.p4
+Run success: ../../../p4c/testdata/p4_16_samples/issue5653.p4
 
 >>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/issue584-1-bmv2.p4
 Run success: ../../../p4c/testdata/p4_16_samples/issue584-1-bmv2.p4
@@ -2547,6 +2595,12 @@ Run success: ../../../p4c/testdata/p4_16_samples/next-def-use.p4
 
 >>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/noMatch.p4
 Run success: ../../../p4c/testdata/p4_16_samples/noMatch.p4
+
+>>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/noWarn-unknown-diagnostic.p4
+Run success: ../../../p4c/testdata/p4_16_samples/noWarn-unknown-diagnostic.p4
+
+>>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/non_header_array_access_in_parser.p4
+Run success: ../../../p4c/testdata/p4_16_samples/non_header_array_access_in_parser.p4
 
 >>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/nonstandard_table_names-bmv2.p4
 Run success: ../../../p4c/testdata/p4_16_samples/nonstandard_table_names-bmv2.p4
@@ -3505,6 +3559,12 @@ Run success: ../../../p4c/testdata/p4_16_samples/simple-actions_ubpf.p4
 >>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/simple-firewall_ubpf.p4
 Run success: ../../../p4c/testdata/p4_16_samples/simple-firewall_ubpf.p4
 
+>>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/simplify-select-cases1.p4
+Run success: ../../../p4c/testdata/p4_16_samples/simplify-select-cases1.p4
+
+>>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/simplify-select-cases2.p4
+Run success: ../../../p4c/testdata/p4_16_samples/simplify-select-cases2.p4
+
 >>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/simplify.p4
 Run success: ../../../p4c/testdata/p4_16_samples/simplify.p4
 
@@ -3514,11 +3574,20 @@ Run success: ../../../p4c/testdata/p4_16_samples/simplify_method_calls.p4
 >>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/simplify_slice.p4
 Run success: ../../../p4c/testdata/p4_16_samples/simplify_slice.p4
 
+>>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/singleton_range_select.p4
+Run success: ../../../p4c/testdata/p4_16_samples/singleton_range_select.p4
+
 >>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/slice-def-use.p4
 Run success: ../../../p4c/testdata/p4_16_samples/slice-def-use.p4
 
 >>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/slice-def-use1.p4
 Run success: ../../../p4c/testdata/p4_16_samples/slice-def-use1.p4
+
+>>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/slice-def-use2.p4
+Run success: ../../../p4c/testdata/p4_16_samples/slice-def-use2.p4
+
+>>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/slice1.p4
+Run success: ../../../p4c/testdata/p4_16_samples/slice1.p4
 
 >>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/spec-ex01.p4
 Run success: ../../../p4c/testdata/p4_16_samples/spec-ex01.p4
@@ -3651,6 +3720,9 @@ Run success: ../../../p4c/testdata/p4_16_samples/strength5.p4
 
 >>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/strength6.p4
 Run success: ../../../p4c/testdata/p4_16_samples/strength6.p4
+
+>>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/strength7.p4
+Run success: ../../../p4c/testdata/p4_16_samples/strength7.p4
 
 >>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/string.p4
 Run success: ../../../p4c/testdata/p4_16_samples/string.p4
@@ -3922,6 +3994,6 @@ Run success: ../../../p4c/testdata/p4_16_samples/xdp_vlan_push_pop_ebpf-kernel.p
 >>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/xor_test.p4
 Run success: ../../../p4c/testdata/p4_16_samples/xor_test.p4
 
-Running interpreter test (Program_inst): [EXCLUDE] 65/1307 (4.97%) [PASS] 1242/1307 (95.03%) [FAIL] 0/1307 (0.00%) [PATCH] 0/1307 (0.00%)
+Running interpreter test (Program_inst): [EXCLUDE] 67/1331 (5.03%) [PASS] 1264/1331 (94.97%) [FAIL] 0/1331 (0.00%) [PATCH] 0/1331 (0.00%)
 
 Running interpreter test (Program_inst): [PATCH]: [EXCLUDE] 0/0 (0.00%) [PASS] 0/0 (0.00%) [FAIL] 0/0 (0.00%)

--- a/p4spec/test/run/run_pos_sl.expected
+++ b/p4spec/test/run/run_pos_sl.expected
@@ -1,4 +1,4 @@
-Running interpreter test (Program_inst) on 1331 files
+Running interpreter test (Program_inst) on 1334 files
 
 
 >>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/action-bind.p4
@@ -888,6 +888,9 @@ Run success: ../../../p4c/testdata/p4_16_samples/gauntlet_variable_shadowing-bmv
 
 >>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/gauntlet_various_ops-bmv2.p4
 Excluding file: ../../../p4c/testdata/p4_16_samples/gauntlet_various_ops-bmv2.p4
+
+>>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/generic-extern-inference.p4
+Excluding file: ../../../p4c/testdata/p4_16_samples/generic-extern-inference.p4
 
 >>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/generic-struct-tuple.p4
 Run success: ../../../p4c/testdata/p4_16_samples/generic-struct-tuple.p4
@@ -1930,9 +1933,6 @@ Run success: ../../../p4c/testdata/p4_16_samples/issue3288.p4
 >>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/issue3289.p4
 Run success: ../../../p4c/testdata/p4_16_samples/issue3289.p4
 
->>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/issue3291-1.p4
-Excluding file: ../../../p4c/testdata/p4_16_samples/issue3291-1.p4
-
 >>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/issue3292.p4
 Run success: ../../../p4c/testdata/p4_16_samples/issue3292.p4
 
@@ -2218,6 +2218,9 @@ Run success: ../../../p4c/testdata/p4_16_samples/issue5237-folding-unused-const.
 >>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/issue5237-folding-unused-minsizeinbits.p4
 Run success: ../../../p4c/testdata/p4_16_samples/issue5237-folding-unused-minsizeinbits.p4
 
+>>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/issue5253_legal_overloads.p4
+Run success: ../../../p4c/testdata/p4_16_samples/issue5253_legal_overloads.p4
+
 >>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/issue529.p4
 Run success: ../../../p4c/testdata/p4_16_samples/issue529.p4
 
@@ -2277,6 +2280,9 @@ Run success: ../../../p4c/testdata/p4_16_samples/issue562-bmv2.p4
 
 >>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/issue5653.p4
 Run success: ../../../p4c/testdata/p4_16_samples/issue5653.p4
+
+>>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/issue5706_header_union_stack.p4
+Run success: ../../../p4c/testdata/p4_16_samples/issue5706_header_union_stack.p4
 
 >>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/issue584-1-bmv2.p4
 Run success: ../../../p4c/testdata/p4_16_samples/issue584-1-bmv2.p4
@@ -3766,6 +3772,9 @@ Run success: ../../../p4c/testdata/p4_16_samples/switch-expression.p4
 >>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/switch_ebpf.p4
 Run success: ../../../p4c/testdata/p4_16_samples/switch_ebpf.p4
 
+>>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/switch_p4_16.p4
+Run success: ../../../p4c/testdata/p4_16_samples/switch_p4_16.p4
+
 >>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/synth-action.p4
 Run success: ../../../p4c/testdata/p4_16_samples/synth-action.p4
 
@@ -3994,6 +4003,6 @@ Run success: ../../../p4c/testdata/p4_16_samples/xdp_vlan_push_pop_ebpf-kernel.p
 >>> Running interpreter test (Program_inst) on ../../../p4c/testdata/p4_16_samples/xor_test.p4
 Run success: ../../../p4c/testdata/p4_16_samples/xor_test.p4
 
-Running interpreter test (Program_inst): [EXCLUDE] 67/1331 (5.03%) [PASS] 1264/1331 (94.97%) [FAIL] 0/1331 (0.00%) [PATCH] 0/1331 (0.00%)
+Running interpreter test (Program_inst): [EXCLUDE] 67/1334 (5.02%) [PASS] 1267/1334 (94.98%) [FAIL] 0/1334 (0.00%) [PATCH] 0/1334 (0.00%)
 
 Running interpreter test (Program_inst): [PATCH]: [EXCLUDE] 0/0 (0.00%) [PASS] 0/0 (0.00%) [FAIL] 0/0 (0.00%)

--- a/p4spec/test/sim/sim_v1model_p4c_al.expected
+++ b/p4spec/test/sim/sim_v1model_p4c_al.expected
@@ -1,4 +1,4 @@
-Running simulation test (v1model) on 203 files
+Running simulation test (v1model) on 204 files
 
 
 >>> Running simulation test (v1model) on ../../../p4c/testdata/p4_16_samples/arith-bmv2.p4 with packet input ../../../p4c/testdata/p4_16_samples/arith-bmv2.stf
@@ -156,6 +156,15 @@ Excluding file: ../../../p4c/testdata/p4_16_samples/extern-funcs-bmv2.stf
 
 >>> Running simulation test (v1model) on ../../../p4c/testdata/p4_16_samples/flag_lost-bmv2.p4 with packet input ../../../p4c/testdata/p4_16_samples/flag_lost-bmv2.stf
 Run success: ../../../p4c/testdata/p4_16_samples/flag_lost-bmv2.stf
+
+>>> Running simulation test (v1model) on ../../../p4c/testdata/p4_16_samples/forloop-bmv2.p4 with packet input ../../../p4c/testdata/p4_16_samples/forloop-bmv2.stf
+[PASS] Transmitted (0) 050000000F00000000
+[PASS] Transmitted (0) 040000000000000010
+[PASS] Transmitted (0) 0A0000000500000000
+[PASS] Transmitted (0) 000000000000000000
+[PASS] Transmitted (0) 060000000500000000
+[PASS] Transmitted (0) 070000000500000000
+Run success: ../../../p4c/testdata/p4_16_samples/forloop-bmv2.stf
 
 >>> Running simulation test (v1model) on ../../../p4c/testdata/p4_16_samples/gauntlet_action_mux-bmv2.p4 with packet input ../../../p4c/testdata/p4_16_samples/gauntlet_action_mux-bmv2.stf
 [PASS] Transmitted (0) 00000000000000000000000000000100
@@ -1184,7 +1193,7 @@ Run success: ../../../p4c/testdata/p4_16_samples/v1model-const-entries-bmv2.stf
 [PASS] Transmitted (8) 525400123502001122330C5508004500001C0001000040118BBD0A00020FE101020316A100500008F9D9
 Run success: ../../../p4c/testdata/p4_16_samples/v1model-special-ops-bmv2.stf
 
-Running simulation test (v1model): [EXCLUDE] 5/203 (2.46%) [PASS] 198/203 (97.54%) [FAIL] 0/203 (0.00%) [PATCH] 0/203 (0.00%)
+Running simulation test (v1model): [EXCLUDE] 5/204 (2.45%) [PASS] 199/204 (97.55%) [FAIL] 0/204 (0.00%) [PATCH] 0/204 (0.00%)
 
 Running simulation test (v1model): [PATCH]: [EXCLUDE] 0/0 (0.00%) [PASS] 0/0 (0.00%) [FAIL] 0/0 (0.00%)
 

--- a/p4spec/test/sim/sim_v1model_p4c_sl.expected
+++ b/p4spec/test/sim/sim_v1model_p4c_sl.expected
@@ -1,4 +1,4 @@
-Running simulation test (v1model) on 203 files
+Running simulation test (v1model) on 204 files
 
 
 >>> Running simulation test (v1model) on ../../../p4c/testdata/p4_16_samples/arith-bmv2.p4 with packet input ../../../p4c/testdata/p4_16_samples/arith-bmv2.stf
@@ -156,6 +156,15 @@ Excluding file: ../../../p4c/testdata/p4_16_samples/extern-funcs-bmv2.stf
 
 >>> Running simulation test (v1model) on ../../../p4c/testdata/p4_16_samples/flag_lost-bmv2.p4 with packet input ../../../p4c/testdata/p4_16_samples/flag_lost-bmv2.stf
 Run success: ../../../p4c/testdata/p4_16_samples/flag_lost-bmv2.stf
+
+>>> Running simulation test (v1model) on ../../../p4c/testdata/p4_16_samples/forloop-bmv2.p4 with packet input ../../../p4c/testdata/p4_16_samples/forloop-bmv2.stf
+[PASS] Transmitted (0) 050000000F00000000
+[PASS] Transmitted (0) 040000000000000010
+[PASS] Transmitted (0) 0A0000000500000000
+[PASS] Transmitted (0) 000000000000000000
+[PASS] Transmitted (0) 060000000500000000
+[PASS] Transmitted (0) 070000000500000000
+Run success: ../../../p4c/testdata/p4_16_samples/forloop-bmv2.stf
 
 >>> Running simulation test (v1model) on ../../../p4c/testdata/p4_16_samples/gauntlet_action_mux-bmv2.p4 with packet input ../../../p4c/testdata/p4_16_samples/gauntlet_action_mux-bmv2.stf
 [PASS] Transmitted (0) 00000000000000000000000000000100
@@ -1184,7 +1193,7 @@ Run success: ../../../p4c/testdata/p4_16_samples/v1model-const-entries-bmv2.stf
 [PASS] Transmitted (8) 525400123502001122330C5508004500001C0001000040118BBD0A00020FE101020316A100500008F9D9
 Run success: ../../../p4c/testdata/p4_16_samples/v1model-special-ops-bmv2.stf
 
-Running simulation test (v1model): [EXCLUDE] 5/203 (2.46%) [PASS] 198/203 (97.54%) [FAIL] 0/203 (0.00%) [PATCH] 0/203 (0.00%)
+Running simulation test (v1model): [EXCLUDE] 5/204 (2.45%) [PASS] 199/204 (97.55%) [FAIL] 0/204 (0.00%) [PATCH] 0/204 (0.00%)
 
 Running simulation test (v1model): [PATCH]: [EXCLUDE] 0/0 (0.00%) [PASS] 0/0 (0.00%) [FAIL] 0/0 (0.00%)
 

--- a/spec/5-typing/5.06.1-typing-expression.watsup
+++ b/spec/5-typing/5.06.1-typing-expression.watsup
@@ -323,7 +323,7 @@ rulegroup Expr_ok/binaryExpression-shift {
     -- if typeIR_r_reduced = $type_of_typedExpressionIR(typedExpressionIR_r_reduced)
     -- if ctk_r_reduced = $ctk_of_typedExpressionIR(typedExpressionIR_r_reduced)
     ---- ;; check that the right-hand side is fixed bit type
-    -- if BIT `< _ `> = typeIR_r_reduced
+    -- if BIT `< _ `> = $unroll_typeIR(typeIR_r_reduced)
     ---- ;; check that if the left-hand side is int type,
     ---- ;; the right-hand side is local compile-time known
     -- if (typeIR_l_reduced = INT) => (ctk_r_reduced = LCTK)
@@ -1315,7 +1315,7 @@ rulegroup Expr_ok/sliceAccessExpression {
     -- if ctk_w_reduced = $ctk_of_typedExpressionIR(typedExpressionIR_w_reduced)
     ---- ;; if offset is not local compile-time known, it must be a bit type
     -- if ctk_l_reduced =/= LCTK
-    -- if BIT `< _ `> = typeIR_l_reduced
+    -- if BIT `< _ `> = $unroll_typeIR(typeIR_l_reduced)
     ---- ;; check that the width is local compile-time known
     -- if ctk_w_reduced = LCTK
     -- Expr_eval_lctk: p TC |- typedExpressionIR_w_reduced ~> integerValue_w


### PR DESCRIPTION
## Test suite change (before → after, SL)

Before = PR base (p4c v1.2.5.10); after = this PR (v1.2.5.16).

| Suite | Total | Pass | Fail | Exclude |
|---|---|---|---|---|
| Parse — samples | 1312 → 1339 | 1302 → 1326 | 10 → 13 | 0 → 0 |
| Parse — errors | 564 → 584 | 531 → 550 | 33 → 34 | 0 → 0 |
| Typecheck — samples (`Program_inst`) | 1307 → 1334 | 1242 → 1267 | 0 → 0 | 65 → 67 |
| Typecheck — errors (`Program_ok`) | 564 → 584 | 0 → 0 | 517 → 535 | 47 → 49 |
| Boot — samples | 1307 → 1334 | 1243 → 1267 | 0 → 0 | 64 → 67 |
| Boot — errors | 564 → 584 | 4 → 0 | 516 → 535 | 44 → 49 |
| Sim — v1model | 203 → 204 | 198 → 199 | 0 → 0 | 5 → 5 |

Totals grow with the corpus (+27 samples, +20 errors across both bumps). Error suites: `Fail` = correctly rejected, `Pass` = wrongly accepted. Every sample suite keeps `Fail` = 0 and every error suite ends at `Pass` = 0 — boot's 4 spurious accepts are cleared by the new excludes. Parse ignores excludes, so its sample `Fail` (10 → 13) counts the unported-syntax files now excluded downstream (`bitexpr1`, `cfoldBitTypedefs`, `generic-extern-inference`).

Three commits: `fix` → `bump v1.2.5.15` → `bump v1.2.5.16`. The typing fix is described with the v1.2.5.15 bump that motivated it.

## 1. Bump p4c submodule to v1.2.5.15

Advance p4c `8c4420e` (v1.2.5.10) → `325e90e` (v1.2.5.15). The corpus gains 39 files (14 errors, 23 samples, 1 renamed errors→samples); the rest of the upstream diff is SPDX license-header reformatting with no semantic effect.

### Typing fix — unroll typedef before fixed-bit checks (commit `6cb4cec7`)

This bump adds `issue5094-typedef-bmv2.p4` (`int<32> << (e : typedef bit<8>)`), a valid sample the spec wrongly rejected. Two expression-typing rules matched the operand type structurally against `BIT<_>` without unrolling the `typedef` wrapper: the shift amount in `a << b` / `a >> b`, and a non-compile-time-known offset in a `hdr[l +: w]` slice.

`$reduce_serenum_binary` / `$reduce_serenum_unary` reduce serializable enums to their underlying type but leave `TYPEDEF` wrappers in place — reduction stops as soon as the `$compat_*` check passes, and `$compat_shift` already unwraps `TYPEDEF` internally:

```
tbl def $compat_shift =
  ...
  | (INT `< _ `>, BIT `< _ `>) => true
  | (typeIR_l, TYPEDEF _ typeIR_r) => $compat_shift(typeIR_l, typeIR_r)
```

So for `int<32> << (e : shiftEnum)` with `typedef bit<8> shiftEnum`, the reduced right-operand type is `TYPEDEF "shiftEnum" (BIT<8>)`, and the fixed-bit check compares that wrapper against `BIT<_>` directly and fails:

```
-- if BIT `< _ `> = typeIR_r_reduced        ;; TYPEDEF _ (BIT<8>) =/= BIT<_>
```

Every other structural type match in `5.06.1-typing-expression.watsup` already guards with `$unroll_typeIR`, and `$is_valid_bitslice` unrolls `TYPEDEF` itself. These two sites were the only structural matches against a `_reduced` operand type that skipped it.

```diff
     ---- ;; check that the right-hand side is fixed bit type
-    -- if BIT `< _ `> = typeIR_r_reduced
+    -- if BIT `< _ `> = $unroll_typeIR(typeIR_r_reduced)
```

```diff
     ---- ;; if offset is not local compile-time known, it must be a bit type
     -- if ctk_l_reduced =/= LCTK
-    -- if BIT `< _ `> = typeIR_l_reduced
+    -- if BIT `< _ `> = $unroll_typeIR(typeIR_l_reduced)
```

The bulk of the fix commit's line count is regenerated `test/lang/*.expected` spec dumps: the `struct.expected` change is almost entirely `Dangling#N` renumbering, since turning a direct case-match into a let-binding plus subtype check shifts the global node counter.

Validation — `issue5094-typedef-bmv2.p4` now type-checks; the invalid siblings still reject:

```
issue5094-typedef-bmv2.p4  -> passed
issue5094-meta-bmv2.p4     -> relation Program_inst failed
issue5094-string-bmv2.p4   -> relation Program_inst failed
issue5094-type-bmv2.p4     -> relation Program_inst failed
```

Slice offset, differential on `data[off +: 4]`: `bit<8> off` passes before and after; `typedef bit<8> off` rejected before, passes after.

### Excludes

New excludes for constructs the spec does not model:

- `p4-spec/pending/nonparenthesized-bit-int-width` — `bitexpr1.p4`, `cfoldBitTypedefs.p4` use bare expressions as `bit<>`/`int<>` width (`bit<2+2>`, `bit<v1>`, `bit<v4[7:0]-v1>`), from p4c #5590. The frontend accepts only an integer literal or a parenthesized expression; the `nonGrtExpression` grammar was never ported.
- `p4c-specific/implicit/v1model-version-check` — `issue5296_invalid_version`, `issue5296_unknown_version` rely on the `V1MODEL_VERSION` macro check, a p4c preprocessor diagnostic outside the language semantics.

`issue3233.p4` moved errors→samples upstream; the spec accepts it as a sample, so it now runs in `run_pos` with no exclude change. Its entry in the `c-5527` exclude (old `p4_16_errors` path) is now inert — left as a follow-up rather than touching an unrelated p4c-confirmed exclude.

Expected outputs regenerated with `make test-all-det` and promoted: parse (pos/neg), run (pos/neg, al/sl), and v1model p4c sim (al/sl).

## 2. Bump p4c submodule to v1.2.5.16

Advance p4c `325e90e` (v1.2.5.15) → `6b7ec98` (v1.2.5.16). The corpus gains 10 files (6 errors, 4 samples) and renames `issue3291-1.p4` samples→errors; the rest of the upstream diff is a second SPDX header pass.

New excludes for constructs the spec does not model:

- `p4-spec/pending/instance-array-declarator` — `generic-extern-inference.p4` declares arrays of instances (`ParametrizedExtern(16w4) name[2];`). The frontend's `instantiation` rule takes a bare `name`, not p4c's `declarator` (`name | declarator "[" expression "]"`), so instance arrays do not parse. The file's headline feature (inferred generic-extern type args) parses fine; only the array declarator breaks.
- `p4c-specific/implicit/header-union-stack-nonconst-index` — `issue5703_header_union_stack.p4` extracts into a header-union stack at a runtime index (`hus[m.idx]`); the spec does not reject the non-constant index that p4c rejects. Its valid sibling `issue5706` (constant index) passes.

`issue3291-1.p4` moved samples→errors upstream and the spec rejects it, so it now runs in `run_neg`. Its entry in the `c-5528` exclude (old `p4_16_samples` path) is now inert — left as a follow-up, same as `c-5527` above.

Expected outputs regenerated with `make test-all-det` plus the boot suite, and promoted: parse (pos/neg), run (pos/neg, al/sl), and boot (pos/neg). `run_pos`/`boot_pos` `[FAIL] 0`, `run_neg`/`boot_neg` `[PASS] 0` — no sample wrongly rejected, no error wrongly accepted.

## Validation

- `make build` — OK
- `make test-all-det` — OK (green after promote)
- `make test-boot` — OK (green after promote)
