### PR TITLE
Remove meta-cache from the meta-language semantics

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,10 +45,10 @@ slspec:
 slspec-html:
 	cd docs/sl && make spec-html && cd ../..
 
-ilspec:
-	cd docs/il && make spec && cd ../..
-ilspec-html:
-	cd docs/il && make spec-html && cd ../..
+alspec:
+	cd docs/al && make spec && cd ../..
+alspec-html:
+	cd docs/al && make spec-html && cd ../..
 
 # Format
 

--- a/docs/al/sections-skeleton/02-semantics/01-context.adoc
+++ b/docs/al/sections-skeleton/02-semantics/01-context.adoc
@@ -42,5 +42,3 @@ yield the resulting collection of contexts.
 ${func-prose: sub_opt}
 
 ${func-prose: sub_list}
-
-${func-prose: sub_list'}

--- a/docs/al/sections-skeleton/02-semantics/05-function.adoc
+++ b/docs/al/sections-skeleton/02-semantics/05-function.adoc
@@ -1,23 +1,13 @@
 === Functions
 
-Function calls are dispatched through a layered chain of relations that first
-checks a memo cache for a previously computed result, then resolves the
-function definition from the context, and finally dispatches to the appropriate
+Function calls are dispatched through a layered chain of relations that resolves
+the function definition from the context, then dispatches to the appropriate
 evaluation strategy based on the function's kind.
 
 An entry point for function calls is the following relation:
 
 ${relation-title-prose: Call_func}
 ${rulegroup-prose: Call_func}
-
-A meta-cache is used for performance reasons. Before evaluating a function call
-from scratch, the cache is consulted for a previously computed result with the
-same identifier, type arguments, and value arguments. If found, the cached
-result is returned immediately; otherwise, the result is computed and stored in
-the cache for future reuse.
-
-${relation-title-prose: Call_func_cache}
-${rulegroup-prose: Call_func_cache}
 
 The actual function call is performed by the following relation, dispatching
 according to the function type. The function definition is looked up in the

--- a/docs/al/sections-skeleton/02-semantics/06-relation.adoc
+++ b/docs/al/sections-skeleton/02-semantics/06-relation.adoc
@@ -1,23 +1,13 @@
 === Relations
 
 Relation calls are dispatched through the same layered chain as function calls:
-a memo cache is checked first for a previously computed result, then the
-relation definition is resolved from the context, and finally evaluation is
+the relation definition is resolved from the context, then evaluation is
 dispatched based on whether the relation is extern or user-defined.
 
 An entry point for relation calls is the following relation:
 
 ${relation-title-prose: Call_rel}
 ${rulegroup-prose: Call_rel}
-
-A meta-cache is used for performance reasons. Before evaluating a relation call
-from scratch, the cache is consulted for a previously computed result with the
-same identifier and input values. If found, the cached result is returned
-immediately; otherwise, the result is computed and stored in the cache for
-future reuse.
-
-${relation-title-prose: Call_rel_cache}
-${rulegroup-prose: Call_rel_cache}
 
 The actual relation call is performed by the following relation, dispatching
 according to the relation type. The relation definition is looked up in the

--- a/docs/al/splice.missing
+++ b/docs/al/splice.missing
@@ -9,72 +9,73 @@ splice warning: rulegroup-prose splice key not found: Eval_exp/fail
 splice warning: func-prose splice key not found: subtyp'
 splice warning: rulegroup-prose splice key not found: Eval_path/fail
 splice warning: rulegroup-prose splice key not found: Eval_path_upd/fail
-splice warning: unused 25 syntax splices out of 77 (32.47%)
-splice warning: 	builtinFuncDef, cachepoint, ctx, ctxres, cursor
-splice warning: 	definedFuncDef, definedRelDef, externFuncDef, externRelDef, funccache
-splice warning: 	funcdef, json, map, pair, relcache
-splice warning: 	reldef, res, set, tableFuncDef, theta
-splice warning: 	typdef, unitres, valres, valsres, varr
-splice warning: unused 32 relation-title-source splices out of 32 (100.00%)
+splice warning: unused 22 syntax splices out of 74 (29.73%)
+splice warning: 	builtinFuncDef, ctx, ctxres, cursor, definedFuncDef
+splice warning: 	definedRelDef, externFuncDef, externRelDef, funcdef, json
+splice warning: 	map, pair, reldef, res, set
+splice warning: 	tableFuncDef, theta, typdef, unitres, valres
+splice warning: 	valsres, varr
+splice warning: unused 30 relation-title-source splices out of 30 (100.00%)
 splice warning: 	Assign_arg, Assign_args, Assign_exp, Assign_exps, Call_builtin_func
 splice warning: 	Call_defined_func, Call_defined_rel, Call_extern_func, Call_extern_rel, Call_func
-splice warning: 	Call_func_cache, Call_func_dispatch, Call_rel, Call_rel_cache, Call_rel_dispatch
+splice warning: 	Call_func_dispatch, Call_rel, Call_rel_dispatch, Call_table_func, Entry
+splice warning: 	Eval_arg, Eval_clause, Eval_clauses, Eval_exp, Eval_path
+splice warning: 	Eval_path_upd, Eval_prem, Eval_prems, Eval_rul, Eval_rulgroup
+splice warning: 	Eval_rulgroups, Eval_ruls, Eval_targs, Eval_tblrow, Eval_tblrows
+splice warning: unused 3 relation-title-prose splices out of 30 (10.00%)
+splice warning: 	Entry, Eval_arg, Eval_targs
+splice warning: unused 80 rulegroup-source splices out of 80 (100.00%)
+splice warning: 	Assign_arg/exp, Assign_arg/fun, Assign_args/, Assign_exp/cons, Assign_exp/inj
+splice warning: 	Assign_exp/iter, Assign_exp/list, Assign_exp/opt, Assign_exp/str, Assign_exp/tup
+splice warning: 	Assign_exp/variable, Assign_exps/, Call_defined_func/, Call_defined_rel/, Call_func/
+splice warning: 	Call_func_dispatch/, Call_rel/, Call_rel_dispatch/, Call_table_func/, Entry/
+splice warning: 	Eval_arg/exp, Eval_arg/fail, Eval_arg/fun, Eval_clause/fail, Eval_clause/succ
+splice warning: 	Eval_clauses/, Eval_exp/binary, Eval_exp/call, Eval_exp/case, Eval_exp/compare
+splice warning: 	Eval_exp/concat, Eval_exp/cons, Eval_exp/dot, Eval_exp/downcast, Eval_exp/fail
+splice warning: 	Eval_exp/idx, Eval_exp/iter, Eval_exp/len, Eval_exp/list, Eval_exp/literal
+splice warning: 	Eval_exp/match, Eval_exp/mem, Eval_exp/opt, Eval_exp/slice, Eval_exp/struct
+splice warning: 	Eval_exp/subtype, Eval_exp/tuple, Eval_exp/unary, Eval_exp/upcast, Eval_exp/upd
+splice warning: 	Eval_exp/variable, Eval_path/dot, Eval_path/fail, Eval_path/idx, Eval_path/root
+splice warning: 	Eval_path/slice, Eval_path_upd/dot, Eval_path_upd/fail, Eval_path_upd/idx, Eval_path_upd/root
+splice warning: 	Eval_path_upd/slice, Eval_prem/dbg, Eval_prem/fail, Eval_prem/ifholdpr, Eval_prem/ifpr
+splice warning: 	Eval_prem/iterpr-list, Eval_prem/iterpr-opt, Eval_prem/letpr, Eval_prem/relpr, Eval_prems/
+splice warning: 	Eval_rul/fail, Eval_rul/succ, Eval_rulgroup/fail, Eval_rulgroup/succ, Eval_rulgroups/
+splice warning: 	Eval_ruls/, Eval_targs/, Eval_tblrow/fail, Eval_tblrow/succ, Eval_tblrows/
+splice warning: unused 6 rulegroup-prose splices out of 71 (8.45%)
+splice warning: 	Assign_exp/tup, Entry/, Eval_arg/exp, Eval_arg/fun, Eval_exp/cons
+splice warning: 	Eval_targs/
+splice warning: unused 27 rulegroup-dispatch-prose splices out of 27 (100.00%)
+splice warning: 	Assign_arg, Assign_args, Assign_exp, Assign_exps, Call_defined_func
+splice warning: 	Call_defined_rel, Call_func, Call_func_dispatch, Call_rel, Call_rel_dispatch
 splice warning: 	Call_table_func, Entry, Eval_arg, Eval_clause, Eval_clauses
 splice warning: 	Eval_exp, Eval_path, Eval_path_upd, Eval_prem, Eval_prems
 splice warning: 	Eval_rul, Eval_rulgroup, Eval_rulgroups, Eval_ruls, Eval_targs
 splice warning: 	Eval_tblrow, Eval_tblrows
-splice warning: unused 3 relation-title-prose splices out of 32 (9.38%)
-splice warning: 	Entry, Eval_arg, Eval_targs
-splice warning: unused 82 rulegroup-source splices out of 82 (100.00%)
-splice warning: 	Assign_arg/exp, Assign_arg/fun, Assign_args/, Assign_exp/cons, Assign_exp/inj
-splice warning: 	Assign_exp/iter, Assign_exp/list, Assign_exp/opt, Assign_exp/str, Assign_exp/tup
-splice warning: 	Assign_exp/variable, Assign_exps/, Call_defined_func/, Call_defined_rel/, Call_func/
-splice warning: 	Call_func_cache/, Call_func_dispatch/, Call_rel/, Call_rel_cache/, Call_rel_dispatch/
-splice warning: 	Call_table_func/, Entry/, Eval_arg/exp, Eval_arg/fail, Eval_arg/fun
-splice warning: 	Eval_clause/fail, Eval_clause/succ, Eval_clauses/, Eval_exp/binary, Eval_exp/call
-splice warning: 	Eval_exp/case, Eval_exp/compare, Eval_exp/concat, Eval_exp/cons, Eval_exp/dot
-splice warning: 	Eval_exp/downcast, Eval_exp/fail, Eval_exp/idx, Eval_exp/iter, Eval_exp/len
-splice warning: 	Eval_exp/list, Eval_exp/literal, Eval_exp/match, Eval_exp/mem, Eval_exp/opt
-splice warning: 	Eval_exp/slice, Eval_exp/struct, Eval_exp/subtype, Eval_exp/tuple, Eval_exp/unary
-splice warning: 	Eval_exp/upcast, Eval_exp/upd, Eval_exp/variable, Eval_path/dot, Eval_path/fail
-splice warning: 	Eval_path/idx, Eval_path/root, Eval_path/slice, Eval_path_upd/dot, Eval_path_upd/fail
-splice warning: 	Eval_path_upd/idx, Eval_path_upd/root, Eval_path_upd/slice, Eval_prem/dbg, Eval_prem/fail
-splice warning: 	Eval_prem/ifholdpr, Eval_prem/ifpr, Eval_prem/iterpr-list, Eval_prem/iterpr-opt, Eval_prem/letpr
-splice warning: 	Eval_prem/relpr, Eval_prems/, Eval_rul/fail, Eval_rul/succ, Eval_rulgroup/fail
-splice warning: 	Eval_rulgroup/succ, Eval_rulgroups/, Eval_ruls/, Eval_targs/, Eval_tblrow/fail
-splice warning: 	Eval_tblrow/succ, Eval_tblrows/
-splice warning: unused 6 rulegroup-prose splices out of 73 (8.22%)
-splice warning: 	Assign_exp/tup, Entry/, Eval_arg/exp, Eval_arg/fun, Eval_exp/cons
-splice warning: 	Eval_targs/
-splice warning: unused 62 func-title-source splices out of 62 (100.00%)
+splice warning: unused 55 func-title-source splices out of 55 (100.00%)
 splice warning: 	add_func, add_map, add_typ, add_vari, add_varis
 splice warning: 	add_varr, add_varrs, adds_map, assoc_, binop_bool
-splice warning: 	binop_number, cache_add_func_maybe, cache_add_rel_maybe, cache_checkpoint, cache_find_func
-splice warning: 	cache_find_rel, cache_seff, cmpop_number, cmpop_poly, downcast
-splice warning: 	elsgroup_as_rulgroup, empty_ctx, empty_layer, empty_map, empty_set
-splice warning: 	exists_, extend_tdenv, find_func, find_map, find_maps
-splice warning: 	find_rel, find_typ, find_vari, find_varis, find_varr
-splice warning: 	find_varrs, finds_vari, forall_, is_fun, is_iter_on_var
-splice warning: 	is_tup, ite, iter_vari, iter_varr, load
-splice warning: 	load_funcdef, load_reldef, load_typdef, opt_as_seq_, repeat_
-splice warning: 	rev_, sub_list, sub_list', sub_opt, subst_typ
-splice warning: 	subst_typ', subtyp, subtyps, theta_of_tdenv, transpose_
-splice warning: 	unop_number, upcast
-splice warning: unused 62 func-title-prose splices out of 62 (100.00%)
+splice warning: 	binop_number, cmpop_number, cmpop_poly, downcast, elsgroup_as_rulgroup
+splice warning: 	empty_ctx, empty_layer, empty_map, empty_set, exists_
+splice warning: 	extend_tdenv, find_func, find_map, find_maps, find_rel
+splice warning: 	find_typ, find_vari, find_varis, find_varr, find_varrs
+splice warning: 	finds_vari, forall_, is_fun, is_iter_on_var, is_tup
+splice warning: 	ite, iter_vari, iter_varr, load, load_funcdef
+splice warning: 	load_reldef, load_typdef, opt_as_seq_, repeat_, rev_
+splice warning: 	sub_list, sub_opt, subst_typ, subst_typ', subtyp
+splice warning: 	subtyps, theta_of_tdenv, transpose_, unop_number, upcast
+splice warning: unused 55 func-title-prose splices out of 55 (100.00%)
 splice warning: 	add_func, add_map, add_typ, add_vari, add_varis
 splice warning: 	add_varr, add_varrs, adds_map, assoc_, binop_bool
-splice warning: 	binop_number, cache_add_func_maybe, cache_add_rel_maybe, cache_checkpoint, cache_find_func
-splice warning: 	cache_find_rel, cache_seff, cmpop_number, cmpop_poly, downcast
-splice warning: 	elsgroup_as_rulgroup, empty_ctx, empty_layer, empty_map, empty_set
-splice warning: 	exists_, extend_tdenv, find_func, find_map, find_maps
-splice warning: 	find_rel, find_typ, find_vari, find_varis, find_varr
-splice warning: 	find_varrs, finds_vari, forall_, is_fun, is_iter_on_var
-splice warning: 	is_tup, ite, iter_vari, iter_varr, load
-splice warning: 	load_funcdef, load_reldef, load_typdef, opt_as_seq_, repeat_
-splice warning: 	rev_, sub_list, sub_list', sub_opt, subst_typ
-splice warning: 	subst_typ', subtyp, subtyps, theta_of_tdenv, transpose_
-splice warning: 	unop_number, upcast
-splice warning: unused 49 func-source splices out of 49 (100.00%)
+splice warning: 	binop_number, cmpop_number, cmpop_poly, downcast, elsgroup_as_rulgroup
+splice warning: 	empty_ctx, empty_layer, empty_map, empty_set, exists_
+splice warning: 	extend_tdenv, find_func, find_map, find_maps, find_rel
+splice warning: 	find_typ, find_vari, find_varis, find_varr, find_varrs
+splice warning: 	finds_vari, forall_, is_fun, is_iter_on_var, is_tup
+splice warning: 	ite, iter_vari, iter_varr, load, load_funcdef
+splice warning: 	load_reldef, load_typdef, opt_as_seq_, repeat_, rev_
+splice warning: 	sub_list, sub_opt, subst_typ, subst_typ', subtyp
+splice warning: 	subtyps, theta_of_tdenv, transpose_, unop_number, upcast
+splice warning: unused 48 func-source splices out of 48 (100.00%)
 splice warning: 	add_func, add_typ, add_vari, add_varis, add_varr
 splice warning: 	add_varrs, binop_bool, binop_number, cmpop_number, cmpop_poly
 splice warning: 	downcast, elsgroup_as_rulgroup, empty_ctx, empty_layer, empty_map
@@ -83,9 +84,9 @@ splice warning: 	find_typ, find_vari, find_varis, find_varr, find_varrs
 splice warning: 	finds_vari, forall_, is_fun, is_iter_on_var, is_tup
 splice warning: 	ite, iter_vari, iter_varr, load, load_funcdef
 splice warning: 	load_reldef, load_typdef, opt_as_seq_, repeat_, sub_list
-splice warning: 	sub_list', sub_opt, subst_typ, subst_typ', subtyp
-splice warning: 	subtyps, theta_of_tdenv, unop_number, upcast
-splice warning: unused 38 func-prose splices out of 49 (77.55%)
+splice warning: 	sub_opt, subst_typ, subst_typ', subtyp, subtyps
+splice warning: 	theta_of_tdenv, unop_number, upcast
+splice warning: unused 38 func-prose splices out of 48 (79.17%)
 splice warning: 	add_func, add_typ, add_vari, add_varis, add_varr
 splice warning: 	add_varrs, binop_bool, binop_number, cmpop_number, cmpop_poly
 splice warning: 	elsgroup_as_rulgroup, empty_ctx, empty_layer, empty_map, empty_set

--- a/docs/sl/sections-skeleton/02-semantics/01-context.adoc
+++ b/docs/sl/sections-skeleton/02-semantics/01-context.adoc
@@ -41,4 +41,3 @@ variables and yield the resulting collection of contexts.
 
 ${func-prose: sub_opt}
 ${func-prose: sub_list}
-${func-prose: sub_list'}

--- a/docs/sl/sections-skeleton/02-semantics/05-function.adoc
+++ b/docs/sl/sections-skeleton/02-semantics/05-function.adoc
@@ -1,23 +1,13 @@
 === Functions
 
-Function calls are dispatched through a layered chain of relations that first
-checks a memo cache for a previously computed result, then resolves the
-function definition from the context, and finally dispatches to the appropriate
+Function calls are dispatched through a layered chain of relations that resolves
+the function definition from the context, then dispatches to the appropriate
 evaluation strategy based on the function's kind.
 
 An entry point for function calls is the following relation:
 
 ${relation-title-prose: Call_func}
 ${rulegroup-prose: Call_func}
-
-A meta-cache is used for performance reasons. Before evaluating a function call
-from scratch, the cache is consulted for a previously computed result with the
-same identifier, type arguments, and value arguments. If found, the cached
-result is returned immediately; otherwise, the result is computed and stored in
-the cache for future reuse.
-
-${relation-title-prose: Call_func_cache}
-${rulegroup-prose: Call_func_cache}
 
 The actual function call is performed by the following relation, dispatching
 according to the function type. The function definition is looked up in the

--- a/docs/sl/sections-skeleton/02-semantics/06-relation.adoc
+++ b/docs/sl/sections-skeleton/02-semantics/06-relation.adoc
@@ -1,23 +1,13 @@
 === Relations
 
 Relation calls are dispatched through the same layered chain as function calls:
-a memo cache is checked first for a previously computed result, then the
-relation definition is resolved from the context, and finally evaluation is
+the relation definition is resolved from the context, then evaluation is
 dispatched based on whether the relation is extern or user-defined.
 
 An entry point for relation calls is the following relation:
 
 ${relation-title-prose: Call_rel}
 ${rulegroup-prose: Call_rel}
-
-A meta-cache is used for performance reasons. Before evaluating a relation call
-from scratch, the cache is consulted for a previously computed result with the
-same identifier and input values. If found, the cached result is returned
-immediately; otherwise, the result is computed and stored in the cache for
-future reuse.
-
-${relation-title-prose: Call_rel_cache}
-${rulegroup-prose: Call_rel_cache}
 
 The actual function call is performed by the following relation, dispatching
 according to the function type. The relation definition is looked up in the

--- a/docs/sl/splice.missing
+++ b/docs/sl/splice.missing
@@ -11,93 +11,96 @@ splice warning: rulegroup-prose splice key not found: Eval_instr/fail
 splice warning: rulegroup-prose splice key not found: Eval_case/fail
 splice warning: rulegroup-prose splice key not found: Eval_let/fail
 splice warning: rulegroup-prose splice key not found: Eval_rel/fail
-splice warning: unused 26 syntax splices out of 77 (33.77%)
-splice warning: 	blockres, builtinFuncDef, cachepoint, ctx, ctxres
-splice warning: 	cursor, definedFuncDef, definedRelDef, externFuncDef, externRelDef
-splice warning: 	funccache, funcdef, json, map, pair
-splice warning: 	relcache, reldef, res, set, tableFuncDef
-splice warning: 	theta, typdef, unitres, valres, valsres
-splice warning: 	varr
-splice warning: unused 33 relation-title-source splices out of 33 (100.00%)
+splice warning: unused 23 syntax splices out of 74 (31.08%)
+splice warning: 	blockres, builtinFuncDef, ctx, ctxres, cursor
+splice warning: 	definedFuncDef, definedRelDef, externFuncDef, externRelDef, funcdef
+splice warning: 	json, map, pair, reldef, res
+splice warning: 	set, tableFuncDef, theta, typdef, unitres
+splice warning: 	valres, valsres, varr
+splice warning: unused 31 relation-title-source splices out of 31 (100.00%)
 splice warning: 	Assign_exp, Assign_exps, Assign_param, Assign_params, Call_builtin_func
 splice warning: 	Call_defined_func, Call_defined_rel, Call_extern_func, Call_extern_rel, Call_func
-splice warning: 	Call_func_cache, Call_func_dispatch, Call_rel, Call_rel_cache, Call_rel_dispatch
+splice warning: 	Call_func_dispatch, Call_rel, Call_rel_dispatch, Call_table_func, Entry
+splice warning: 	Eval_arg, Eval_block, Eval_case, Eval_cases, Eval_exp
+splice warning: 	Eval_if_cond, Eval_ifhold_cond, Eval_instr, Eval_instrs, Eval_let
+splice warning: 	Eval_path, Eval_path_upd, Eval_rel, Eval_targs, Eval_tblrow
+splice warning: 	Eval_tblrows
+splice warning: unused 3 relation-title-prose splices out of 31 (9.68%)
+splice warning: 	Entry, Eval_arg, Eval_targs
+splice warning: unused 85 rulegroup-source splices out of 85 (100.00%)
+splice warning: 	Assign_exp/cons, Assign_exp/inj, Assign_exp/iter, Assign_exp/list, Assign_exp/opt
+splice warning: 	Assign_exp/str, Assign_exp/tup, Assign_exp/variable, Assign_exps/, Assign_param/exp
+splice warning: 	Assign_param/fun, Assign_params/, Call_defined_func/fail, Call_defined_func/ret, Call_defined_rel/fail
+splice warning: 	Call_defined_rel/succ, Call_func/, Call_func_dispatch/, Call_rel/, Call_rel_dispatch/
+splice warning: 	Call_table_func/, Entry/, Eval_arg/exp, Eval_arg/fail, Eval_arg/fun
+splice warning: 	Eval_block/, Eval_case/fail, Eval_case/hit, Eval_cases/, Eval_exp/binary
+splice warning: 	Eval_exp/call, Eval_exp/case, Eval_exp/compare, Eval_exp/concat, Eval_exp/cons
+splice warning: 	Eval_exp/dot, Eval_exp/downcast, Eval_exp/fail, Eval_exp/idx, Eval_exp/iter
+splice warning: 	Eval_exp/len, Eval_exp/list, Eval_exp/literal, Eval_exp/match, Eval_exp/mem
+splice warning: 	Eval_exp/opt, Eval_exp/slice, Eval_exp/struct, Eval_exp/subtype, Eval_exp/tuple
+splice warning: 	Eval_exp/unary, Eval_exp/upcast, Eval_exp/upd, Eval_exp/variable, Eval_if_cond/
+splice warning: 	Eval_ifhold_cond/, Eval_instr/case, Eval_instr/dbg, Eval_instr/fail, Eval_instr/group
+splice warning: 	Eval_instr/ifhold, Eval_instr/ifinstr, Eval_instr/let, Eval_instr/rel, Eval_instr/result
+splice warning: 	Eval_instr/return, Eval_instrs/, Eval_let/, Eval_let/fail, Eval_path/dot
+splice warning: 	Eval_path/fail, Eval_path/idx, Eval_path/root, Eval_path/slice, Eval_path_upd/dot
+splice warning: 	Eval_path_upd/fail, Eval_path_upd/idx, Eval_path_upd/root, Eval_path_upd/slice, Eval_rel/
+splice warning: 	Eval_rel/fail, Eval_targs/, Eval_tblrow/fail, Eval_tblrow/succ, Eval_tblrows/
+splice warning: unused 7 rulegroup-prose splices out of 74 (9.46%)
+splice warning: 	Assign_exp/tup, Entry/, Eval_arg/exp, Eval_arg/fun, Eval_exp/cons
+splice warning: 	Eval_instr/dbg, Eval_targs/
+splice warning: unused 28 rulegroup-dispatch-prose splices out of 28 (100.00%)
+splice warning: 	Assign_exp, Assign_exps, Assign_param, Assign_params, Call_defined_func
+splice warning: 	Call_defined_rel, Call_func, Call_func_dispatch, Call_rel, Call_rel_dispatch
 splice warning: 	Call_table_func, Entry, Eval_arg, Eval_block, Eval_case
 splice warning: 	Eval_cases, Eval_exp, Eval_if_cond, Eval_ifhold_cond, Eval_instr
 splice warning: 	Eval_instrs, Eval_let, Eval_path, Eval_path_upd, Eval_rel
 splice warning: 	Eval_targs, Eval_tblrow, Eval_tblrows
-splice warning: unused 3 relation-title-prose splices out of 33 (9.09%)
-splice warning: 	Entry, Eval_arg, Eval_targs
-splice warning: unused 87 rulegroup-source splices out of 87 (100.00%)
-splice warning: 	Assign_exp/cons, Assign_exp/inj, Assign_exp/iter, Assign_exp/list, Assign_exp/opt
-splice warning: 	Assign_exp/str, Assign_exp/tup, Assign_exp/variable, Assign_exps/, Assign_param/exp
-splice warning: 	Assign_param/fun, Assign_params/, Call_defined_func/fail, Call_defined_func/ret, Call_defined_rel/fail
-splice warning: 	Call_defined_rel/succ, Call_func/, Call_func_cache/, Call_func_dispatch/, Call_rel/
-splice warning: 	Call_rel_cache/, Call_rel_dispatch/, Call_table_func/, Entry/, Eval_arg/exp
-splice warning: 	Eval_arg/fail, Eval_arg/fun, Eval_block/, Eval_case/fail, Eval_case/hit
-splice warning: 	Eval_cases/, Eval_exp/binary, Eval_exp/call, Eval_exp/case, Eval_exp/compare
-splice warning: 	Eval_exp/concat, Eval_exp/cons, Eval_exp/dot, Eval_exp/downcast, Eval_exp/fail
-splice warning: 	Eval_exp/idx, Eval_exp/iter, Eval_exp/len, Eval_exp/list, Eval_exp/literal
-splice warning: 	Eval_exp/match, Eval_exp/mem, Eval_exp/opt, Eval_exp/slice, Eval_exp/struct
-splice warning: 	Eval_exp/subtype, Eval_exp/tuple, Eval_exp/unary, Eval_exp/upcast, Eval_exp/upd
-splice warning: 	Eval_exp/variable, Eval_if_cond/, Eval_ifhold_cond/, Eval_instr/case, Eval_instr/dbg
-splice warning: 	Eval_instr/fail, Eval_instr/group, Eval_instr/ifhold, Eval_instr/ifinstr, Eval_instr/let
-splice warning: 	Eval_instr/rel, Eval_instr/result, Eval_instr/return, Eval_instrs/, Eval_let/
-splice warning: 	Eval_let/fail, Eval_path/dot, Eval_path/fail, Eval_path/idx, Eval_path/root
-splice warning: 	Eval_path/slice, Eval_path_upd/dot, Eval_path_upd/fail, Eval_path_upd/idx, Eval_path_upd/root
-splice warning: 	Eval_path_upd/slice, Eval_rel/, Eval_rel/fail, Eval_targs/, Eval_tblrow/fail
-splice warning: 	Eval_tblrow/succ, Eval_tblrows/
-splice warning: unused 7 rulegroup-prose splices out of 76 (9.21%)
-splice warning: 	Assign_exp/tup, Entry/, Eval_arg/exp, Eval_arg/fun, Eval_exp/cons
-splice warning: 	Eval_instr/dbg, Eval_targs/
-splice warning: unused 62 func-title-source splices out of 62 (100.00%)
+splice warning: unused 56 func-title-source splices out of 56 (100.00%)
 splice warning: 	add_func, add_map, add_typ, add_vari, add_varis
 splice warning: 	add_varr, add_varrs, adds_map, assoc_, binop_bool
-splice warning: 	binop_number, cache_add_func_maybe, cache_add_rel_maybe, cache_checkpoint, cache_find_func
-splice warning: 	cache_find_rel, cache_seff, cmpop_number, cmpop_poly, downcast
-splice warning: 	elsblock_as_block, empty_ctx, empty_layer, empty_map, empty_set
-splice warning: 	exists_, find_func, find_map, find_maps, find_rel
+splice warning: 	binop_number, cmpop_number, cmpop_poly, downcast, elsblock_as_block
+splice warning: 	empty_ctx, empty_layer, empty_map, empty_set, exists_
+splice warning: 	extend_tdenv, find_func, find_map, find_maps, find_rel
 splice warning: 	find_typ, find_vari, find_varis, find_varr, find_varrs
 splice warning: 	finds_vari, forall_, guard_as_exp, is_fun, is_iter_on_var
 splice warning: 	is_tup, ite, iter_vari, iter_varr, load
 splice warning: 	load_funcdef, load_reldef, load_typdef, opt_as_seq_, repeat_
-splice warning: 	rev_, sub_list, sub_list', sub_opt, subst_typ
-splice warning: 	subst_typ', subtyp, subtyps, theta_of_tdenv, transpose_
-splice warning: 	unop_number, upcast
-splice warning: unused 62 func-title-prose splices out of 62 (100.00%)
+splice warning: 	rev_, sub_list, sub_opt, subst_typ, subst_typ'
+splice warning: 	subtyp, subtyps, theta_of_tdenv, transpose_, unop_number
+splice warning: 	upcast
+splice warning: unused 56 func-title-prose splices out of 56 (100.00%)
 splice warning: 	add_func, add_map, add_typ, add_vari, add_varis
 splice warning: 	add_varr, add_varrs, adds_map, assoc_, binop_bool
-splice warning: 	binop_number, cache_add_func_maybe, cache_add_rel_maybe, cache_checkpoint, cache_find_func
-splice warning: 	cache_find_rel, cache_seff, cmpop_number, cmpop_poly, downcast
-splice warning: 	elsblock_as_block, empty_ctx, empty_layer, empty_map, empty_set
-splice warning: 	exists_, find_func, find_map, find_maps, find_rel
+splice warning: 	binop_number, cmpop_number, cmpop_poly, downcast, elsblock_as_block
+splice warning: 	empty_ctx, empty_layer, empty_map, empty_set, exists_
+splice warning: 	extend_tdenv, find_func, find_map, find_maps, find_rel
 splice warning: 	find_typ, find_vari, find_varis, find_varr, find_varrs
 splice warning: 	finds_vari, forall_, guard_as_exp, is_fun, is_iter_on_var
 splice warning: 	is_tup, ite, iter_vari, iter_varr, load
 splice warning: 	load_funcdef, load_reldef, load_typdef, opt_as_seq_, repeat_
-splice warning: 	rev_, sub_list, sub_list', sub_opt, subst_typ
-splice warning: 	subst_typ', subtyp, subtyps, theta_of_tdenv, transpose_
-splice warning: 	unop_number, upcast
+splice warning: 	rev_, sub_list, sub_opt, subst_typ, subst_typ'
+splice warning: 	subtyp, subtyps, theta_of_tdenv, transpose_, unop_number
+splice warning: 	upcast
 splice warning: unused 49 func-source splices out of 49 (100.00%)
 splice warning: 	add_func, add_typ, add_vari, add_varis, add_varr
 splice warning: 	add_varrs, binop_bool, binop_number, cmpop_number, cmpop_poly
 splice warning: 	downcast, elsblock_as_block, empty_ctx, empty_layer, empty_map
-splice warning: 	empty_set, exists_, find_func, find_rel, find_typ
-splice warning: 	find_vari, find_varis, find_varr, find_varrs, finds_vari
-splice warning: 	forall_, guard_as_exp, is_fun, is_iter_on_var, is_tup
-splice warning: 	ite, iter_vari, iter_varr, load, load_funcdef
-splice warning: 	load_reldef, load_typdef, opt_as_seq_, repeat_, sub_list
-splice warning: 	sub_list', sub_opt, subst_typ, subst_typ', subtyp
+splice warning: 	empty_set, exists_, extend_tdenv, find_func, find_rel
+splice warning: 	find_typ, find_vari, find_varis, find_varr, find_varrs
+splice warning: 	finds_vari, forall_, guard_as_exp, is_fun, is_iter_on_var
+splice warning: 	is_tup, ite, iter_vari, iter_varr, load
+splice warning: 	load_funcdef, load_reldef, load_typdef, opt_as_seq_, repeat_
+splice warning: 	sub_list, sub_opt, subst_typ, subst_typ', subtyp
 splice warning: 	subtyps, theta_of_tdenv, unop_number, upcast
-splice warning: unused 38 func-prose splices out of 49 (77.55%)
+splice warning: unused 39 func-prose splices out of 49 (79.59%)
 splice warning: 	add_func, add_typ, add_vari, add_varis, add_varr
 splice warning: 	add_varrs, binop_bool, binop_number, cmpop_number, cmpop_poly
 splice warning: 	elsblock_as_block, empty_ctx, empty_layer, empty_map, empty_set
-splice warning: 	exists_, find_func, find_rel, find_typ, find_vari
-splice warning: 	find_varis, find_varr, find_varrs, finds_vari, forall_
-splice warning: 	guard_as_exp, is_fun, is_iter_on_var, is_tup, ite
-splice warning: 	iter_vari, iter_varr, opt_as_seq_, repeat_, subst_typ
-splice warning: 	subst_typ', theta_of_tdenv, unop_number
+splice warning: 	exists_, extend_tdenv, find_func, find_rel, find_typ
+splice warning: 	find_vari, find_varis, find_varr, find_varrs, finds_vari
+splice warning: 	forall_, guard_as_exp, is_fun, is_iter_on_var, is_tup
+splice warning: 	ite, iter_vari, iter_varr, opt_as_seq_, repeat_
+splice warning: 	subst_typ, subst_typ', theta_of_tdenv, unop_number
 splice warning: unused 0 table-source splices out of 0 (0.00%)
 splice warning: 	
 splice warning: unused 0 table-prose splices out of 0 (0.00%)

--- a/p4spec/lib/backend-boot/spectec.ml
+++ b/p4spec/lib/backend-boot/spectec.ml
@@ -77,59 +77,6 @@ module Make_null
 
   (* Cache management *)
 
-  let cache_find_func (values_input : Value.t list) : Value.t =
-    let _value_id, _value_values_input =
-      match values_input with
-      | [ value_id; value_values_input ] -> (value_id, value_values_input)
-      | _ -> error_no_region "unexpected number of arguments to cache_find_func"
-    in
-    Value.Make.("NONE" <| [] <<| "funccache")
-
-  let cache_add_func_maybe (values_input : Value.t list) : Value.t =
-    let _value_seff, _value_id, _value_values_input, _value_valres =
-      match values_input with
-      | [ value_seff; value_id; value_values_input; value_valres ] ->
-          (value_seff, value_id, value_values_input, value_valres)
-      | _ ->
-          error_no_region
-            "unexpected number of arguments to cache_add_func_maybe"
-    in
-    Value.Make.bool true
-
-  let cache_find_rel (values_input : Value.t list) : Value.t =
-    let _value_id, _value_values_input =
-      match values_input with
-      | [ value_id; value_values_input ] -> (value_id, value_values_input)
-      | _ -> error_no_region "unexpected number of arguments to cache_find_rel"
-    in
-    Value.Make.("NONE" <| [] <<| "relcache")
-
-  let cache_checkpoint (values_input : Value.t list) : Value.t =
-    (match values_input with
-    | [] -> ()
-    | _ -> error_no_region "unexpected number of arguments to cache_checkpoint");
-    Value.Make.extern (Typ.Make.var ("cachepoint" $ no_region) []) (`Int 42)
-
-  let cache_add_rel_maybe (values_input : Value.t list) : Value.t =
-    let _value_seff, _value_id, _value_values_input, _value_valsres =
-      match values_input with
-      | [ value_seff; value_id; value_values_input; value_valsres ] ->
-          (value_seff, value_id, value_values_input, value_valsres)
-      | _ ->
-          error_no_region
-            "unexpected number of arguments to cache_add_rel_maybe"
-    in
-    Value.Make.bool true
-
-  let cache_seff (values_input : Value.t list) : Value.t =
-    let _value_cachepoint_before, _value_cachepoint_after =
-      match values_input with
-      | [ value_cachepoint_before; value_cachepoint_after ] ->
-          (value_cachepoint_before, value_cachepoint_after)
-      | _ -> error_no_region "unexpected number of arguments to cache_seff"
-    in
-    Value.Make.bool false
-
   (* Externs *)
 
   let eval_extern_rel (name : string) (values_input : Value.t list) :
@@ -144,16 +91,10 @@ module Make_null
     with Util.Error.ExternError (at, msg) -> Run.Fail (at, msg)
 
   let eval_extern_func (name : string) (_typs : Typ.t list)
-      (values_input : Value.t list) : Run.func_result =
+      (_values_input : Value.t list) : Run.func_result =
     try
       Run.Pass
         (match name with
-        | "cache_find_func" -> cache_find_func values_input
-        | "cache_add_func_maybe" -> cache_add_func_maybe values_input
-        | "cache_find_rel" -> cache_find_rel values_input
-        | "cache_add_rel_maybe" -> cache_add_rel_maybe values_input
-        | "cache_checkpoint" -> cache_checkpoint values_input
-        | "cache_seff" -> cache_seff values_input
         | _ ->
             error no_region
               (Format.asprintf "unimplemented extern function: %s" name))
@@ -187,37 +128,19 @@ module Make_parametric
   let init_mode _ = ()
 
   (* Caches
-   * a meta-cache for storing results of meta-relation and meta-meta-function calls
    * an interface cache for storing results of booting and unbooting values, types, and mixops *)
 
-  type cache_meta = {
-    mutable enabled : bool;
-    func : Value.t CCache.t;
-    rel : Value.t CCache.t;
-  }
-
-  type cache = { meta : cache_meta; interface : Interface_SpecTec.cache }
+  type cache = { interface : Interface_SpecTec.cache }
 
   let cache : cache =
-    let meta : cache_meta =
-      {
-        enabled = true;
-        func = CCache.create ~size:(256 * 1024);
-        rel = CCache.create ~size:(256 * 1024);
-      }
-    in
     let interface = Interface_SpecTec.make_cache () in
-    { meta; interface }
+    { interface }
 
   module Cache = struct
     let cache_on () =
-      cache.meta.enabled <- true;
       Interface_SpecTec.cache_enable cache.interface
 
     let cache_off () =
-      cache.meta.enabled <- false;
-      CCache.empty cache.meta.func;
-      CCache.empty cache.meta.rel;
       Interface_SpecTec.cache_disable_reset cache.interface
   end
 
@@ -291,117 +214,6 @@ module Make_parametric
     Interface_SpecTec.pop_cache ();
     [ value_values_output_res ]
 
-  (* Meta-cache management *)
-
-  let cache_find_func (values_input : Value.t list) : Value.t =
-    if not cache.meta.enabled then Value.Make.("NONE" <| [] <<| "funccache")
-    else
-      let value_id, value_values_input =
-        match values_input with
-        | [ value_id; value_values_input ] -> (value_id, value_values_input)
-        | _ ->
-            error_no_region "unexpected number of arguments to cache_find_func"
-      in
-      let id = value_id |> Interface_SpecTec.unboot_id in
-      let cache_result =
-        CCache.find cache.meta.func (id.it, [ value_values_input ])
-      in
-      match cache_result with
-      | Some value_value_output ->
-          Value.Make.("OK val" <| [ value_value_output ] <<| "funccache")
-      | None -> Value.Make.("NONE" <| [] <<| "funccache")
-
-  let cache_add_func_maybe (values_input : Value.t list) : Value.t =
-    if not cache.meta.enabled then Value.Make.bool true
-    else
-      let value_seff, value_id, value_values_input, value_valres =
-        match values_input with
-        | [ value_seff; value_id; value_values_input; value_valres ] ->
-            (value_seff, value_id, value_values_input, value_valres)
-        | _ ->
-            error_no_region
-              "unexpected number of arguments to cache_add_func_maybe"
-      in
-      let seff = value_seff |> Value.Get.bool in
-      (if not seff then
-         match Value.Get.(value_valres |>>? "OK val") with
-         | Some [ value_value_output ] ->
-             let id = value_id |> Interface_SpecTec.unboot_id in
-             CCache.add cache.meta.func
-               (id.it, [ value_values_input ])
-               value_value_output
-         | _ -> ());
-      Value.Make.bool true
-
-  let cache_find_rel (values_input : Value.t list) : Value.t =
-    if not cache.meta.enabled then Value.Make.("NONE" <| [] <<| "relcache")
-    else
-      let value_id, value_values_input =
-        match values_input with
-        | [ value_id; value_values_input ] -> (value_id, value_values_input)
-        | _ ->
-            error_no_region "unexpected number of arguments to cache_find_rel"
-      in
-      let id = value_id |> Interface_SpecTec.unboot_id in
-      let cache_result =
-        CCache.find cache.meta.rel (id.it, [ value_values_input ])
-      in
-      match cache_result with
-      | Some value_values_output ->
-          Value.Make.("OK val*" <| [ value_values_output ] <<| "relcache")
-      | None -> Value.Make.("NONE" <| [] <<| "relcache")
-
-  let cache_add_rel_maybe (values_input : Value.t list) : Value.t =
-    if not cache.meta.enabled then Value.Make.bool true
-    else
-      let value_seff, value_id, value_values_input, value_valsres =
-        match values_input with
-        | [ value_seff; value_id; value_values_input; value_valsres ] ->
-            (value_seff, value_id, value_values_input, value_valsres)
-        | _ ->
-            error_no_region
-              "unexpected number of arguments to cache_add_rel_maybe"
-      in
-      let seff = value_seff |> Value.Get.bool in
-      (if not seff then
-         match Value.Get.(value_valsres |>>? "OK val*") with
-         | Some [ value_values_output ] ->
-             let id = value_id |> Interface_SpecTec.unboot_id in
-             CCache.add cache.meta.rel
-               (id.it, [ value_values_input ])
-               value_values_output
-         | _ -> ());
-      Value.Make.bool true
-
-  let cache_checkpoint (values_input : Value.t list) : Value.t =
-    (match values_input with
-    | [] -> ()
-    | _ -> error_no_region "unexpected number of arguments to cache_checkpoint");
-    let checkpoint = Runner.Interface.checkpoint () in
-    Value.Make.extern
-      (Typ.Make.var ("cachepoint" $ no_region) [])
-      (`Int checkpoint)
-
-  let cache_seff (values_input : Value.t list) : Value.t =
-    let value_cachepoint_before, value_cachepoint_after =
-      match values_input with
-      | [ value_cachepoint_before; value_cachepoint_after ] ->
-          (value_cachepoint_before, value_cachepoint_after)
-      | _ -> error_no_region "unexpected number of arguments to cache_seff"
-    in
-    let cachepoint_before =
-      value_cachepoint_before |> Value.Get.extern |> function
-      | `Int i -> i
-      | _ -> error_no_region "unexpected type for cachepoint_before"
-    in
-    let cachepoint_after =
-      value_cachepoint_after |> Value.Get.extern |> function
-      | `Int i -> i
-      | _ -> error_no_region "unexpected type for cachepoint_after"
-    in
-    let seff = Runner.Interface.seff cachepoint_before cachepoint_after in
-    Value.Make.bool seff
-
   (* Extern handlers *)
 
   let eval_extern_rel (name : string) (values_input : Value.t list) :
@@ -418,16 +230,10 @@ module Make_parametric
     with Util.Error.ExternError (at, msg) -> Run.Fail (at, msg)
 
   let eval_extern_func (name : string) (_typs : Typ.t list)
-      (values_input : Value.t list) : Run.func_result =
+      (_values_input : Value.t list) : Run.func_result =
     try
       Run.Pass
         (match name with
-        | "cache_find_func" -> cache_find_func values_input
-        | "cache_add_func_maybe" -> cache_add_func_maybe values_input
-        | "cache_find_rel" -> cache_find_rel values_input
-        | "cache_add_rel_maybe" -> cache_add_rel_maybe values_input
-        | "cache_checkpoint" -> cache_checkpoint values_input
-        | "cache_seff" -> cache_seff values_input
         | _ ->
             error no_region
               (Format.asprintf "unimplemented extern function: %s" name))
@@ -446,7 +252,5 @@ module Make_parametric
     Interface_SpecTec.cache_clear cache.interface
 
   let clear () : unit =
-    clear_cache_interface ();
-    CCache.empty cache.meta.func;
-    CCache.empty cache.meta.rel
+    clear_cache_interface ()
 end

--- a/spec-meta/al/3-context.watsup
+++ b/spec-meta/al/3-context.watsup
@@ -184,12 +184,12 @@ def $find_typ(C, id) = $find_map<id, typdef>(C.GLOBAL.TYP, id)
 
 ;;; Function finders
 
-dec $find_func(ctx, id) : (cursor, funcdef)?
+dec $find_func(ctx, id) : funcdef?
   hint(prose_in "the function definition of" %1 "in" %0)
 
-def $find_func(C, id) = (LOCAL, funcdef)
+def $find_func(C, id) = funcdef
   -- if funcdef = $find_map<id, funcdef>(C.LOCAL.FUNC, id)
-def $find_func(C, id) = (GLOBAL, funcdef)
+def $find_func(C, id) = funcdef
   -- if eps = $find_map<id, funcdef>(C.LOCAL.FUNC, id)
   -- if funcdef = $find_map<id, funcdef>(C.GLOBAL.FUNC, id)
 def $find_func(C, id) = eps
@@ -216,14 +216,8 @@ def $sub_opt(C, vari*) = eps
   -- if (vari_iter = $iter_vari(vari, QUEST))*
   -- if (OPT eps = $find_vari(C, vari_iter))*
 
-dec $sub_list'(ctx, vari*, val*) : ctx
-def $sub_list'(C, eps, eps) = C
-def $sub_list'(C, vari_h :: vari_t*, val_h :: val_t*)
-  = $sub_list'(C', vari_t*, val_t*)
-  -- if C' = $add_vari(C, vari_h, val_h)
-
 def $sub_list(C, vari*) = C'*
   -- if (vari_iter = $iter_vari(vari, STAR))*
   -- if (LIST val* = $find_vari(C, vari_iter))*
   -- if val_trans** = $transpose_<val>(val**)
-  -- if (C' = $sub_list'(C, vari*, val_trans*))*
+  -- if (C' = $add_varis(C, vari*, val_trans*))*

--- a/spec-meta/al/4-relation.watsup
+++ b/spec-meta/al/4-relation.watsup
@@ -38,10 +38,6 @@ relation Call_func_dispatch:
   ctx |- funcdef targ* val* : res<val>
   hint(input %0 %1 %2 %3)
 
-relation Call_func_cache:
-  ctx |- id typ* val* funccache : res<val>
-  hint(input %0 %1 %2 %3 %4)
-
 relation Call_func:
   ctx |- id targ* val* : res<val>
   hint(input %0 %1 %2 %3)
@@ -51,10 +47,6 @@ relation Call_func:
 relation Call_rel_dispatch:
   ctx |- reldef val* : res<val*>
   hint(input %0 %1 %2)
-
-relation Call_rel_cache:
-  ctx |- id val* relcache : res<val*>
-  hint(input %0 %1 %2 %3)
 
 relation Call_rel:
   ctx |- id val* : res<val*>

--- a/spec-meta/al/5.2-eval-assign.watsup
+++ b/spec-meta/al/5.2-eval-assign.watsup
@@ -124,7 +124,7 @@ rule Assign_arg/exp:
 
 rule Assign_arg/fun:
   C_callee '/' C_caller |- FUN id_callee := FUNC id_caller : C_callee'
-  -- if (_, funcdef) = $find_func(C_caller, id_caller)
+  -- if funcdef = $find_func(C_caller, id_caller)
   -- if C_callee' = $add_func(C_callee, id_callee, funcdef)
 
 ;;; Assigning to a sequence of arguments

--- a/spec-meta/al/5.6-eval-call-func.watsup
+++ b/spec-meta/al/5.6-eval-call-func.watsup
@@ -141,32 +141,9 @@ rulegroup Call_func_dispatch {
 
 }
 
-;; Meta-function call wrapper with cache
+;; Meta-function call
 
 rule Call_func:
   C |- id typ* val* : valres
-  -- if funccache = $cache_find_func(id, val*)
-  -- Call_func_cache:
-      C |- id typ* val* funccache : valres
-
-rulegroup Call_func_cache {
-
-  rule Call_func_cache/hit:
-    C |- id typ* val* (OK val_cached) : OK val_cached
-
-  rule Call_func_cache/miss:
-    C |- id typ* val* NONE : valres
-    -- if (cursor, funcdef) = $find_func(C, id)
-    -- if cp_before = $cache_checkpoint()
-    -- Call_func_dispatch: C |- funcdef typ* val* : valres
-    -- if cp_after = $cache_checkpoint()
-    -- if b_ext = (funcdef <: externFuncDef)
-    -- if b_seff = $cache_seff(cp_before, cp_after)
-    -- if b_anon = (cursor = LOCAL)
-    -- if b_hoff = $exists_($is_fun(val)*)
-    -- if $cache_add_func_maybe(
-            b_ext \/ b_seff \/ b_anon \/ b_hoff,
-            ;; true,
-            id, val*, valres)
-
-}
+  -- if funcdef = $find_func(C, id)
+  -- Call_func_dispatch: C |- funcdef typ* val* : valres

--- a/spec-meta/al/5.7-eval-call-rel.watsup
+++ b/spec-meta/al/5.7-eval-call-rel.watsup
@@ -115,29 +115,9 @@ rulegroup Call_rel_dispatch {
 
 }
 
-;; Relation call wrapper with cache
+;; Relation call
 
 rule Call_rel:
   C |- id val* : valsres
-  -- if relcache = $cache_find_rel(id, val*)
-  -- Call_rel_cache: C |- id val* relcache : valsres
-
-rulegroup Call_rel_cache {
-
-  rule Call_rel_cache/hit:
-    C |- id val_input* (OK val_cached*) : OK val_cached*
-
-  rule Call_rel_cache/miss:
-    C |- id val_input* NONE : valsres
-    -- if reldef = $find_rel(C, id)
-    -- if cp_before = $cache_checkpoint()
-    -- Call_rel_dispatch: C |- reldef val_input* : valsres
-    -- if cp_after = $cache_checkpoint()
-    -- if b_ext = (reldef <: externRelDef)
-    -- if b_seff = $cache_seff(cp_before, cp_after)
-    -- if $cache_add_rel_maybe(
-            b_ext \/ b_seff,
-            ;; true,
-            id, val_input*, valsres)
-
-}
+  -- if reldef = $find_rel(C, id)
+  -- Call_rel_dispatch: C |- reldef val* : valsres

--- a/spec-meta/common/4-relation.watsup
+++ b/spec-meta/common/4-relation.watsup
@@ -6,32 +6,6 @@ syntax res<X> = OK X | FAIL
 syntax valres = res<val>
 syntax valsres = res<val*>
 
-;; Interface to an external cache
-
-extern syntax cachepoint
-syntax funccache = OK val | NONE
-syntax relcache = OK val* | NONE
-
-var cp : cachepoint
-
-extern dec $cache_find_func(id, val*) : funccache
-  hint(prose_in "meta-cache entry for function" %0 "with inputs" %1)
-extern dec $cache_add_func_maybe(bool, id, val*, valres) : bool
-  hint(prose_in "adding meta-cache entry for function" %1
-                "with inputs" %2#", result" %3#", and side-effects" %0)
-
-extern dec $cache_find_rel(id, val*) : relcache
-  hint(prose_in "meta-cache entry for relation" %0 "with inputs" %1)
-extern dec $cache_add_rel_maybe(bool, id, val*, valsres) : bool
-  hint(prose_in "adding meta-cache entry for relation" %1
-                "with inputs" %2#", result" %3#", and side-effects" %0)
-
-extern dec $cache_checkpoint() : cachepoint
-  hint(prose_in "cache checkpoint")
-extern dec $cache_seff(cachepoint, cachepoint) : bool
-  hint(prose_true "side-effect occurred between checkpoints" %0 "and" %1)
-  hint(prose_false "no side-effect occurred between checkpoints" %0 "and" %1)
-
 ;;; Extern meta-function invocation
 
 extern relation Call_extern_func:

--- a/spec-meta/sl/3-context.watsup
+++ b/spec-meta/sl/3-context.watsup
@@ -184,25 +184,18 @@ def $find_typ(C, id) = $find_map<id, typdef>(C.GLOBAL.TYP, id)
 
 ;;; Function finders
 
-dec $find_func(ctx, id) : (cursor, funcdef)?
+dec $find_func(ctx, id) : funcdef?
   hint(prose_in "the function definition of" %1 "in" %0)
 
-def $find_func(C, id) = (LOCAL, funcdef)
+def $find_func(C, id) = funcdef
   -- if funcdef = $find_map<id, funcdef>(C.LOCAL.FUNC, id)
-def $find_func(C, id) = (GLOBAL, funcdef)
+def $find_func(C, id) = funcdef
   -- if eps = $find_map<id, funcdef>(C.LOCAL.FUNC, id)
   -- if funcdef = $find_map<id, funcdef>(C.GLOBAL.FUNC, id)
 def $find_func(C, id) = eps
   -- otherwise
 
 ;;; Relation finders
-
-dec $find_typ2(tdenv, tdenv, id) : typdef?
-  hint(prose_in "the type definition of" %2 "in type environments" %0 "and" %1)
-def $find_typ2(tdenv_l, tdenv_g, id) = typdef
-  -- if typdef = $find_map<id, typdef>(tdenv_l, id)
-def $find_typ2(tdenv_l, tdenv_g, id) = $find_map<id, typdef>(tdenv_g, id)
-  -- if eps = $find_map<id, typdef>(tdenv_l, id)
 
 dec $find_rel(ctx, id) : reldef?
   hint(prose_in "the relation definition of" %1 "in" %0)
@@ -223,14 +216,8 @@ def $sub_opt(C, vari*) = eps
   -- if (vari_iter = $iter_vari(vari, QUEST))*
   -- if (OPT eps = $find_vari(C, vari_iter))*
 
-dec $sub_list'(ctx, vari*, val*) : ctx
-def $sub_list'(C, eps, eps) = C
-def $sub_list'(C, vari_h :: vari_t*, val_h :: val_t*)
-  = $sub_list'(C', vari_t*, val_t*)
-  -- if C' = $add_vari(C, vari_h, val_h)
-
 def $sub_list(C, vari*) = C'*
   -- if (vari_iter = $iter_vari(vari, STAR))*
   -- if (LIST val* = $find_vari(C, vari_iter))*
   -- if val_trans** = $transpose_<val>(val**)
-  -- if (C' = $sub_list'(C, vari*, val_trans*))*
+  -- if (C' = $add_varis(C, vari*, val_trans*))*

--- a/spec-meta/sl/4-relation.watsup
+++ b/spec-meta/sl/4-relation.watsup
@@ -51,10 +51,6 @@ relation Call_func_dispatch:
   ctx |- funcdef targ* val* : res<val>
   hint(input %0 %1 %2 %3)
 
-relation Call_func_cache:
-  ctx |- id typ* val* funccache : res<val>
-  hint(input %0 %1 %2 %3 %4)
-
 relation Call_func:
   ctx |- id targ* val* : res<val>
   hint(input %0 %1 %2 %3)
@@ -64,10 +60,6 @@ relation Call_func:
 relation Call_rel_dispatch:
   ctx |- reldef val* : res<val*>
   hint(input %0 %1 %2)
-
-relation Call_rel_cache:
-  ctx |- id val* relcache : res<val*>
-  hint(input %0 %1 %2 %3)
 
 relation Call_rel:
   ctx |- id val* : res<val*>

--- a/spec-meta/sl/5.2-eval-assign.watsup
+++ b/spec-meta/sl/5.2-eval-assign.watsup
@@ -124,7 +124,7 @@ rule Assign_param/exp:
 
 rule Assign_param/fun:
   C_callee '/' C_caller |- FUN id_callee ':' _ _ '->' _ := FUNC id_caller : C_callee'
-  -- if (_, funcdef) = $find_func(C_caller, id_caller)
+  -- if funcdef = $find_func(C_caller, id_caller)
   -- if C_callee' = $add_func(C_callee, id_callee, funcdef)
 
 ;;; Assigning to a sequence of parameters

--- a/spec-meta/sl/5.6-eval-call-func.watsup
+++ b/spec-meta/sl/5.6-eval-call-func.watsup
@@ -112,32 +112,9 @@ rulegroup Call_func_dispatch {
 
 }
 
-;; Meta-function call wrapper with cache
+;; Meta-function call
 
 rule Call_func:
   C |- id typ* val* : valres
-  -- if funccache = $cache_find_func(id, val*)
-  -- Call_func_cache:
-      C |- id typ* val* funccache : valres
-
-rulegroup Call_func_cache {
-
-  rule Call_func_cache/hit:
-    C |- id typ* val* (OK val_cached) : OK val_cached
-
-  rule Call_func_cache/miss:
-    C |- id typ* val* NONE : valres
-    -- if (cursor, funcdef) = $find_func(C, id)
-    -- if cp_before = $cache_checkpoint()
-    -- Call_func_dispatch: C |- funcdef typ* val* : valres
-    -- if cp_after = $cache_checkpoint()
-    -- if b_ext = (funcdef <: externFuncDef)
-    -- if b_seff = $cache_seff(cp_before, cp_after)
-    -- if b_anon = (cursor = LOCAL)
-    -- if b_hoff = $exists_($is_fun(val)*)
-    -- if $cache_add_func_maybe(
-            b_ext \/ b_seff \/ b_anon \/ b_hoff,
-            ;; true,
-            id, val*, valres)
-
-}
+  -- if funcdef = $find_func(C, id)
+  -- Call_func_dispatch: C |- funcdef typ* val* : valres

--- a/spec-meta/sl/5.7-eval-call-rel.watsup
+++ b/spec-meta/sl/5.7-eval-call-rel.watsup
@@ -36,29 +36,9 @@ rulegroup Call_rel_dispatch {
 
 }
 
-;; Relation call wrapper with cache
+;; Relation call
 
 rule Call_rel:
   C |- id val* : valsres
-  -- if relcache = $cache_find_rel(id, val*)
-  -- Call_rel_cache: C |- id val* relcache : valsres
-
-rulegroup Call_rel_cache {
-
-  rule Call_rel_cache/hit:
-    C |- id val_input* (OK val_cached*) : OK val_cached*
-
-  rule Call_rel_cache/miss:
-    C |- id val_input* NONE : valsres
-    -- if reldef = $find_rel(C, id)
-    -- if cp_before = $cache_checkpoint()
-    -- Call_rel_dispatch: C |- reldef val_input* : valsres
-    -- if cp_after = $cache_checkpoint()
-    -- if b_ext = (reldef <: externRelDef)
-    -- if b_seff = $cache_seff(cp_before, cp_after)
-    -- if $cache_add_rel_maybe(
-            b_ext \/ b_seff,
-            ;; true,
-            id, val_input*, valsres)
-
-}
+  -- if reldef = $find_rel(C, id)
+  -- Call_rel_dispatch: C |- reldef val* : valsres


### PR DESCRIPTION
## Summary

The meta-circular interpreter memoized meta-function and meta-relation calls through an external cache. This made the meta-language specification document a memoization strategy rather than the semantics it is meant to define: `Call_func`/`Call_rel` were wrappers that dispatched through `Call_func_cache`/`Call_rel_cache`, with hit/miss rules and checkpoint-based side-effect tracking around the actual dispatch.

This PR removes the cache. The specification now reads as the semantics — resolve the definition from the context, then dispatch — which is what we want documented for the meta-language.

## What changed

The entry rule for a meta-function call goes from a cache wrapper to a direct lookup-and-dispatch:

```diff
-;; Meta-function call wrapper with cache
+;; Meta-function call

 rule Call_func:
   C |- id typ* val* : valres
-  -- if funccache = $cache_find_func(id, val*)
-  -- Call_func_cache:
-      C |- id typ* val* funccache : valres
-
-rulegroup Call_func_cache {
-
-  rule Call_func_cache/hit:
-    C |- id typ* val* (OK val_cached) : OK val_cached
-
-  rule Call_func_cache/miss:
-    C |- id typ* val* NONE : valres
-    -- if (cursor, funcdef) = $find_func(C, id)
-    -- if cp_before = $cache_checkpoint()
-    -- Call_func_dispatch: C |- funcdef typ* val* : valres
-    -- if cp_after = $cache_checkpoint()
-    -- if b_ext = (funcdef <: externFuncDef)
-    -- if b_seff = $cache_seff(cp_before, cp_after)
-    -- if b_anon = (cursor = LOCAL)
-    -- if b_hoff = $exists_($is_fun(val)*)
-    -- if $cache_add_func_maybe(
-            b_ext \/ b_seff \/ b_anon \/ b_hoff,
-            id, val*, valres)
-
-}
+  -- if funcdef = $find_func(C, id)
+  -- Call_func_dispatch: C |- funcdef typ* val* : valres
```

`Call_rel` is simplified the same way.

Supporting changes:

- **Cache interface removed** (`spec-meta/common/4-relation.watsup`): the `$cache_find_func`, `$cache_add_func_maybe`, `$cache_find_rel`, `$cache_add_rel_maybe`, `$cache_checkpoint`, `$cache_seff` extern decls and the `cachepoint`/`funccache`/`relcache` syntaxes.
- **`$find_func` return type** (`3-context.watsup`): `(cursor, funcdef)?` → `funcdef?`. The `cursor` existed only to feed the cache's `b_anon` heuristic; its two other call sites (`Assign_arg/exp`, and the `$find_func` in `Call_func`) discarded it via `(_, funcdef)`.
- **`$sub_list'` → `$add_varis`**: the local recursive binder helper is replaced by the existing `$add_varis`, dropping a now-redundant function.

  ```diff
  -  -- if (C' = $sub_list'(C, vari*, val_trans*))*
  +  -- if (C' = $add_varis(C, vari*, val_trans*))*
  ```
- **`backend-boot/spectec.ml`**: removes the OCaml implementations of the six cache externs in `Make_parametric` and their no-op stubs in `Make_null` (206 lines, −201 net).
- **Docs**: regenerated `docs/al` and `docs/sl` (the removed relations/functions no longer splice), and renamed the Makefile doc target `ilspec` → `alspec`.

Both `spec-meta/al` and `spec-meta/sl` receive the identical change.

## Cost

Without the cache, previously-memoized meta-calls are recomputed. Measured on the `al-al` tower (`towers/al-al.json`, release build), before = cache present, after = cache removed:

| program | before | after | delta |
|---|---|---|---|
| `action-bind.p4` | 18.52s (median of 5) | 19.96s (median of 5) | +8% |
| `action-synth.p4` | 202.63s (1 run) | 289.61s (1 run) | +43% |

The hit scales with meta-call count: small for `action-bind`, larger for the heavier `action-synth`. `action-bind` runs were noisy (BEFORE 18.4–20.2s, AFTER 18.8–20.5s, ranges overlap) — treat these as indicative, not guaranteed.

## Validation

- `dune build --profile=release bin/boot.exe` succeeds.
- `al-al` tower boots and passes on both programs above (`passed`), before and after — the meta-spec still elaborates and the tower result is unchanged.
- Not run: `make test-boot`, `make test-all-det`, and the doc build (`make alspec`, needs asciidoctor).
