### PR TITLE
Fix nested index guards insertion order when structuring

### DIFF
--- a/p4spec/lib/pass/algo/sidecondition/guard.ml
+++ b/p4spec/lib/pass/algo/sidecondition/guard.ml
@@ -247,7 +247,7 @@ let collector : Result.t Walk.Collect.collector =
         let prems_insert = gen_index_guard exp exp_b exp_i in
         let result_b = c.collect_exp c exp_b in
         let result_i = c.collect_exp c exp_i in
-        Result.compose ([], prems_insert) (Result.compose result_b result_i)
+        Result.compose result_b (Result.compose result_i ([], prems_insert))
     | IterE (exp_inner, iterexp) ->
         let iter, vars = iterexp in
         let result = c.collect_exp c exp_inner in


### PR DESCRIPTION
## Summary

Generate bounds guards for the child expressions of an index access before
generating the guard for the parent access.

This prevents a nested index expression from being evaluated before its own
bounds guard has been checked.

## Problem

Consider the following EL execution rule:

```watsup
rule Step_plain_instr/global-get:
  STO fr v* |- GLOBAL.GET x :
    (STO, fr, STO.GLOBALS[fr.MODULE.GLOBALS[x]].VALUE :: v*, eps)
```

The result expression contains a nested index access:

```text
STO.GLOBALS[fr.MODULE.GLOBALS[x]]
```

The side-condition pass generates a bounds guard for each index access.
Previously, it emitted the parent guard before recursively collected guards
from the base and index expressions.

### Structured output before this change

```text
1. If ((fr.MODULE.GLOBALS[x] < |STO.GLOBALS|)), then

    1. If ((x < |fr.MODULE.GLOBALS|)), then

        1. Result in: % % % |- % :
           (STO, fr,
            STO.GLOBALS[fr.MODULE.GLOBALS[x]].VALUE ::
              (v''''''')*{v''''''' <- v'''''''*},
            [])

    1. Else Dangling#2294

1. Else Dangling#2293
```

The outer condition itself evaluates `fr.MODULE.GLOBALS[x]`. If

```text
x >= |fr.MODULE.GLOBALS|
```

then the SL interpreter fails while evaluating the outer condition's nested
index expression.

Consequently, the outer condition never produces a Boolean value, and the
dangling-coverage hook is never invoked. The execution therefore fails through
an index-out-of-bounds backtracking/runtime error instead of reaching either
generated dangling branch. In particular, the inner `x` bounds dangling branch
is operationally unreachable.

## Fix

Collect guards from the base and index expressions before appending the guard
for the current index access.

```diff
- Result.compose ([], prems_insert) (Result.compose result_b result_i)
+ Result.compose result_b (Result.compose result_i ([], prems_insert))
```

This follows the dependency order:

```text
guards required to evaluate the base
→ guards required to evaluate the index
→ guard for the current index access
```

### Structured output after this change

```text
1. If ((x < |fr.MODULE.GLOBALS|)), then

    1. If ((fr.MODULE.GLOBALS[x] < |STO.GLOBALS|)), then

        1. Result in: % % % |- % :
           (STO, fr,
            STO.GLOBALS[fr.MODULE.GLOBALS[x]].VALUE ::
              (v''''''')*{v''''''' <- v'''''''*},
            [])

    1. Else Dangling#2294

1. Else Dangling#2293
```

Now the two failure cases are distinguished correctly:

- If `x >= |fr.MODULE.GLOBALS|`, the first condition evaluates to `false` and
  reaches `Dangling#2293`.
- If `x` is valid but
  `fr.MODULE.GLOBALS[x] >= |STO.GLOBALS|`, the second condition evaluates to
  `false` and reaches `Dangling#2294`.