### PR TITLE
Refactor exception-based error handling to typed results through a single facade

### DIFF
--- a/p4spec/bin/boot.ml
+++ b/p4spec/bin/boot.ml
@@ -1,7 +1,6 @@
 open Lang
 open Runtime.Dynamic_Runner.Signature
 open Backend_boot.Config
-open Util.Error
 
 let version = "0.1"
 
@@ -234,7 +233,8 @@ let parse_command =
            try
              match Runner.Interface.parse_program [] [ path_spectec ] with
              | Fail (`Syntax (at, msg)) ->
-                 Format.printf "Parse error: %s\n" (string_of_error at msg)
+                 Format.printf "Parse error: %s\n"
+                   (Util.Error.string_of_error at msg)
              | Pass value_program ->
                  let str_program =
                    Runner.Interface.unparse_program value_program
@@ -245,7 +245,7 @@ let parse_command =
                    with
                    | Fail (`Syntax (at, msg)) ->
                        Format.printf "Parse error: %s\n"
-                         (string_of_error at msg)
+                         (Util.Error.string_of_error at msg)
                    | Pass value_program_roundtrip ->
                        Il.Eq.eq_value ~dbg:true value_program
                          value_program_roundtrip

--- a/p4spec/bin/boot.ml
+++ b/p4spec/bin/boot.ml
@@ -1,7 +1,9 @@
 open Lang
 open Runtime.Dynamic_Runner.Signature
+module Error = P4spectec.Error
 open Backend_boot.Config
 
+let ( let* ) = Result.bind
 let version = "0.1"
 
 (* Tune GC for the allocation-heavy meta-circular interpreter *)
@@ -14,8 +16,6 @@ let () =
       Gc.space_overhead = 2000;
     }
 
-exception CommandError of string
-
 (* Commands *)
 
 let elab_command =
@@ -26,9 +26,9 @@ let elab_command =
        anon (non_empty_sequence_as_list ("path" %: string))
      in
      fun () ->
-       match Pass.elab paths_spec with
+       match P4spectec.elab paths_spec with
        | Ok spec_il -> Format.printf "%s\n" (Il.Print.string_of_spec spec_il)
-       | Error e -> Format.printf "%s\n" (Pass.string_of_error e))
+       | Error e -> Format.printf "%s\n" (Error.to_string e))
 
 let algo_command =
   Core.Command.basic ~summary:"check algorithmic property of a spec"
@@ -38,9 +38,9 @@ let algo_command =
        anon (non_empty_sequence_as_list ("path" %: string))
      in
      fun () ->
-       match Pass.algo paths_spec with
+       match P4spectec.algo paths_spec with
        | Ok spec_al -> Format.printf "%s\n" (Al.Print.string_of_spec spec_al)
-       | Error e -> Format.printf "%s\n" (Pass.string_of_error e))
+       | Error e -> Format.printf "%s\n" (Error.to_string e))
 
 let struct_command =
   Core.Command.basic ~summary:"insert structured control flow to a spec"
@@ -50,9 +50,9 @@ let struct_command =
        anon (non_empty_sequence_as_list ("path" %: string))
      in
      fun () ->
-       match Pass.structure ~final:true paths_spec with
+       match P4spectec.structure ~final:true paths_spec with
        | Ok spec_sl -> Format.printf "%s\n" (Sl.Print.string_of_spec spec_sl)
-       | Error e -> Format.printf "%s\n" (Pass.string_of_error e))
+       | Error e -> Format.printf "%s\n" (Error.to_string e))
 
 let prose_command =
   Core.Command.basic ~summary:"generate AsciiDoc prose from a spec"
@@ -62,9 +62,9 @@ let prose_command =
        anon (non_empty_sequence_as_list ("path" %: string))
      in
      fun () ->
-       match Pass.annotate paths_spec with
+       match P4spectec.annotate paths_spec with
        | Ok spec_pl -> Format.printf "%s\n" (Pl.Render.render_spec spec_pl)
-       | Error e -> Format.printf "%s\n" (Pass.string_of_error e))
+       | Error e -> Format.printf "%s\n" (Error.to_string e))
 
 let run_command =
   Core.Command.basic ~summary:"execute the spec"
@@ -111,39 +111,36 @@ let run_command =
      fun () ->
        let cache = not no_cache in
        match
-         Backend_boot.Build.build_null ~cache ~det ~guard mode interface
-           paths_spec
+         let* spec = P4spectec.spec_of_mode mode paths_spec in
+         let* runner = P4spectec.build_null ~cache ~det ~guard interface spec in
+         Ok (spec, runner)
        with
-       | Error e -> Format.printf "%s\n" (Pass.string_of_error e)
-       | Ok (spec, (module Runner)) -> (
-           try
-             let handlers =
-               if profile then
-                 let (module PH : Inst.Handler.HANDLER) =
-                   Inst.Profile.make ()
+       | Error e -> Format.printf "%s\n" (Error.to_string e)
+       | Ok (spec, (module Runner : RUNNER)) -> (
+           let handlers =
+             if profile then
+               let (module PH : Inst.Handler.HANDLER) = Inst.Profile.make () in
+               [ (module PH : Inst.Handler.HANDLER) ]
+             else []
+           in
+           let handlers =
+             match trace with
+             | Some level ->
+                 let (module TH : Inst.Handler.HANDLER) =
+                   Inst.Trace.make ~level ()
                  in
-                 [ (module PH : Inst.Handler.HANDLER) ]
-               else []
-             in
-             let handlers =
-               match trace with
-               | Some level ->
-                   let (module TH : Inst.Handler.HANDLER) =
-                     Inst.Trace.make ~level ()
-                   in
-                   handlers @ [ (module TH : Inst.Handler.HANDLER) ]
-               | None -> handlers
-             in
-             Inst.Hook.register handlers;
-             Inst.Hook.init_spec spec;
-             let result = Runner.Interp.eval_program relname [] path_spectec in
-             Inst.Hook.finish ();
-             match result with
-             | Pass _ -> Format.printf "passed\n"
-             | Fail (`Syntax (_, msg)) -> Format.printf "syntax error: %s\n" msg
-             | Fail (`Runtime (_, msg)) ->
-                 Format.printf "runtime error: %s\n" msg
-           with CommandError msg -> Format.printf "%s\n" msg))
+                 handlers @ [ (module TH : Inst.Handler.HANDLER) ]
+             | None -> handlers
+           in
+           Inst.Hook.register handlers;
+           Inst.Hook.init_spec spec;
+           let result = Runner.Interp.eval_program relname [] path_spectec in
+           Inst.Hook.finish ();
+           match result with
+           | Pass _ -> Format.printf "passed\n"
+           | Fail (`Syntax (_, msg)) -> Format.printf "syntax error: %s\n" msg
+           | Fail (`Runtime (_, msg)) -> Format.printf "runtime error: %s\n" msg
+           ))
 
 let boot_n_command =
   Core.Command.basic ~summary:"run meta-circular interpreter"
@@ -169,45 +166,40 @@ let boot_n_command =
          ~if_nothing_chosen:(Default_to None)
      in
      fun () ->
-       try
-         let target = { includes = includes_target; path = path_target } in
-         let tower =
-           try Backend_boot.Config.tower_of_file path_tower target
-           with Failure msg -> raise (CommandError msg)
+       let target = { includes = includes_target; path = path_target } in
+       match
+         let* tower = P4spectec.tower_of_file path_tower target in
+         let* spec_boot, booter =
+           P4spectec.build_tower ~cache:(not no_cache) ~det ~guard tower
          in
-         match
-           Backend_boot.Build.build_tower ~cache:(not no_cache) ~det ~guard
-             tower
-         with
-         | Error e -> Format.printf "%s\n" (Pass.string_of_error e)
-         | Ok (spec, _runner_target, _runners_interm, (module Booter)) -> (
-             let handlers =
-               if profile then
-                 let (module PH : Inst.Handler.HANDLER) =
-                   Inst.Profile.make ()
+         Ok (tower, spec_boot, booter)
+       with
+       | Error e -> Format.printf "%s\n" (Error.to_string e)
+       | Ok (tower, spec, (module Booter : RUNNER)) -> (
+           let handlers =
+             if profile then
+               let (module PH : Inst.Handler.HANDLER) = Inst.Profile.make () in
+               [ (module PH : Inst.Handler.HANDLER) ]
+             else []
+           in
+           let handlers =
+             match trace with
+             | Some level ->
+                 let (module TH : Inst.Handler.HANDLER) =
+                   Inst.Trace.make ~level ()
                  in
-                 [ (module PH : Inst.Handler.HANDLER) ]
-               else []
-             in
-             let handlers =
-               match trace with
-               | Some level ->
-                   let (module TH : Inst.Handler.HANDLER) =
-                     Inst.Trace.make ~level ()
-                   in
-                   handlers @ [ (module TH : Inst.Handler.HANDLER) ]
-               | None -> handlers
-             in
-             Inst.Hook.register handlers;
-             Inst.Hook.init_spec spec;
-             let rel_boot = tower.level_boot.layer.rel in
-             let value = Backend_boot.Patch.apply_tower tower in
-             let result = Booter.Interp.eval_rel rel_boot [ value ] in
-             Inst.Hook.finish ();
-             match result with
-             | Pass _ -> Format.printf "passed\n"
-             | Fail (_, msg) -> Format.printf "runtime error: %s\n" msg)
-       with CommandError msg -> Format.eprintf "error: %s\n" msg)
+                 handlers @ [ (module TH : Inst.Handler.HANDLER) ]
+             | None -> handlers
+           in
+           Inst.Hook.register handlers;
+           Inst.Hook.init_spec spec;
+           let rel_boot = tower.level_boot.layer.rel in
+           let value = Backend_boot.Patch.apply_tower tower in
+           let result = Booter.Interp.eval_rel rel_boot [ value ] in
+           Inst.Hook.finish ();
+           match result with
+           | Pass _ -> Format.printf "passed\n"
+           | Fail (_, msg) -> Format.printf "runtime error: %s\n" msg))
 
 let parse_command =
   Core.Command.basic ~summary:"parse a SpecTec program"
@@ -227,9 +219,12 @@ let parse_command =
          ~if_nothing_chosen:(Default_to SL_interface)
      in
      fun () ->
-       match Backend_boot.Build.build_null SL_mode interface paths_spec with
-       | Error e -> Format.printf "%s\n" (Pass.string_of_error e)
-       | Ok (_, (module Runner)) -> (
+       match
+         let* spec = P4spectec.spec_of_mode SL_mode paths_spec in
+         P4spectec.build_null interface spec
+       with
+       | Error e -> Format.printf "%s\n" (Error.to_string e)
+       | Ok (module Runner) -> (
            try
              match Runner.Interface.parse_program [] [ path_spectec ] with
              | Fail (`Syntax (at, msg)) ->

--- a/p4spec/bin/boot.ml
+++ b/p4spec/bin/boot.ml
@@ -27,13 +27,9 @@ let elab_command =
        anon (non_empty_sequence_as_list ("path" %: string))
      in
      fun () ->
-       try
-         let spec_il = Pass.elab paths_spec in
-         Format.printf "%s\n" (Il.Print.string_of_spec spec_il);
-         ()
-       with
-       | ParseError (at, msg) -> Format.printf "%s\n" (string_of_error at msg)
-       | ElabError (at, msg) -> Format.printf "%s\n" (string_of_error at msg))
+       match Pass.elab paths_spec with
+       | Ok spec_il -> Format.printf "%s\n" (Il.Print.string_of_spec spec_il)
+       | Error e -> Format.printf "%s\n" (Pass.string_of_error e))
 
 let algo_command =
   Core.Command.basic ~summary:"check algorithmic property of a spec"
@@ -43,15 +39,9 @@ let algo_command =
        anon (non_empty_sequence_as_list ("path" %: string))
      in
      fun () ->
-       try
-         let spec_al = Pass.algo paths_spec in
-         Format.printf "%s\n" (Al.Print.string_of_spec spec_al);
-         ()
-       with
-       | CommandError msg -> Format.printf "%s\n" msg
-       | ParseError (at, msg) -> Format.printf "%s\n" (string_of_error at msg)
-       | ElabError (at, msg) -> Format.printf "%s\n" (string_of_error at msg)
-       | AlgoError (at, msg) -> Format.printf "%s\n" (string_of_error at msg))
+       match Pass.algo paths_spec with
+       | Ok spec_al -> Format.printf "%s\n" (Al.Print.string_of_spec spec_al)
+       | Error e -> Format.printf "%s\n" (Pass.string_of_error e))
 
 let struct_command =
   Core.Command.basic ~summary:"insert structured control flow to a spec"
@@ -61,13 +51,9 @@ let struct_command =
        anon (non_empty_sequence_as_list ("path" %: string))
      in
      fun () ->
-       try
-         let spec_sl = Pass.structure ~final:true paths_spec in
-         Format.printf "%s\n" (Sl.Print.string_of_spec spec_sl);
-         ()
-       with
-       | ParseError (at, msg) -> Format.printf "%s\n" (string_of_error at msg)
-       | ElabError (at, msg) -> Format.printf "%s\n" (string_of_error at msg))
+       match Pass.structure ~final:true paths_spec with
+       | Ok spec_sl -> Format.printf "%s\n" (Sl.Print.string_of_spec spec_sl)
+       | Error e -> Format.printf "%s\n" (Pass.string_of_error e))
 
 let prose_command =
   Core.Command.basic ~summary:"generate AsciiDoc prose from a spec"
@@ -77,13 +63,9 @@ let prose_command =
        anon (non_empty_sequence_as_list ("path" %: string))
      in
      fun () ->
-       try
-         let spec_pl = Pass.annotate paths_spec in
-         Format.printf "%s\n" (Pl.Render.render_spec spec_pl);
-         ()
-       with
-       | ParseError (at, msg) | ElabError (at, msg) | ProseError (at, msg) ->
-         Format.printf "%s\n" (string_of_error at msg))
+       match Pass.annotate paths_spec with
+       | Ok spec_pl -> Format.printf "%s\n" (Pl.Render.render_spec spec_pl)
+       | Error e -> Format.printf "%s\n" (Pass.string_of_error e))
 
 let run_command =
   Core.Command.basic ~summary:"execute the spec"
@@ -128,39 +110,41 @@ let run_command =
          ~if_nothing_chosen:(Default_to SL_interface)
      in
      fun () ->
-       try
-         let cache = not no_cache in
-         let spec, (module Runner) =
-           Backend_boot.Build.build_null ~cache ~det ~guard mode interface
-             paths_spec
-         in
-         let handlers =
-           if profile then
-             let (module PH : Inst.Handler.HANDLER) = Inst.Profile.make () in
-             [ (module PH : Inst.Handler.HANDLER) ]
-           else []
-         in
-         let handlers =
-           match trace with
-           | Some level ->
-               let (module TH : Inst.Handler.HANDLER) =
-                 Inst.Trace.make ~level ()
-               in
-               handlers @ [ (module TH : Inst.Handler.HANDLER) ]
-           | None -> handlers
-         in
-         Inst.Hook.register handlers;
-         Inst.Hook.init_spec spec;
-         let result = Runner.Interp.eval_program relname [] path_spectec in
-         Inst.Hook.finish ();
-         match result with
-         | Pass _ -> Format.printf "passed\n"
-         | Fail (`Syntax (_, msg)) -> Format.printf "syntax error: %s\n" msg
-         | Fail (`Runtime (_, msg)) -> Format.printf "runtime error: %s\n" msg
+       let cache = not no_cache in
+       match
+         Backend_boot.Build.build_null ~cache ~det ~guard mode interface
+           paths_spec
        with
-       | CommandError msg -> Format.printf "%s\n" msg
-       | ParseError (at, msg) -> Format.printf "%s\n" (string_of_error at msg)
-       | ElabError (at, msg) -> Format.printf "%s\n" (string_of_error at msg))
+       | Error e -> Format.printf "%s\n" (Pass.string_of_error e)
+       | Ok (spec, (module Runner)) -> (
+           try
+             let handlers =
+               if profile then
+                 let (module PH : Inst.Handler.HANDLER) =
+                   Inst.Profile.make ()
+                 in
+                 [ (module PH : Inst.Handler.HANDLER) ]
+               else []
+             in
+             let handlers =
+               match trace with
+               | Some level ->
+                   let (module TH : Inst.Handler.HANDLER) =
+                     Inst.Trace.make ~level ()
+                   in
+                   handlers @ [ (module TH : Inst.Handler.HANDLER) ]
+               | None -> handlers
+             in
+             Inst.Hook.register handlers;
+             Inst.Hook.init_spec spec;
+             let result = Runner.Interp.eval_program relname [] path_spectec in
+             Inst.Hook.finish ();
+             match result with
+             | Pass _ -> Format.printf "passed\n"
+             | Fail (`Syntax (_, msg)) -> Format.printf "syntax error: %s\n" msg
+             | Fail (`Runtime (_, msg)) ->
+                 Format.printf "runtime error: %s\n" msg
+           with CommandError msg -> Format.printf "%s\n" msg))
 
 let boot_n_command =
   Core.Command.basic ~summary:"run meta-circular interpreter"
@@ -192,38 +176,39 @@ let boot_n_command =
            try Backend_boot.Config.tower_of_file path_tower target
            with Failure msg -> raise (CommandError msg)
          in
-         let spec, _, _, (module Booter) =
+         match
            Backend_boot.Build.build_tower ~cache:(not no_cache) ~det ~guard
              tower
-         in
-         let handlers =
-           if profile then
-             let (module PH : Inst.Handler.HANDLER) = Inst.Profile.make () in
-             [ (module PH : Inst.Handler.HANDLER) ]
-           else []
-         in
-         let handlers =
-           match trace with
-           | Some level ->
-               let (module TH : Inst.Handler.HANDLER) =
-                 Inst.Trace.make ~level ()
-               in
-               handlers @ [ (module TH : Inst.Handler.HANDLER) ]
-           | None -> handlers
-         in
-         Inst.Hook.register handlers;
-         Inst.Hook.init_spec spec;
-         let rel_boot = tower.level_boot.layer.rel in
-         let value = Backend_boot.Patch.apply_tower tower in
-         let result = Booter.Interp.eval_rel rel_boot [ value ] in
-         Inst.Hook.finish ();
-         match result with
-         | Pass _ -> Format.printf "passed\n"
-         | Fail (_, msg) -> Format.printf "runtime error: %s\n" msg
-       with
-       | CommandError msg -> Format.eprintf "error: %s\n" msg
-       | ParseError (at, msg) -> Format.printf "%s\n" (string_of_error at msg)
-       | ElabError (at, msg) -> Format.printf "%s\n" (string_of_error at msg))
+         with
+         | Error e -> Format.printf "%s\n" (Pass.string_of_error e)
+         | Ok (spec, _runner_target, _runners_interm, (module Booter)) -> (
+             let handlers =
+               if profile then
+                 let (module PH : Inst.Handler.HANDLER) =
+                   Inst.Profile.make ()
+                 in
+                 [ (module PH : Inst.Handler.HANDLER) ]
+               else []
+             in
+             let handlers =
+               match trace with
+               | Some level ->
+                   let (module TH : Inst.Handler.HANDLER) =
+                     Inst.Trace.make ~level ()
+                   in
+                   handlers @ [ (module TH : Inst.Handler.HANDLER) ]
+               | None -> handlers
+             in
+             Inst.Hook.register handlers;
+             Inst.Hook.init_spec spec;
+             let rel_boot = tower.level_boot.layer.rel in
+             let value = Backend_boot.Patch.apply_tower tower in
+             let result = Booter.Interp.eval_rel rel_boot [ value ] in
+             Inst.Hook.finish ();
+             match result with
+             | Pass _ -> Format.printf "passed\n"
+             | Fail (_, msg) -> Format.printf "runtime error: %s\n" msg)
+       with CommandError msg -> Format.eprintf "error: %s\n" msg)
 
 let parse_command =
   Core.Command.basic ~summary:"parse a SpecTec program"
@@ -243,34 +228,35 @@ let parse_command =
          ~if_nothing_chosen:(Default_to SL_interface)
      in
      fun () ->
-       try
-         let _, (module Runner) =
-           Backend_boot.Build.build_null SL_mode interface paths_spec
-         in
-         let value_program =
-           match Runner.Interface.parse_program [] [ path_spectec ] with
-           | Pass value_program -> value_program
-           | Fail (`Syntax (at, msg)) -> raise (ParseError (at, msg))
-         in
-         let str_program = Runner.Interface.unparse_program value_program in
-         if roundtrip then
-           let value_program_roundtrip =
-             match Runner.Interface.parse_string path_spectec str_program with
-             | Pass value_program_roundtrip -> value_program_roundtrip
-             | Fail (`Syntax (at, msg)) -> raise (ParseError (at, msg))
-           in
-           Il.Eq.eq_value ~dbg:true value_program value_program_roundtrip
-           |> (fun b ->
-                if b then "Roundtrip successful" else "Roundtrip failed")
-           |> print_endline
-         else str_program |> print_endline
-       with
-       | Sys_error msg -> Format.printf "File error: %s\n" msg
-       | ElabError (at, msg) ->
-           Format.printf "Elaboration error: %s\n" (string_of_error at msg)
-       | ParseError (at, msg) ->
-           Format.printf "Parse error: %s\n" (string_of_error at msg)
-       | e -> Format.printf "Unknown error: %s\n" (Printexc.to_string e))
+       match Backend_boot.Build.build_null SL_mode interface paths_spec with
+       | Error e -> Format.printf "%s\n" (Pass.string_of_error e)
+       | Ok (_, (module Runner)) -> (
+           try
+             match Runner.Interface.parse_program [] [ path_spectec ] with
+             | Fail (`Syntax (at, msg)) ->
+                 Format.printf "Parse error: %s\n" (string_of_error at msg)
+             | Pass value_program ->
+                 let str_program =
+                   Runner.Interface.unparse_program value_program
+                 in
+                 if roundtrip then
+                   match
+                     Runner.Interface.parse_string path_spectec str_program
+                   with
+                   | Fail (`Syntax (at, msg)) ->
+                       Format.printf "Parse error: %s\n"
+                         (string_of_error at msg)
+                   | Pass value_program_roundtrip ->
+                       Il.Eq.eq_value ~dbg:true value_program
+                         value_program_roundtrip
+                       |> (fun b ->
+                            if b then "Roundtrip successful"
+                            else "Roundtrip failed")
+                       |> print_endline
+                 else str_program |> print_endline
+           with
+           | Sys_error msg -> Format.printf "File error: %s\n" msg
+           | e -> Format.printf "Unknown error: %s\n" (Printexc.to_string e)))
 
 (* Command-line interface *)
 

--- a/p4spec/bin/main.ml
+++ b/p4spec/bin/main.ml
@@ -59,9 +59,8 @@ let sim_with_dangling (module Simulator : SIM) spec_sim includes_p4 path_p4
 
 let cover_run_instr ?(arch : string option) mode paths_spec relname includes_p4
     paths_p4 path_cov =
-  let spec_sim, (module Simulator) =
-    Backend_sim.Build.build ?arch ~final:true mode paths_spec
-  in
+  let spec_sim = Backend_boot.Build.spec_of_mode mode paths_spec in
+  let (module Simulator) = Backend_sim.Build.build ?arch spec_sim in
   let spec_sl =
     match spec_sim with
     | SL spec_sl -> spec_sl
@@ -81,9 +80,8 @@ let cover_run_instr ?(arch : string option) mode paths_spec relname includes_p4
 
 let cover_run_dangling ?(arch : string option) mode paths_spec relname
     includes_p4 paths_p4 path_cov =
-  let spec_sim, (module Simulator) =
-    Backend_sim.Build.build ?arch ~final:true mode paths_spec
-  in
+  let spec_sim = Backend_boot.Build.spec_of_mode mode paths_spec in
+  let (module Simulator) = Backend_sim.Build.build ?arch spec_sim in
   let spec_sl =
     match spec_sim with
     | SL spec_sl -> spec_sl
@@ -112,9 +110,8 @@ let cover_run_dangling ?(arch : string option) mode paths_spec relname
 
 let cover_sim_instr ?(arch : string option) mode paths_spec includes_p4 paths_p4
     paths_stf path_cov =
-  let spec_sim, (module Simulator) =
-    Backend_sim.Build.build ?arch ~final:true mode paths_spec
-  in
+  let spec_sim = Backend_boot.Build.spec_of_mode mode paths_spec in
+  let (module Simulator) = Backend_sim.Build.build ?arch spec_sim in
   let spec_sl =
     match spec_sim with
     | SL spec_sl -> spec_sl
@@ -136,9 +133,8 @@ let cover_sim_instr ?(arch : string option) mode paths_spec includes_p4 paths_p4
 
 let cover_sim_dangling ?(arch : string option) mode paths_spec includes_p4
     paths_p4 paths_stf path_cov =
-  let spec_sim, (module Simulator) =
-    Backend_sim.Build.build ?arch ~final:true mode paths_spec
-  in
+  let spec_sim = Backend_boot.Build.spec_of_mode mode paths_spec in
+  let (module Simulator) = Backend_sim.Build.build ?arch spec_sim in
   let spec_sl =
     match spec_sim with
     | SL spec_sl -> spec_sl
@@ -275,9 +271,9 @@ let run_command =
      fun () ->
        try
          let cache = not no_cache in
-         let spec_sim, (module Simulator) =
-           Backend_sim.Build.build ~cache ~det ~guard ~final:true mode
-             paths_spec
+         let spec_sim = Backend_boot.Build.spec_of_mode mode paths_spec in
+         let (module Simulator) =
+           Backend_sim.Build.build ~cache ~det ~guard spec_sim
          in
          let handlers =
            if profile then
@@ -349,9 +345,9 @@ let sim_command =
      fun () ->
        try
          let cache = not no_cache in
-         let spec_sim, (module Simulator) =
-           Backend_sim.Build.build ~cache ~det ~guard ~arch ~final:true mode
-             paths_spec
+         let spec_sim = Backend_boot.Build.spec_of_mode mode paths_spec in
+         let (module Simulator) =
+           Backend_sim.Build.build ~cache ~det ~guard ~arch spec_sim
          in
          let handlers =
            if profile then
@@ -595,9 +591,8 @@ let interesting_command =
      and path_p4 = flag "-p" (required string) ~doc:"P4 program" in
      fun () ->
        try
-         let spec_sim, (module Simulator) =
-           Backend_sim.Build.build ~final:true SL_mode paths_spec
-         in
+         let spec_sim = Backend_boot.Build.spec_of_mode SL_mode paths_spec in
+         let (module Simulator) = Backend_sim.Build.build spec_sim in
          let result, cover =
            run_with_dangling
              (module Simulator)
@@ -689,8 +684,9 @@ let parse_command =
      in
      fun () ->
        try
-         let _, (module Simulator) =
-           Backend_sim.Build.build ~final:true AL_mode paths_spec
+         let (module Simulator) =
+           Backend_sim.Build.build
+             (Backend_boot.Build.spec_of_mode AL_mode paths_spec)
          in
          let value_program =
            match Simulator.Interface.parse_program includes_p4 [ path_p4 ] with

--- a/p4spec/bin/main.ml
+++ b/p4spec/bin/main.ml
@@ -1,21 +1,9 @@
 open Lang
 open Runtime.Sim.Signature
-open Util.Source
+module Error = P4spectec.Error
 
 let version = "0.1"
-
-exception CommandError of string
-
 let ( let* ) = Result.bind
-
-let spec_of_mode (mode : mode) (paths_spec : string list) :
-    (spec, Pass.error) result =
-  match mode with
-  | AL_mode -> Result.map (fun s -> AL s) (Pass.algo paths_spec)
-  | SL_mode ->
-      Result.map (fun s -> SL s) (Pass.structure ~final:true paths_spec)
-  | PL_mode -> Result.map (fun s -> PL s) (Pass.annotate paths_spec)
-  | Empty_mode -> assert false
 
 (* Operations *)
 
@@ -69,12 +57,15 @@ let sim_with_dangling (module Simulator : SIM) spec_sim includes_p4 path_p4
 
 let cover_run_instr ?(arch : string option) mode paths_spec relname includes_p4
     paths_p4 path_cov =
-  let* spec_sim = spec_of_mode mode paths_spec in
-  let (module Simulator) = Backend_sim.Build.build ?arch spec_sim in
-  let spec_sl =
+  let* spec_sim = P4spectec.spec_of_mode mode paths_spec in
+  let* simulator = P4spectec.build_sim ?arch spec_sim in
+  let (module Simulator : SIM) = simulator in
+  let* spec_sl =
     match spec_sim with
-    | SL spec_sl -> spec_sl
-    | _ -> raise (CommandError "instruction coverage is only supported for SL")
+    | SL spec_sl -> Ok spec_sl
+    | _ ->
+        Error
+          (Error.CommandError "instruction coverage is only supported for SL")
   in
   let cover_multi = Coverage.Instr.Multi.init spec_sl in
   let cover_multi =
@@ -91,12 +82,14 @@ let cover_run_instr ?(arch : string option) mode paths_spec relname includes_p4
 
 let cover_run_dangling ?(arch : string option) mode paths_spec relname
     includes_p4 paths_p4 path_cov =
-  let* spec_sim = spec_of_mode mode paths_spec in
-  let (module Simulator) = Backend_sim.Build.build ?arch spec_sim in
-  let spec_sl =
+  let* spec_sim = P4spectec.spec_of_mode mode paths_spec in
+  let* simulator = P4spectec.build_sim ?arch spec_sim in
+  let (module Simulator : SIM) = simulator in
+  let* spec_sl =
     match spec_sim with
-    | SL spec_sl -> spec_sl
-    | _ -> raise (CommandError "instruction coverage is only supported for SL")
+    | SL spec_sl -> Ok spec_sl
+    | _ ->
+        Error (Error.CommandError "dangling coverage is only supported for SL")
   in
   let cover_multi = Coverage.Dangling.Multi.init spec_sl in
   let cover_multi =
@@ -122,12 +115,15 @@ let cover_run_dangling ?(arch : string option) mode paths_spec relname
 
 let cover_sim_instr ?(arch : string option) mode paths_spec includes_p4 paths_p4
     paths_stf path_cov =
-  let* spec_sim = spec_of_mode mode paths_spec in
-  let (module Simulator) = Backend_sim.Build.build ?arch spec_sim in
-  let spec_sl =
+  let* spec_sim = P4spectec.spec_of_mode mode paths_spec in
+  let* simulator = P4spectec.build_sim ?arch spec_sim in
+  let (module Simulator : SIM) = simulator in
+  let* spec_sl =
     match spec_sim with
-    | SL spec_sl -> spec_sl
-    | _ -> raise (CommandError "instruction coverage is only supported for SL")
+    | SL spec_sl -> Ok spec_sl
+    | _ ->
+        Error
+          (Error.CommandError "instruction coverage is only supported for SL")
   in
   let cover_multi = Coverage.Instr.Multi.init spec_sl in
   let cover_multi =
@@ -146,12 +142,14 @@ let cover_sim_instr ?(arch : string option) mode paths_spec includes_p4 paths_p4
 
 let cover_sim_dangling ?(arch : string option) mode paths_spec includes_p4
     paths_p4 paths_stf path_cov =
-  let* spec_sim = spec_of_mode mode paths_spec in
-  let (module Simulator) = Backend_sim.Build.build ?arch spec_sim in
-  let spec_sl =
+  let* spec_sim = P4spectec.spec_of_mode mode paths_spec in
+  let* simulator = P4spectec.build_sim ?arch spec_sim in
+  let (module Simulator : SIM) = simulator in
+  let* spec_sl =
     match spec_sim with
-    | SL spec_sl -> spec_sl
-    | _ -> raise (CommandError "dangling coverage is only supported for SL")
+    | SL spec_sl -> Ok spec_sl
+    | _ ->
+        Error (Error.CommandError "dangling coverage is only supported for SL")
   in
   let cover_multi = Coverage.Dangling.Multi.init spec_sl in
   let cover_multi =
@@ -185,9 +183,9 @@ let elab_command =
        anon (non_empty_sequence_as_list ("path" %: string))
      in
      fun () ->
-       match Pass.elab paths_spec with
+       match P4spectec.elab paths_spec with
        | Ok spec_il -> Format.printf "%s\n" (Il.Print.string_of_spec spec_il)
-       | Error e -> Format.printf "%s\n" (Pass.string_of_error e))
+       | Error e -> Format.printf "%s\n" (Error.to_string e))
 
 let algo_command =
   Core.Command.basic ~summary:"check algorithmic property of a P4 spec"
@@ -197,9 +195,9 @@ let algo_command =
        anon (non_empty_sequence_as_list ("path" %: string))
      in
      fun () ->
-       match Pass.algo paths_spec with
+       match P4spectec.algo paths_spec with
        | Ok spec_al -> Format.printf "%s\n" (Al.Print.string_of_spec spec_al)
-       | Error e -> Format.printf "%s\n" (Pass.string_of_error e))
+       | Error e -> Format.printf "%s\n" (Error.to_string e))
 
 let struct_command =
   Core.Command.basic ~summary:"insert structured control flow to a P4 spec"
@@ -209,9 +207,9 @@ let struct_command =
        anon (non_empty_sequence_as_list ("path" %: string))
      in
      fun () ->
-       match Pass.structure ~final:true paths_spec with
+       match P4spectec.structure ~final:true paths_spec with
        | Ok spec_sl -> Format.printf "%s\n" (Sl.Print.string_of_spec spec_sl)
-       | Error e -> Format.printf "%s\n" (Pass.string_of_error e))
+       | Error e -> Format.printf "%s\n" (Error.to_string e))
 
 let prose_command =
   Core.Command.basic ~summary:"generate AsciiDoc prose from a P4 spec"
@@ -221,9 +219,9 @@ let prose_command =
        anon (non_empty_sequence_as_list ("path" %: string))
      in
      fun () ->
-       match Pass.annotate paths_spec with
+       match P4spectec.annotate paths_spec with
        | Ok spec_pl -> Format.printf "%s\n" (Pl.Render.render_spec spec_pl)
-       | Error e -> Format.printf "%s\n" (Pass.string_of_error e))
+       | Error e -> Format.printf "%s\n" (Error.to_string e))
 
 let run_command =
   Core.Command.basic ~summary:"execute the P4 spec against a P4 program"
@@ -261,45 +259,40 @@ let run_command =
      in
      fun () ->
        let cache = not no_cache in
-       match spec_of_mode mode paths_spec with
-       | Error e -> Format.printf "%s\n" (Pass.string_of_error e)
-       | Ok spec_sim -> (
-           try
-             let (module Simulator) =
-               Backend_sim.Build.build ~cache ~det ~guard spec_sim
-             in
-             let handlers =
-               if profile then
-                 let (module PH : Inst.Handler.HANDLER) =
-                   Inst.Profile.make ()
+       match
+         let* spec_sim = P4spectec.spec_of_mode mode paths_spec in
+         let* simulator = P4spectec.build_sim ~cache ~det ~guard spec_sim in
+         Ok (spec_sim, simulator)
+       with
+       | Error e -> Format.printf "%s\n" (Error.to_string e)
+       | Ok (spec_sim, simulator) -> (
+           let (module Simulator : SIM) = simulator in
+           let handlers =
+             if profile then
+               let (module PH : Inst.Handler.HANDLER) = Inst.Profile.make () in
+               [ (module PH : Inst.Handler.HANDLER) ]
+             else []
+           in
+           let handlers =
+             match trace with
+             | Some level ->
+                 let (module TH : Inst.Handler.HANDLER) =
+                   Inst.Trace.make ~level ()
                  in
-                 [ (module PH : Inst.Handler.HANDLER) ]
-               else []
-             in
-             let handlers =
-               match trace with
-               | Some level ->
-                   let (module TH : Inst.Handler.HANDLER) =
-                     Inst.Trace.make ~level ()
-                   in
-                   handlers @ [ (module TH : Inst.Handler.HANDLER) ]
-               | None -> handlers
-             in
-             Inst.Hook.register handlers;
-             Inst.Hook.init_spec spec_sim;
-             let result =
-               Simulator.Interp.eval_program relname includes_p4 path_p4
-             in
-             Inst.Hook.finish ();
-             match result with
-             | Pass _ -> Format.printf "passed\n"
-             | Fail (`Syntax (_, msg)) -> Format.printf "syntax error: %s\n" msg
-             | Fail (`Runtime (_, msg)) ->
-                 Format.printf "runtime error: %s\n" msg
-           with
-           | CommandError msg -> Format.printf "%s\n" msg
-           | Interp_common.Error.InterpError (at, msg) ->
-               Format.printf "%s\n" (Util.Error.string_of_error at msg)))
+                 handlers @ [ (module TH : Inst.Handler.HANDLER) ]
+             | None -> handlers
+           in
+           Inst.Hook.register handlers;
+           Inst.Hook.init_spec spec_sim;
+           let result =
+             Simulator.Interp.eval_program relname includes_p4 path_p4
+           in
+           Inst.Hook.finish ();
+           match result with
+           | Pass _ -> Format.printf "passed\n"
+           | Fail (`Syntax (_, msg)) -> Format.printf "syntax error: %s\n" msg
+           | Fail (`Runtime (_, msg)) -> Format.printf "runtime error: %s\n" msg
+           ))
 
 let sim_command =
   Core.Command.basic
@@ -339,46 +332,40 @@ let sim_command =
      in
      fun () ->
        let cache = not no_cache in
-       match spec_of_mode mode paths_spec with
-       | Error e -> Format.printf "%s\n" (Pass.string_of_error e)
-       | Ok spec_sim -> (
-           try
-             let (module Simulator) =
-               Backend_sim.Build.build ~cache ~det ~guard ~arch spec_sim
-             in
-             let handlers =
-               if profile then
-                 let (module PH : Inst.Handler.HANDLER) =
-                   Inst.Profile.make ()
+       match
+         let* spec_sim = P4spectec.spec_of_mode mode paths_spec in
+         let* simulator =
+           P4spectec.build_sim ~cache ~det ~guard ~arch spec_sim
+         in
+         Ok (spec_sim, simulator)
+       with
+       | Error e -> Format.printf "%s\n" (Error.to_string e)
+       | Ok (spec_sim, simulator) -> (
+           let (module Simulator : SIM) = simulator in
+           let handlers =
+             if profile then
+               let (module PH : Inst.Handler.HANDLER) = Inst.Profile.make () in
+               [ (module PH : Inst.Handler.HANDLER) ]
+             else []
+           in
+           let handlers =
+             match trace with
+             | Some level ->
+                 let (module TH : Inst.Handler.HANDLER) =
+                   Inst.Trace.make ~level ()
                  in
-                 [ (module PH : Inst.Handler.HANDLER) ]
-               else []
-             in
-             let handlers =
-               match trace with
-               | Some level ->
-                   let (module TH : Inst.Handler.HANDLER) =
-                     Inst.Trace.make ~level ()
-                   in
-                   handlers @ [ (module TH : Inst.Handler.HANDLER) ]
-               | None -> handlers
-             in
-             Inst.Hook.register handlers;
-             Inst.Hook.init_spec spec_sim;
-             let result = Simulator.run_stf_test includes_p4 path_p4 path_stf in
-             Inst.Hook.finish ();
-             match result with
-             | Pass -> Format.printf "passed\n"
-             | Fail (`Syntax (_, msg)) -> Format.printf "syntax error: %s\n" msg
-             | Fail (`Runtime (_, msg)) ->
-                 Format.printf "runtime error: %s\n" msg
-           with
-           | CommandError msg -> Format.printf "%s\n" msg
-           | Interp_common.Error.InterpError (at, msg)
-           | Runtime.Dynamic_Runner.Signature.ExternError (at, msg) ->
-               Format.printf "%s\n" (Util.Error.string_of_error at msg)
-           | Stf.Error.StfError msg ->
-               Format.printf "%s\n" (Util.Error.string_of_error no_region msg)))
+                 handlers @ [ (module TH : Inst.Handler.HANDLER) ]
+             | None -> handlers
+           in
+           Inst.Hook.register handlers;
+           Inst.Hook.init_spec spec_sim;
+           let result = Simulator.run_stf_test includes_p4 path_p4 path_stf in
+           Inst.Hook.finish ();
+           match result with
+           | Pass -> Format.printf "passed\n"
+           | Fail (`Syntax (_, msg)) -> Format.printf "syntax error: %s\n" msg
+           | Fail (`Runtime (_, msg)) -> Format.printf "runtime error: %s\n" msg
+           ))
 
 let cover_run_command =
   Core.Command.basic ~summary:"measure coverage of the spec"
@@ -401,30 +388,24 @@ let cover_run_command =
          ~if_nothing_chosen:(Default_to `Instr)
      in
      fun () ->
-       try
-         let excludes_p4 = Util.Test.collect_excludes excludes_p4 in
-         let paths_p4 =
-           testdirs_p4
-           |> List.concat_map (Util.Filesys.collect_files ~suffix:".p4")
-           |> List.filter (fun path_p4 ->
-                  not (List.exists (String.equal path_p4) excludes_p4))
-         in
-         match
-           match mode with
-           | `Instr ->
-               cover_run_instr SL_mode paths_spec relname includes_p4 paths_p4
-                 path_cov
-           | `Dangling ->
-               cover_run_dangling SL_mode paths_spec relname includes_p4
-                 paths_p4 path_cov
-         with
-         | Ok () -> ()
-         | Error e -> Format.printf "%s\n" (Pass.string_of_error e)
+       let excludes_p4 = Util.Test.collect_excludes excludes_p4 in
+       let paths_p4 =
+         testdirs_p4
+         |> List.concat_map (Util.Filesys.collect_files ~suffix:".p4")
+         |> List.filter (fun path_p4 ->
+                not (List.exists (String.equal path_p4) excludes_p4))
+       in
+       match
+         match mode with
+         | `Instr ->
+             cover_run_instr SL_mode paths_spec relname includes_p4 paths_p4
+               path_cov
+         | `Dangling ->
+             cover_run_dangling SL_mode paths_spec relname includes_p4 paths_p4
+               path_cov
        with
-       | CommandError msg -> Format.printf "%s\n" msg
-       | Interp_common.Error.InterpError (at, msg)
-       | Runtime.Dynamic_Runner.Signature.ExternError (at, msg) ->
-           Format.printf "%s\n" (Util.Error.string_of_error at msg))
+       | Ok () -> ()
+       | Error e -> Format.printf "%s\n" (Error.to_string e))
 
 let cover_sim_command =
   Core.Command.basic
@@ -452,31 +433,25 @@ let cover_sim_command =
          ~if_nothing_chosen:(Default_to `Instr)
      in
      fun () ->
-       try
-         let excludes_p4 = Util.Test.collect_excludes excludes_p4 in
-         let paths_p4, paths_stf =
-           Util.Test.collect_test_pairs arch testdirs_p4 testdirs_stf patchdir
-           |> List.map (fun (path_p4, path_stf, _) -> (path_p4, path_stf))
-           |> List.filter (fun (path_p4, _) ->
-                  not (List.exists (String.equal path_p4) excludes_p4))
-           |> List.split
-         in
-         match
-           match mode with
-           | `Instr ->
-               cover_sim_instr ~arch SL_mode paths_spec includes_p4 paths_p4
-                 paths_stf path_cov
-           | `Dangling ->
-               cover_sim_dangling ~arch SL_mode paths_spec includes_p4 paths_p4
-                 paths_stf path_cov
-         with
-         | Ok () -> ()
-         | Error e -> Format.printf "%s\n" (Pass.string_of_error e)
+       let excludes_p4 = Util.Test.collect_excludes excludes_p4 in
+       let paths_p4, paths_stf =
+         Util.Test.collect_test_pairs arch testdirs_p4 testdirs_stf patchdir
+         |> List.map (fun (path_p4, path_stf, _) -> (path_p4, path_stf))
+         |> List.filter (fun (path_p4, _) ->
+                not (List.exists (String.equal path_p4) excludes_p4))
+         |> List.split
+       in
+       match
+         match mode with
+         | `Instr ->
+             cover_sim_instr ~arch SL_mode paths_spec includes_p4 paths_p4
+               paths_stf path_cov
+         | `Dangling ->
+             cover_sim_dangling ~arch SL_mode paths_spec includes_p4 paths_p4
+               paths_stf path_cov
        with
-       | CommandError msg -> Format.printf "%s\n" msg
-       | Interp_common.Error.InterpError (at, msg)
-       | Runtime.Dynamic_Runner.Signature.ExternError (at, msg) ->
-           Format.printf "%s\n" (Util.Error.string_of_error at msg))
+       | Ok () -> ()
+       | Error e -> Format.printf "%s\n" (Error.to_string e))
 
 let run_testgen_command =
   Core.Command.basic
@@ -510,46 +485,41 @@ let run_testgen_command =
          ~doc:"cover a new dangling only if it was intended by a mutation"
      in
      fun () ->
-       match Pass.structure ~final:true paths_spec with
-       | Error e -> Format.printf "%s\n" (Pass.string_of_error e)
-       | Ok spec_sl -> (
-           try
-             let logmode =
-               if silent then Backend_testgen_neg.Modes.Silent
-               else Backend_testgen_neg.Modes.Verbose
-             in
-             let bootmode =
-               match (bootdir, path_boot) with
-               | Some bootdir, None ->
-                   Backend_testgen_neg.Modes.Cold (excludes_p4, bootdir)
-               | None, Some path_boot ->
-                   Backend_testgen_neg.Modes.Warm path_boot
-               | Some _, Some _ ->
-                   raise
-                     (CommandError
-                        "Error: should specify only one of -boot-dir or \
-                         -boot-file")
-               | None, None ->
-                   raise
-                     (CommandError "Error: should specify either -cold or -warm")
-             in
-             let mutationmode =
-               if random then Backend_testgen_neg.Modes.Random
-               else if hybrid then Backend_testgen_neg.Modes.Hybrid
-               else Backend_testgen_neg.Modes.Derive
-             in
-             let covermode =
-               if strict then Backend_testgen_neg.Modes.Strict
-               else Backend_testgen_neg.Modes.Relaxed
-             in
-             Backend_testgen_neg.Gen.fuzzer fuel spec_sl relname includes_p4
-               gendir name_campaign randseed logmode bootmode mutationmode
-               covermode
-           with
-           | CommandError msg -> Format.printf "%s\n" msg
-           | Interp_common.Error.InterpError (at, msg)
-           | Runtime.Dynamic_Runner.Signature.ExternError (at, msg) ->
-               Format.printf "%s\n" (Util.Error.string_of_error at msg)))
+       match
+         let* spec_sl = P4spectec.structure ~final:true paths_spec in
+         let logmode =
+           if silent then Backend_testgen_neg.Modes.Silent
+           else Backend_testgen_neg.Modes.Verbose
+         in
+         let* bootmode =
+           match (bootdir, path_boot) with
+           | Some bootdir, None ->
+               Ok (Backend_testgen_neg.Modes.Cold (excludes_p4, bootdir))
+           | None, Some path_boot ->
+               Ok (Backend_testgen_neg.Modes.Warm path_boot)
+           | Some _, Some _ ->
+               Error
+                 (Error.CommandError
+                    "Error: should specify only one of -boot-dir or -boot-file")
+           | None, None ->
+               Error
+                 (Error.CommandError
+                    "Error: should specify either -cold or -warm")
+         in
+         let mutationmode =
+           if random then Backend_testgen_neg.Modes.Random
+           else if hybrid then Backend_testgen_neg.Modes.Hybrid
+           else Backend_testgen_neg.Modes.Derive
+         in
+         let covermode =
+           if strict then Backend_testgen_neg.Modes.Strict
+           else Backend_testgen_neg.Modes.Relaxed
+         in
+         P4spectec.fuzzer fuel spec_sl relname includes_p4 gendir name_campaign
+           randseed logmode bootmode mutationmode covermode
+       with
+       | Ok () -> ()
+       | Error e -> Format.printf "%s\n" (Error.to_string e))
 
 let run_testgen_debug_command =
   Core.Command.basic
@@ -564,17 +534,13 @@ let run_testgen_debug_command =
        flag "-debug" (required string) ~doc:"directory for debug files"
      and iid = flag "-iid" (required int) ~doc:"dangling id to close-miss" in
      fun () ->
-       match Pass.structure ~final:true paths_spec with
-       | Error e -> Format.printf "%s\n" (Pass.string_of_error e)
-       | Ok spec_sl -> (
-           try
-             Backend_testgen_neg.Derive.debug_dangling spec_sl relname
-               includes_p4 path_p4 debugdir iid
-           with
-           | CommandError msg -> Format.printf "%s\n" msg
-           | Interp_common.Error.InterpError (at, msg)
-           | Runtime.Dynamic_Runner.Signature.ExternError (at, msg) ->
-               Format.printf "%s\n" (Util.Error.string_of_error at msg)))
+       match
+         let* spec_sl = P4spectec.structure ~final:true paths_spec in
+         P4spectec.debug_dangling spec_sl relname includes_p4 path_p4 debugdir
+           iid
+       with
+       | Ok () -> ()
+       | Error e -> Format.printf "%s\n" (Error.to_string e))
 
 let interesting_command =
   Core.Command.basic ~summary:"interestingness test for reducing P4 programs"
@@ -591,57 +557,55 @@ let interesting_command =
      and iid = flag "-iid" (required int) ~doc:"dangling id to test"
      and path_p4 = flag "-p" (required string) ~doc:"P4 program" in
      fun () ->
-       match spec_of_mode SL_mode paths_spec with
-       | Error e -> Format.printf "%s\n" (Pass.string_of_error e)
-       | Ok spec_sim -> (
-           try
-             let (module Simulator) = Backend_sim.Build.build spec_sim in
-             let result, cover =
-               run_with_dangling
-                 (module Simulator)
-                 spec_sim relname includes_p4 path_p4
-             in
-             match result with
-             | Pass _ ->
-                 if check_well_typed then (
-                   let branch = Coverage.Dangling.Single.Cover.find iid cover in
-                   match branch.status with
-                   | Hit ->
-                       Printf.printf "WellTyped: Hit\n";
-                       if check_close_miss then exit 3 else exit 0
-                   | Miss (_ :: _) ->
-                       Printf.printf "WellTyped: Close\n";
-                       if check_close_miss then exit 0 else exit 2
-                   | Miss [] ->
-                       Printf.printf "WellTyped: Miss\n";
-                       exit 1)
-                 else (
-                   Printf.printf "WellTyped\n";
-                   exit 11)
-             | Fail (`Syntax _) ->
-                 Printf.printf "IllFormed";
-                 exit 12
-             | Fail (`Runtime _) -> (
-                 if check_well_typed then (
-                   Printf.printf "IllTyped\n";
-                   exit 10)
-                 else
-                   let branch = Coverage.Dangling.Single.Cover.find iid cover in
-                   match branch.status with
-                   | Hit ->
-                       Printf.printf "IllTyped: Hit\n";
-                       if check_close_miss then exit 3 else exit 0
-                   | Miss (_ :: _) ->
-                       Printf.printf "IllTyped: Close\n";
-                       if check_close_miss then exit 0 else exit 2
-                   | Miss [] ->
-                       Printf.printf "IllTyped: Miss\n";
-                       exit 1)
-           with
-           | CommandError msg -> Format.printf "%s\n" msg
-           | Interp_common.Error.InterpError (at, msg)
-           | Runtime.Dynamic_Runner.Signature.ExternError (at, msg) ->
-               Format.printf "%s\n" (Util.Error.string_of_error at msg)))
+       match
+         let* spec_sim = P4spectec.spec_of_mode SL_mode paths_spec in
+         let* simulator = P4spectec.build_sim spec_sim in
+         Ok (spec_sim, simulator)
+       with
+       | Error e -> Format.printf "%s\n" (Error.to_string e)
+       | Ok (spec_sim, simulator) -> (
+           let (module Simulator : SIM) = simulator in
+           let result, cover =
+             run_with_dangling
+               (module Simulator)
+               spec_sim relname includes_p4 path_p4
+           in
+           match result with
+           | Pass _ ->
+               if check_well_typed then (
+                 let branch = Coverage.Dangling.Single.Cover.find iid cover in
+                 match branch.status with
+                 | Hit ->
+                     Printf.printf "WellTyped: Hit\n";
+                     if check_close_miss then exit 3 else exit 0
+                 | Miss (_ :: _) ->
+                     Printf.printf "WellTyped: Close\n";
+                     if check_close_miss then exit 0 else exit 2
+                 | Miss [] ->
+                     Printf.printf "WellTyped: Miss\n";
+                     exit 1)
+               else (
+                 Printf.printf "WellTyped\n";
+                 exit 11)
+           | Fail (`Syntax _) ->
+               Printf.printf "IllFormed";
+               exit 12
+           | Fail (`Runtime _) -> (
+               if check_well_typed then (
+                 Printf.printf "IllTyped\n";
+                 exit 10)
+               else
+                 let branch = Coverage.Dangling.Single.Cover.find iid cover in
+                 match branch.status with
+                 | Hit ->
+                     Printf.printf "IllTyped: Hit\n";
+                     if check_close_miss then exit 3 else exit 0
+                 | Miss (_ :: _) ->
+                     Printf.printf "IllTyped: Close\n";
+                     if check_close_miss then exit 0 else exit 2
+                 | Miss [] ->
+                     Printf.printf "IllTyped: Miss\n";
+                     exit 1)))
 
 let splice_command =
   Core.Command.basic ~summary:"splice a skeleton p4_16 specification document"
@@ -653,29 +617,26 @@ let splice_command =
      and inplace = flag "-inplace" no_arg ~doc:"splice in place" in
      fun () ->
        match
-         let* spec = Pass.parse paths_spec in
-         let* spec_pl = Pass.annotate paths_spec in
-         Ok (spec, spec_pl)
+         let* spec = P4spectec.parse paths_spec in
+         let* spec_pl = P4spectec.annotate paths_spec in
+         let* paths =
+           if
+             (not inplace)
+             && List.length paths_input <> List.length paths_output
+           then
+             Error
+               (Error.CommandError "number of input and output files must match")
+           else if inplace then Ok (List.combine paths_input paths_input)
+           else Ok (List.combine paths_input paths_output)
+         in
+         Ok (spec, spec_pl, paths)
        with
-       | Error e -> Format.printf "%s\n" (Pass.string_of_error e)
-       | Ok (spec, spec_pl) -> (
-           try
-             if
-               (not inplace)
-               && List.length paths_input <> List.length paths_output
-             then
-               raise
-                 (CommandError "number of input and output files must match");
-             let paths =
-               if inplace then List.combine paths_input paths_input
-               else List.combine paths_input paths_output
-             in
-             Backend_splice.Driver.splice_files spec spec_pl paths
-           with
-           | CommandError msg -> Format.printf "%s\n" msg
-           | Backend_splice.Error.SpliceError (at, msg) ->
-               Format.eprintf "%s\n" (Util.Error.string_of_error at msg);
-               Format.printf "%s\n" (Util.Error.string_of_error at msg)))
+       | Error e -> Format.printf "%s\n" (Error.to_string e)
+       | Ok (spec, spec_pl, paths) -> (
+           try Backend_splice.Driver.splice_files spec spec_pl paths
+           with Backend_splice.Error.SpliceError (at, msg) ->
+             Format.eprintf "%s\n" (Util.Error.string_of_error at msg);
+             Format.printf "%s\n" (Util.Error.string_of_error at msg)))
 
 let parse_command =
   Core.Command.basic ~summary:"parse a P4 program"
@@ -688,11 +649,14 @@ let parse_command =
        flag "-r" no_arg ~doc:"perform a round-trip parse/unparse"
      in
      fun () ->
-       match spec_of_mode AL_mode paths_spec with
-       | Error e -> Format.printf "%s\n" (Pass.string_of_error e)
-       | Ok spec_sim -> (
+       match
+         let* spec_sim = P4spectec.spec_of_mode AL_mode paths_spec in
+         P4spectec.build_sim spec_sim
+       with
+       | Error e -> Format.printf "%s\n" (Error.to_string e)
+       | Ok simulator -> (
+           let (module Simulator : SIM) = simulator in
            try
-             let (module Simulator) = Backend_sim.Build.build spec_sim in
              match
                Simulator.Interface.parse_program includes_p4 [ path_p4 ]
              with

--- a/p4spec/bin/main.ml
+++ b/p4spec/bin/main.ml
@@ -7,6 +7,17 @@ let version = "0.1"
 
 exception CommandError of string
 
+let ( let* ) = Result.bind
+
+let spec_of_mode (mode : mode) (paths_spec : string list) :
+    (spec, Pass.error) result =
+  match mode with
+  | AL_mode -> Result.map (fun s -> AL s) (Pass.algo paths_spec)
+  | SL_mode ->
+      Result.map (fun s -> SL s) (Pass.structure ~final:true paths_spec)
+  | PL_mode -> Result.map (fun s -> PL s) (Pass.annotate paths_spec)
+  | Empty_mode -> assert false
+
 (* Operations *)
 
 let run_with_instr (module Simulator : SIM) spec_sim relname includes_p4 path_p4
@@ -59,7 +70,7 @@ let sim_with_dangling (module Simulator : SIM) spec_sim includes_p4 path_p4
 
 let cover_run_instr ?(arch : string option) mode paths_spec relname includes_p4
     paths_p4 path_cov =
-  let spec_sim = Backend_boot.Build.spec_of_mode mode paths_spec in
+  let* spec_sim = spec_of_mode mode paths_spec in
   let (module Simulator) = Backend_sim.Build.build ?arch spec_sim in
   let spec_sl =
     match spec_sim with
@@ -76,11 +87,12 @@ let cover_run_instr ?(arch : string option) mode paths_spec relname includes_p4
         Coverage.Instr.Multi.extend cover_multi path_p4 cover_single)
       cover_multi paths_p4
   in
-  Coverage.Instr.Log.log_spec ~path_cov_opt:(Some path_cov) cover_multi spec_sl
+  Coverage.Instr.Log.log_spec ~path_cov_opt:(Some path_cov) cover_multi spec_sl;
+  Ok ()
 
 let cover_run_dangling ?(arch : string option) mode paths_spec relname
     includes_p4 paths_p4 path_cov =
-  let spec_sim = Backend_boot.Build.spec_of_mode mode paths_spec in
+  let* spec_sim = spec_of_mode mode paths_spec in
   let (module Simulator) = Backend_sim.Build.build ?arch spec_sim in
   let spec_sl =
     match spec_sim with
@@ -106,11 +118,12 @@ let cover_run_dangling ?(arch : string option) mode paths_spec relname
           cover_single)
       cover_multi paths_p4
   in
-  Coverage.Dangling.Multi.log ~path_cov_opt:(Some path_cov) cover_multi
+  Coverage.Dangling.Multi.log ~path_cov_opt:(Some path_cov) cover_multi;
+  Ok ()
 
 let cover_sim_instr ?(arch : string option) mode paths_spec includes_p4 paths_p4
     paths_stf path_cov =
-  let spec_sim = Backend_boot.Build.spec_of_mode mode paths_spec in
+  let* spec_sim = spec_of_mode mode paths_spec in
   let (module Simulator) = Backend_sim.Build.build ?arch spec_sim in
   let spec_sl =
     match spec_sim with
@@ -129,11 +142,12 @@ let cover_sim_instr ?(arch : string option) mode paths_spec includes_p4 paths_p4
         Coverage.Instr.Multi.extend cover_multi path_p4 cover_single)
       cover_multi paths_p4 paths_stf
   in
-  Coverage.Instr.Log.log_spec ~path_cov_opt:(Some path_cov) cover_multi spec_sl
+  Coverage.Instr.Log.log_spec ~path_cov_opt:(Some path_cov) cover_multi spec_sl;
+  Ok ()
 
 let cover_sim_dangling ?(arch : string option) mode paths_spec includes_p4
     paths_p4 paths_stf path_cov =
-  let spec_sim = Backend_boot.Build.spec_of_mode mode paths_spec in
+  let* spec_sim = spec_of_mode mode paths_spec in
   let (module Simulator) = Backend_sim.Build.build ?arch spec_sim in
   let spec_sl =
     match spec_sim with
@@ -159,7 +173,8 @@ let cover_sim_dangling ?(arch : string option) mode paths_spec includes_p4
           cover_single)
       cover_multi paths_p4 paths_stf
   in
-  Coverage.Dangling.Multi.log ~path_cov_opt:(Some path_cov) cover_multi
+  Coverage.Dangling.Multi.log ~path_cov_opt:(Some path_cov) cover_multi;
+  Ok ()
 
 (* Commands *)
 
@@ -171,14 +186,9 @@ let elab_command =
        anon (non_empty_sequence_as_list ("path" %: string))
      in
      fun () ->
-       try
-         let spec_il = Pass.elab paths_spec in
-         Format.printf "%s\n" (Il.Print.string_of_spec spec_il);
-         ()
-       with
-       | CommandError msg -> Format.printf "%s\n" msg
-       | ParseError (at, msg) -> Format.printf "%s\n" (string_of_error at msg)
-       | ElabError (at, msg) -> Format.printf "%s\n" (string_of_error at msg))
+       match Pass.elab paths_spec with
+       | Ok spec_il -> Format.printf "%s\n" (Il.Print.string_of_spec spec_il)
+       | Error e -> Format.printf "%s\n" (Pass.string_of_error e))
 
 let algo_command =
   Core.Command.basic ~summary:"check algorithmic property of a P4 spec"
@@ -188,15 +198,9 @@ let algo_command =
        anon (non_empty_sequence_as_list ("path" %: string))
      in
      fun () ->
-       try
-         let spec_al = Pass.algo paths_spec in
-         Format.printf "%s\n" (Al.Print.string_of_spec spec_al);
-         ()
-       with
-       | CommandError msg -> Format.printf "%s\n" msg
-       | ParseError (at, msg) -> Format.printf "%s\n" (string_of_error at msg)
-       | ElabError (at, msg) -> Format.printf "%s\n" (string_of_error at msg)
-       | AlgoError (at, msg) -> Format.printf "%s\n" (string_of_error at msg))
+       match Pass.algo paths_spec with
+       | Ok spec_al -> Format.printf "%s\n" (Al.Print.string_of_spec spec_al)
+       | Error e -> Format.printf "%s\n" (Pass.string_of_error e))
 
 let struct_command =
   Core.Command.basic ~summary:"insert structured control flow to a P4 spec"
@@ -206,13 +210,9 @@ let struct_command =
        anon (non_empty_sequence_as_list ("path" %: string))
      in
      fun () ->
-       try
-         let spec_sl = Pass.structure ~final:true paths_spec in
-         Format.printf "%s\n" (Sl.Print.string_of_spec spec_sl);
-         ()
-       with
-       | ParseError (at, msg) | ElabError (at, msg) | StructError (at, msg) ->
-         Format.printf "%s\n" (string_of_error at msg))
+       match Pass.structure ~final:true paths_spec with
+       | Ok spec_sl -> Format.printf "%s\n" (Sl.Print.string_of_spec spec_sl)
+       | Error e -> Format.printf "%s\n" (Pass.string_of_error e))
 
 let prose_command =
   Core.Command.basic ~summary:"generate AsciiDoc prose from a P4 spec"
@@ -222,17 +222,9 @@ let prose_command =
        anon (non_empty_sequence_as_list ("path" %: string))
      in
      fun () ->
-       try
-         let spec_pl = Pass.annotate paths_spec in
-         Format.printf "%s\n" (Pl.Render.render_spec spec_pl);
-         ()
-       with
-       | ParseError (at, msg)
-       | ElabError (at, msg)
-       | StructError (at, msg)
-       | ProseError (at, msg)
-       ->
-         Format.printf "%s\n" (string_of_error at msg))
+       match Pass.annotate paths_spec with
+       | Ok spec_pl -> Format.printf "%s\n" (Pl.Render.render_spec spec_pl)
+       | Error e -> Format.printf "%s\n" (Pass.string_of_error e))
 
 let run_command =
   Core.Command.basic ~summary:"execute the P4 spec against a P4 program"
@@ -269,42 +261,46 @@ let run_command =
          ~if_nothing_chosen:(Default_to SL_mode)
      in
      fun () ->
-       try
-         let cache = not no_cache in
-         let spec_sim = Backend_boot.Build.spec_of_mode mode paths_spec in
-         let (module Simulator) =
-           Backend_sim.Build.build ~cache ~det ~guard spec_sim
-         in
-         let handlers =
-           if profile then
-             let (module PH : Inst.Handler.HANDLER) = Inst.Profile.make () in
-             [ (module PH : Inst.Handler.HANDLER) ]
-           else []
-         in
-         let handlers =
-           match trace with
-           | Some level ->
-               let (module TH : Inst.Handler.HANDLER) =
-                 Inst.Trace.make ~level ()
-               in
-               handlers @ [ (module TH : Inst.Handler.HANDLER) ]
-           | None -> handlers
-         in
-         Inst.Hook.register handlers;
-         Inst.Hook.init_spec spec_sim;
-         let result =
-           Simulator.Interp.eval_program relname includes_p4 path_p4
-         in
-         Inst.Hook.finish ();
-         match result with
-         | Pass _ -> Format.printf "passed\n"
-         | Fail (`Syntax (_, msg)) -> Format.printf "syntax error: %s\n" msg
-         | Fail (`Runtime (_, msg)) -> Format.printf "runtime error: %s\n" msg
-       with
-       | CommandError msg -> Format.printf "%s\n" msg
-       | ParseError (at, msg) | ElabError (at, msg) | StructError (at, msg) ->
-           Format.printf "%s\n" (string_of_error at msg)
-       | InterpError (at, msg) -> Format.printf "%s\n" (string_of_error at msg))
+       let cache = not no_cache in
+       match spec_of_mode mode paths_spec with
+       | Error e -> Format.printf "%s\n" (Pass.string_of_error e)
+       | Ok spec_sim -> (
+           try
+             let (module Simulator) =
+               Backend_sim.Build.build ~cache ~det ~guard spec_sim
+             in
+             let handlers =
+               if profile then
+                 let (module PH : Inst.Handler.HANDLER) =
+                   Inst.Profile.make ()
+                 in
+                 [ (module PH : Inst.Handler.HANDLER) ]
+               else []
+             in
+             let handlers =
+               match trace with
+               | Some level ->
+                   let (module TH : Inst.Handler.HANDLER) =
+                     Inst.Trace.make ~level ()
+                   in
+                   handlers @ [ (module TH : Inst.Handler.HANDLER) ]
+               | None -> handlers
+             in
+             Inst.Hook.register handlers;
+             Inst.Hook.init_spec spec_sim;
+             let result =
+               Simulator.Interp.eval_program relname includes_p4 path_p4
+             in
+             Inst.Hook.finish ();
+             match result with
+             | Pass _ -> Format.printf "passed\n"
+             | Fail (`Syntax (_, msg)) -> Format.printf "syntax error: %s\n" msg
+             | Fail (`Runtime (_, msg)) ->
+                 Format.printf "runtime error: %s\n" msg
+           with
+           | CommandError msg -> Format.printf "%s\n" msg
+           | InterpError (at, msg) ->
+               Format.printf "%s\n" (string_of_error at msg)))
 
 let sim_command =
   Core.Command.basic
@@ -343,44 +339,46 @@ let sim_command =
          ~if_nothing_chosen:(Default_to SL_mode)
      in
      fun () ->
-       try
-         let cache = not no_cache in
-         let spec_sim = Backend_boot.Build.spec_of_mode mode paths_spec in
-         let (module Simulator) =
-           Backend_sim.Build.build ~cache ~det ~guard ~arch spec_sim
-         in
-         let handlers =
-           if profile then
-             let (module PH : Inst.Handler.HANDLER) = Inst.Profile.make () in
-             [ (module PH : Inst.Handler.HANDLER) ]
-           else []
-         in
-         let handlers =
-           match trace with
-           | Some level ->
-               let (module TH : Inst.Handler.HANDLER) =
-                 Inst.Trace.make ~level ()
-               in
-               handlers @ [ (module TH : Inst.Handler.HANDLER) ]
-           | None -> handlers
-         in
-         Inst.Hook.register handlers;
-         Inst.Hook.init_spec spec_sim;
-         let result = Simulator.run_stf_test includes_p4 path_p4 path_stf in
-         Inst.Hook.finish ();
-         match result with
-         | Pass -> Format.printf "passed\n"
-         | Fail (`Syntax (_, msg)) -> Format.printf "syntax error: %s\n" msg
-         | Fail (`Runtime (_, msg)) -> Format.printf "runtime error: %s\n" msg
-       with
-       | CommandError msg -> Format.printf "%s\n" msg
-       | ParseError (at, msg)
-       | ElabError (at, msg)
-       | StructError (at, msg)
-       | InterpError (at, msg)
-       | ExternError (at, msg) ->
-           Format.printf "%s\n" (string_of_error at msg)
-       | StfError msg -> Format.printf "%s\n" (string_of_error no_region msg))
+       let cache = not no_cache in
+       match spec_of_mode mode paths_spec with
+       | Error e -> Format.printf "%s\n" (Pass.string_of_error e)
+       | Ok spec_sim -> (
+           try
+             let (module Simulator) =
+               Backend_sim.Build.build ~cache ~det ~guard ~arch spec_sim
+             in
+             let handlers =
+               if profile then
+                 let (module PH : Inst.Handler.HANDLER) =
+                   Inst.Profile.make ()
+                 in
+                 [ (module PH : Inst.Handler.HANDLER) ]
+               else []
+             in
+             let handlers =
+               match trace with
+               | Some level ->
+                   let (module TH : Inst.Handler.HANDLER) =
+                     Inst.Trace.make ~level ()
+                   in
+                   handlers @ [ (module TH : Inst.Handler.HANDLER) ]
+               | None -> handlers
+             in
+             Inst.Hook.register handlers;
+             Inst.Hook.init_spec spec_sim;
+             let result = Simulator.run_stf_test includes_p4 path_p4 path_stf in
+             Inst.Hook.finish ();
+             match result with
+             | Pass -> Format.printf "passed\n"
+             | Fail (`Syntax (_, msg)) -> Format.printf "syntax error: %s\n" msg
+             | Fail (`Runtime (_, msg)) ->
+                 Format.printf "runtime error: %s\n" msg
+           with
+           | CommandError msg -> Format.printf "%s\n" msg
+           | InterpError (at, msg) | ExternError (at, msg) ->
+               Format.printf "%s\n" (string_of_error at msg)
+           | StfError msg ->
+               Format.printf "%s\n" (string_of_error no_region msg)))
 
 let cover_run_command =
   Core.Command.basic ~summary:"measure coverage of the spec"
@@ -411,20 +409,20 @@ let cover_run_command =
            |> List.filter (fun path_p4 ->
                   not (List.exists (String.equal path_p4) excludes_p4))
          in
-         match mode with
-         | `Instr ->
-             cover_run_instr SL_mode paths_spec relname includes_p4 paths_p4
-               path_cov
-         | `Dangling ->
-             cover_run_dangling SL_mode paths_spec relname includes_p4 paths_p4
-               path_cov
+         match
+           match mode with
+           | `Instr ->
+               cover_run_instr SL_mode paths_spec relname includes_p4 paths_p4
+                 path_cov
+           | `Dangling ->
+               cover_run_dangling SL_mode paths_spec relname includes_p4
+                 paths_p4 path_cov
+         with
+         | Ok () -> ()
+         | Error e -> Format.printf "%s\n" (Pass.string_of_error e)
        with
        | CommandError msg -> Format.printf "%s\n" msg
-       | ParseError (at, msg)
-       | ElabError (at, msg)
-       | StructError (at, msg)
-       | InterpError (at, msg)
-       | ExternError (at, msg) ->
+       | InterpError (at, msg) | ExternError (at, msg) ->
            Format.printf "%s\n" (string_of_error at msg))
 
 let cover_sim_command =
@@ -462,20 +460,20 @@ let cover_sim_command =
                   not (List.exists (String.equal path_p4) excludes_p4))
            |> List.split
          in
-         match mode with
-         | `Instr ->
-             cover_sim_instr ~arch SL_mode paths_spec includes_p4 paths_p4
-               paths_stf path_cov
-         | `Dangling ->
-             cover_sim_dangling ~arch SL_mode paths_spec includes_p4 paths_p4
-               paths_stf path_cov
+         match
+           match mode with
+           | `Instr ->
+               cover_sim_instr ~arch SL_mode paths_spec includes_p4 paths_p4
+                 paths_stf path_cov
+           | `Dangling ->
+               cover_sim_dangling ~arch SL_mode paths_spec includes_p4 paths_p4
+                 paths_stf path_cov
+         with
+         | Ok () -> ()
+         | Error e -> Format.printf "%s\n" (Pass.string_of_error e)
        with
        | CommandError msg -> Format.printf "%s\n" msg
-       | ParseError (at, msg)
-       | ElabError (at, msg)
-       | StructError (at, msg)
-       | InterpError (at, msg)
-       | ExternError (at, msg) ->
+       | InterpError (at, msg) | ExternError (at, msg) ->
            Format.printf "%s\n" (string_of_error at msg))
 
 let run_testgen_command =
@@ -510,44 +508,45 @@ let run_testgen_command =
          ~doc:"cover a new dangling only if it was intended by a mutation"
      in
      fun () ->
-       try
-         let spec_sl = Pass.structure ~final:true paths_spec in
-         let logmode =
-           if silent then Backend_testgen_neg.Modes.Silent
-           else Backend_testgen_neg.Modes.Verbose
-         in
-         let bootmode =
-           match (bootdir, path_boot) with
-           | Some bootdir, None ->
-               Backend_testgen_neg.Modes.Cold (excludes_p4, bootdir)
-           | None, Some path_boot -> Backend_testgen_neg.Modes.Warm path_boot
-           | Some _, Some _ ->
-               raise
-                 (CommandError
-                    "Error: should specify only one of -boot-dir or -boot-file")
-           | None, None ->
-               raise
-                 (CommandError "Error: should specify either -cold or -warm")
-         in
-         let mutationmode =
-           if random then Backend_testgen_neg.Modes.Random
-           else if hybrid then Backend_testgen_neg.Modes.Hybrid
-           else Backend_testgen_neg.Modes.Derive
-         in
-         let covermode =
-           if strict then Backend_testgen_neg.Modes.Strict
-           else Backend_testgen_neg.Modes.Relaxed
-         in
-         Backend_testgen_neg.Gen.fuzzer fuel spec_sl relname includes_p4 gendir
-           name_campaign randseed logmode bootmode mutationmode covermode
-       with
-       | CommandError msg -> Format.printf "%s\n" msg
-       | ParseError (at, msg)
-       | ElabError (at, msg)
-       | StructError (at, msg)
-       | InterpError (at, msg)
-       | ExternError (at, msg) ->
-           Format.printf "%s\n" (string_of_error at msg))
+       match Pass.structure ~final:true paths_spec with
+       | Error e -> Format.printf "%s\n" (Pass.string_of_error e)
+       | Ok spec_sl -> (
+           try
+             let logmode =
+               if silent then Backend_testgen_neg.Modes.Silent
+               else Backend_testgen_neg.Modes.Verbose
+             in
+             let bootmode =
+               match (bootdir, path_boot) with
+               | Some bootdir, None ->
+                   Backend_testgen_neg.Modes.Cold (excludes_p4, bootdir)
+               | None, Some path_boot ->
+                   Backend_testgen_neg.Modes.Warm path_boot
+               | Some _, Some _ ->
+                   raise
+                     (CommandError
+                        "Error: should specify only one of -boot-dir or \
+                         -boot-file")
+               | None, None ->
+                   raise
+                     (CommandError "Error: should specify either -cold or -warm")
+             in
+             let mutationmode =
+               if random then Backend_testgen_neg.Modes.Random
+               else if hybrid then Backend_testgen_neg.Modes.Hybrid
+               else Backend_testgen_neg.Modes.Derive
+             in
+             let covermode =
+               if strict then Backend_testgen_neg.Modes.Strict
+               else Backend_testgen_neg.Modes.Relaxed
+             in
+             Backend_testgen_neg.Gen.fuzzer fuel spec_sl relname includes_p4
+               gendir name_campaign randseed logmode bootmode mutationmode
+               covermode
+           with
+           | CommandError msg -> Format.printf "%s\n" msg
+           | InterpError (at, msg) | ExternError (at, msg) ->
+               Format.printf "%s\n" (string_of_error at msg)))
 
 let run_testgen_debug_command =
   Core.Command.basic
@@ -562,18 +561,16 @@ let run_testgen_debug_command =
        flag "-debug" (required string) ~doc:"directory for debug files"
      and iid = flag "-iid" (required int) ~doc:"dangling id to close-miss" in
      fun () ->
-       try
-         let spec_sl = Pass.structure ~final:true paths_spec in
-         Backend_testgen_neg.Derive.debug_dangling spec_sl relname includes_p4
-           path_p4 debugdir iid
-       with
-       | CommandError msg -> Format.printf "%s\n" msg
-       | ParseError (at, msg)
-       | ElabError (at, msg)
-       | StructError (at, msg)
-       | InterpError (at, msg)
-       | ExternError (at, msg) ->
-           Format.printf "%s\n" (string_of_error at msg))
+       match Pass.structure ~final:true paths_spec with
+       | Error e -> Format.printf "%s\n" (Pass.string_of_error e)
+       | Ok spec_sl -> (
+           try
+             Backend_testgen_neg.Derive.debug_dangling spec_sl relname
+               includes_p4 path_p4 debugdir iid
+           with
+           | CommandError msg -> Format.printf "%s\n" msg
+           | InterpError (at, msg) | ExternError (at, msg) ->
+               Format.printf "%s\n" (string_of_error at msg)))
 
 let interesting_command =
   Core.Command.basic ~summary:"interestingness test for reducing P4 programs"
@@ -590,58 +587,56 @@ let interesting_command =
      and iid = flag "-iid" (required int) ~doc:"dangling id to test"
      and path_p4 = flag "-p" (required string) ~doc:"P4 program" in
      fun () ->
-       try
-         let spec_sim = Backend_boot.Build.spec_of_mode SL_mode paths_spec in
-         let (module Simulator) = Backend_sim.Build.build spec_sim in
-         let result, cover =
-           run_with_dangling
-             (module Simulator)
-             spec_sim relname includes_p4 path_p4
-         in
-         match result with
-         | Pass _ ->
-             if check_well_typed then (
-               let branch = Coverage.Dangling.Single.Cover.find iid cover in
-               match branch.status with
-               | Hit ->
-                   Printf.printf "WellTyped: Hit\n";
-                   if check_close_miss then exit 3 else exit 0
-               | Miss (_ :: _) ->
-                   Printf.printf "WellTyped: Close\n";
-                   if check_close_miss then exit 0 else exit 2
-               | Miss [] ->
-                   Printf.printf "WellTyped: Miss\n";
-                   exit 1)
-             else (
-               Printf.printf "WellTyped\n";
-               exit 11)
-         | Fail (`Syntax _) ->
-             Printf.printf "IllFormed";
-             exit 12
-         | Fail (`Runtime _) -> (
-             if check_well_typed then (
-               Printf.printf "IllTyped\n";
-               exit 10)
-             else
-               let branch = Coverage.Dangling.Single.Cover.find iid cover in
-               match branch.status with
-               | Hit ->
-                   Printf.printf "IllTyped: Hit\n";
-                   if check_close_miss then exit 3 else exit 0
-               | Miss (_ :: _) ->
-                   Printf.printf "IllTyped: Close\n";
-                   if check_close_miss then exit 0 else exit 2
-               | Miss [] ->
-                   Printf.printf "IllTyped: Miss\n";
-                   exit 1)
-       with
-       | CommandError msg -> Format.printf "%s\n" msg
-       | ParseError (at, msg)
-       | ElabError (at, msg)
-       | StructError (at, msg)
-       | InterpError (at, msg)
-       | ExternError (at, msg) ->
-           Format.printf "%s\n" (string_of_error at msg))
+       match spec_of_mode SL_mode paths_spec with
+       | Error e -> Format.printf "%s\n" (Pass.string_of_error e)
+       | Ok spec_sim -> (
+           try
+             let (module Simulator) = Backend_sim.Build.build spec_sim in
+             let result, cover =
+               run_with_dangling
+                 (module Simulator)
+                 spec_sim relname includes_p4 path_p4
+             in
+             match result with
+             | Pass _ ->
+                 if check_well_typed then (
+                   let branch = Coverage.Dangling.Single.Cover.find iid cover in
+                   match branch.status with
+                   | Hit ->
+                       Printf.printf "WellTyped: Hit\n";
+                       if check_close_miss then exit 3 else exit 0
+                   | Miss (_ :: _) ->
+                       Printf.printf "WellTyped: Close\n";
+                       if check_close_miss then exit 0 else exit 2
+                   | Miss [] ->
+                       Printf.printf "WellTyped: Miss\n";
+                       exit 1)
+                 else (
+                   Printf.printf "WellTyped\n";
+                   exit 11)
+             | Fail (`Syntax _) ->
+                 Printf.printf "IllFormed";
+                 exit 12
+             | Fail (`Runtime _) -> (
+                 if check_well_typed then (
+                   Printf.printf "IllTyped\n";
+                   exit 10)
+                 else
+                   let branch = Coverage.Dangling.Single.Cover.find iid cover in
+                   match branch.status with
+                   | Hit ->
+                       Printf.printf "IllTyped: Hit\n";
+                       if check_close_miss then exit 3 else exit 0
+                   | Miss (_ :: _) ->
+                       Printf.printf "IllTyped: Close\n";
+                       if check_close_miss then exit 0 else exit 2
+                   | Miss [] ->
+                       Printf.printf "IllTyped: Miss\n";
+                       exit 1)
+           with
+           | CommandError msg -> Format.printf "%s\n" msg
+           | InterpError (at, msg) | ExternError (at, msg) ->
+               Format.printf "%s\n" (string_of_error at msg)))
 
 let splice_command =
   Core.Command.basic ~summary:"splice a skeleton p4_16 specification document"
@@ -652,25 +647,30 @@ let splice_command =
      and paths_output = flag "-out" (listed string) ~doc:"output files"
      and inplace = flag "-inplace" no_arg ~doc:"splice in place" in
      fun () ->
-       try
-         if (not inplace) && List.length paths_input <> List.length paths_output
-         then raise (CommandError "number of input and output files must match");
-         let paths =
-           if inplace then List.combine paths_input paths_input
-           else List.combine paths_input paths_output
-         in
-         let spec = Pass.parse paths_spec in
-         let spec_pl = Pass.annotate paths_spec in
-         Backend_splice.Driver.splice_files spec spec_pl paths
+       match
+         let* spec = Pass.parse paths_spec in
+         let* spec_pl = Pass.annotate paths_spec in
+         Ok (spec, spec_pl)
        with
-       | CommandError msg -> Format.printf "%s\n" msg
-       | ParseError (at, msg)
-       | ElabError (at, msg)
-       | StructError (at, msg)
-       | ProseError (at, msg)
-       | SpliceError (at, msg) ->
-           Format.eprintf "%s\n" (string_of_error at msg);
-           Format.printf "%s\n" (string_of_error at msg))
+       | Error e -> Format.printf "%s\n" (Pass.string_of_error e)
+       | Ok (spec, spec_pl) -> (
+           try
+             if
+               (not inplace)
+               && List.length paths_input <> List.length paths_output
+             then
+               raise
+                 (CommandError "number of input and output files must match");
+             let paths =
+               if inplace then List.combine paths_input paths_input
+               else List.combine paths_input paths_output
+             in
+             Backend_splice.Driver.splice_files spec spec_pl paths
+           with
+           | CommandError msg -> Format.printf "%s\n" msg
+           | SpliceError (at, msg) ->
+               Format.eprintf "%s\n" (string_of_error at msg);
+               Format.printf "%s\n" (string_of_error at msg)))
 
 let parse_command =
   Core.Command.basic ~summary:"parse a P4 program"
@@ -683,35 +683,38 @@ let parse_command =
        flag "-r" no_arg ~doc:"perform a round-trip parse/unparse"
      in
      fun () ->
-       try
-         let (module Simulator) =
-           Backend_sim.Build.build
-             (Backend_boot.Build.spec_of_mode AL_mode paths_spec)
-         in
-         let value_program =
-           match Simulator.Interface.parse_program includes_p4 [ path_p4 ] with
-           | Pass value_program -> value_program
-           | Fail (`Syntax (at, msg)) -> raise (ParseError (at, msg))
-         in
-         let str_program = Simulator.Interface.unparse_program value_program in
-         if roundtrip then
-           let value_program_roundtrip =
-             match Simulator.Interface.parse_string path_p4 str_program with
-             | Pass value_program_roundtrip -> value_program_roundtrip
-             | Fail (`Syntax (at, msg)) -> raise (ParseError (at, msg))
-           in
-           Il.Eq.eq_value ~dbg:true value_program value_program_roundtrip
-           |> (fun b ->
-                if b then "Roundtrip successful" else "Roundtrip failed")
-           |> print_endline
-         else str_program |> print_endline
-       with
-       | Sys_error msg -> Format.printf "File error: %s\n" msg
-       | ElabError (at, msg) ->
-           Format.printf "Elaboration error: %s\n" (string_of_error at msg)
-       | ParseError (at, msg) ->
-           Format.printf "Parse error: %s\n" (string_of_error at msg)
-       | e -> Format.printf "Unknown error: %s\n" (Printexc.to_string e))
+       match spec_of_mode AL_mode paths_spec with
+       | Error e -> Format.printf "%s\n" (Pass.string_of_error e)
+       | Ok spec_sim -> (
+           try
+             let (module Simulator) = Backend_sim.Build.build spec_sim in
+             match
+               Simulator.Interface.parse_program includes_p4 [ path_p4 ]
+             with
+             | Fail (`Syntax (at, msg)) ->
+                 Format.printf "Parse error: %s\n" (string_of_error at msg)
+             | Pass value_program ->
+                 let str_program =
+                   Simulator.Interface.unparse_program value_program
+                 in
+                 if roundtrip then
+                   match
+                     Simulator.Interface.parse_string path_p4 str_program
+                   with
+                   | Fail (`Syntax (at, msg)) ->
+                       Format.printf "Parse error: %s\n"
+                         (string_of_error at msg)
+                   | Pass value_program_roundtrip ->
+                       Il.Eq.eq_value ~dbg:true value_program
+                         value_program_roundtrip
+                       |> (fun b ->
+                            if b then "Roundtrip successful"
+                            else "Roundtrip failed")
+                       |> print_endline
+                 else str_program |> print_endline
+           with
+           | Sys_error msg -> Format.printf "File error: %s\n" msg
+           | e -> Format.printf "Unknown error: %s\n" (Printexc.to_string e)))
 
 let command =
   Core.Command.group

--- a/p4spec/bin/main.ml
+++ b/p4spec/bin/main.ml
@@ -1,6 +1,5 @@
 open Lang
 open Runtime.Sim.Signature
-open Util.Error
 open Util.Source
 
 let version = "0.1"
@@ -299,8 +298,8 @@ let run_command =
                  Format.printf "runtime error: %s\n" msg
            with
            | CommandError msg -> Format.printf "%s\n" msg
-           | InterpError (at, msg) ->
-               Format.printf "%s\n" (string_of_error at msg)))
+           | Interp_common.Error.InterpError (at, msg) ->
+               Format.printf "%s\n" (Util.Error.string_of_error at msg)))
 
 let sim_command =
   Core.Command.basic
@@ -375,10 +374,11 @@ let sim_command =
                  Format.printf "runtime error: %s\n" msg
            with
            | CommandError msg -> Format.printf "%s\n" msg
-           | InterpError (at, msg) | ExternError (at, msg) ->
-               Format.printf "%s\n" (string_of_error at msg)
-           | StfError msg ->
-               Format.printf "%s\n" (string_of_error no_region msg)))
+           | Interp_common.Error.InterpError (at, msg)
+           | Runtime.Dynamic_Runner.Signature.ExternError (at, msg) ->
+               Format.printf "%s\n" (Util.Error.string_of_error at msg)
+           | Stf.Error.StfError msg ->
+               Format.printf "%s\n" (Util.Error.string_of_error no_region msg)))
 
 let cover_run_command =
   Core.Command.basic ~summary:"measure coverage of the spec"
@@ -422,8 +422,9 @@ let cover_run_command =
          | Error e -> Format.printf "%s\n" (Pass.string_of_error e)
        with
        | CommandError msg -> Format.printf "%s\n" msg
-       | InterpError (at, msg) | ExternError (at, msg) ->
-           Format.printf "%s\n" (string_of_error at msg))
+       | Interp_common.Error.InterpError (at, msg)
+       | Runtime.Dynamic_Runner.Signature.ExternError (at, msg) ->
+           Format.printf "%s\n" (Util.Error.string_of_error at msg))
 
 let cover_sim_command =
   Core.Command.basic
@@ -473,8 +474,9 @@ let cover_sim_command =
          | Error e -> Format.printf "%s\n" (Pass.string_of_error e)
        with
        | CommandError msg -> Format.printf "%s\n" msg
-       | InterpError (at, msg) | ExternError (at, msg) ->
-           Format.printf "%s\n" (string_of_error at msg))
+       | Interp_common.Error.InterpError (at, msg)
+       | Runtime.Dynamic_Runner.Signature.ExternError (at, msg) ->
+           Format.printf "%s\n" (Util.Error.string_of_error at msg))
 
 let run_testgen_command =
   Core.Command.basic
@@ -545,8 +547,9 @@ let run_testgen_command =
                covermode
            with
            | CommandError msg -> Format.printf "%s\n" msg
-           | InterpError (at, msg) | ExternError (at, msg) ->
-               Format.printf "%s\n" (string_of_error at msg)))
+           | Interp_common.Error.InterpError (at, msg)
+           | Runtime.Dynamic_Runner.Signature.ExternError (at, msg) ->
+               Format.printf "%s\n" (Util.Error.string_of_error at msg)))
 
 let run_testgen_debug_command =
   Core.Command.basic
@@ -569,8 +572,9 @@ let run_testgen_debug_command =
                includes_p4 path_p4 debugdir iid
            with
            | CommandError msg -> Format.printf "%s\n" msg
-           | InterpError (at, msg) | ExternError (at, msg) ->
-               Format.printf "%s\n" (string_of_error at msg)))
+           | Interp_common.Error.InterpError (at, msg)
+           | Runtime.Dynamic_Runner.Signature.ExternError (at, msg) ->
+               Format.printf "%s\n" (Util.Error.string_of_error at msg)))
 
 let interesting_command =
   Core.Command.basic ~summary:"interestingness test for reducing P4 programs"
@@ -635,8 +639,9 @@ let interesting_command =
                        exit 1)
            with
            | CommandError msg -> Format.printf "%s\n" msg
-           | InterpError (at, msg) | ExternError (at, msg) ->
-               Format.printf "%s\n" (string_of_error at msg)))
+           | Interp_common.Error.InterpError (at, msg)
+           | Runtime.Dynamic_Runner.Signature.ExternError (at, msg) ->
+               Format.printf "%s\n" (Util.Error.string_of_error at msg)))
 
 let splice_command =
   Core.Command.basic ~summary:"splice a skeleton p4_16 specification document"
@@ -668,9 +673,9 @@ let splice_command =
              Backend_splice.Driver.splice_files spec spec_pl paths
            with
            | CommandError msg -> Format.printf "%s\n" msg
-           | SpliceError (at, msg) ->
-               Format.eprintf "%s\n" (string_of_error at msg);
-               Format.printf "%s\n" (string_of_error at msg)))
+           | Backend_splice.Error.SpliceError (at, msg) ->
+               Format.eprintf "%s\n" (Util.Error.string_of_error at msg);
+               Format.printf "%s\n" (Util.Error.string_of_error at msg)))
 
 let parse_command =
   Core.Command.basic ~summary:"parse a P4 program"
@@ -692,7 +697,8 @@ let parse_command =
                Simulator.Interface.parse_program includes_p4 [ path_p4 ]
              with
              | Fail (`Syntax (at, msg)) ->
-                 Format.printf "Parse error: %s\n" (string_of_error at msg)
+                 Format.printf "Parse error: %s\n"
+                   (Util.Error.string_of_error at msg)
              | Pass value_program ->
                  let str_program =
                    Simulator.Interface.unparse_program value_program
@@ -703,7 +709,7 @@ let parse_command =
                    with
                    | Fail (`Syntax (at, msg)) ->
                        Format.printf "Parse error: %s\n"
-                         (string_of_error at msg)
+                         (Util.Error.string_of_error at msg)
                    | Pass value_program_roundtrip ->
                        Il.Eq.eq_value ~dbg:true value_program
                          value_program_roundtrip

--- a/p4spec/lib/backend-boot/build.ml
+++ b/p4spec/lib/backend-boot/build.ml
@@ -1,5 +1,5 @@
 module Run = Runtime.Dynamic_Runner.Signature
-open Error
+open Util.Source
 
 let ( let* ) = Result.bind
 
@@ -30,10 +30,50 @@ let spec_of_mode (mode : Run.mode) (paths_spec : string list) :
       Ok (PL spec_pl : Run.spec)
   | Empty_mode -> assert false
 
+(* The specs of a tower, paired with the level each one belongs to, ordered from
+   the target down to the boot level *)
+
+type tower_specs = {
+  target : Config.level * Run.spec;
+  interms : (Config.level * Run.spec) list;
+  boot : Config.level * Run.spec;
+}
+
+let specs_of_tower (tower : Config.tower) : (tower_specs, Pass.error) result =
+  let* spec_target = structured_spec [ tower.level_target.layer.specdir ] in
+  let* specs_interm =
+    tower.levels_interm |> List.rev
+    |> map_result (fun (level : Config.level) ->
+           let* spec = structured_spec [ level.layer.specdir ] in
+           Ok (level, spec))
+  in
+  let* spec_boot = spec_of_mode tower.mode [ tower.level_boot.layer.specdir ] in
+  Ok
+    {
+      target = (tower.level_target, spec_target);
+      interms = specs_interm;
+      boot = (tower.level_boot, spec_boot);
+    }
+
+(* The SpecTec interface backing a non-target level *)
+
+let spectec_interface_of (interface : Config.interface) :
+    ((module Spectec.INTERFACE_SPECTEC), Run.error) result =
+  match interface with
+  | P4_interface ->
+      Error
+        {
+          Run.at = no_region;
+          msg = "P4 interface not supported outside of target level";
+        }
+  | AL_interface -> Ok (module Interface.SpecTec_AL : Spectec.INTERFACE_SPECTEC)
+  | SL_interface -> Ok (module Interface.SpecTec_SL : Spectec.INTERFACE_SPECTEC)
+
 (* Building a tower *)
 
 let build_target ?(cache = true) ?(det = false) ?(guard = false)
-    (level : Config.level) (spec : Run.spec) =
+    (level : Config.level) (spec : Run.spec) :
+    ((module Run.RUNNER), Run.error) result =
   (* Create the target runner *)
   let (module Runner_target) =
     match level.interface with
@@ -55,19 +95,15 @@ let build_target ?(cache = true) ?(det = false) ?(guard = false)
                   (Interp_sl.Interp.Make)
                   (Interp_pl.Interp.Make) : Run.RUNNER)
   in
-  Runner_target.init ~cache ~det ~guard spec;
-  (module Runner_target : Run.RUNNER)
+  let* () = Runner_target.init ~cache ~det ~guard spec in
+  Ok (module Runner_target : Run.RUNNER)
 
 let build_interm ?(cache = true) ?(det = false) ?(guard = false)
     (module Runner_above : Run.RUNNER) (level : Config.level) (spec : Run.spec)
-    =
+    : ((module Run.RUNNER), Run.error) result =
   (* Create the intermediate runner *)
-  let (module Interface_SpecTec) =
-    match level.interface with
-    | P4_interface ->
-        error_no_region "P4 interface not supported outside of target level"
-    | AL_interface -> (module Interface.SpecTec_AL : Spectec.INTERFACE_SPECTEC)
-    | SL_interface -> (module Interface.SpecTec_SL : Spectec.INTERFACE_SPECTEC)
+  let* (module Interface_SpecTec : Spectec.INTERFACE_SPECTEC) =
+    spectec_interface_of level.interface
   in
   let (module Runner) =
     (module Runner.Make.Make_nonrec
@@ -77,19 +113,15 @@ let build_interm ?(cache = true) ?(det = false) ?(guard = false)
               (Interp_sl.Interp.Make)
               (Interp_pl.Interp.Make) : Run.RUNNER)
   in
-  Runner.init ~cache ~det ~guard spec;
-  (module Runner : Run.RUNNER)
+  let* () = Runner.init ~cache ~det ~guard spec in
+  Ok (module Runner : Run.RUNNER)
 
 let build_boot ?(cache = true) ?(det = false) ?(guard = false)
     (module Runner_above : Run.RUNNER) (level : Config.level) (spec : Run.spec)
-    =
+    : ((module Run.RUNNER), Run.error) result =
   (* Create the booter *)
-  let (module Interface_SpecTec) =
-    match level.interface with
-    | P4_interface ->
-        error_no_region "P4 interface not supported outside of target level"
-    | AL_interface -> (module Interface.SpecTec_AL : Spectec.INTERFACE_SPECTEC)
-    | SL_interface -> (module Interface.SpecTec_SL : Spectec.INTERFACE_SPECTEC)
+  let* (module Interface_SpecTec : Spectec.INTERFACE_SPECTEC) =
+    spectec_interface_of level.interface
   in
   let (module Booter) =
     (module Runner.Make.Make_nonrec
@@ -99,61 +131,33 @@ let build_boot ?(cache = true) ?(det = false) ?(guard = false)
               (Interp_sl.Interp.Make)
               (Interp_pl.Interp.Make) : Run.RUNNER)
   in
-  Booter.init ~cache ~det ~guard spec;
-  (module Booter : Run.RUNNER)
+  let* () = Booter.init ~cache ~det ~guard spec in
+  Ok (module Booter : Run.RUNNER)
 
 let build_tower ?(cache = true) ?(det = false) ?(guard = false)
-    (tower : Config.tower) =
-  (* Build the target runner *)
-  let* spec_target = structured_spec [ tower.level_target.layer.specdir ] in
-  let runner_target =
-    build_target ~cache ~det ~guard tower.level_target spec_target
+    (specs : tower_specs) : ((module Run.RUNNER), Run.error) result =
+  (* Build the levels from the target down to the boot level *)
+  let level_target, spec_target = specs.target in
+  let* runner_target =
+    build_target ~cache ~det ~guard level_target spec_target
   in
-  (* Reverse the levels, so that we build levels from the target to boot *)
-  let levels = tower.level_boot :: tower.levels_interm |> List.rev in
-  let n = List.length levels in
-  let* level_specs =
-    levels
-    |> List.mapi (fun idx level -> (idx = n - 1, level))
-    |> map_result (fun (is_boot, (level : Config.level)) ->
-           let* spec =
-             if is_boot then spec_of_mode tower.mode [ level.layer.specdir ]
-             else structured_spec [ level.layer.specdir ]
-           in
-           Ok (is_boot, level, spec))
+  let* runner_above =
+    List.fold_left
+      (fun acc (level, spec) ->
+        let* runner_above = acc in
+        let (module Runner_above : Run.RUNNER) = runner_above in
+        build_interm ~cache ~det ~guard (module Runner_above) level spec)
+      (Ok runner_target) specs.interms
   in
-  let spec_boot = ref None in
-  let booter, runners_interm =
-    level_specs
-    |> List.fold_left
-         (fun ((module Runner_above : Run.RUNNER), runners)
-              (is_boot, level, spec) ->
-           if not is_boot then
-             let runner_interm =
-               build_interm ~cache ~det ~guard (module Runner_above) level spec
-             in
-             (runner_interm, runner_interm :: runners)
-           else
-             let booter =
-               build_boot ~cache ~det ~guard (module Runner_above) level spec
-             in
-             spec_boot := Some spec;
-             (booter, runners))
-         (runner_target, [])
-  in
-  let spec_boot =
-    match !spec_boot with Some spec -> spec | None -> assert false
-  in
-  Ok (spec_boot, runner_target, runners_interm, booter)
+  let (module Runner_above : Run.RUNNER) = runner_above in
+  let level_boot, spec_boot = specs.boot in
+  build_boot ~cache ~det ~guard (module Runner_above) level_boot spec_boot
 
-let build_null ?(cache = true) ?(det = false) ?(guard = false) (mode : Run.mode)
-    (interface : Config.interface) (paths_spec : string list) =
-  let (module Interface_SpecTec) =
-    match interface with
-    | P4_interface ->
-        error_no_region "P4 interface not supported outside of target level"
-    | AL_interface -> (module Interface.SpecTec_AL : Spectec.INTERFACE_SPECTEC)
-    | SL_interface -> (module Interface.SpecTec_SL : Spectec.INTERFACE_SPECTEC)
+let build_null ?(cache = true) ?(det = false) ?(guard = false)
+    (interface : Config.interface) (spec : Run.spec) :
+    ((module Run.RUNNER), Run.error) result =
+  let* (module Interface_SpecTec : Spectec.INTERFACE_SPECTEC) =
+    spectec_interface_of interface
   in
   let (module Runner) =
     (module Runner.Make.Make_rec
@@ -163,6 +167,5 @@ let build_null ?(cache = true) ?(det = false) ?(guard = false) (mode : Run.mode)
               (Interp_sl.Interp.Make)
               (Interp_pl.Interp.Make) : Run.RUNNER)
   in
-  let* spec = spec_of_mode mode paths_spec in
-  Runner.init ~cache ~det ~guard spec;
-  Ok (spec, (module Runner : Run.RUNNER))
+  let* () = Runner.init ~cache ~det ~guard spec in
+  Ok (module Runner : Run.RUNNER)

--- a/p4spec/lib/backend-boot/build.ml
+++ b/p4spec/lib/backend-boot/build.ml
@@ -1,23 +1,33 @@
 module Run = Runtime.Dynamic_Runner.Signature
 open Error
 
+let ( let* ) = Result.bind
+
+let rec map_result f = function
+  | [] -> Ok []
+  | x :: xs ->
+      let* y = f x in
+      let* ys = map_result f xs in
+      Ok (y :: ys)
+
 (* Specs *)
 
-let structured_spec (paths_spec : string list) : Run.spec =
-  let spec_sl = Pass.structure ~final:true paths_spec in
-  (SL spec_sl : Run.spec)
+let structured_spec (paths_spec : string list) : (Run.spec, Pass.error) result =
+  let* spec_sl = Pass.structure ~final:true paths_spec in
+  Ok (SL spec_sl : Run.spec)
 
-let spec_of_mode (mode : Run.mode) (paths_spec : string list) : Run.spec =
+let spec_of_mode (mode : Run.mode) (paths_spec : string list) :
+    (Run.spec, Pass.error) result =
   match mode with
   | AL_mode ->
-      let spec_al = Pass.algo paths_spec in
-      (AL spec_al : Run.spec)
+      let* spec_al = Pass.algo paths_spec in
+      Ok (AL spec_al : Run.spec)
   | SL_mode ->
-      let spec_sl = Pass.structure ~final:true paths_spec in
-      (SL spec_sl : Run.spec)
+      let* spec_sl = Pass.structure ~final:true paths_spec in
+      Ok (SL spec_sl : Run.spec)
   | PL_mode ->
-      let spec_pl = Pass.annotate paths_spec in
-      (PL spec_pl : Run.spec)
+      let* spec_pl = Pass.annotate paths_spec in
+      Ok (PL spec_pl : Run.spec)
   | Empty_mode -> assert false
 
 (* Building a tower *)
@@ -95,22 +105,22 @@ let build_boot ?(cache = true) ?(det = false) ?(guard = false)
 let build_tower ?(cache = true) ?(det = false) ?(guard = false)
     (tower : Config.tower) =
   (* Build the target runner *)
-  let spec_target = structured_spec [ tower.level_target.layer.specdir ] in
+  let* spec_target = structured_spec [ tower.level_target.layer.specdir ] in
   let runner_target =
     build_target ~cache ~det ~guard tower.level_target spec_target
   in
   (* Reverse the levels, so that we build levels from the target to boot *)
   let levels = tower.level_boot :: tower.levels_interm |> List.rev in
   let n = List.length levels in
-  let level_specs =
+  let* level_specs =
     levels
     |> List.mapi (fun idx level -> (idx = n - 1, level))
-    |> List.map (fun (is_boot, (level : Config.level)) ->
-           let spec =
+    |> map_result (fun (is_boot, (level : Config.level)) ->
+           let* spec =
              if is_boot then spec_of_mode tower.mode [ level.layer.specdir ]
              else structured_spec [ level.layer.specdir ]
            in
-           (is_boot, level, spec))
+           Ok (is_boot, level, spec))
   in
   let spec_boot = ref None in
   let booter, runners_interm =
@@ -134,7 +144,7 @@ let build_tower ?(cache = true) ?(det = false) ?(guard = false)
   let spec_boot =
     match !spec_boot with Some spec -> spec | None -> assert false
   in
-  (spec_boot, runner_target, runners_interm, booter)
+  Ok (spec_boot, runner_target, runners_interm, booter)
 
 let build_null ?(cache = true) ?(det = false) ?(guard = false) (mode : Run.mode)
     (interface : Config.interface) (paths_spec : string list) =
@@ -153,6 +163,6 @@ let build_null ?(cache = true) ?(det = false) ?(guard = false) (mode : Run.mode)
               (Interp_sl.Interp.Make)
               (Interp_pl.Interp.Make) : Run.RUNNER)
   in
-  let spec = spec_of_mode mode paths_spec in
+  let* spec = spec_of_mode mode paths_spec in
   Runner.init ~cache ~det ~guard spec;
-  (spec, (module Runner : Run.RUNNER))
+  Ok (spec, (module Runner : Run.RUNNER))

--- a/p4spec/lib/backend-boot/build.ml
+++ b/p4spec/lib/backend-boot/build.ml
@@ -1,10 +1,29 @@
 module Run = Runtime.Dynamic_Runner.Signature
 open Error
 
+(* Specs *)
+
+let structured_spec (paths_spec : string list) : Run.spec =
+  let spec_sl = Pass.structure ~final:true paths_spec in
+  (SL spec_sl : Run.spec)
+
+let spec_of_mode (mode : Run.mode) (paths_spec : string list) : Run.spec =
+  match mode with
+  | AL_mode ->
+      let spec_al = Pass.algo paths_spec in
+      (AL spec_al : Run.spec)
+  | SL_mode ->
+      let spec_sl = Pass.structure ~final:true paths_spec in
+      (SL spec_sl : Run.spec)
+  | PL_mode ->
+      let spec_pl = Pass.annotate paths_spec in
+      (PL spec_pl : Run.spec)
+  | Empty_mode -> assert false
+
 (* Building a tower *)
 
 let build_target ?(cache = true) ?(det = false) ?(guard = false)
-    (level : Config.level) =
+    (level : Config.level) (spec : Run.spec) =
   (* Create the target runner *)
   let (module Runner_target) =
     match level.interface with
@@ -26,16 +45,12 @@ let build_target ?(cache = true) ?(det = false) ?(guard = false)
                   (Interp_sl.Interp.Make)
                   (Interp_pl.Interp.Make) : Run.RUNNER)
   in
-  (* Initialize the target runner, as an SL spec *)
-  let spec =
-    let spec_sl = Pass.structure ~final:true [ level.layer.specdir ] in
-    (SL spec_sl : Run.spec)
-  in
   Runner_target.init ~cache ~det ~guard spec;
   (module Runner_target : Run.RUNNER)
 
 let build_interm ?(cache = true) ?(det = false) ?(guard = false)
-    (module Runner_above : Run.RUNNER) (level : Config.level) =
+    (module Runner_above : Run.RUNNER) (level : Config.level) (spec : Run.spec)
+    =
   (* Create the intermediate runner *)
   let (module Interface_SpecTec) =
     match level.interface with
@@ -52,16 +67,11 @@ let build_interm ?(cache = true) ?(det = false) ?(guard = false)
               (Interp_sl.Interp.Make)
               (Interp_pl.Interp.Make) : Run.RUNNER)
   in
-  (* Initialize the runner, as an SL spec *)
-  let spec =
-    let spec_sl = Pass.structure ~final:true [ level.layer.specdir ] in
-    (SL spec_sl : Run.spec)
-  in
   Runner.init ~cache ~det ~guard spec;
   (module Runner : Run.RUNNER)
 
 let build_boot ?(cache = true) ?(det = false) ?(guard = false)
-    (module Runner_above : Run.RUNNER) (mode : Run.mode) (level : Config.level)
+    (module Runner_above : Run.RUNNER) (level : Config.level) (spec : Run.spec)
     =
   (* Create the booter *)
   let (module Interface_SpecTec) =
@@ -79,46 +89,43 @@ let build_boot ?(cache = true) ?(det = false) ?(guard = false)
               (Interp_sl.Interp.Make)
               (Interp_pl.Interp.Make) : Run.RUNNER)
   in
-  (* Initialize the booter, as mode *)
-  let spec =
-    match mode with
-    | AL_mode ->
-        let spec_al = Pass.algo [ level.layer.specdir ] in
-        (AL spec_al : Run.spec)
-    | SL_mode ->
-        let spec_sl = Pass.structure ~final:true [ level.layer.specdir ] in
-        (SL spec_sl : Run.spec)
-    | PL_mode ->
-        let spec_pl = Pass.annotate [ level.layer.specdir ] in
-        (PL spec_pl : Run.spec)
-    | Empty_mode -> assert false
-  in
   Booter.init ~cache ~det ~guard spec;
-  (spec, (module Booter : Run.RUNNER))
+  (module Booter : Run.RUNNER)
 
 let build_tower ?(cache = true) ?(det = false) ?(guard = false)
     (tower : Config.tower) =
   (* Build the target runner *)
-  let runner_target = build_target ~cache ~det ~guard tower.level_target in
+  let spec_target = structured_spec [ tower.level_target.layer.specdir ] in
+  let runner_target =
+    build_target ~cache ~det ~guard tower.level_target spec_target
+  in
   (* Reverse the levels, so that we build levels from the target to boot *)
   let levels = tower.level_boot :: tower.levels_interm |> List.rev in
+  let n = List.length levels in
+  let level_specs =
+    levels
+    |> List.mapi (fun idx level -> (idx = n - 1, level))
+    |> List.map (fun (is_boot, (level : Config.level)) ->
+           let spec =
+             if is_boot then spec_of_mode tower.mode [ level.layer.specdir ]
+             else structured_spec [ level.layer.specdir ]
+           in
+           (is_boot, level, spec))
+  in
   let spec_boot = ref None in
   let booter, runners_interm =
-    levels
-    |> List.mapi (fun idx level ->
-           if idx = List.length levels - 1 then (true, level) else (false, level))
+    level_specs
     |> List.fold_left
-         (fun ((module Runner_above : Run.RUNNER), runners) (last, level) ->
-           if not last then
+         (fun ((module Runner_above : Run.RUNNER), runners)
+              (is_boot, level, spec) ->
+           if not is_boot then
              let runner_interm =
-               build_interm ~cache ~det ~guard (module Runner_above) level
+               build_interm ~cache ~det ~guard (module Runner_above) level spec
              in
              (runner_interm, runner_interm :: runners)
            else
-             let spec, booter =
-               build_boot ~cache ~det ~guard
-                 (module Runner_above)
-                 tower.mode level
+             let booter =
+               build_boot ~cache ~det ~guard (module Runner_above) level spec
              in
              spec_boot := Some spec;
              (booter, runners))
@@ -146,18 +153,6 @@ let build_null ?(cache = true) ?(det = false) ?(guard = false) (mode : Run.mode)
               (Interp_sl.Interp.Make)
               (Interp_pl.Interp.Make) : Run.RUNNER)
   in
-  let spec =
-    match mode with
-    | AL_mode ->
-        let spec_al = Pass.algo paths_spec in
-        (AL spec_al : Run.spec)
-    | SL_mode ->
-        let spec_sl = Pass.structure ~final:true paths_spec in
-        (SL spec_sl : Run.spec)
-    | PL_mode ->
-        let spec_pl = Pass.annotate paths_spec in
-        (PL spec_pl : Run.spec)
-    | Empty_mode -> assert false
-  in
+  let spec = spec_of_mode mode paths_spec in
   Runner.init ~cache ~det ~guard spec;
   (spec, (module Runner : Run.RUNNER))

--- a/p4spec/lib/backend-boot/build.ml
+++ b/p4spec/lib/backend-boot/build.ml
@@ -12,10 +12,6 @@ let rec map_result f = function
 
 (* Specs *)
 
-let structured_spec (paths_spec : string list) : (Run.spec, Pass.error) result =
-  let* spec_sl = Pass.structure ~final:true paths_spec in
-  Ok (SL spec_sl : Run.spec)
-
 let spec_of_mode (mode : Run.mode) (paths_spec : string list) :
     (Run.spec, Pass.error) result =
   match mode with
@@ -40,11 +36,13 @@ type tower_specs = {
 }
 
 let specs_of_tower (tower : Config.tower) : (tower_specs, Pass.error) result =
-  let* spec_target = structured_spec [ tower.level_target.layer.specdir ] in
+  let* spec_target =
+    spec_of_mode SL_mode [ tower.level_target.layer.specdir ]
+  in
   let* specs_interm =
     tower.levels_interm |> List.rev
     |> map_result (fun (level : Config.level) ->
-           let* spec = structured_spec [ level.layer.specdir ] in
+           let* spec = spec_of_mode SL_mode [ level.layer.specdir ] in
            Ok (level, spec))
   in
   let* spec_boot = spec_of_mode tower.mode [ tower.level_boot.layer.specdir ] in

--- a/p4spec/lib/backend-boot/error.ml
+++ b/p4spec/lib/backend-boot/error.ml
@@ -1,13 +1,13 @@
-open Util.Error
 open Util.Source
 
 (* Error *)
 
-let error (at : region) (msg : string) = error_extern at msg
-let error_stf (msg : string) = error_stf msg
-let error_no_region (msg : string) = error_extern no_region msg
-let warn (at : region) (msg : string) = warn_extern at msg
-let warn_no_region (msg : string) = warn_extern no_region msg
+let error (at : region) (msg : string) =
+  raise (Runtime.Dynamic_Runner.Signature.ExternError (at, msg))
+
+let error_no_region (msg : string) = error no_region msg
+let warn (at : region) (msg : string) = Util.Error.warn at "extern" msg
+let warn_no_region (msg : string) = warn no_region msg
 
 (* Check *)
 

--- a/p4spec/lib/backend-boot/p4.ml
+++ b/p4spec/lib/backend-boot/p4.ml
@@ -44,7 +44,8 @@ module Make () : RUNNER = struct
       in
       Spec_.Func.register call_func;
       Spec_.Rel.register call_rel;
-      Spec_.Pgm.register call_pgm
+      Spec_.Pgm.register call_pgm;
+      Ok ()
 
     let checkpoint () : int = 0
     let seff (before : int) (after : int) : bool = before <> after

--- a/p4spec/lib/backend-boot/spectec.ml
+++ b/p4spec/lib/backend-boot/spectec.ml
@@ -53,7 +53,7 @@ module Make_null
       | Fail (at, msg) -> error at msg
     in
     call_func := call_func_;
-    ()
+    Ok ()
 
   (* Threading extern calls to the interpreter *)
 
@@ -125,7 +125,7 @@ module Make_parametric
     () : Run.EXTERN = struct
   (* Mode initialization *)
 
-  let init_mode _ = ()
+  let init_mode _ = Ok ()
 
   (* Caches
    * an interface cache for storing results of booting and unbooting values, types, and mixops *)

--- a/p4spec/lib/backend-boot/spectec.ml
+++ b/p4spec/lib/backend-boot/spectec.ml
@@ -88,7 +88,7 @@ module Make_null
         | _ ->
             error no_region
               (Format.asprintf "unimplemented extern relation: %s" name))
-    with Util.Error.ExternError (at, msg) -> Run.Fail (at, msg)
+    with Run.ExternError (at, msg) -> Run.Fail (at, msg)
 
   let eval_extern_func (name : string) (_typs : Typ.t list)
       (_values_input : Value.t list) : Run.func_result =
@@ -98,7 +98,7 @@ module Make_null
         | _ ->
             error no_region
               (Format.asprintf "unimplemented extern function: %s" name))
-    with Util.Error.ExternError (at, msg) -> Run.Fail (at, msg)
+    with Run.ExternError (at, msg) -> Run.Fail (at, msg)
 
   (* State management *)
 
@@ -224,7 +224,7 @@ module Make_parametric
         | _ ->
             error no_region
               (Format.asprintf "unimplemented extern relation: %s" name))
-    with Util.Error.ExternError (at, msg) -> Run.Fail (at, msg)
+    with Run.ExternError (at, msg) -> Run.Fail (at, msg)
 
   let eval_extern_func (name : string) (_typs : Typ.t list)
       (_values_input : Value.t list) : Run.func_result =
@@ -234,7 +234,7 @@ module Make_parametric
         | _ ->
             error no_region
               (Format.asprintf "unimplemented extern function: %s" name))
-    with Util.Error.ExternError (at, msg) -> Run.Fail (at, msg)
+    with Run.ExternError (at, msg) -> Run.Fail (at, msg)
 
   (* State management *)
 

--- a/p4spec/lib/backend-sim/build.ml
+++ b/p4spec/lib/backend-sim/build.ml
@@ -25,23 +25,9 @@ let gen_p4_placeholder () =
             (Interp_pl.Interp.Make) : Sim.SIM)
 
 let build ?(cache = true) ?(det = false) ?(guard = false)
-    ?(arch : string option) ~(final : bool) (mode : Sim.mode)
-    (paths_spec : string list) =
-  let spec_sim =
-    match mode with
-    | AL_mode ->
-        let spec_al = Pass.algo paths_spec in
-        (AL spec_al : Sim.spec)
-    | SL_mode ->
-        let spec_sl = Pass.structure ~final paths_spec in
-        (SL spec_sl : Sim.spec)
-    | PL_mode ->
-        let spec_pl = Pass.annotate paths_spec in
-        (PL spec_pl : Sim.spec)
-    | Empty_mode -> assert false
-  in
+    ?(arch : string option) (spec_sim : Sim.spec) =
   let (module Simulator) =
     match arch with Some arch -> gen_p4 arch | None -> gen_p4_placeholder ()
   in
   Simulator.init ~cache ~det ~guard spec_sim;
-  (spec_sim, (module Simulator : Sim.SIM))
+  (module Simulator : Sim.SIM)

--- a/p4spec/lib/backend-sim/build.ml
+++ b/p4spec/lib/backend-sim/build.ml
@@ -1,33 +1,47 @@
 module Sim = Runtime.Sim.Signature
-open Error
+open Util.Source
 
-let gen_p4 arch =
+let ( let* ) = Result.bind
+
+let gen_p4 (arch : string) : ((module Sim.SIM), Sim.error) result =
   match arch with
   | "v1model" ->
-      (module Make.Make (Interface.P4) (V1model.Pipe.Make)
-                (Interp_al.Interp.Make)
-                (Interp_sl.Interp.Make)
-                (Interp_pl.Interp.Make) : Sim.SIM)
+      Ok
+        (module Make.Make (Interface.P4) (V1model.Pipe.Make)
+                  (Interp_al.Interp.Make)
+                  (Interp_sl.Interp.Make)
+                  (Interp_pl.Interp.Make) : Sim.SIM)
   | "ebpf" ->
-      (module Make.Make (Interface.P4) (Ebpf.Pipe.Make) (Interp_al.Interp.Make)
-                (Interp_sl.Interp.Make)
-                (Interp_pl.Interp.Make) : Sim.SIM)
+      Ok
+        (module Make.Make (Interface.P4) (Ebpf.Pipe.Make)
+                  (Interp_al.Interp.Make)
+                  (Interp_sl.Interp.Make)
+                  (Interp_pl.Interp.Make) : Sim.SIM)
   | "psa" ->
-      (module Make.Make (Interface.P4) (Psa.Pipe.Make) (Interp_al.Interp.Make)
-                (Interp_sl.Interp.Make)
-                (Interp_pl.Interp.Make) : Sim.SIM)
+      Ok
+        (module Make.Make (Interface.P4) (Psa.Pipe.Make) (Interp_al.Interp.Make)
+                  (Interp_sl.Interp.Make)
+                  (Interp_pl.Interp.Make) : Sim.SIM)
   | _ ->
-      Format.asprintf "architecture %s is not supported" arch |> error_no_region
+      Error
+        {
+          Sim.at = no_region;
+          msg = Format.asprintf "architecture %s is not supported" arch;
+        }
 
-let gen_p4_placeholder () =
+let gen_p4_placeholder () : (module Sim.SIM) =
   (module Make.Make (Interface.P4) (Placeholder.Make) (Interp_al.Interp.Make)
             (Interp_sl.Interp.Make)
             (Interp_pl.Interp.Make) : Sim.SIM)
 
 let build ?(cache = true) ?(det = false) ?(guard = false)
-    ?(arch : string option) (spec_sim : Sim.spec) =
-  let (module Simulator) =
-    match arch with Some arch -> gen_p4 arch | None -> gen_p4_placeholder ()
+    ?(arch : string option) (spec_sim : Sim.spec) :
+    ((module Sim.SIM), Sim.error) result =
+  let* simulator =
+    match arch with
+    | Some arch -> gen_p4 arch
+    | None -> Ok (gen_p4_placeholder ())
   in
-  Simulator.init ~cache ~det ~guard spec_sim;
-  (module Simulator : Sim.SIM)
+  let (module Simulator : Sim.SIM) = simulator in
+  let* () = Simulator.init ~cache ~det ~guard spec_sim in
+  Ok simulator

--- a/p4spec/lib/backend-sim/error.ml
+++ b/p4spec/lib/backend-sim/error.ml
@@ -1,13 +1,14 @@
-open Util.Error
 open Util.Source
 
 (* Error *)
 
-let error (at : region) (msg : string) = error_extern at msg
-let error_stf (msg : string) = error_stf msg
-let error_no_region (msg : string) = error_extern no_region msg
-let warn (at : region) (msg : string) = warn_extern at msg
-let warn_no_region (msg : string) = warn_extern no_region msg
+let error (at : region) (msg : string) =
+  raise (Runtime.Dynamic_Runner.Signature.ExternError (at, msg))
+
+let error_stf (msg : string) = Stf.Error.error msg
+let error_no_region (msg : string) = error no_region msg
+let warn (at : region) (msg : string) = Util.Error.warn at "extern" msg
+let warn_no_region (msg : string) = warn no_region msg
 
 (* Check *)
 

--- a/p4spec/lib/backend-sim/extern.ml
+++ b/p4spec/lib/backend-sim/extern.ml
@@ -35,7 +35,7 @@ module Make (A : IMPL) : Run.EXTERN = struct
         | _ ->
             error no_region
               (Format.asprintf "unimplemented extern relation: %s" name))
-    with Util.Error.ExternError (at, msg) -> Run.Fail (at, msg)
+    with Run.ExternError (at, msg) -> Run.Fail (at, msg)
 
   let eval_extern_func (name : string) (_typs : Typ.t list)
       (values_input : Value.t list) : Run.func_result =
@@ -47,5 +47,5 @@ module Make (A : IMPL) : Run.EXTERN = struct
         | _ ->
             error no_region
               (Format.asprintf "unimplemented extern function: %s" name))
-    with Util.Error.ExternError (at, msg) -> Run.Fail (at, msg)
+    with Run.ExternError (at, msg) -> Run.Fail (at, msg)
 end

--- a/p4spec/lib/backend-sim/extern.ml
+++ b/p4spec/lib/backend-sim/extern.ml
@@ -13,7 +13,7 @@ module type IMPL = sig
 end
 
 module Make (A : IMPL) : Run.EXTERN = struct
-  let init_mode _ = ()
+  let init_mode _ = Ok ()
   let checkpoint () : int = 0
   let seff (before : int) (after : int) : bool = before <> after
   let clear () = ()

--- a/p4spec/lib/backend-sim/make.ml
+++ b/p4spec/lib/backend-sim/make.ml
@@ -70,7 +70,8 @@ module Make
       in
       Spec_.Func.register call_func;
       Spec_.Rel.register call_rel;
-      Spec_.Pgm.register call_pgm
+      Spec_.Pgm.register call_pgm;
+      Ok ()
 
     let checkpoint () : int = 0
     let seff (before : int) (after : int) : bool = before <> after

--- a/p4spec/lib/backend-sim/make.ml
+++ b/p4spec/lib/backend-sim/make.ml
@@ -416,8 +416,9 @@ module Make
       run_stf_stmts value_ctx value_arch stf_stmts;
       Pass
     with
-    | Util.Error.ParseError (at, msg) -> Fail (`Syntax (at, msg))
-    | Util.Error.InterpError (at, msg) | Util.Error.ExternError (at, msg) ->
+    | P4.Error.ParseError (at, msg) -> Fail (`Syntax (at, msg))
+    | Interp_common.Error.InterpError (at, msg)
+    | Runtime.Dynamic_Runner.Signature.ExternError (at, msg) ->
         Fail (`Runtime (at, msg))
-    | Util.Error.StfError msg -> Fail (`Runtime (no_region, msg))
+    | Stf.Error.StfError msg -> Fail (`Runtime (no_region, msg))
 end

--- a/p4spec/lib/backend-splice/error.ml
+++ b/p4spec/lib/backend-splice/error.ml
@@ -1,10 +1,11 @@
-open Util.Error
 open Util.Source
 
 (* Error *)
 
-let error (at : region) (msg : string) = error_splice at msg
-let warn (at : region) (msg : string) = warn_splice at msg
+exception SpliceError of region * string
+
+let error (at : region) (msg : string) = raise (SpliceError (at, msg))
+let warn (at : region) (msg : string) = Util.Error.warn at "splice" msg
 
 (* Check *)
 

--- a/p4spec/lib/backend-testgen-neg/config.ml
+++ b/p4spec/lib/backend-testgen-neg/config.ml
@@ -9,6 +9,8 @@ open Runtime.Testgen_neg
 open Envs
 module Sim = Runtime.Sim.Signature
 
+let ( let* ) = Result.bind
+
 (* Hyperparameters for the fuzzing loop *)
 
 (* Max number of seeds per dangle *)
@@ -136,16 +138,16 @@ let load_spec (tdenv : TDEnv.t) (mixopenv : MixopEnv.t) (spec : spec) :
 (* Constructor *)
 
 let init_specenv (spec : spec) (relname : string) (includes_p4 : string list) :
-    specenv =
+    (specenv, Sim.error) result =
   let (module Simulator : Sim.SIM) = Backend_sim.Build.gen_p4_placeholder () in
-  Simulator.init (Sim.SL spec);
+  let* () = Simulator.init (Sim.SL spec) in
   let simulator = (module Simulator : Sim.SIM) in
   let printer value_program =
     Simulator.Interface.unparse_program value_program
   in
   let tdenv, mixopenv = load_spec TDEnv.empty MixopEnv.empty spec in
   let spec = Sim.SL spec in
-  { simulator; printer; spec; relname; tdenv; mixopenv; includes_p4 }
+  Ok { simulator; printer; spec; relname; tdenv; mixopenv; includes_p4 }
 
 let init_storage (dirname_gen : string) : storage =
   Util.Filesys.mkdir dirname_gen;

--- a/p4spec/lib/backend-testgen-neg/derive.ml
+++ b/p4spec/lib/backend-testgen-neg/derive.ml
@@ -3,6 +3,9 @@ open Lang
 open Sl
 module DCov_single = Coverage.Dangling.Single
 module Sim = Runtime.Sim.Signature
+
+let ( let* ) = Result.bind
+
 module Dep = Runtime.Testgen_neg.Dep
 module F = Format
 
@@ -59,17 +62,20 @@ let derive_dangling (iid : iid) (vdg : Dep.Graph.t) (cover : DCov_single.t) :
 (* Entry point for debugging close-ASTs *)
 
 let debug_dangling (spec : spec) (relname : string) (includes_p4 : string list)
-    (filename_p4 : string) (dirname_debug : string) (iid : iid) : unit =
+    (filename_p4 : string) (dirname_debug : string) (iid : iid) :
+    (unit, Sim.error) result =
+  let spec = Sim.SL spec in
+  let (module Simulator) = Backend_sim.Build.gen_p4_placeholder () in
+  let* () = Simulator.init spec in
   let program_result, cover, vdg =
-    let spec = Sim.SL spec in
-    let (module Simulator) = Backend_sim.Build.gen_p4_placeholder () in
-    Simulator.init spec;
     Runner.run_program_with_dangling_and_vdg ~derive:true
       (module Simulator)
       spec relname includes_p4 filename_p4
   in
   match program_result with
-  | Fail _ -> print_endline "failed"
+  | Fail _ ->
+      print_endline "failed";
+      Ok ()
   | Pass _ ->
       (* Find related values that contributed to the close-miss *)
       let vids_related =
@@ -152,4 +158,5 @@ let debug_dangling (spec : spec) (relname : string) (includes_p4 : string list)
                     (Sl.Print.string_of_value value_source)
                   |> output_string oc_value)
                 derivations_source)
-        vids_related
+        vids_related;
+      Ok ()

--- a/p4spec/lib/backend-testgen-neg/gen.ml
+++ b/p4spec/lib/backend-testgen-neg/gen.ml
@@ -5,6 +5,9 @@ module DCov_single = Coverage.Dangling.Single
 module DCov_multi = Coverage.Dangling.Multi
 module Dep = Runtime.Testgen_neg.Dep
 module Sim = Runtime.Sim.Signature
+
+let ( let* ) = Result.bind
+
 module F = Format
 open Util.Source
 
@@ -557,7 +560,7 @@ let fuzzer_init (spec : spec) (relname : string) (includes_p4 : string list)
     (dirname_gen : string) (name_campaign : string option)
     (randseed : int option) (logmode : Modes.logmode)
     (bootmode : Modes.bootmode) (mutationmode : Modes.mutationmode)
-    (covermode : Modes.covermode) : Config.t =
+    (covermode : Modes.covermode) : (Config.t, Sim.error) result =
   (* Name the campaign *)
   let name_campaign =
     match name_campaign with
@@ -594,7 +597,7 @@ let fuzzer_init (spec : spec) (relname : string) (includes_p4 : string list)
   (* Create a spec environment *)
   "Loading type definitions from the spec file"
   |> Logger.log modes.logmode log_init;
-  let specenv = Config.init_specenv spec relname includes_p4 in
+  let* specenv = Config.init_specenv spec relname includes_p4 in
   (* Create a seed *)
   "Booting initial coverage" |> Logger.log modes.logmode log_init;
   let cover_seed =
@@ -627,15 +630,16 @@ let fuzzer_init (spec : spec) (relname : string) (includes_p4 : string list)
   Logger.close log_init;
   (* Create a configuration *)
   let config = Config.init randseed modes specenv storage seed in
-  config
+  Ok config
 
 let fuzzer (fuel : int) (spec : spec) (relname : string)
     (includes_p4 : string list) (dirname_gen : string)
     (name_campaign : string option) (randseed : int option)
     (logmode : Modes.logmode) (bootmode : Modes.bootmode)
-    (mutationmode : Modes.mutationmode) (covermode : Modes.covermode) : unit =
+    (mutationmode : Modes.mutationmode) (covermode : Modes.covermode) :
+    (unit, Sim.error) result =
   (* Initialize the fuzzing configuration *)
-  let config =
+  let* config =
     fuzzer_init spec relname includes_p4 dirname_gen name_campaign randseed
       logmode bootmode mutationmode covermode
   in
@@ -643,4 +647,5 @@ let fuzzer (fuel : int) (spec : spec) (relname : string)
   let config = fuzz_loop fuel config in
   (* Log the final coverage *)
   let path_cov = config.storage.dirname_gen ^ "/final.coverage" in
-  DCov_multi.log ~path_cov_opt:(Some path_cov) config.seed.cover
+  DCov_multi.log ~path_cov_opt:(Some path_cov) config.seed.cover;
+  Ok ()

--- a/p4spec/lib/backend-testgen-neg/gen.ml
+++ b/p4spec/lib/backend-testgen-neg/gen.ml
@@ -226,7 +226,7 @@ let classify_mutation (fuel : int) (iid : iid) (idx_seed : int)
     classify_mutation' fuel iid idx_seed strategy idx_method idx_mutation trials
       config log dirname_gen_tmp path_p4 comment_gen_p4 kind value_source
       value_mutated value_program
-  with Util.Error.UnparseError msg ->
+  with Spectec.Common.Error.UnparseError msg ->
     Logger.warn config.modes.logmode log
       (Format.asprintf "error while printing the mutated program: %s" msg)
 

--- a/p4spec/lib/dune
+++ b/p4spec/lib/dune
@@ -1,6 +1,6 @@
 (library
  (name p4spectec)
- (modules)
+ (modules error p4spectec)
  (libraries
   (re_export util)
   (re_export frontend)

--- a/p4spec/lib/error.ml
+++ b/p4spec/lib/error.ml
@@ -1,0 +1,18 @@
+module Run = Runtime.Dynamic_Runner.Signature
+open Util.Source
+
+(* Failures reported by the p4spectec entry points *)
+
+type t =
+  | PassError of Pass.error
+  | RunError of Run.error
+  | CommandError of string
+
+let to_region_msg = function
+  | PassError e -> Pass.to_region_msg e
+  | RunError e -> Run.to_region_msg e
+  | CommandError msg -> (no_region, msg)
+
+let to_string (e : t) : string =
+  let at, msg = to_region_msg e in
+  Util.Error.string_of_error at msg

--- a/p4spec/lib/frontend/error.ml
+++ b/p4spec/lib/frontend/error.ml
@@ -1,4 +1,5 @@
-open Util.Error
 open Util.Source
 
-let error (at : region) (msg : string) = error_parse at msg
+exception ParseError of region * string
+
+let error (at : region) (msg : string) = raise (ParseError (at, msg))

--- a/p4spec/lib/frontend/parse.ml
+++ b/p4spec/lib/frontend/parse.ml
@@ -4,6 +4,12 @@ open Error
 module Source = Util.Source
 open Source
 
+(* Errors *)
+
+type error = { at : region; msg : string }
+
+let to_region_msg { at; msg } = (at, msg)
+
 let with_lexbuf name lexbuf start =
   let open Lexing in
   lexbuf.lex_curr_p <- { lexbuf.lex_curr_p with pos_fname = name };
@@ -40,17 +46,31 @@ let parse_mixop str =
   mixop_of_typ typ
 
 let parse_file file =
-  let ic = open_in file in
   try
+    let ic = open_in file in
     Fun.protect
       (fun () -> with_lexbuf file (Lexing.from_channel ic) Parser.spec)
       ~finally:(fun () -> close_in ic)
   with Sys_error msg ->
     error (Source.region_of_file file) ("i/o error: " ^ msg)
 
+(* A directory expands to its .watsup files. A plain path stands for itself. *)
+let expand_path path =
+  if Sys_unix.is_directory_exn path then
+    Util.Filesys.collect_files ~suffix:".watsup" path
+  else [ path ]
+
+let parse_files paths =
+  try
+    Ok (paths |> List.concat_map expand_path |> List.concat_map parse_file)
+  with
+  | ParseError (at, msg) -> Error { at; msg }
+  | Sys_error msg -> Error { at = no_region; msg }
+
 let parse_string str =
   let lexbuf = Lexing.from_string str in
-  try Parser.spec Lexer.token lexbuf
-  with Parser.Error ->
-    error (Lexer.region lexbuf)
-      (Format.asprintf "syntax error in spec string: %s" str)
+  try Ok (Parser.spec Lexer.token lexbuf) with
+  | Parser.Error ->
+      let at = Lexer.region lexbuf in
+      Error { at; msg = Format.asprintf "syntax error in spec string: %s" str }
+  | ParseError (at, msg) -> Error { at; msg }

--- a/p4spec/lib/frontend/parse.ml
+++ b/p4spec/lib/frontend/parse.ml
@@ -54,7 +54,6 @@ let parse_file file =
   with Sys_error msg ->
     error (Source.region_of_file file) ("i/o error: " ^ msg)
 
-(* A directory expands to its .watsup files. A plain path stands for itself. *)
 let expand_path path =
   if Sys_unix.is_directory_exn path then
     Util.Filesys.collect_files ~suffix:".watsup" path

--- a/p4spec/lib/frontend/parse.mli
+++ b/p4spec/lib/frontend/parse.mli
@@ -1,0 +1,8 @@
+open Util.Source
+
+type error
+
+val to_region_msg : error -> region * string
+val parse_files : string list -> (Lang.El.spec, error) result
+val parse_string : string -> (Lang.El.spec, error) result
+val parse_mixop : string -> Domain.Mixfix.mixop

--- a/p4spec/lib/interface/builtin/error.ml
+++ b/p4spec/lib/interface/builtin/error.ml
@@ -1,10 +1,11 @@
-open Util.Error
 open Util.Source
 
 (* Error *)
 
-let error (at : region) (msg : string) = error_builtin at msg
-let warn (at : region) (msg : string) = warn_builtin at msg
+exception BuiltinError of region * string
+
+let error (at : region) (msg : string) = raise (BuiltinError (at, msg))
+let warn (at : region) (msg : string) = Util.Error.warn at "builtin" msg
 
 (* Checks *)
 

--- a/p4spec/lib/interface/interface.ml
+++ b/p4spec/lib/interface/interface.ml
@@ -112,12 +112,11 @@ module SpecTec_AL = struct
         Run.Fail (`Syntax (at, msg))
 
   let parse_string (path : string) (str : string) : Run.parse_result =
-    try
-      let value_spec = Spectec.Parse.parse_string Run.AL_mode path str in
-      Run.Pass value_spec
-    with
-    | ParseError (at, msg) -> Run.Fail (`Syntax (at, msg))
-    | ElabError (at, msg) -> Run.Fail (`Syntax (at, msg))
+    match Spectec.Parse.parse_string Run.AL_mode path str with
+    | Ok value_spec -> Run.Pass value_spec
+    | Error e ->
+        let at, msg = Pass.to_region_msg e in
+        Run.Fail (`Syntax (at, msg))
 
   (* Program unparsing *)
 
@@ -160,12 +159,11 @@ module SpecTec_SL = struct
         Run.Fail (`Syntax (at, msg))
 
   let parse_string (path : string) (str : string) : Run.parse_result =
-    try
-      let value_spec = Spectec.Parse.parse_string Run.SL_mode path str in
-      Run.Pass value_spec
-    with
-    | ParseError (at, msg) -> Run.Fail (`Syntax (at, msg))
-    | ElabError (at, msg) -> Run.Fail (`Syntax (at, msg))
+    match Spectec.Parse.parse_string Run.SL_mode path str with
+    | Ok value_spec -> Run.Pass value_spec
+    | Error e ->
+        let at, msg = Pass.to_region_msg e in
+        Run.Fail (`Syntax (at, msg))
 
   (* Program unparsing *)
 

--- a/p4spec/lib/interface/interface.ml
+++ b/p4spec/lib/interface/interface.ml
@@ -74,7 +74,7 @@ module P4 = struct
 
   (* Initialization *)
 
-  let init (spec : Run.spec) : unit =
+  let init (spec : Run.spec) : (unit, Run.error) result =
     let printer (value : Value.t) =
       match spec with
       | AL spec_al ->
@@ -88,7 +88,8 @@ module P4 = struct
           Format.asprintf "%a" (P4.Unparse.pp_value henv) value
       | Empty -> assert false
     in
-    unparser := printer
+    unparser := printer;
+    Ok ()
 end
 
 (* SpecTec IL *)
@@ -135,7 +136,7 @@ module SpecTec_AL = struct
 
   (* Initialization *)
 
-  let init (_spec : Run.spec) : unit = ()
+  let init (_spec : Run.spec) : (unit, Run.error) result = Ok ()
 end
 
 (* SpecTec SL *)
@@ -182,5 +183,5 @@ module SpecTec_SL = struct
 
   (* Initialization *)
 
-  let init (_spec : Run.spec) : unit = ()
+  let init (_spec : Run.spec) : (unit, Run.error) result = Ok ()
 end

--- a/p4spec/lib/interface/interface.ml
+++ b/p4spec/lib/interface/interface.ml
@@ -2,7 +2,6 @@ open Lang
 module Typ = Runtime.Type.Typ
 module Value = Runtime.Value
 module Run = Runtime.Dynamic_Runner.Signature
-open Util.Error
 open Util.Source
 
 (* Interfaces *)
@@ -25,13 +24,13 @@ module P4 = struct
           Run.Pass value_program
       | _ ->
           Run.Fail (`Syntax (no_region, "exactly one P4 file must be provided"))
-    with ParseError (at, msg) -> Run.Fail (`Syntax (at, msg))
+    with P4.Error.ParseError (at, msg) -> Run.Fail (`Syntax (at, msg))
 
   let parse_string (path_p4 : string) (str : string) : Run.parse_result =
     try
       let value_program = P4.Parse.parse_string path_p4 str in
       Run.Pass value_program
-    with ParseError (at, msg) -> Run.Fail (`Syntax (at, msg))
+    with P4.Error.ParseError (at, msg) -> Run.Fail (`Syntax (at, msg))
 
   (* Program unparsing *)
 

--- a/p4spec/lib/interface/interface.ml
+++ b/p4spec/lib/interface/interface.ml
@@ -105,12 +105,11 @@ module SpecTec_AL = struct
 
   let parse_program (_includes : string list) (paths : string list) :
       Run.parse_result =
-    try
-      let value_spec = Spectec.Parse.parse_files Run.AL_mode paths in
-      Run.Pass value_spec
-    with
-    | ParseError (at, msg) -> Run.Fail (`Syntax (at, msg))
-    | ElabError (at, msg) -> Run.Fail (`Syntax (at, msg))
+    match Spectec.Parse.parse_files Run.AL_mode paths with
+    | Ok value_spec -> Run.Pass value_spec
+    | Error e ->
+        let at, msg = Pass.to_region_msg e in
+        Run.Fail (`Syntax (at, msg))
 
   let parse_string (path : string) (str : string) : Run.parse_result =
     try
@@ -154,12 +153,11 @@ module SpecTec_SL = struct
 
   let parse_program (_includes : string list) (paths : string list) :
       Run.parse_result =
-    try
-      let value_spec = Spectec.Parse.parse_files Run.SL_mode paths in
-      Run.Pass value_spec
-    with
-    | ParseError (at, msg) -> Run.Fail (`Syntax (at, msg))
-    | ElabError (at, msg) -> Run.Fail (`Syntax (at, msg))
+    match Spectec.Parse.parse_files Run.SL_mode paths with
+    | Ok value_spec -> Run.Pass value_spec
+    | Error e ->
+        let at, msg = Pass.to_region_msg e in
+        Run.Fail (`Syntax (at, msg))
 
   let parse_string (path : string) (str : string) : Run.parse_result =
     try

--- a/p4spec/lib/interface/p4/error.ml
+++ b/p4spec/lib/interface/p4/error.ml
@@ -1,0 +1,6 @@
+open Util.Source
+
+exception ParseError of region * string
+
+let error (at : region) (msg : string) = raise (ParseError (at, msg))
+let error_no_region (msg : string) = raise (ParseError (no_region, msg))

--- a/p4spec/lib/interface/p4/extract.ml
+++ b/p4spec/lib/interface/p4/extract.ml
@@ -8,11 +8,10 @@
 open Lang
 open Il
 module Value = Runtime.Value
-open Util.Error
 open Util.Source
 module F = Format
 
-let error = error_parse
+let error = Error.error
 
 (* Identifier extraction *)
 

--- a/p4spec/lib/interface/p4/parse.ml
+++ b/p4spec/lib/interface/p4/parse.ml
@@ -1,8 +1,7 @@
 module Value = Runtime.Value
-open Util.Error
 
-let error = error_parse
-let error_no_region = error_parse_no_region
+let error = Error.error
+let error_no_region = Error.error_no_region
 
 let preprocess (includes : string list) (path : string) =
   try Preprocessor.preprocess includes path

--- a/p4spec/lib/interface/spectec/common/error.ml
+++ b/p4spec/lib/interface/spectec/common/error.ml
@@ -1,0 +1,3 @@
+exception UnparseError of string
+
+let error (msg : string) = raise (UnparseError msg)

--- a/p4spec/lib/interface/spectec/common/stub.ml
+++ b/p4spec/lib/interface/spectec/common/stub.ml
@@ -2,12 +2,11 @@ module Mixfix = Domain.Mixfix
 open Lang
 module Value = Runtime.Value
 open Mixops
-open Util.Error
 open Util.Source
 
 (* Errors *)
 
-let error = error_unparse
+let error = Error.error
 
 (* Stubs for lossy unboot conversions *)
 

--- a/p4spec/lib/interface/spectec/common/unboot.ml
+++ b/p4spec/lib/interface/spectec/common/unboot.ml
@@ -7,12 +7,11 @@ module VCache = Runtime.Dynamic.Caches.ValueCache
 open Mixops
 open Stub
 open Caches
-open Util.Error
 open Util.Source
 
 (* Errors *)
 
-let error = error_unparse
+let error = Error.error
 
 (* Forward references for match dispatch tables,
    populated after all sub-match functions are defined *)

--- a/p4spec/lib/interface/spectec/parse.ml
+++ b/p4spec/lib/interface/spectec/parse.ml
@@ -15,15 +15,19 @@ let parse_files (mode : Run.mode) (paths_spec : string list) :
   | PL_mode -> assert false
   | Empty_mode -> assert false
 
-let parse_string (mode : Run.mode) (_path : string) (str : string) : Value.t =
+let parse_string (mode : Run.mode) (_path : string) (str : string) :
+    (Value.t, Pass.error) result =
   match mode with
   | AL_mode ->
-      str |> Frontend.Parse.parse_string |> Pass.Elaborate.Elab.elab_spec
-      |> Pass.Algo.algo_spec |> Ali.Boot.boot_spec
+      let* spec_el = Pass.parse_string str in
+      let* spec_il = Pass.elab_spec spec_el in
+      let* spec_al = Pass.algo_spec spec_il in
+      Ok (Ali.Boot.boot_spec spec_al)
   | SL_mode ->
-      str |> Frontend.Parse.parse_string |> Pass.Elaborate.Elab.elab_spec
-      |> Pass.Algo.algo_spec
-      |> Pass.Structure.Struct.struct_spec ~final:true
-      |> Sli.Boot.boot_spec
+      let* spec_el = Pass.parse_string str in
+      let* spec_il = Pass.elab_spec spec_el in
+      let* spec_al = Pass.algo_spec spec_il in
+      let* spec_sl = Pass.struct_spec ~final:true spec_al in
+      Ok (Sli.Boot.boot_spec spec_sl)
   | PL_mode -> assert false
   | Empty_mode -> assert false

--- a/p4spec/lib/interface/spectec/parse.ml
+++ b/p4spec/lib/interface/spectec/parse.ml
@@ -1,10 +1,17 @@
 module Value = Runtime.Value
 module Run = Runtime.Dynamic_Runner.Signature
 
-let parse_files (mode : Run.mode) (paths_spec : string list) : Value.t =
+let ( let* ) = Result.bind
+
+let parse_files (mode : Run.mode) (paths_spec : string list) :
+    (Value.t, Pass.error) result =
   match mode with
-  | AL_mode -> paths_spec |> Pass.algo |> Ali.Boot.boot_spec
-  | SL_mode -> paths_spec |> Pass.structure ~final:true |> Sli.Boot.boot_spec
+  | AL_mode ->
+      let* spec_al = Pass.algo paths_spec in
+      Ok (Ali.Boot.boot_spec spec_al)
+  | SL_mode ->
+      let* spec_sl = Pass.structure ~final:true paths_spec in
+      Ok (Sli.Boot.boot_spec spec_sl)
   | PL_mode -> assert false
   | Empty_mode -> assert false
 

--- a/p4spec/lib/interp/interp-al/dune
+++ b/p4spec/lib/interp/interp-al/dune
@@ -1,4 +1,4 @@
 (library
  (name interp_al)
  (public_name p4spectec.interp.interp_al)
- (libraries util domain lang runtime interface builtin inst))
+ (libraries util domain lang runtime interface builtin inst interp_common))

--- a/p4spec/lib/interp/interp-al/error.ml
+++ b/p4spec/lib/interp/interp-al/error.ml
@@ -1,10 +1,9 @@
-open Util.Error
 open Util.Source
 
 (* Error *)
 
-let error (at : region) (msg : string) = error_interp at msg
-let warn (at : region) (msg : string) = warn_interp at msg
+let error (at : region) (msg : string) = Interp_common.Error.error at msg
+let warn (at : region) (msg : string) = Interp_common.Error.warn at msg
 
 (* Check *)
 

--- a/p4spec/lib/interp/interp-al/interp.ml
+++ b/p4spec/lib/interp/interp-al/interp.ml
@@ -1464,7 +1464,7 @@ module Make (Interface : Run.INTERFACE) (Extern : Run.EXTERN) () :
       in
       check_func_output ctx id tparams typ_output targs value_output;
       Ok value_output
-    with Util.Error.BuiltinError (at, msg) -> back_unmatch at msg
+    with Builtin.Error.BuiltinError (at, msg) -> back_unmatch at msg
 
   and match_tablerow (ctx_caller : Ctx.t) (ctx_callee : Ctx.t)
       (tablerow : tablerow) (values_input : value list) :
@@ -1601,15 +1601,15 @@ module Make (Interface : Run.INTERFACE) (Extern : Run.EXTERN) () :
           (Run.Pass values_output : Run.program_result)
       | Fail (`Syntax (at, msg)) -> Run.Fail (`Syntax (at, msg))
     with
-    | Util.Error.ParseError (at, msg) -> Run.Fail (`Syntax (at, msg))
-    | Util.Error.InterpError (at, msg) -> Run.Fail (`Runtime (at, msg))
+    | P4.Error.ParseError (at, msg) -> Run.Fail (`Syntax (at, msg))
+    | Interp_common.Error.InterpError (at, msg) -> Run.Fail (`Runtime (at, msg))
 
   let eval_rel (relname : string) (values_input : value list) : Run.rel_result =
     clear ();
     try
       let+ values_output = do_eval_rel relname values_input in
       (Run.Pass values_output : Run.rel_result)
-    with Util.Error.InterpError (at, msg) -> Run.Fail (at, msg)
+    with Interp_common.Error.InterpError (at, msg) -> Run.Fail (at, msg)
 
   let eval_func (funcname : string) (targs : targ list)
       (values_input : value list) : Run.func_result =
@@ -1617,7 +1617,7 @@ module Make (Interface : Run.INTERFACE) (Extern : Run.EXTERN) () :
     try
       let+ value_output = do_eval_func funcname targs values_input in
       (Run.Pass value_output : Run.func_result)
-    with Util.Error.InterpError (at, msg) -> Run.Fail (at, msg)
+    with Interp_common.Error.InterpError (at, msg) -> Run.Fail (at, msg)
 
   (* Initialization *)
 

--- a/p4spec/lib/interp/interp-al/interp.ml
+++ b/p4spec/lib/interp/interp-al/interp.ml
@@ -1602,14 +1602,17 @@ module Make (Interface : Run.INTERFACE) (Extern : Run.EXTERN) () :
       | Fail (`Syntax (at, msg)) -> Run.Fail (`Syntax (at, msg))
     with
     | P4.Error.ParseError (at, msg) -> Run.Fail (`Syntax (at, msg))
-    | Interp_common.Error.InterpError (at, msg) -> Run.Fail (`Runtime (at, msg))
+    | Interp_common.Error.InterpError (at, msg) | Run.ExternError (at, msg) ->
+        Run.Fail (`Runtime (at, msg))
 
   let eval_rel (relname : string) (values_input : value list) : Run.rel_result =
     clear ();
     try
       let+ values_output = do_eval_rel relname values_input in
       (Run.Pass values_output : Run.rel_result)
-    with Interp_common.Error.InterpError (at, msg) -> Run.Fail (at, msg)
+    with
+    | Interp_common.Error.InterpError (at, msg) | Run.ExternError (at, msg) ->
+      Run.Fail (at, msg)
 
   let eval_func (funcname : string) (targs : targ list)
       (values_input : value list) : Run.func_result =
@@ -1617,12 +1620,16 @@ module Make (Interface : Run.INTERFACE) (Extern : Run.EXTERN) () :
     try
       let+ value_output = do_eval_func funcname targs values_input in
       (Run.Pass value_output : Run.func_result)
-    with Interp_common.Error.InterpError (at, msg) -> Run.Fail (at, msg)
+    with
+    | Interp_common.Error.InterpError (at, msg) | Run.ExternError (at, msg) ->
+      Run.Fail (at, msg)
 
   (* Initialization *)
 
-  let init ~(cache : bool) ~(det : bool) ~(guard : bool) (spec : spec) : unit =
+  let init ~(cache : bool) ~(det : bool) ~(guard : bool) (spec : spec) :
+      (unit, Run.error) result =
     if cache then Cache.cache_on () else Cache.cache_off ();
     check_guard := guard;
-    Ctx.init ~det spec
+    try Ok (Ctx.init ~det spec)
+    with Interp_common.Error.InterpError (at, msg) -> Error { Run.at; msg }
 end

--- a/p4spec/lib/interp/interp-common/error.ml
+++ b/p4spec/lib/interp/interp-common/error.ml
@@ -1,10 +1,11 @@
-open Util.Error
 open Util.Source
 
 (* Error *)
 
-let error (at : region) (msg : string) = error_interp at msg
-let warn (at : region) (msg : string) = warn_interp at msg
+exception InterpError of region * string
+
+let error (at : region) (msg : string) = raise (InterpError (at, msg))
+let warn (at : region) (msg : string) = Util.Error.warn at "interp" msg
 
 (* Check *)
 

--- a/p4spec/lib/interp/interp-pl/interp.ml
+++ b/p4spec/lib/interp/interp-pl/interp.ml
@@ -2313,7 +2313,9 @@ module Make (Interface : Run.INTERFACE) (Extern : Run.EXTERN) () :
 
   (* Initialization *)
 
-  let init ~(cache : bool) ~(det : bool) ~guard:_ (spec : spec) : unit =
+  let init ~(cache : bool) ~(det : bool) ~guard:_ (spec : spec) :
+      (unit, Run.error) result =
     if cache then Cache.cache_on () else Cache.cache_off ();
-    Ctx.init ~det spec
+    try Ok (Ctx.init ~det spec)
+    with Interp_common.Error.InterpError (at, msg) -> Error { Run.at; msg }
 end

--- a/p4spec/lib/interp/interp-pl/interp.ml
+++ b/p4spec/lib/interp/interp-pl/interp.ml
@@ -2175,7 +2175,7 @@ module Make (Interface : Run.INTERFACE) (Extern : Run.EXTERN) () :
         Interface.call_builtin
           (fun value -> Hook.on_value value)
           id targs values_input
-      with Util.Error.BuiltinError (at, msg) -> back_unmatch at msg
+      with Builtin.Error.BuiltinError (at, msg) -> back_unmatch at msg
     in
     check_func_output ctx id tparams typ_output targs value_output;
     List.iteri
@@ -2282,14 +2282,14 @@ module Make (Interface : Run.INTERFACE) (Extern : Run.EXTERN) () :
       let value_program =
         match Interface.parse_program includes_p4 [ filename_p4 ] with
         | Pass value_program -> value_program
-        | Fail (`Syntax (at, msg)) -> raise (Util.Error.ParseError (at, msg))
+        | Fail (`Syntax (at, msg)) -> raise (P4.Error.ParseError (at, msg))
       in
       Hook.on_program value_program;
       let values_output = do_eval_rel relname [ value_program ] in
       Run.Pass values_output
     with
-    | Util.Error.ParseError (at, msg) -> Run.Fail (`Syntax (at, msg))
-    | Util.Error.InterpError (at, msg) | Util.Error.ExternError (at, msg) ->
+    | P4.Error.ParseError (at, msg) -> Run.Fail (`Syntax (at, msg))
+    | Interp_common.Error.InterpError (at, msg) | Run.ExternError (at, msg) ->
         Run.Fail (`Runtime (at, msg))
 
   let eval_rel (relname : string) (values_input : value list) : Run.rel_result =
@@ -2298,7 +2298,7 @@ module Make (Interface : Run.INTERFACE) (Extern : Run.EXTERN) () :
       let values_output = do_eval_rel relname values_input in
       Run.Pass values_output
     with
-    | Util.Error.InterpError (at, msg) | Util.Error.ExternError (at, msg) ->
+    | Interp_common.Error.InterpError (at, msg) | Run.ExternError (at, msg) ->
       Run.Fail (at, msg)
 
   let eval_func (funcname : string) (targs : targ list)
@@ -2308,7 +2308,7 @@ module Make (Interface : Run.INTERFACE) (Extern : Run.EXTERN) () :
       let value_output = do_eval_func funcname targs values_input in
       Run.Pass value_output
     with
-    | Util.Error.InterpError (at, msg) | Util.Error.ExternError (at, msg) ->
+    | Interp_common.Error.InterpError (at, msg) | Run.ExternError (at, msg) ->
       Run.Fail (at, msg)
 
   (* Initialization *)

--- a/p4spec/lib/interp/interp-sl/interp.ml
+++ b/p4spec/lib/interp/interp-sl/interp.ml
@@ -2125,7 +2125,7 @@ module Make (Interface : Run.INTERFACE) (Extern : Run.EXTERN) () :
       =
     let value_output =
       try Interface.call_builtin Hook.on_value id targs values_input
-      with Util.Error.BuiltinError (at, msg) -> back_unmatch at msg
+      with Builtin.Error.BuiltinError (at, msg) -> back_unmatch at msg
     in
     check_func_output ctx id tparams typ_output targs value_output;
     List.iteri
@@ -2223,8 +2223,8 @@ module Make (Interface : Run.INTERFACE) (Extern : Run.EXTERN) () :
           Run.Pass values_output
       | Fail (`Syntax (at, msg)) -> Run.Fail (`Syntax (at, msg))
     with
-    | Util.Error.ParseError (at, msg) -> Run.Fail (`Syntax (at, msg))
-    | Util.Error.InterpError (at, msg) | Util.Error.ExternError (at, msg) ->
+    | P4.Error.ParseError (at, msg) -> Run.Fail (`Syntax (at, msg))
+    | Interp_common.Error.InterpError (at, msg) | Run.ExternError (at, msg) ->
         Run.Fail (`Runtime (at, msg))
 
   let eval_rel (relname : string) (values_input : value list) : Run.rel_result =
@@ -2233,7 +2233,7 @@ module Make (Interface : Run.INTERFACE) (Extern : Run.EXTERN) () :
       let values_output = do_eval_rel relname values_input in
       Run.Pass values_output
     with
-    | Util.Error.InterpError (at, msg) | Util.Error.ExternError (at, msg) ->
+    | Interp_common.Error.InterpError (at, msg) | Run.ExternError (at, msg) ->
       Run.Fail (at, msg)
 
   let eval_func (funcname : string) (targs : targ list)
@@ -2243,7 +2243,7 @@ module Make (Interface : Run.INTERFACE) (Extern : Run.EXTERN) () :
       let value_output = do_eval_func funcname targs values_input in
       Run.Pass value_output
     with
-    | Util.Error.InterpError (at, msg) | Util.Error.ExternError (at, msg) ->
+    | Interp_common.Error.InterpError (at, msg) | Run.ExternError (at, msg) ->
       Run.Fail (at, msg)
 
   (* Initialization *)

--- a/p4spec/lib/interp/interp-sl/interp.ml
+++ b/p4spec/lib/interp/interp-sl/interp.ml
@@ -2248,8 +2248,10 @@ module Make (Interface : Run.INTERFACE) (Extern : Run.EXTERN) () :
 
   (* Initialization *)
 
-  let init ~(cache : bool) ~(det : bool) ~(guard : bool) (spec : spec) : unit =
+  let init ~(cache : bool) ~(det : bool) ~(guard : bool) (spec : spec) :
+      (unit, Run.error) result =
     if cache then Cache.cache_on () else Cache.cache_off ();
     check_guard := guard;
-    Ctx.init ~det spec
+    try Ok (Ctx.init ~det spec)
+    with Interp_common.Error.InterpError (at, msg) -> Error { Run.at; msg }
 end

--- a/p4spec/lib/lang/pl/render/adoc.ml
+++ b/p4spec/lib/lang/pl/render/adoc.ml
@@ -134,7 +134,7 @@ let warned : (string, unit) Hashtbl.t = Hashtbl.create 64
 let warn (msg : string) : unit =
   if not (Hashtbl.mem warned msg) then (
     Hashtbl.add warned msg ();
-    Util.Error.warn_prose Util.Source.no_region msg)
+    Util.Error.warn Util.Source.no_region "prose" msg)
 
 let warn_nested ~(lint : bool) ~(outer : string) ~(inner : string) : unit =
   if lint then

--- a/p4spec/lib/p4spectec.ml
+++ b/p4spec/lib/p4spectec.ml
@@ -53,6 +53,19 @@ let tower_of_file (path_tower : string) (target : Config.target) :
       Error (Error.CommandError msg)
   | Yojson.Basic.Util.Type_error (msg, _) -> Error (Error.CommandError msg)
 
+let build_tower ?(cache = true) ?(det = false) ?(guard = false)
+    (tower : Config.tower) : (Run.spec * (module Run.RUNNER)) result =
+  let* (specs : Boot_build.tower_specs) =
+    Boot_build.specs_of_tower tower
+    |> Result.map_error (fun e -> Error.PassError e)
+  in
+  let* booter =
+    Boot_build.build_tower ~cache ~det ~guard specs
+    |> Result.map_error (fun e -> Error.RunError e)
+  in
+  let _, spec_boot = specs.boot in
+  Ok (spec_boot, booter)
+
 (* Negative test generation *)
 
 let fuzzer (fuel : int) (spec_sl : Lang.Sl.spec) (relname : string)
@@ -72,16 +85,3 @@ let debug_dangling (spec_sl : Lang.Sl.spec) (relname : string)
   Backend_testgen_neg.Derive.debug_dangling spec_sl relname includes_p4 path_p4
     debugdir iid
   |> Result.map_error (fun e -> Error.RunError e)
-
-let build_tower ?(cache = true) ?(det = false) ?(guard = false)
-    (tower : Config.tower) : (Run.spec * (module Run.RUNNER)) result =
-  let* (specs : Boot_build.tower_specs) =
-    Boot_build.specs_of_tower tower
-    |> Result.map_error (fun e -> Error.PassError e)
-  in
-  let* booter =
-    Boot_build.build_tower ~cache ~det ~guard specs
-    |> Result.map_error (fun e -> Error.RunError e)
-  in
-  let _, spec_boot = specs.boot in
-  Ok (spec_boot, booter)

--- a/p4spec/lib/p4spectec.ml
+++ b/p4spec/lib/p4spectec.ml
@@ -1,0 +1,87 @@
+module Error = Error
+module Run = Runtime.Dynamic_Runner.Signature
+module Sim = Runtime.Sim.Signature
+module Config = Backend_boot.Config
+module Boot_build = Backend_boot.Build
+
+type 'a result = ('a, Error.t) Stdlib.result
+
+let ( let* ) = Result.bind
+
+(* Spec transformations *)
+
+let parse (paths_spec : string list) : Lang.El.spec result =
+  Pass.parse paths_spec |> Result.map_error (fun e -> Error.PassError e)
+
+let elab (paths_spec : string list) : Lang.Il.spec result =
+  Pass.elab paths_spec |> Result.map_error (fun e -> Error.PassError e)
+
+let algo (paths_spec : string list) : Lang.Al.spec result =
+  Pass.algo paths_spec |> Result.map_error (fun e -> Error.PassError e)
+
+let structure ~(final : bool) (paths_spec : string list) : Lang.Sl.spec result =
+  Pass.structure ~final paths_spec
+  |> Result.map_error (fun e -> Error.PassError e)
+
+let annotate (paths_spec : string list) : Lang.Pl.spec result =
+  Pass.annotate paths_spec |> Result.map_error (fun e -> Error.PassError e)
+
+let spec_of_mode (mode : Run.mode) (paths_spec : string list) : Run.spec result
+    =
+  Boot_build.spec_of_mode mode paths_spec
+  |> Result.map_error (fun e -> Error.PassError e)
+
+(* Simulator, for the P4 target *)
+
+let build_sim ?(cache = true) ?(det = false) ?(guard = false)
+    ?(arch : string option) (spec_sim : Sim.spec) : (module Sim.SIM) result =
+  Backend_sim.Build.build ~cache ~det ~guard ?arch spec_sim
+  |> Result.map_error (fun e -> Error.RunError e)
+
+(* Runners, for the meta-circular interpreter *)
+
+let build_null ?(cache = true) ?(det = false) ?(guard = false)
+    (interface : Config.interface) (spec : Run.spec) :
+    (module Run.RUNNER) result =
+  Boot_build.build_null ~cache ~det ~guard interface spec
+  |> Result.map_error (fun e -> Error.RunError e)
+
+let tower_of_file (path_tower : string) (target : Config.target) :
+    Config.tower result =
+  try Ok (Config.tower_of_file path_tower target) with
+  | Failure msg | Sys_error msg | Yojson.Json_error msg ->
+      Error (Error.CommandError msg)
+  | Yojson.Basic.Util.Type_error (msg, _) -> Error (Error.CommandError msg)
+
+(* Negative test generation *)
+
+let fuzzer (fuel : int) (spec_sl : Lang.Sl.spec) (relname : string)
+    (includes_p4 : string list) (gendir : string)
+    (name_campaign : string option) (randseed : int option)
+    (logmode : Backend_testgen_neg.Modes.logmode)
+    (bootmode : Backend_testgen_neg.Modes.bootmode)
+    (mutationmode : Backend_testgen_neg.Modes.mutationmode)
+    (covermode : Backend_testgen_neg.Modes.covermode) : unit result =
+  Backend_testgen_neg.Gen.fuzzer fuel spec_sl relname includes_p4 gendir
+    name_campaign randseed logmode bootmode mutationmode covermode
+  |> Result.map_error (fun e -> Error.RunError e)
+
+let debug_dangling (spec_sl : Lang.Sl.spec) (relname : string)
+    (includes_p4 : string list) (path_p4 : string) (debugdir : string)
+    (iid : int) : unit result =
+  Backend_testgen_neg.Derive.debug_dangling spec_sl relname includes_p4 path_p4
+    debugdir iid
+  |> Result.map_error (fun e -> Error.RunError e)
+
+let build_tower ?(cache = true) ?(det = false) ?(guard = false)
+    (tower : Config.tower) : (Run.spec * (module Run.RUNNER)) result =
+  let* (specs : Boot_build.tower_specs) =
+    Boot_build.specs_of_tower tower
+    |> Result.map_error (fun e -> Error.PassError e)
+  in
+  let* booter =
+    Boot_build.build_tower ~cache ~det ~guard specs
+    |> Result.map_error (fun e -> Error.RunError e)
+  in
+  let _, spec_boot = specs.boot in
+  Ok (spec_boot, booter)

--- a/p4spec/lib/p4spectec.mli
+++ b/p4spec/lib/p4spectec.mli
@@ -1,0 +1,76 @@
+(* Entry points for the p4spectec tool, reporting every failure as Error.t *)
+
+module Error = Error
+
+type 'a result = ('a, Error.t) Stdlib.result
+
+(* Spec transformations *)
+
+val parse : string list -> Lang.El.spec result
+val elab : string list -> Lang.Il.spec result
+val algo : string list -> Lang.Al.spec result
+val structure : final:bool -> string list -> Lang.Sl.spec result
+val annotate : string list -> Lang.Pl.spec result
+
+val spec_of_mode :
+  Runtime.Dynamic_Runner.Signature.mode ->
+  string list ->
+  Runtime.Dynamic_Runner.Signature.spec result
+
+(* Simulator, for the P4 target *)
+
+val build_sim :
+  ?cache:bool ->
+  ?det:bool ->
+  ?guard:bool ->
+  ?arch:string ->
+  Runtime.Sim.Signature.spec ->
+  (module Runtime.Sim.Signature.SIM) result
+
+(* Runners, for the meta-circular interpreter *)
+
+val build_null :
+  ?cache:bool ->
+  ?det:bool ->
+  ?guard:bool ->
+  Backend_boot.Config.interface ->
+  Runtime.Dynamic_Runner.Signature.spec ->
+  (module Runtime.Dynamic_Runner.Signature.RUNNER) result
+
+val tower_of_file :
+  string -> Backend_boot.Config.target -> Backend_boot.Config.tower result
+
+(* Builds every level of the tower, returning the boot spec and its runner *)
+val build_tower :
+  ?cache:bool ->
+  ?det:bool ->
+  ?guard:bool ->
+  Backend_boot.Config.tower ->
+  (Runtime.Dynamic_Runner.Signature.spec
+  * (module Runtime.Dynamic_Runner.Signature.RUNNER))
+  result
+
+(* Negative test generation *)
+
+val fuzzer :
+  int ->
+  Lang.Sl.spec ->
+  string ->
+  string list ->
+  string ->
+  string option ->
+  int option ->
+  Backend_testgen_neg.Modes.logmode ->
+  Backend_testgen_neg.Modes.bootmode ->
+  Backend_testgen_neg.Modes.mutationmode ->
+  Backend_testgen_neg.Modes.covermode ->
+  unit result
+
+val debug_dangling :
+  Lang.Sl.spec ->
+  string ->
+  string list ->
+  string ->
+  string ->
+  int ->
+  unit result

--- a/p4spec/lib/p4spectec.mli
+++ b/p4spec/lib/p4spectec.mli
@@ -40,7 +40,6 @@ val build_null :
 val tower_of_file :
   string -> Backend_boot.Config.target -> Backend_boot.Config.tower result
 
-(* Builds every level of the tower, returning the boot spec and its runner *)
 val build_tower :
   ?cache:bool ->
   ?det:bool ->

--- a/p4spec/lib/pass/algo/algo.ml
+++ b/p4spec/lib/pass/algo/algo.ml
@@ -1,7 +1,16 @@
 open Lang
 open Il
+open Util.Source
+
+(* Errors *)
+
+type error = { at : region; msg : string }
+
+let to_region_msg { at; msg } = (at, msg)
 
 (* Entry point *)
 
-let algo_spec (spec : spec) : Al.spec =
-  spec |> Binding.Analyze.analyze_spec |> Sidecondition.Guard.insert_spec
+let algo_spec (spec : spec) : (Al.spec, error) result =
+  try
+    Ok (spec |> Binding.Analyze.analyze_spec |> Sidecondition.Guard.insert_spec)
+  with Error.AlgoError (at, msg) -> Error { at; msg }

--- a/p4spec/lib/pass/algo/error.ml
+++ b/p4spec/lib/pass/algo/error.ml
@@ -1,10 +1,11 @@
-open Util.Error
 open Util.Source
 
 (* Error *)
 
-let error (at : region) (msg : string) = error_algo at msg
-let warn (at : region) (msg : string) = warn_algo at msg
+exception AlgoError of region * string
+
+let error (at : region) (msg : string) = raise (AlgoError (at, msg))
+let warn (at : region) (msg : string) = Util.Error.warn at "algo" msg
 
 (* Checks *)
 

--- a/p4spec/lib/pass/annotate/annotate.ml
+++ b/p4spec/lib/pass/annotate/annotate.ml
@@ -597,10 +597,19 @@ let annotate_def (ctx : Ctx.t) (def : def) : Pl.def =
 let annotate_defs (ctx : Ctx.t) (spec : spec) : Pl.spec =
   List.map (annotate_def ctx) spec
 
+(* Errors *)
+
+type error = { at : region; msg : string }
+
+let to_region_msg { at; msg } = (at, msg)
+
 (* Entry point *)
 
-let annotate_spec (spec : spec) : Pl.spec =
-  let ctx = Ctx.init () in
-  let ctx = Ctx.load_spec ctx spec in
-  spec |> Expand.expand_spec |> annotate_defs ctx |> Shorthand.shorten_defs
-  |> Stamp.stamp_defs
+let annotate_spec (spec : spec) : (Pl.spec, error) result =
+  try
+    let ctx = Ctx.init () in
+    let ctx = Ctx.load_spec ctx spec in
+    Ok
+      (spec |> Expand.expand_spec |> annotate_defs ctx |> Shorthand.shorten_defs
+     |> Stamp.stamp_defs)
+  with Error.ProseError (at, msg) -> Error { at; msg }

--- a/p4spec/lib/pass/annotate/error.ml
+++ b/p4spec/lib/pass/annotate/error.ml
@@ -1,4 +1,5 @@
-open Util.Error
 open Util.Source
 
-let error (at : region) (msg : string) = error_prose at msg
+exception ProseError of region * string
+
+let error (at : region) (msg : string) = raise (ProseError (at, msg))

--- a/p4spec/lib/pass/elaborate/elaborate.ml
+++ b/p4spec/lib/pass/elaborate/elaborate.ml
@@ -1,0 +1,14 @@
+open Lang
+open Util.Source
+
+(* Errors *)
+
+type error = { at : region; msg : string }
+
+let to_region_msg { at; msg } = (at, msg)
+
+(* Entry point *)
+
+let elab_spec (spec : El.spec) : (Il.spec, error) result =
+  try Ok (Elab.elab_spec spec)
+  with Error.ElabError (at, msg) -> Error { at; msg }

--- a/p4spec/lib/pass/elaborate/error.ml
+++ b/p4spec/lib/pass/elaborate/error.ml
@@ -1,10 +1,11 @@
-open Util.Error
 open Util.Source
 
 (* Error *)
 
-let error (at : region) (msg : string) = error_elab at msg
-let warn (at : region) (msg : string) = warn_elab at msg
+exception ElabError of region * string
+
+let error (at : region) (msg : string) = raise (ElabError (at, msg))
+let warn (at : region) (msg : string) = Util.Error.warn at "elab" msg
 
 (* Checks *)
 

--- a/p4spec/lib/pass/pass.ml
+++ b/p4spec/lib/pass/pass.ml
@@ -14,10 +14,6 @@ let to_region_msg = function
   | StructError e -> Structure.to_region_msg e
   | ProseError e -> Annotate.to_region_msg e
 
-let string_of_error e =
-  let at, msg = to_region_msg e in
-  Util.Error.string_of_error at msg
-
 let ( let* ) = Result.bind
 
 (* Stages *)

--- a/p4spec/lib/pass/pass.ml
+++ b/p4spec/lib/pass/pass.ml
@@ -1,46 +1,49 @@
-open Util.Source
-module Elaborate = Elaborate
-module Algo = Algo
-module Structure = Structure
-module Annotate = Annotate
-
 (* Errors *)
 
-type error = { at : region; msg : string }
+type error =
+  | ParseError of Frontend.Parse.error
+  | ElabError of Elaborate.error
+  | AlgoError of Algo.error
+  | StructError of Structure.error
+  | ProseError of Annotate.error
 
-let string_of_error { at; msg } = Util.Error.string_of_error at msg
-let to_region_msg { at; msg } = (at, msg)
+let to_region_msg = function
+  | ParseError e -> Frontend.Parse.to_region_msg e
+  | ElabError e -> Elaborate.to_region_msg e
+  | AlgoError e -> Algo.to_region_msg e
+  | StructError e -> Structure.to_region_msg e
+  | ProseError e -> Annotate.to_region_msg e
+
+let string_of_error e =
+  let at, msg = to_region_msg e in
+  Util.Error.string_of_error at msg
+
 let ( let* ) = Result.bind
 
-(* Surface a pass failure as an [error]. Anything else (bugs, Stdlib
-   exceptions) propagates untouched. *)
+(* Stages *)
 
-let guard f =
-  try Ok (f ())
-  with
-  | Util.Error.ParseError (at, msg)
-  | Util.Error.ElabError (at, msg)
-  | Util.Error.AlgoError (at, msg)
-  | Util.Error.StructError (at, msg)
-  | Util.Error.ProseError (at, msg)
-  ->
-    Error { at; msg }
+let parse_string str =
+  Frontend.Parse.parse_string str |> Result.map_error (fun e -> ParseError e)
 
-(* File expansion *)
+let parse_files paths =
+  Frontend.Parse.parse_files paths |> Result.map_error (fun e -> ParseError e)
 
-let expand_spec filenames =
-  List.concat_map
-    (fun filename ->
-      if Sys_unix.is_directory_exn filename then
-        Util.Filesys.collect_files ~suffix:".watsup" filename
-      else [ filename ])
-    filenames
+let elab_spec spec_el =
+  Elaborate.elab_spec spec_el |> Result.map_error (fun e -> ElabError e)
+
+let algo_spec spec_il =
+  Algo.algo_spec spec_il |> Result.map_error (fun e -> AlgoError e)
+
+let struct_spec ~final spec_al =
+  Structure.struct_spec ~final spec_al
+  |> Result.map_error (fun e -> StructError e)
+
+let annotate_spec spec_sl =
+  Annotate.annotate_spec spec_sl |> Result.map_error (fun e -> ProseError e)
 
 (* Parsing *)
 
-let parse paths_spec =
-  guard (fun () ->
-      paths_spec |> expand_spec |> List.concat_map Frontend.Parse.parse_file)
+let parse paths_spec = parse_files paths_spec
 
 (* Elaboration *)
 
@@ -51,7 +54,7 @@ let elab paths_spec =
   | Some spec -> Ok spec
   | None ->
       let* spec_el = parse paths_spec in
-      let* spec_il = guard (fun () -> Elaborate.Elab.elab_spec spec_el) in
+      let* spec_il = elab_spec spec_el in
       Hashtbl.replace cache_elab paths_spec spec_il;
       Ok spec_il
 
@@ -64,7 +67,7 @@ let algo paths_spec =
   | Some spec -> Ok spec
   | None ->
       let* spec_il = elab paths_spec in
-      let* spec_al = guard (fun () -> Algo.algo_spec spec_il) in
+      let* spec_al = algo_spec spec_il in
       Hashtbl.replace cache_algo paths_spec spec_al;
       Ok spec_al
 
@@ -77,9 +80,7 @@ let structure ~(final : bool) paths_spec =
   | Some spec -> Ok spec
   | None ->
       let* spec_al = algo paths_spec in
-      let* spec_sl =
-        guard (fun () -> Structure.Struct.struct_spec ~final spec_al)
-      in
+      let* spec_sl = struct_spec ~final spec_al in
       Hashtbl.replace structure_cache (final, paths_spec) spec_sl;
       Ok spec_sl
 
@@ -87,4 +88,4 @@ let structure ~(final : bool) paths_spec =
 
 let annotate paths_spec =
   let* spec_sl = structure ~final:false paths_spec in
-  guard (fun () -> Annotate.annotate_spec spec_sl)
+  annotate_spec spec_sl

--- a/p4spec/lib/pass/pass.ml
+++ b/p4spec/lib/pass/pass.ml
@@ -1,9 +1,32 @@
+open Util.Source
 module Elaborate = Elaborate
 module Algo = Algo
 module Structure = Structure
 module Annotate = Annotate
 
-(* Shortcuts *)
+(* Errors *)
+
+type error = { at : region; msg : string }
+
+let string_of_error { at; msg } = Util.Error.string_of_error at msg
+let to_region_msg { at; msg } = (at, msg)
+let ( let* ) = Result.bind
+
+(* Surface a pass failure as an [error]. Anything else (bugs, Stdlib
+   exceptions) propagates untouched. *)
+
+let guard f =
+  try Ok (f ())
+  with
+  | Util.Error.ParseError (at, msg)
+  | Util.Error.ElabError (at, msg)
+  | Util.Error.AlgoError (at, msg)
+  | Util.Error.StructError (at, msg)
+  | Util.Error.ProseError (at, msg)
+  ->
+    Error { at; msg }
+
+(* File expansion *)
 
 let expand_spec filenames =
   List.concat_map
@@ -16,19 +39,21 @@ let expand_spec filenames =
 (* Parsing *)
 
 let parse paths_spec =
-  paths_spec |> expand_spec |> List.concat_map Frontend.Parse.parse_file
+  guard (fun () ->
+      paths_spec |> expand_spec |> List.concat_map Frontend.Parse.parse_file)
 
-(* Elaboration. *)
+(* Elaboration *)
 
 let cache_elab = Hashtbl.create 8
 
 let elab paths_spec =
   match Hashtbl.find_opt cache_elab paths_spec with
-  | Some spec -> spec
+  | Some spec -> Ok spec
   | None ->
-      let spec = paths_spec |> parse |> Elaborate.Elab.elab_spec in
-      Hashtbl.replace cache_elab paths_spec spec;
-      spec
+      let* spec_el = parse paths_spec in
+      let* spec_il = guard (fun () -> Elaborate.Elab.elab_spec spec_el) in
+      Hashtbl.replace cache_elab paths_spec spec_il;
+      Ok spec_il
 
 (* Algorithmic conversion *)
 
@@ -36,11 +61,12 @@ let cache_algo = Hashtbl.create 8
 
 let algo paths_spec =
   match Hashtbl.find_opt cache_algo paths_spec with
-  | Some spec -> spec
+  | Some spec -> Ok spec
   | None ->
-      let spec = paths_spec |> elab |> Algo.algo_spec in
-      Hashtbl.replace cache_algo paths_spec spec;
-      spec
+      let* spec_il = elab paths_spec in
+      let* spec_al = guard (fun () -> Algo.algo_spec spec_il) in
+      Hashtbl.replace cache_algo paths_spec spec_al;
+      Ok spec_al
 
 (* Structuring *)
 
@@ -48,13 +74,17 @@ let structure_cache = Hashtbl.create 8
 
 let structure ~(final : bool) paths_spec =
   match Hashtbl.find_opt structure_cache (final, paths_spec) with
-  | Some spec -> spec
+  | Some spec -> Ok spec
   | None ->
-      let spec = paths_spec |> algo |> Structure.Struct.struct_spec ~final in
-      Hashtbl.replace structure_cache (final, paths_spec) spec;
-      spec
+      let* spec_al = algo paths_spec in
+      let* spec_sl =
+        guard (fun () -> Structure.Struct.struct_spec ~final spec_al)
+      in
+      Hashtbl.replace structure_cache (final, paths_spec) spec_sl;
+      Ok spec_sl
 
 (* Annotation (prose) generation *)
 
 let annotate paths_spec =
-  paths_spec |> structure ~final:false |> Annotate.annotate_spec
+  let* spec_sl = structure ~final:false paths_spec in
+  guard (fun () -> Annotate.annotate_spec spec_sl)

--- a/p4spec/lib/pass/pass.mli
+++ b/p4spec/lib/pass/pass.mli
@@ -1,0 +1,24 @@
+open Util.Source
+
+(* Pass submodules. The deep, raising entry points (e.g. [Elaborate.Elab.elab_spec])
+   are still consumed directly by the interface layer. *)
+
+module Elaborate = Elaborate
+module Algo = Algo
+module Structure = Structure
+module Annotate = Annotate
+
+(* Errors *)
+
+type error
+
+val string_of_error : error -> string
+val to_region_msg : error -> region * string
+
+(* Pipeline. Each stage returns its result or the first pass failure. *)
+
+val parse : string list -> (Lang.El.spec, error) result
+val elab : string list -> (Lang.Il.spec, error) result
+val algo : string list -> (Lang.Al.spec, error) result
+val structure : final:bool -> string list -> (Lang.Sl.spec, error) result
+val annotate : string list -> (Lang.Pl.spec, error) result

--- a/p4spec/lib/pass/pass.mli
+++ b/p4spec/lib/pass/pass.mli
@@ -1,13 +1,5 @@
 open Util.Source
 
-(* Pass submodules. The deep, raising entry points (e.g. [Elaborate.Elab.elab_spec])
-   are still consumed directly by the interface layer. *)
-
-module Elaborate = Elaborate
-module Algo = Algo
-module Structure = Structure
-module Annotate = Annotate
-
 (* Errors *)
 
 type error
@@ -15,7 +7,15 @@ type error
 val string_of_error : error -> string
 val to_region_msg : error -> region * string
 
-(* Pipeline. Each stage returns its result or the first pass failure. *)
+(* Stages *)
+
+val parse_string : string -> (Lang.El.spec, error) result
+val elab_spec : Lang.El.spec -> (Lang.Il.spec, error) result
+val algo_spec : Lang.Il.spec -> (Lang.Al.spec, error) result
+val struct_spec : final:bool -> Lang.Al.spec -> (Lang.Sl.spec, error) result
+val annotate_spec : Lang.Sl.spec -> (Lang.Pl.spec, error) result
+
+(* Cached pipeline *)
 
 val parse : string list -> (Lang.El.spec, error) result
 val elab : string list -> (Lang.Il.spec, error) result

--- a/p4spec/lib/pass/pass.mli
+++ b/p4spec/lib/pass/pass.mli
@@ -4,7 +4,6 @@ open Util.Source
 
 type error
 
-val string_of_error : error -> string
 val to_region_msg : error -> region * string
 
 (* Stages *)

--- a/p4spec/lib/pass/structure/error.ml
+++ b/p4spec/lib/pass/structure/error.ml
@@ -1,4 +1,5 @@
-open Util.Error
 open Util.Source
 
-let error (at : region) (msg : string) = error_struct at msg
+exception StructError of region * string
+
+let error (at : region) (msg : string) = raise (StructError (at, msg))

--- a/p4spec/lib/pass/structure/structure.ml
+++ b/p4spec/lib/pass/structure/structure.ml
@@ -1,0 +1,14 @@
+open Lang
+open Util.Source
+
+(* Errors *)
+
+type error = { at : region; msg : string }
+
+let to_region_msg { at; msg } = (at, msg)
+
+(* Entry point *)
+
+let struct_spec ~(final : bool) (spec : Al.spec) : (Sl.spec, error) result =
+  try Ok (Struct.struct_spec ~final spec)
+  with Error.StructError (at, msg) -> Error { at; msg }

--- a/p4spec/lib/runner/make.ml
+++ b/p4spec/lib/runner/make.ml
@@ -1,6 +1,8 @@
 module Value = Runtime.Value
 open Runtime.Dynamic_Runner.Signature
 
+let ( let* ) = Result.bind
+
 module Make_rec
     (Interface : INTERFACE)
     (MakeExtern : functor
@@ -99,20 +101,22 @@ module Make_rec
 
   (* Initialization *)
 
-  let init ?(cache = true) ?(det = false) ?(guard = false) (spec_ : spec) : unit
-      =
-    Interface.init spec_;
-    (match spec_ with
-    | AL spec_al ->
-        init_mode AL_mode;
-        Interp_AL.init ~cache ~det ~guard spec_al
-    | SL spec_sl ->
-        init_mode SL_mode;
-        Interp_SL.init ~cache ~det ~guard spec_sl
-    | PL spec_pl ->
-        init_mode PL_mode;
-        Interp_PL.init ~cache ~det ~guard spec_pl
-    | Empty -> assert false);
+  let init ?(cache = true) ?(det = false) ?(guard = false) (spec_ : spec) :
+      (unit, error) result =
+    let* () = Interface.init spec_ in
+    let* () =
+      match spec_ with
+      | AL spec_al ->
+          init_mode AL_mode;
+          Interp_AL.init ~cache ~det ~guard spec_al
+      | SL spec_sl ->
+          init_mode SL_mode;
+          Interp_SL.init ~cache ~det ~guard spec_sl
+      | PL spec_pl ->
+          init_mode PL_mode;
+          Interp_PL.init ~cache ~det ~guard spec_pl
+      | Empty -> assert false
+    in
     Extern.init_mode !mode
 
   (* Cache management *)
@@ -220,20 +224,22 @@ module Make_nonrec
 
   (* Initialization *)
 
-  let init ?(cache = true) ?(det = false) ?(guard = false) (spec_ : spec) : unit
-      =
-    Interface.init spec_;
-    (match spec_ with
-    | AL spec_al ->
-        init_mode AL_mode;
-        Interp_AL.init ~cache ~det ~guard spec_al
-    | SL spec_sl ->
-        init_mode SL_mode;
-        Interp_SL.init ~cache ~det ~guard spec_sl
-    | PL spec_pl ->
-        init_mode PL_mode;
-        Interp_PL.init ~cache ~det ~guard spec_pl
-    | Empty -> assert false);
+  let init ?(cache = true) ?(det = false) ?(guard = false) (spec_ : spec) :
+      (unit, error) result =
+    let* () = Interface.init spec_ in
+    let* () =
+      match spec_ with
+      | AL spec_al ->
+          init_mode AL_mode;
+          Interp_AL.init ~cache ~det ~guard spec_al
+      | SL spec_sl ->
+          init_mode SL_mode;
+          Interp_SL.init ~cache ~det ~guard spec_sl
+      | PL spec_pl ->
+          init_mode PL_mode;
+          Interp_PL.init ~cache ~det ~guard spec_pl
+      | Empty -> assert false
+    in
     Extern.init_mode !mode
 
   (* Cache management *)

--- a/p4spec/lib/runtime/dynamic-runner/signature.ml
+++ b/p4spec/lib/runtime/dynamic-runner/signature.ml
@@ -8,6 +8,10 @@ open Util.Source
 type mode = AL_mode | SL_mode | PL_mode | Empty_mode
 type spec = AL of Al.spec | SL of Sl.spec | PL of Pl.spec | Empty
 
+(* Raised by an extern implementation, caught by its caller *)
+
+exception ExternError of region * string
+
 (* Result types *)
 
 type rel_result = Pass of Value.t list | Fail of region * string

--- a/p4spec/lib/runtime/dynamic-runner/signature.ml
+++ b/p4spec/lib/runtime/dynamic-runner/signature.ml
@@ -12,6 +12,12 @@ type spec = AL of Al.spec | SL of Sl.spec | PL of Pl.spec | Empty
 
 exception ExternError of region * string
 
+(* Failure reported by the entry points below *)
+
+type error = { at : region; msg : string }
+
+let to_region_msg { at; msg } = (at, msg)
+
 (* Result types *)
 
 type rel_result = Pass of Value.t list | Fail of region * string
@@ -57,7 +63,7 @@ module type INTERFACE = sig
 
   (* Initialization *)
 
-  val init : spec -> unit
+  val init : spec -> (unit, error) result
 end
 
 (* Interface for the interaction between SpecTec and external code *)
@@ -78,7 +84,7 @@ module type EXTERN = sig
 
   (* Mode initialization for interp-extern knot *)
 
-  val init_mode : mode -> unit
+  val init_mode : mode -> (unit, error) result
 end
 
 (* SpecTec interperter(s) *)
@@ -102,7 +108,8 @@ module type INTERP_AL = sig
 
   (* Initialization *)
 
-  val init : cache:bool -> det:bool -> guard:bool -> Al.spec -> unit
+  val init :
+    cache:bool -> det:bool -> guard:bool -> Al.spec -> (unit, error) result
 end
 
 module type INTERP_SL = sig
@@ -110,7 +117,8 @@ module type INTERP_SL = sig
 
   (* Initialization *)
 
-  val init : cache:bool -> det:bool -> guard:bool -> Sl.spec -> unit
+  val init :
+    cache:bool -> det:bool -> guard:bool -> Sl.spec -> (unit, error) result
 end
 
 module type INTERP_PL = sig
@@ -118,7 +126,8 @@ module type INTERP_PL = sig
 
   (* Initialization *)
 
-  val init : cache:bool -> det:bool -> guard:bool -> Pl.spec -> unit
+  val init :
+    cache:bool -> det:bool -> guard:bool -> Pl.spec -> (unit, error) result
 end
 
 (* Runner for SpecTec, which glues together the interface, the extern, and the interpreter *)
@@ -130,7 +139,8 @@ module type RUNNER = sig
 
   (* Initialization *)
 
-  val init : ?cache:bool -> ?det:bool -> ?guard:bool -> spec -> unit
+  val init :
+    ?cache:bool -> ?det:bool -> ?guard:bool -> spec -> (unit, error) result
 
   (* Clear the state *)
 

--- a/p4spec/lib/runtime/error_runtime/error.ml
+++ b/p4spec/lib/runtime/error_runtime/error.ml
@@ -1,10 +1,11 @@
-open Util.Error
 open Util.Source
 
 (* Error *)
 
-let error (at : region) (msg : string) = error_runtime at msg
-let warn (at : region) (msg : string) = warn_runtime at msg
+exception RuntimeError of region * string
+
+let error (at : region) (msg : string) = raise (RuntimeError (at, msg))
+let warn (at : region) (msg : string) = Util.Error.warn at "runtime" msg
 
 (* Checks *)
 

--- a/p4spec/lib/stf/error.ml
+++ b/p4spec/lib/stf/error.ml
@@ -1,0 +1,3 @@
+exception StfError of string
+
+let error (msg : string) = raise (StfError msg)

--- a/p4spec/lib/stf/parse.ml
+++ b/p4spec/lib/stf/parse.ml
@@ -13,14 +13,11 @@
  * under the License.
  *)
 
-open Core
-open Util.Error
-
-let error = error_stf
+let error = Error.error
 
 let lex (filename : string) =
   try
-    let file = In_channel.read_all filename in
+    let file = Core.In_channel.read_all filename in
     Lexing.from_string file
   with Lexer.Error s -> Format.asprintf "lexer error: %s" s |> error
 

--- a/p4spec/lib/util/error.ml
+++ b/p4spec/lib/util/error.ml
@@ -3,10 +3,6 @@ open Source
 exception ParseError of region * string
 exception UnparseError of string
 exception RuntimeError of region * string
-exception ElabError of region * string
-exception AlgoError of region * string
-exception StructError of region * string
-exception ProseError of region * string
 exception BuiltinError of region * string
 exception InterpError of region * string
 exception ExternError of region * string
@@ -34,26 +30,6 @@ let error_unparse (msg : string) = raise (UnparseError msg)
 
 let error_runtime (at : region) (msg : string) = raise (RuntimeError (at, msg))
 let warn_runtime (at : region) (msg : string) = warn at "runtime" msg
-
-(* Elaboration errors *)
-
-let error_elab (at : region) (msg : string) = raise (ElabError (at, msg))
-let warn_elab (at : region) (msg : string) = warn at "elab" msg
-
-(* Algo errors *)
-
-let error_algo (at : region) (msg : string) = raise (AlgoError (at, msg))
-let warn_algo (at : region) (msg : string) = warn at "algo" msg
-
-(* Structuring errors *)
-
-let error_struct (at : region) (msg : string) = raise (StructError (at, msg))
-let warn_struct (at : region) (msg : string) = warn at "struct" msg
-
-(* Prosification errors *)
-
-let error_prose (at : region) (msg : string) = raise (ProseError (at, msg))
-let warn_prose (at : region) (msg : string) = warn at "prose" msg
 
 (* Builtin errors *)
 

--- a/p4spec/lib/util/error.ml
+++ b/p4spec/lib/util/error.ml
@@ -1,50 +1,7 @@
 open Source
 
-exception ParseError of region * string
-exception UnparseError of string
-exception RuntimeError of region * string
-exception BuiltinError of region * string
-exception InterpError of region * string
-exception ExternError of region * string
-exception StfError of string
-exception SpliceError of region * string
-
-let debug_errors = false
-
 let string_of_error at msg =
   if at = no_region then msg else string_of_region at ^ ": " ^ msg
 
 let warn (at : region) (category : string) (msg : string) =
   Printf.eprintf "%s\n%!" (string_of_error at (category ^ " warning: " ^ msg))
-
-(* Parser errors *)
-
-let error_parse (at : region) (msg : string) = raise (ParseError (at, msg))
-let error_parse_no_region (msg : string) = raise (ParseError (no_region, msg))
-
-(* Unparser errors *)
-
-let error_unparse (msg : string) = raise (UnparseError msg)
-
-(* Runtime errors *)
-
-let error_runtime (at : region) (msg : string) = raise (RuntimeError (at, msg))
-let warn_runtime (at : region) (msg : string) = warn at "runtime" msg
-
-(* Builtin errors *)
-
-let error_builtin (at : region) (msg : string) = raise (BuiltinError (at, msg))
-let warn_builtin (at : region) (msg : string) = warn at "builtin" msg
-
-(* Interpreter errors *)
-
-let error_interp (at : region) (msg : string) = raise (InterpError (at, msg))
-let warn_interp (at : region) (msg : string) = warn at "interp" msg
-let error_extern (at : region) (msg : string) = raise (ExternError (at, msg))
-let warn_extern (at : region) (msg : string) = warn at "extern" msg
-let error_stf (msg : string) = raise (StfError msg)
-
-(* Splicer errors *)
-
-let error_splice (at : region) (msg : string) = raise (SpliceError (at, msg))
-let warn_splice (at : region) (msg : string) = warn at "splice" msg

--- a/p4spec/test/boot/test.ml
+++ b/p4spec/test/boot/test.ml
@@ -1,5 +1,4 @@
 open Test_common
-open Util.Error
 open Runtime.Sim.Signature
 open Backend_boot.Config
 module Test = Util.Test
@@ -48,7 +47,8 @@ let boot_test (module Booter : RUNNER) neg stat tower excludes_p4 path_p4 =
     | TestRunErr (msg, at, time_start) ->
         let duration = stop time_start in
         Format.asprintf "Error on run: %s" path_p4 |> print_endline;
-        Format.eprintf "Error on run: %s\n%s\n" path_p4 (string_of_error at msg);
+        Format.eprintf "Error on run: %s\n%s\n" path_p4
+          (Util.Error.string_of_error at msg);
         Format.eprintf ">>> took %.6f seconds\n" duration;
         {
           stat with

--- a/p4spec/test/boot/test.ml
+++ b/p4spec/test/boot/test.ml
@@ -104,7 +104,11 @@ let boot_test_driver path_tower det neg includes_p4 excludes_p4 testdirs_p4 =
   let rel_p4 = tower.level_target.layer.rel in
   Format.asprintf "Running boot test (%s/%s) on %d files\n" rel rel_p4 total
   |> print_endline;
-  let _, _, _, (module Booter) = Backend_boot.Build.build_tower ~det tower in
+  let _, _, _, (module Booter) =
+    match Backend_boot.Build.build_tower ~det tower with
+    | Ok r -> r
+    | Error e -> failwith (Pass.string_of_error e)
+  in
   let _, stat =
     List.fold_left
       (fun (idx, stat) path_p4 ->

--- a/p4spec/test/boot/test.ml
+++ b/p4spec/test/boot/test.ml
@@ -84,7 +84,9 @@ let boot_test_driver path_tower det neg includes_p4 excludes_p4 testdirs_p4 =
   let total = List.length paths_p4 in
   let tower =
     let target = { includes = includes_p4; path = "" } in
-    Backend_boot.Config.tower_of_file path_tower target
+    match P4spectec.tower_of_file path_tower target with
+    | Ok tower -> tower
+    | Error e -> failwith (Error.to_string e)
   in
   let prefix (level : level) =
     {
@@ -104,10 +106,10 @@ let boot_test_driver path_tower det neg includes_p4 excludes_p4 testdirs_p4 =
   let rel_p4 = tower.level_target.layer.rel in
   Format.asprintf "Running boot test (%s/%s) on %d files\n" rel rel_p4 total
   |> print_endline;
-  let _, _, _, (module Booter) =
-    match Backend_boot.Build.build_tower ~det tower with
+  let _, (module Booter) =
+    match P4spectec.build_tower ~det tower with
     | Ok r -> r
-    | Error e -> failwith (Pass.string_of_error e)
+    | Error e -> failwith (Error.to_string e)
   in
   let _, stat =
     List.fold_left

--- a/p4spec/test/lang/test.ml
+++ b/p4spec/test/lang/test.ml
@@ -1,73 +1,62 @@
 open Lang
 open Test_common
-open Util.Error
 
 (* Spec elaboration test *)
 
 let elab_test path_spec =
-  let spec_il = Pass.elab path_spec in
-  Il.Print.string_of_spec spec_il |> print_endline
+  match Pass.elab path_spec with
+  | Ok spec_il -> Il.Print.string_of_spec spec_il |> print_endline
+  | Error e ->
+      Format.printf "Error on elaboration: %s\n" (Pass.string_of_error e)
 
 let elab_command =
   Core.Command.basic ~summary:"run elaboration test"
     (let open Core.Command.Let_syntax in
      let open Core.Command.Param in
      let%map path_spec = flag "-s" (required string) ~doc:"p4 spec directory" in
-     fun () ->
-       try elab_test [ path_spec ]
-       with ParseError (at, msg) | ElabError (at, msg) ->
-         Format.printf "Error on elaboration: %s\n" (string_of_error at msg))
+     fun () -> elab_test [ path_spec ])
 
 (* Algo test *)
 
 let algo_test path_spec =
-  let spec_al = Pass.algo path_spec in
-  Al.Print.string_of_spec spec_al |> print_endline
+  match Pass.algo path_spec with
+  | Ok spec_al -> Al.Print.string_of_spec spec_al |> print_endline
+  | Error e -> Format.printf "%s\n" (Pass.string_of_error e)
 
 let algo_command =
   Core.Command.basic ~summary:"run algo test"
     (let open Core.Command.Let_syntax in
      let open Core.Command.Param in
      let%map path_spec = flag "-s" (required string) ~doc:"p4 spec directory" in
-     fun () ->
-       try algo_test [ path_spec ]
-       with
-       | ParseError (at, msg) | ElabError (at, msg) | AlgoError (at, msg) ->
-         Format.printf "%s\n" (string_of_error at msg))
+     fun () -> algo_test [ path_spec ])
 
 (* Structuring test *)
 
 let structure_test path_spec =
-  let spec_sl = Pass.structure ~final:true path_spec in
-  Sl.Print.string_of_spec spec_sl |> print_endline
+  match Pass.structure ~final:true path_spec with
+  | Ok spec_sl -> Sl.Print.string_of_spec spec_sl |> print_endline
+  | Error e -> Format.printf "%s\n" (Pass.string_of_error e)
 
 let structure_command =
   Core.Command.basic ~summary:"run structuring test"
     (let open Core.Command.Let_syntax in
      let open Core.Command.Param in
      let%map path_spec = flag "-s" (required string) ~doc:"p4 spec directory" in
-     fun () ->
-       try structure_test [ path_spec ]
-       with
-       | ParseError (at, msg) | ElabError (at, msg) | AlgoError (at, msg) ->
-         Format.printf "%s\n" (string_of_error at msg))
+     fun () -> structure_test [ path_spec ])
 
 (* Annotate (prose) test *)
 
 let annotate_test path_spec =
-  let spec_pl = Pass.annotate path_spec in
-  Pl.Render.render_spec spec_pl |> print_endline
+  match Pass.annotate path_spec with
+  | Ok spec_pl -> Pl.Render.render_spec spec_pl |> print_endline
+  | Error e -> Format.printf "%s\n" (Pass.string_of_error e)
 
 let annotate_command =
   Core.Command.basic ~summary:"run annotate test"
     (let open Core.Command.Let_syntax in
      let open Core.Command.Param in
      let%map path_spec = flag "-s" (required string) ~doc:"p4 spec directory" in
-     fun () ->
-       try annotate_test [ path_spec ]
-       with
-       | ParseError (at, msg) | ElabError (at, msg) | AlgoError (at, msg) ->
-         Format.printf "%s\n" (string_of_error at msg))
+     fun () -> annotate_test [ path_spec ])
 
 let command =
   Core.Command.group ~summary:"p4spec-test-lang"

--- a/p4spec/test/lang/test.ml
+++ b/p4spec/test/lang/test.ml
@@ -4,10 +4,9 @@ open Test_common
 (* Spec elaboration test *)
 
 let elab_test path_spec =
-  match Pass.elab path_spec with
+  match P4spectec.elab path_spec with
   | Ok spec_il -> Il.Print.string_of_spec spec_il |> print_endline
-  | Error e ->
-      Format.printf "Error on elaboration: %s\n" (Pass.string_of_error e)
+  | Error e -> Format.printf "Error on elaboration: %s\n" (Error.to_string e)
 
 let elab_command =
   Core.Command.basic ~summary:"run elaboration test"
@@ -19,9 +18,9 @@ let elab_command =
 (* Algo test *)
 
 let algo_test path_spec =
-  match Pass.algo path_spec with
+  match P4spectec.algo path_spec with
   | Ok spec_al -> Al.Print.string_of_spec spec_al |> print_endline
-  | Error e -> Format.printf "%s\n" (Pass.string_of_error e)
+  | Error e -> Format.printf "%s\n" (Error.to_string e)
 
 let algo_command =
   Core.Command.basic ~summary:"run algo test"
@@ -33,9 +32,9 @@ let algo_command =
 (* Structuring test *)
 
 let structure_test path_spec =
-  match Pass.structure ~final:true path_spec with
+  match P4spectec.structure ~final:true path_spec with
   | Ok spec_sl -> Sl.Print.string_of_spec spec_sl |> print_endline
-  | Error e -> Format.printf "%s\n" (Pass.string_of_error e)
+  | Error e -> Format.printf "%s\n" (Error.to_string e)
 
 let structure_command =
   Core.Command.basic ~summary:"run structuring test"
@@ -47,9 +46,9 @@ let structure_command =
 (* Annotate (prose) test *)
 
 let annotate_test path_spec =
-  match Pass.annotate path_spec with
+  match P4spectec.annotate path_spec with
   | Ok spec_pl -> Pl.Render.render_spec spec_pl |> print_endline
-  | Error e -> Format.printf "%s\n" (Pass.string_of_error e)
+  | Error e -> Format.printf "%s\n" (Error.to_string e)
 
 let annotate_command =
   Core.Command.basic ~summary:"run annotate test"

--- a/p4spec/test/parse/test.ml
+++ b/p4spec/test/parse/test.ml
@@ -1,7 +1,6 @@
 open Lang
 open Test_common
 open Runtime.Sim.Signature
-open Util.Error
 module Test = Util.Test
 module Filesys = Util.Filesys
 
@@ -58,7 +57,7 @@ let parser_test_ stat (module Simulator : SIM) includes_p4 excludes_p4 path_p4 =
         let duration = stop time_start in
         let log =
           Format.asprintf "Error parsing file: %s\n%s" path_p4
-            (string_of_error at msg)
+            (Util.Error.string_of_error at msg)
         in
         log |> print_endline;
         Format.eprintf "%s\n" log;
@@ -72,7 +71,7 @@ let parser_test_ stat (module Simulator : SIM) includes_p4 excludes_p4 path_p4 =
         let duration = stop time_start in
         let log =
           Format.asprintf "Error parsing string: %s\n%s" path_p4
-            (string_of_error at msg)
+            (Util.Error.string_of_error at msg)
         in
         log |> print_endline;
         Format.eprintf "%s\n" log;

--- a/p4spec/test/parse/test.ml
+++ b/p4spec/test/parse/test.ml
@@ -113,8 +113,9 @@ let parser_test_driver includes_p4 excludes_p4 testdirs_p4 path_spec =
   let paths_p4 =
     testdirs_p4 |> List.concat_map (Filesys.collect_files ~suffix:".p4")
   in
-  let _, (module Simulator) =
-    Backend_sim.Build.build ~final:true SL_mode [ path_spec ]
+  let (module Simulator) =
+    Backend_sim.Build.build
+      (Backend_boot.Build.spec_of_mode SL_mode [ path_spec ])
   in
   let total = List.length paths_p4 in
   let stat = empty_stat in

--- a/p4spec/test/parse/test.ml
+++ b/p4spec/test/parse/test.ml
@@ -113,10 +113,7 @@ let parser_test_driver includes_p4 excludes_p4 testdirs_p4 path_spec =
   let paths_p4 =
     testdirs_p4 |> List.concat_map (Filesys.collect_files ~suffix:".p4")
   in
-  let (module Simulator) =
-    Backend_sim.Build.build
-      (Backend_boot.Build.spec_of_mode SL_mode [ path_spec ])
-  in
+  let _, (module Simulator) = build_sim SL_mode [ path_spec ] in
   let total = List.length paths_p4 in
   let stat = empty_stat in
   Format.asprintf "Running parser tests on %d files\n" total |> print_endline;

--- a/p4spec/test/run/test.ml
+++ b/p4spec/test/run/test.ml
@@ -81,8 +81,9 @@ let run_test_driver mode det neg path_spec relname includes_p4 excludes_p4
   let stat = empty_stat in
   Format.asprintf "Running interpreter test (%s) on %d files\n" relname total
   |> print_endline;
-  let _spec_sim, (module Simulator) =
-    Backend_sim.Build.build ~det ~final:true mode [ path_spec ]
+  let (module Simulator) =
+    Backend_sim.Build.build ~det
+      (Backend_boot.Build.spec_of_mode mode [ path_spec ])
   in
   let stat =
     List.fold_left

--- a/p4spec/test/run/test.ml
+++ b/p4spec/test/run/test.ml
@@ -1,5 +1,4 @@
 open Test_common
-open Util.Error
 open Runtime.Sim.Signature
 module Test = Util.Test
 module Filesys = Util.Filesys
@@ -43,7 +42,8 @@ let run_test (module Simulator : SIM) neg stat relname includes_p4 excludes_p4
     | TestRunErr (msg, at, time_start) ->
         let duration = stop time_start in
         Format.asprintf "Error on run: %s" path_p4 |> print_endline;
-        Format.eprintf "Error on run: %s\n%s\n" path_p4 (string_of_error at msg);
+        Format.eprintf "Error on run: %s\n%s\n" path_p4
+          (Util.Error.string_of_error at msg);
         Format.eprintf ">>> took %.6f seconds\n" duration;
         {
           stat with

--- a/p4spec/test/run/test.ml
+++ b/p4spec/test/run/test.ml
@@ -81,10 +81,7 @@ let run_test_driver mode det neg path_spec relname includes_p4 excludes_p4
   let stat = empty_stat in
   Format.asprintf "Running interpreter test (%s) on %d files\n" relname total
   |> print_endline;
-  let (module Simulator) =
-    Backend_sim.Build.build ~det
-      (Backend_boot.Build.spec_of_mode mode [ path_spec ])
-  in
+  let _spec_sim, (module Simulator) = build_sim ~det mode [ path_spec ] in
   let stat =
     List.fold_left
       (fun stat path_p4 ->

--- a/p4spec/test/sim/test.ml
+++ b/p4spec/test/sim/test.ml
@@ -116,8 +116,9 @@ let run_sim_test_driver mode det arch path_spec includes_p4 excludes_p4
   let stat = empty_stat in
   Format.asprintf "Running simulation test (%s) on %d files\n" arch total
   |> print_endline;
-  let _spec_sim, (module Simulator) =
-    Backend_sim.Build.build ~det ~arch ~final:true mode [ path_spec ]
+  let (module Simulator) =
+    Backend_sim.Build.build ~det ~arch
+      (Backend_boot.Build.spec_of_mode mode [ path_spec ])
   in
   let stat =
     List.fold_left

--- a/p4spec/test/sim/test.ml
+++ b/p4spec/test/sim/test.ml
@@ -1,5 +1,4 @@
 open Test_common
-open Util.Error
 open Runtime.Sim.Signature
 module Test = Util.Test
 module Filesys = Util.Filesys
@@ -76,7 +75,7 @@ let run_sim_test (module Simulator : SIM) stat includes_p4 excludes
         let duration = stop time_start in
         Format.asprintf "Error on run: %s" path_stf |> print_endline;
         Format.eprintf "Error on run: %s\n%s\n" path_stf
-          (string_of_error at msg);
+          (Util.Error.string_of_error at msg);
         Format.eprintf ">>> took %.6f seconds\n" duration;
         {
           stat with

--- a/p4spec/test/sim/test.ml
+++ b/p4spec/test/sim/test.ml
@@ -116,10 +116,7 @@ let run_sim_test_driver mode det arch path_spec includes_p4 excludes_p4
   let stat = empty_stat in
   Format.asprintf "Running simulation test (%s) on %d files\n" arch total
   |> print_endline;
-  let (module Simulator) =
-    Backend_sim.Build.build ~det ~arch
-      (Backend_boot.Build.spec_of_mode mode [ path_spec ])
-  in
+  let _spec_sim, (module Simulator) = build_sim ~det ~arch mode [ path_spec ] in
   let stat =
     List.fold_left
       (fun stat (path_p4, path_stf, is_patched) ->

--- a/p4spec/test/test_common.ml
+++ b/p4spec/test/test_common.ml
@@ -1,23 +1,19 @@
 open Runtime.Sim.Signature
+module Error = P4spectec.Error
 module Filesys = Util.Filesys
 open Util.Source
 
 let version = "0.1"
-
-let spec_of_mode (mode : mode) (paths_spec : string list) :
-    (spec, Pass.error) result =
-  match mode with
-  | AL_mode -> Result.map (fun s -> AL s) (Pass.algo paths_spec)
-  | SL_mode ->
-      Result.map (fun s -> SL s) (Pass.structure ~final:true paths_spec)
-  | PL_mode -> Result.map (fun s -> PL s) (Pass.annotate paths_spec)
-  | Empty_mode -> assert false
+let ( let* ) = Result.bind
 
 let build_sim ?cache ?det ?guard ?(arch : string option) mode paths_spec =
-  match spec_of_mode mode paths_spec with
-  | Ok spec_sim ->
-      (spec_sim, Backend_sim.Build.build ?cache ?det ?guard ?arch spec_sim)
-  | Error e -> failwith (Pass.string_of_error e)
+  match
+    let* spec_sim = P4spectec.spec_of_mode mode paths_spec in
+    let* simulator = P4spectec.build_sim ?cache ?det ?guard ?arch spec_sim in
+    Ok (spec_sim, simulator)
+  with
+  | Ok (spec_sim, simulator) -> (spec_sim, simulator)
+  | Error e -> failwith (Error.to_string e)
 
 (* Statistics *)
 

--- a/p4spec/test/test_common.ml
+++ b/p4spec/test/test_common.ml
@@ -147,9 +147,8 @@ let sim_with_dangling (module Simulator : SIM) spec_sim includes_p4 path_p4
 
 let cover_run_instr ?(arch : string option) mode paths_spec relname includes_p4
     paths_p4 =
-  let spec_sim, (module Simulator) =
-    Backend_sim.Build.build ?arch ~final:true mode paths_spec
-  in
+  let spec_sim = Backend_boot.Build.spec_of_mode mode paths_spec in
+  let (module Simulator) = Backend_sim.Build.build ?arch spec_sim in
   let spec_sl =
     match spec_sim with SL spec_sl -> spec_sl | _ -> assert false
   in
@@ -167,9 +166,8 @@ let cover_run_instr ?(arch : string option) mode paths_spec relname includes_p4
 
 let cover_run_dangling ?(arch : string option) mode paths_spec relname
     includes_p4 paths_p4 =
-  let spec_sim, (module Simulator) =
-    Backend_sim.Build.build ?arch ~final:true mode paths_spec
-  in
+  let spec_sim = Backend_boot.Build.spec_of_mode mode paths_spec in
+  let (module Simulator) = Backend_sim.Build.build ?arch spec_sim in
   let spec_sl =
     match spec_sim with SL spec_sl -> spec_sl | _ -> assert false
   in
@@ -196,9 +194,8 @@ let cover_run_dangling ?(arch : string option) mode paths_spec relname
 
 let cover_sim_instr ?(arch : string option) mode paths_spec includes_p4 paths_p4
     paths_stf =
-  let spec_sim, (module Simulator) =
-    Backend_sim.Build.build ?arch ~final:true mode paths_spec
-  in
+  let spec_sim = Backend_boot.Build.spec_of_mode mode paths_spec in
+  let (module Simulator) = Backend_sim.Build.build ?arch spec_sim in
   let spec_sl =
     match spec_sim with SL spec_sl -> spec_sl | _ -> assert false
   in
@@ -218,9 +215,8 @@ let cover_sim_instr ?(arch : string option) mode paths_spec includes_p4 paths_p4
 
 let cover_sim_dangling ?(arch : string option) mode paths_spec includes_p4
     paths_p4 paths_stf =
-  let spec_sim, (module Simulator) =
-    Backend_sim.Build.build ?arch ~final:true mode paths_spec
-  in
+  let spec_sim = Backend_boot.Build.spec_of_mode mode paths_spec in
+  let (module Simulator) = Backend_sim.Build.build ?arch spec_sim in
   let spec_sl =
     match spec_sim with SL spec_sl -> spec_sl | _ -> assert false
   in

--- a/p4spec/test/test_common.ml
+++ b/p4spec/test/test_common.ml
@@ -4,6 +4,21 @@ open Util.Source
 
 let version = "0.1"
 
+let spec_of_mode (mode : mode) (paths_spec : string list) :
+    (spec, Pass.error) result =
+  match mode with
+  | AL_mode -> Result.map (fun s -> AL s) (Pass.algo paths_spec)
+  | SL_mode ->
+      Result.map (fun s -> SL s) (Pass.structure ~final:true paths_spec)
+  | PL_mode -> Result.map (fun s -> PL s) (Pass.annotate paths_spec)
+  | Empty_mode -> assert false
+
+let build_sim ?cache ?det ?guard ?(arch : string option) mode paths_spec =
+  match spec_of_mode mode paths_spec with
+  | Ok spec_sim ->
+      (spec_sim, Backend_sim.Build.build ?cache ?det ?guard ?arch spec_sim)
+  | Error e -> failwith (Pass.string_of_error e)
+
 (* Statistics *)
 
 type stat = {
@@ -147,8 +162,7 @@ let sim_with_dangling (module Simulator : SIM) spec_sim includes_p4 path_p4
 
 let cover_run_instr ?(arch : string option) mode paths_spec relname includes_p4
     paths_p4 =
-  let spec_sim = Backend_boot.Build.spec_of_mode mode paths_spec in
-  let (module Simulator) = Backend_sim.Build.build ?arch spec_sim in
+  let spec_sim, (module Simulator) = build_sim ?arch mode paths_spec in
   let spec_sl =
     match spec_sim with SL spec_sl -> spec_sl | _ -> assert false
   in
@@ -166,8 +180,7 @@ let cover_run_instr ?(arch : string option) mode paths_spec relname includes_p4
 
 let cover_run_dangling ?(arch : string option) mode paths_spec relname
     includes_p4 paths_p4 =
-  let spec_sim = Backend_boot.Build.spec_of_mode mode paths_spec in
-  let (module Simulator) = Backend_sim.Build.build ?arch spec_sim in
+  let spec_sim, (module Simulator) = build_sim ?arch mode paths_spec in
   let spec_sl =
     match spec_sim with SL spec_sl -> spec_sl | _ -> assert false
   in
@@ -194,8 +207,7 @@ let cover_run_dangling ?(arch : string option) mode paths_spec relname
 
 let cover_sim_instr ?(arch : string option) mode paths_spec includes_p4 paths_p4
     paths_stf =
-  let spec_sim = Backend_boot.Build.spec_of_mode mode paths_spec in
-  let (module Simulator) = Backend_sim.Build.build ?arch spec_sim in
+  let spec_sim, (module Simulator) = build_sim ?arch mode paths_spec in
   let spec_sl =
     match spec_sim with SL spec_sl -> spec_sl | _ -> assert false
   in
@@ -215,8 +227,7 @@ let cover_sim_instr ?(arch : string option) mode paths_spec includes_p4 paths_p4
 
 let cover_sim_dangling ?(arch : string option) mode paths_spec includes_p4
     paths_p4 paths_stf =
-  let spec_sim = Backend_boot.Build.spec_of_mode mode paths_spec in
-  let (module Simulator) = Backend_sim.Build.build ?arch spec_sim in
+  let spec_sim, (module Simulator) = build_sim ?arch mode paths_spec in
   let spec_sl =
     match spec_sim with SL spec_sl -> spec_sl | _ -> assert false
   in


### PR DESCRIPTION
## Motivation

Failure handling in the pipeline and runners was done through exceptions, and the exception types lived in a shared `Util.Error` module that every fallible module pulled in through `open`. This led to two problems:
- Signatures were dishonest. A function that ran a pass or initialized a runner returned a plain value but could fail with an exception, so every CLI-facing caller wrapped the call in a `try` and re-listed every exception that might happen.
- Ownership was enforced by convention only. Any module could raise or catch any error, and nothing restricted which failures a given pass could produce.

This is phase 1 of the diagnostics/LSP port (#175): make every failure flow as a typed value through a single boundary, so following work can attach positions and render diagnostics in one place instead of at each `try`.

## Core Concepts

### 1. A pass returns a result instead of raising an exception

The pipeline stages returned bare values and raised exceptions on failure. They now return a result over `Pass.error`, which is made abstract by a new `pass.mli`.

```ocaml
(* before: each command re-lists the pass exceptions it might see *)
fun () ->
  try
    let spec_sl = Pass.structure ~final:true paths_spec in
    Format.printf "%s\n" (Sl.Print.string_of_spec spec_sl)
  with
  | ParseError (at, msg) | ElabError (at, msg) | StructError (at, msg) ->
      Format.printf "%s\n" (string_of_error at msg)
```
```ocaml
(* after: pass/structure/structure.ml catches its exception and returns a result *)
let struct_spec ~(final : bool) (spec : Al.spec) : (Sl.spec, error) result =
  try Ok (Struct.struct_spec ~final spec)
  with Error.StructError (at, msg) -> Error { at; msg }

(* pass.ml converts each pass's error into Pass.error *)
let struct_spec ~final spec_al =
  Structure.struct_spec ~final spec_al
  |> Result.map_error (fun e -> StructError e)

(* pass.mli makes the error type abstract *)
type error
val structure : final:bool -> string list -> (Lang.Sl.spec, error) result
```

### 2. Each module owns its error

`Util.Error` declared twelve exceptions and their raise helpers and was `open`ed by every fallible module, so any module could raise or catch any failure. It now keeps only error rendering and warning printing. Each pass declares its own exception and converts it to its own error type at its entry point, and `Pass.error` is the union.

```ocaml
(* before: util/error.ml owns all errors *)
exception ElabError of region * string
exception StructError of region * string
(* ... *)
let error_elab at msg = raise (ElabError (at, msg))
```

```ocaml
(* after: pass/elaborate/error.ml owns the elaboration failure *)
exception ElabError of region * string
let error at msg = raise (ElabError (at, msg))

(* pass.ml: unions submodules' error types *)
type error =
  | ParseError of Frontend.Parse.error
  | ElabError of Elaborate.error
  | AlgoError of Algo.error
  | StructError of Structure.error
  | ProseError of Annotate.error
```
### 3. Callers compose through one facade

The new `p4spectec.ml(i)` acts as a facade, exposing pass/runner/command operations as functions whose failures share a single `Error.t`, which is a union of all pass, runner, and command errors. Callers chain with `let*`, match once, and render with `Error.to_string`. Effectively, `Pass`, `Backend_sim`, and `Backend_boot.Build` no longer appear in any consumer under `bin` and `test`.
```ocaml
(* before: the builder raises, and each caller re-invents a CommandError *)
let spec_sim, (module Simulator) =
  Backend_sim.Build.build ?arch ~final:true mode paths_spec
in
let spec_sl =
  match spec_sim with
  | SL spec_sl -> spec_sl
  | _ -> raise (CommandError "instruction coverage is only supported for SL")
in
```
```ocaml
(* after: every step is a result threaded through the facade *)
let* spec_sim = P4spectec.spec_of_mode mode paths_spec in
let* simulator = P4spectec.build_sim ?arch spec_sim in
let (module Simulator : SIM) = simulator in
let* spec_sl =
  match spec_sim with
  | SL spec_sl -> Ok spec_sl
  | _ -> Error (Error.CommandError "instruction coverage is only supported for SL")
in

(* error.ml: the one type every entry point reports, and its renderer *)
type t =
  | PassError of Pass.error
  | RunError of Run.error
  | CommandError of string

let to_string (e : t) : string =
  let at, msg = to_region_msg e in
  Util.Error.string_of_error at msg
```
## Scope

No spec output changes, and the only behavioral differences are the minor fixes below.

### Minor Fixes

Several bugs are found and fixed along the way, most of them converting uncaught exceptions to graceful failures.
- **Parser:** path resolution (`expand_path`) moves into `Frontend.Parse, and `Sys_error` is caught by `parse_files` instead of escaping uncaught.
- **Tower:** `P4spectec.tower_of_file` now catches `Sys_error`, `Yojson.Json_error`, and `Yojson.Basic.Util.Type_error`, and returns it as a `CommandError`.
- **AL Interpreter:** an `ExternError` escaped uncaught and was caught later by boot/main. `Interp-al` now catches it internally, matching the SL and PL interpreters, so it is complete without relying on callers.
- **Dangling Coverage:** the `cover_run_dangling` command used to report "instruction coverage is only supported for SL", it now says "dangling coverage is only supported for SL".

## Future Work

Attaching source positions to `Error.t` and rendering real diagnostics is the next phase of #175.

## Commit Log

- refactor(build): build the tower and simulator from a prebuilt spec
- refactor(pass): return results from the pipeline aggregators
- refactor(pass): give each pass its own error type
- refactor(error): move each exception to the module that owns it
- refactor(error): give callers a single error type