### PR TITLE
fix: totalize bitstr decode at width 0 and wrap unsigned negation

### DIFF
--- a/p4spec/lib/interface/builtin/numerics.ml
+++ b/p4spec/lib/interface/builtin/numerics.ml
@@ -103,11 +103,13 @@ let pow2 (add : value -> unit) (at : region) (targs : targ list)
 (* dec $bitstr_to_int(int, bitstr) : int *)
 
 let rec bitstr_to_int' (w : Bigint.t) (n : Bigint.t) : Bigint.t =
-  let two = Bigint.(one + one) in
-  let w' = pow2' w in
-  if Bigint.(n >= w' / two) then bitstr_to_int' w Bigint.(n - w')
-  else if Bigint.(n < -(w' / two)) then bitstr_to_int' w Bigint.(n + w')
-  else n
+  if Bigint.(w <= zero) then Bigint.zero
+  else
+    let two = Bigint.(one + one) in
+    let w' = pow2' w in
+    if Bigint.(n >= w' / two) then bitstr_to_int' w Bigint.(n - w')
+    else if Bigint.(n < -(w' / two)) then bitstr_to_int' w Bigint.(n + w')
+    else n
 
 let bitstr_to_int (add : value -> unit) (at : region) (targs : targ list)
     (values_input : value list) : value =

--- a/spec/3-operations/3-operations.watsup
+++ b/spec/3-operations/3-operations.watsup
@@ -80,7 +80,7 @@ dec $un_minus(value) : value
 
 def $un_minus(D i) = D $(-i)
 def $un_minus(w W i) = w W i'
-  -- if i' = $($pow2(w) - i)
+  -- if i' = $int_to_bitstr(w, $($pow2(w) - i))
 def $un_minus(w S i) = w S i'
   -- if i' = $int_to_bitstr(w, $bitstr_to_int(w, $(-i)))
 


### PR DESCRIPTION
Two independent bugs show up at the edges of fixed-width arithmetic: `bit<0>`
arithmetic makes the checker not terminate, and unsigned negation produces values
outside the type's range. Both reproduce from a two-line P4 program.

## ⑴ `bit<0>` arithmetic diverges

```bash
printf 'const bit<0> A = 0;\nconst bit<0> B = A + A;\n' > /tmp/bit0.p4
./p4spectec run $(find spec -name '*.watsup' | sort) \
  -p /tmp/bit0.p4 -i p4c/p4include -rel Program_ok
```

Before this PR the command never returns and sits at 100% CPU. The first line
typechecks on its own, it is the addition that hangs.

`$bitstr_to_int(w, n)` normalizes `n` into `[-2^(w-1), 2^(w-1))` by adding or
subtracting `2^w` until the value lands inside
(`p4spec/lib/interface/builtin/numerics.ml:105`):

```ocaml
let rec bitstr_to_int' (w : Bigint.t) (n : Bigint.t) : Bigint.t =
  let two = Bigint.(one + one) in
  let w' = pow2' w in
  if Bigint.(n >= w' / two) then bitstr_to_int' w Bigint.(n - w')
  else if Bigint.(n < -(w' / two)) then bitstr_to_int' w Bigint.(n + w')
  else n
```

That strategy assumes the interval contains something. At `w = 0` it degenerates
to `[0, 0)`, which is empty, so the base case is unreachable and the only input
that can arrive, `n = 0`, oscillates forever: `0 → −1 → 0 → …`.

A `bit<0>` value reaches the decode because the unsigned clauses decode too, not
just the signed ones — `$bin_plus(w W i_l, w W i_r)` opens with
`-- if i_l' = $bitstr_to_int(w, i_l)`. So do `- * / %` and `<< >>`, and each of
them hangs at width 0.

Width 0 is admitted in the first place because `Type_ok` imposes no positivity
condition on `BIT` (`spec/5-typing/5.05.1-typing-type.watsup:68`), whereas
`INT<n>` carries `-- if $(n > 0)` (`:46`) and rejects `int<0>`.

**Fix.** `bit<0>` holds exactly one value, `0`, so the decode does have an answer
at width 0 — the correction loop simply cannot reach it. One guard ahead of the
recursion returns it directly, and everything below the guard now runs with
`w ≥ 1`, where `w' / two ≥ 1` keeps the interval non-empty:

```ocaml
let rec bitstr_to_int' (w : Bigint.t) (n : Bigint.t) : Bigint.t =
  if Bigint.(w <= zero) then Bigint.zero
  else
    ...unchanged...
```

The alternative would be to reject `bit<0>` arithmetic in type well-formedness,
the way `int<0>` is rejected today. That is a maintainer's call; totalizing the
decode is the option that preserves P4-16's acceptance of `bit<0>`.

## ⑵ `-0` overflows `bit<w>`

```bash
printf 'const bit<8> A = 0;\nconst bit<8> B = -A;\n' > /tmp/neg.p4
./p4spectec run $(find spec -name '*.watsup' | sort) \
  -p /tmp/neg.p4 -i p4c/p4include -rel Program_ok -trace-full | grep '8 W +'
```

Before this PR the program typechecks and `B` comes out as `8 W +256`, which a
`bit<8>` cannot hold. Negation in P4 is `(2^w − i) mod 2^w`, but the unsigned
clause performs the subtraction and stops there
(`spec/3-operations/3-operations.watsup:82`):

```
def $un_minus(w W i) = w W i'
  -- if i' = $($pow2(w) - i)
```

This is wrong at every width, not only at `w = 0`; negating zero at `bit<0>`
yields `0 W +1` the same way. Nothing flags it, because the program still
typechecks and only the computed value is out of range. The signed clause is
correct, since it decodes and re-encodes around the subtraction.

**Fix.** The unsigned clause re-encodes its result the way the signed clause
already does:

```
def $un_minus(w W i) = w W i'
  -- if i' = $int_to_bitstr(w, $($pow2(w) - i))
```

## Changes

- `p4spec/lib/interface/builtin/numerics.ml` — guard `bitstr_to_int'` at `w ≤ 0`.
- `spec/3-operations/3-operations.watsup` — wrap the result of `$un_minus`'s
  unsigned clause through `$int_to_bitstr`.

## Testing

Both repro programs now typecheck, and negation wraps:

| program | before | after |
| --- | --- | --- |
| `bit<0>`: `A + A` | hangs | passes |
| `bit<0>`: `A << 1` | hangs | passes |
| `bit<8>`: `-0` | `8 W +256` | `8 W +0` |
| `bit<0>`: `-0` | `0 W +1` | `0 W +0` |

Nothing above width 0 moves. `bit<1>` and `bit<8>` addition still pass,
negating `3` at `bit<8>` still gives `8 W +253`, and `int<0>` is still rejected
by well-formedness with `condition (n > 0) was not met`.
