### PR TITLE
fix: totalize bitstr decode at width 0 and wrap unsigned negation

### DIFF
--- a/p4spec/lib/interface/builtin/numerics.ml
+++ b/p4spec/lib/interface/builtin/numerics.ml
@@ -103,11 +103,13 @@ let pow2 (add : value -> unit) (at : region) (targs : targ list)
 (* dec $bitstr_to_int(int, bitstr) : int *)
 
 let rec bitstr_to_int' (w : Bigint.t) (n : Bigint.t) : Bigint.t =
-  let two = Bigint.(one + one) in
-  let w' = pow2' w in
-  if Bigint.(n >= w' / two) then bitstr_to_int' w Bigint.(n - w')
-  else if Bigint.(n < -(w' / two)) then bitstr_to_int' w Bigint.(n + w')
-  else n
+  if Bigint.(w <= zero) then Bigint.zero
+  else
+    let two = Bigint.(one + one) in
+    let w' = pow2' w in
+    if Bigint.(n >= w' / two) then bitstr_to_int' w Bigint.(n - w')
+    else if Bigint.(n < -(w' / two)) then bitstr_to_int' w Bigint.(n + w')
+    else n
 
 let bitstr_to_int (add : value -> unit) (at : region) (targs : targ list)
     (values_input : value list) : value =

--- a/p4spec/test/lang/algo.expected
+++ b/p4spec/test/lang/algo.expected
@@ -5495,7 +5495,7 @@ def $un_minus(value) : value =
   -- let integerLiteral = value as integerLiteral
   -- if integerLiteral matches `% W %`
   -- let w W i = integerLiteral
-  -- let i' = ($pow2(w) - i)
+  -- let i' = $int_to_bitstr(w as int, ($pow2(w) - i))
 
   clause 2 : (value) = w S i' as value
   -- if value <: integerLiteral

--- a/p4spec/test/lang/annotate.expected
+++ b/p4spec/test/lang/annotate.expected
@@ -6482,7 +6482,7 @@ def $un_minus(value)
 
       1. (Let int be $pow2(w))
 
-      2. (Let i' be (int - i))
+      2. (Let i' be $int_to_bitstr((w as int), (int - i)))
 
       3. Return ((w W i') as value)
 

--- a/p4spec/test/lang/elab.expected
+++ b/p4spec/test/lang/elab.expected
@@ -4057,7 +4057,7 @@ def $un_minus(value) : value =
   clause 0 : (D i as value) = D -i as value
 
   clause 1 : (w W i as value) = w W i' as value
-  -- if (i' = ($pow2(w) - i))
+  -- if (i' = $int_to_bitstr(w as int, ($pow2(w) - i)))
 
   clause 2 : (w S i as value) = w S i' as value
   -- if (i' = $int_to_bitstr(w as int, $bitstr_to_int(w as int, -i)))

--- a/p4spec/test/lang/struct.expected
+++ b/p4spec/test/lang/struct.expected
@@ -7082,7 +7082,7 @@ def $un_minus(value)
 
         1. (Let (w W i) be integerLiteral)
 
-          1. (Let i' be ($pow2(w) - i))
+          1. (Let i' be $int_to_bitstr((w as int), ($pow2(w) - i)))
 
             1. Return ((w W i') as value)
 

--- a/spec/3-operations/3-operations.watsup
+++ b/spec/3-operations/3-operations.watsup
@@ -80,7 +80,7 @@ dec $un_minus(value) : value
 
 def $un_minus(D i) = D $(-i)
 def $un_minus(w W i) = w W i'
-  -- if i' = $($pow2(w) - i)
+  -- if i' = $int_to_bitstr(w, $($pow2(w) - i))
 def $un_minus(w S i) = w S i'
   -- if i' = $int_to_bitstr(w, $bitstr_to_int(w, $(-i)))
 


### PR DESCRIPTION
Two independent defects at the boundary of fixed-width arithmetic.

$bitstr_to_int(w, n) normalizes n into [-2^(w-1), 2^(w-1)) by adding or subtracting 2^w until the value lands inside. At w = 0 that interval is empty, so the base case is unreachable and n = 0 oscillates 0 -> -1 -> 0 forever. bit<0> reaches it because the unsigned clauses of + - * / % and << >> decode as well as the signed ones, so `const bit<0> B = A + A;` makes the checker spin. Guard the recursion at w <= 0, where bit<0>'s single value 0 is the answer.

$un_minus's unsigned clause computes 2^w - i without reducing modulo 2^w, so negating 0 yields 2^w, outside the range of bit<w>. Re-encode through $int_to_bitstr the way the signed clause already does.

It follows previous [PR](https://github.com/kaist-plrg/p4-spectec/pull/284).