### PR TITLE
Fix operand type tag on generated index guards

### DIFF
--- a/p4spec/lib/pass/algo/sidecondition/guard.ml
+++ b/p4spec/lib/pass/algo/sidecondition/guard.ml
@@ -172,7 +172,7 @@ end
 let gen_index_guard (exp : exp) (exp_b : exp) (exp_i : exp) : prem list =
   let exp_l = Il.LenE exp_b $$ (exp.at, Typ.Make.nat') in
   let exp_if =
-    Il.CmpE (`LtOp, `BoolT, exp_i, exp_l) $$ (exp.at, Typ.Make.bool')
+    Il.CmpE (`LtOp, `NatT, exp_i, exp_l) $$ (exp.at, Typ.Make.bool')
   in
   [ Il.IfPr exp_if $ exp.at ]
 


### PR DESCRIPTION
**Summary**

Tag the bounds guard generated for an index access with `` `NatT `` instead of `` `BoolT ``, so that it compares equal to an equivalent hand-written premise and the existing redundant-guard filter can drop it.

**Problem**

`gen_index_guard` emits the guard for `b[i]` as

```ocaml
Il.CmpE (`LtOp, `BoolT, exp_i, exp_l)
```

The second field of `CmpE` is the *operand* type. For an ordering comparison the elaborator fills it from `cmpop_candidates` in `infer_cmpop_num`, which yields `` `NatT `` for `nat` operands; `` `BoolT `` is only correct on the equality path. Since `Il.Eq.eq_exp` compares this tag, a generated guard never matches a hand-written `$(i < |b|)` premise, and `Result.filter` — which exists precisely to drop guards already entailed by earlier premises — cannot recognise it.

Every rule that states its own bounds premise and then indexes therefore carries the check twice. For example `Expr_inst/tuple` in `spec/7-instantiation/7.04-inst-expression.watsup`:

```
-- if $(n_index < |value_e*|)
-- if value = value_e*[n_index]
```

structures into a doubled conditional:

```
1. If ((n_index < |(value_e)*{...}|)), then
  1. If ((n_index < |(value_e)*{...}|)), then
    1. (Let value be (value_e)*{...}[n_index])
```

The inner condition is implied by the outer one, so its else-branch is marked dangling but can never be taken. These premises inflate the dangling-coverage denominator and give the negative test generator targets that no program can ever hit.

The wrong tag is otherwise invisible because the interpreter ignores it — `eval_cmp_exp` takes the operand type as `_optyp` and dispatches on the comparison operator alone.

**Fix**

Build the guard with `` `NatT ``. The redundant-guard filter then recognises the duplicate and drops it.

Structuring the P4 spec goes from 2173 to 2166 dangling premises; all 7 removals are index guards (`n_index < |value_e*|` x6, `n_index < |typeIR_e*|` x1) and nothing new appears. `make build` and `dune build @runtest` pass.

Note that dangling instruction ids shift as a result, so coverage files produced before this change are no longer comparable with ones produced after.
